### PR TITLE
ci: licence report (non-blocking) with JSON artifact

### DIFF
--- a/.github/workflows/licence-report.yml
+++ b/.github/workflows/licence-report.yml
@@ -1,0 +1,32 @@
+name: Licence Report
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  licence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+
+      - name: Generate licence report
+        run: node tools/licence-report.js
+        continue-on-error: true
+
+      - name: Upload licence report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: licence-report
+          path: reports/licences.json
+          if-no-files-found: warn

--- a/tools/licence-report.js
+++ b/tools/licence-report.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function write(file, obj) {
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(obj, null, 2));
+}
+
+function run(cmd, args) {
+  return new Promise((resolve) => {
+    const p = spawn(cmd, args, { shell: true });
+    let out = '', err = '';
+    p.stdout.on('data', d => out += String(d));
+    p.stderr.on('data', d => err += String(d));
+    p.on('close', code => resolve({ code, out, err }));
+  });
+}
+
+(async function main(){
+  const outFile = path.resolve(process.cwd(), 'reports/licences.json');
+  let summary = { ok: true, skipped: false, tool: 'license-checker', ts: new Date().toISOString() };
+  try {
+    const { code, out, err } = await run('npx', ['license-checker', '--json']);
+    if (code === 0 && out) {
+      write(outFile, { ok: true, dependencies: JSON.parse(out) });
+      return;
+    }
+    summary.ok = false;
+    summary.error = err || 'license-checker failed';
+  } catch (e) {
+    summary.ok = false;
+    summary.error = e.message || String(e);
+  }
+  write(outFile, summary);
+})();


### PR DESCRIPTION
### What
- 

### How to verify
- `npm test` → green
- (optional) `npm run replay` → All fixtures match

### Risk
- 

### Checklist
- [ ] No `parse_text` in logs
- [ ] Determinism preserved (fixtures unchanged)