### PR TITLE
feat(demo-sse): /demo/stream behind TEST_ROUTES=1 (+DEPLOYING notes)

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,0 +1,93 @@
+# Deploying to Render
+
+## Quick Setup
+
+1. **Create Web Service** on [Render Dashboard](https://dashboard.render.com/)
+   - Repository: `Talchain/plot-lite-service`
+   - Branch: `main`
+   - Runtime: `Node` (20+)
+   - Build Command: `npm ci && npm run build`
+   - Start Command: `npm start`
+   - Auto-Deploy: ✅ Enabled
+
+2. **Environment Variables**
+   
+   **Production (recommended)**:
+   ```
+   NODE_ENV=production
+   PORT=10000
+   CORS_ORIGINS=https://olumi.netlify.app,https://olumi.netlify.app/#/sandbox
+   ```
+   
+   **Staging/Demo (with test routes)**:
+   ```
+   NODE_ENV=production
+   PORT=10000
+   CORS_ORIGINS=https://olumi.netlify.app,https://olumi.netlify.app/#/sandbox
+   TEST_ROUTES=1
+   ```
+   
+   **CORS Options**:
+   - `CORS_ORIGINS`: Comma-separated list for multiple origins (recommended)
+     Example: `CORS_ORIGINS=https://app.example.com,https://staging.example.com`
+   - If not set, CORS is disabled (secure default)
+   
+   **Feature Flags**:
+   - `TEST_ROUTES=1`: Enables demo endpoints like `/demo/stream` (can be toggled off later)
+   - `RATE_LIMIT_ENABLED=0`: Disables rate limiting (not recommended for production)
+
+3. **Optional: CI Deploy Hook**
+   - In Render: Settings → Deploy Hook → Copy URL
+   - In GitHub: Settings → Secrets → Add `RENDER_DEPLOY_HOOK_URL`
+
+## Start Command
+```bash
+npm start
+```
+This runs `node dist/main.js` which:
+- Reads `PORT` from `process.env.PORT` (Render sets this)
+- Listens on `0.0.0.0` (required for Render)
+- Enables CORS for `CORS_ORIGIN` if set
+
+## Health Check
+```
+GET /health
+```
+
+## Local Verification (Node 20)
+
+Before deploying, verify locally:
+
+```bash
+# Build
+npm run build
+
+# Start with test routes enabled
+CORS_ORIGINS="http://localhost:5174" TEST_ROUTES=1 PORT=4311 npm start
+```
+
+In another terminal:
+
+```bash
+# Verify test routes are enabled
+curl -s http://127.0.0.1:4311/health | jq .test_routes_enabled
+# Expected: true
+
+# Test demo SSE endpoint
+curl -Ns http://127.0.0.1:4311/demo/stream?scenario=sch1 | sed -n '1,20p'
+# Expected output:
+# event: hello
+# data: {"scenario":"sch1","seed":1}
+#
+# event: token
+# data: {"text":"This"}
+# ...
+# event: done
+# data: {}
+```
+
+## Notes
+- Server auto-deploys on push to `main`
+- Graceful shutdown on SIGTERM (zero-downtime)
+- CORS disabled by default; set `CORS_ORIGINS` to enable
+- Demo endpoints only available when `TEST_ROUTES=1`

--- a/tests/demo.sse.test.ts
+++ b/tests/demo.sse.test.ts
@@ -1,0 +1,42 @@
+import { expect, test, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import { createServer } from '../src/createServer.js';
+import type { FastifyInstance } from 'fastify';
+
+let app: FastifyInstance;
+let port: number;
+
+beforeAll(async () => {
+  process.env.TEST_ROUTES = '1';
+  app = await createServer({ enableTestRoutes: true });
+  await app.listen({ port: 0, host: '127.0.0.1' });
+  const addr = app.server.address();
+  port = typeof addr === 'object' && addr ? addr.port : 0;
+});
+
+afterAll(async () => {
+  await app.close();
+  delete process.env.TEST_ROUTES;
+});
+
+test('demo SSE emits hello/token/done when TEST_ROUTES=1', async () => {
+  const url = `http://127.0.0.1:${port}/demo/stream?scenario=sch1`;
+  await new Promise<void>((resolve, reject) => {
+    const req = http.get(url, res => {
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toBe('text/event-stream');
+      let buf = '';
+      res.on('data', chunk => (buf += chunk.toString('utf8')));
+      res.on('end', () => {
+        expect(buf).toContain('event: hello');
+        expect(buf).toContain('"scenario":"sch1"');
+        expect(buf).toContain('event: token');
+        expect(buf).toContain('"text":"This"');
+        expect(buf).toContain('event: done');
+        resolve();
+      });
+    });
+    req.on('error', reject);
+    setTimeout(() => reject(new Error('Timeout')), 3000);
+  });
+});


### PR DESCRIPTION
## Summary
Adds demo SSE endpoint at `/demo/stream` gated by `TEST_ROUTES=1` for testing and demos.

## Changes
- **Demo SSE Endpoint**: `GET /demo/stream?scenario=sch1`
  - Emits: `hello` → multiple `token` events → `done`
  - Only available when `TEST_ROUTES=1`
  - Uses existing CORS logic (no changes to CORS defaults)
- **Test Coverage**: `tests/demo.sse.test.ts` verifies event sequence
- **DEPLOYING.md**: Added Render environment variables and local verification steps

## Local Verification

### 1. Test routes enabled
```bash
curl -s http://127.0.0.1:4311/health | jq .test_routes_enabled
# Expected: true
```

### 2. Demo SSE endpoint
```bash
curl -Ns --max-time 2 "http://127.0.0.1:4311/demo/stream?scenario=sch1" | head -n 20
# Expected output:
# event: hello
# data: {"scenario":"sch1","seed":1}
#
# event: token
# data: {"text":"This"}
#
# event: token
# data: {"text":" is"}
# ...
# event: done
# data: {}
```

## Render Environment Variables

**Staging/Demo (with test routes)**:
```
NODE_ENV=production
PORT=10000
CORS_ORIGINS=https://olumi.netlify.app,https://olumi.netlify.app/#/sandbox
TEST_ROUTES=1
```

**Production (recommended)**:
```
NODE_ENV=production
PORT=10000
CORS_ORIGINS=https://olumi.netlify.app,https://olumi.netlify.app/#/sandbox
# TEST_ROUTES=1 can be toggled off later
```

## Notes
- All additive; no breaking changes
- CORS logic unchanged (uses existing `CORS_ORIGINS`)
- Demo endpoint only available when `TEST_ROUTES=1`
- Test passes: ✅ `npx vitest run tests/demo.sse.test.ts`