### PR TITLE
fix(idempotency): clear inflight on 429; prevent stuck keys

### DIFF
--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -3,6 +3,7 @@ import { ERR_MSG } from '../lib/error-messages.js';
 import { FLAGS } from '../config/flags.js';
 import { getRateLimitRpm } from '../config/runtimeConfig.js';
 import { incJson429Count, incSse429Count } from '../metrics.js';
+import { clearInflight, principalFor } from './idempotency.js';
 
 
 interface State { count: number; pending: number; resetAt: number }
@@ -153,6 +154,19 @@ export function makeRateLimiter() {
       reply.header('Retry-After', String(retryAfter));
       reply.header('X-RateLimit-Reason', 'per_ip');
       
+      // Clear inflight idempotency key on early 429 so retries don't bypass limiter
+      const hdrs = (req.headers as Record<string, string | string[] | undefined>);
+      const idkRaw = hdrs['idempotency-key'] ?? (hdrs as any)['Idempotency-Key'];
+      const idk = Array.isArray(idkRaw) ? idkRaw[0] : idkRaw;
+      if (idk && typeof idk === 'string') {
+        try {
+          const principal = principalFor(req);
+          clearInflight(principal, idk.trim());
+        } catch {
+          // don't block the 429 on cleanup failure
+        }
+      }
+      
       // Increment 429 counters via metrics helpers
       const wantsSSE = (req.headers.accept || '').includes('text/event-stream');
       if (wantsSSE) {
@@ -164,6 +178,7 @@ export function makeRateLimiter() {
       return reply.code(429).send({
         error: { type: 'RATE_LIMIT', message: ERR_MSG.RATE_LIMIT_RPM }
       });
+
     }
     
     done();

--- a/tests/idempotency-429.test.ts
+++ b/tests/idempotency-429.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, afterEach, expect, it, describe } from 'vitest';
+import { createServer } from '../src/createServer.js';
+
+let app: any;
+
+beforeEach(async () => {
+  process.env.RATE_LIMIT_ENABLED = '1';
+  process.env.RATE_LIMIT_RPM = '1';
+  app = await createServer();
+  await app.ready();
+});
+
+afterEach(async () => {
+  if (app) await app.close();
+  delete process.env.RATE_LIMIT_ENABLED;
+  delete process.env.RATE_LIMIT_RPM;
+});
+
+describe('idempotency + 429 interaction', () => {
+  it('clears inflight on 429 so retry is still rate-limited', async () => {
+    const payload = {
+      graph: { nodes: [{ id: 'A', label: 'A' }], edges: [] },
+      seed: 4242,
+    };
+
+    // Exhaust quota with a request WITHOUT idempotency key
+    const r0 = await app.inject({ 
+      method: 'POST', 
+      url: '/v1/run', 
+      headers: { 'content-type': 'application/json' },
+      payload 
+    });
+    expect(r0.statusCode).toBe(200);
+
+    // Now send a request WITH idempotency key - should get 429
+    const headers = {
+      'content-type': 'application/json',
+      'idempotency-key': 'test-429-key',
+    };
+    
+    const r1 = await app.inject({ method: 'POST', url: '/v1/run', headers, payload });
+    expect(r1.statusCode).toBe(429);
+
+    // Retry with same key - should STILL get 429 (not bypass as cached replay)
+    const r2 = await app.inject({ method: 'POST', url: '/v1/run', headers, payload });
+    expect(r2.statusCode).toBe(429);
+  });
+});


### PR DESCRIPTION
Clear the inflight Idempotency-Key on early 429 (preHandler) so retries don't bypass the limiter. Adds a contract test with RATE_LIMIT_RPM=1 to force 429 and prove behaviour. Safe, low-risk hotfix.