### PR TITLE
chore(smoke): prod smoke script; docs(stream): client tips + Retry-After note

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -174,6 +174,11 @@ paths:
       tags: [v1, stream]
       description: |
         Streams the first tokens for a run. `?demo=1`  short-circuits validation and returns a canonical deterministic sample.
+        
+        Client Tips:
+        - Progress events should cap at ≤90% until a final COMPLETE/done event is emitted.
+        - A heartbeat event is emitted on a regular cadence (see heartbeat_ms) to keep connections healthy.
+        - Clients MAY cancel by closing the connection; server will cleanup deterministically.
       parameters:
         - in: query
           name: demo
@@ -225,7 +230,7 @@ paths:
           description: Too many concurrent streams
           headers:
             Retry-After:
-              description: Seconds to wait before retrying
+              description: Seconds to wait before retrying (integer seconds)
               schema: { type: integer, minimum: 0 }
             X-RateLimit-Reason:
               description: Reason for rate limit decision

--- a/tools/smoke/prod.sh
+++ b/tools/smoke/prod.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE="${1:-https://plot-lite-service.onrender.com}"
+echo "Health:" && curl -sfS "$BASE/v1/health" && echo
+
+echo -e "\nHEAD /v1/run:" && curl -si -X HEAD "$BASE/v1/run" | sed -n '1,10p'
+
+echo -e "\nOpenAPI:" && curl -si "$BASE/v1/openapi.json" | sed -n '1,10p'
+
+echo -e "\nTemplates (count):" && curl -sfS "$BASE/v1/templates" | jq length
+
+echo -e "\nTemplate small/graph (headers):"
+etag=$(curl -si "$BASE/v1/templates/small/graph" | tee /dev/stderr | awk -F': ' 'tolower($1)=="etag"{print $2}' | tr -d '\r')
+
+echo -e "\nRevalidate (If-None-Match):"
+curl -si -H "If-None-Match: $etag" "$BASE/v1/templates/small/graph" | sed -n '1,10p'
+
+echo -e "\nOK ✅"


### PR DESCRIPTION
Adds tools/smoke/prod.sh for quick prod validation (health, HEAD /v1/run, OpenAPI, templates ETag + 304).\nUpdates OpenAPI stream docs with Client Tips and clarifies Retry-After is integer seconds.\nAdditive only; no runtime changes.