### PR TITLE
fix(openapi): restore P0 documentation lost in templates merge

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -156,7 +156,17 @@ paths:
                     schema: error.v1
                     code: FORBIDDEN
                     message: Invalid token
-  
+    head:
+      summary: Capability probe (method not allowed)
+      operationId: runHeadV1
+      tags: [v1, inference]
+      responses:
+        '405':
+          description: Method Not Allowed
+          headers:
+            Allow:
+              schema: { type: string, example: 'POST, OPTIONS, HEAD' }
+
   /v1/stream:
     get:
       summary: Stream first tokens
@@ -230,6 +240,7 @@ paths:
                     schema: error.v1
                     code: RATE_LIMITED
                     message: Too many streams
+                    retry_after_s: 120
   /v1/health:
     get:
       summary: v1 Health endpoint


### PR DESCRIPTION
## Problem
During templates PR #60 merge conflict resolution (commit `aef37ff`), P0 API documentation was accidentally removed from `contracts/openapi.yaml`:

1. **HEAD /v1/run** capability probe documentation (405 + Allow header)
2. **retry_after_s** field in stream 429 response example

The implementations exist in the code (from PR #61) but are undocumented.

## Fix
This PR restores the missing documentation:
- Adds HEAD operation documentation under `/v1/run`
- Adds `retry_after_s: 120` to stream 429 response example

## Verification
```bash
# Verify HEAD documentation exists
grep -A8 'head:' contracts/openapi.yaml | head -10

# Verify retry_after_s exists  
grep 'retry_after_s' contracts/openapi.yaml
```

## Impact
- OpenAPI spec now matches actual API behavior
- Clients can discover HEAD probe capability
- Stream 429 responses properly documented

Fixes: aef37ff