### PR TITLE
ci: add concurrency group and 30m timeout to main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         node-version: [18.x, 20.x]


### PR DESCRIPTION
### What
- 

### How to verify
- `npm test` → green
- (optional) `npm run replay` → All fixtures match

### Risk
- 

### Checklist
- [ ] No `parse_text` in logs
- [ ] Determinism preserved (fixtures unchanged)