### PR TITLE
feat: governance & audit surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,3 +622,40 @@ K = clamp(250 + 25×edges + 10×nodes, 250, 1000)
 **Rationale**: Conservative guardrail that scales with graph complexity while maintaining determinism (same graph structure → same K → same hashes).
 
 The computed K and reason are recorded in `model_card.compute_budget`.
+
+
+## Governance & Audit Surfaces
+
+PLoT-lite maintains minimal immutable audit surfaces for compliance and debugging without storing sensitive payloads.
+
+### Audit Ring Buffer
+
+Runtime-only in-memory ring buffer (max 100 entries) records:
+- `evt`: Event type (score, intervene, evidence, etc.)
+- `route`: Endpoint path
+- `id`: Request ID
+- `seed`: Deterministic seed (if applicable)
+- `inference_mode`: Model mode used
+- `response_hash`: SHA-256 hash of response (first 16 chars)
+- `status`: HTTP status code
+- `ts`: ISO timestamp
+
+**No payload bodies or PII are logged** - only hashes and metadata.
+
+### Test-Only Audit Endpoint
+
+When `TEST_ROUTES=1`:
+```bash
+GET /__audit__/recent?limit=50
+```
+
+Returns recent audit events for CI verification. Not available in production.
+
+### Compliance Notes
+
+- Audit events are ephemeral (in-memory only, cleared on restart)
+- Response hashes enable cache verification without storing payloads
+- Suitable for debugging, performance analysis, and compliance spot-checks
+- For persistent audit trails, integrate with external logging systems
+
+

--- a/src/governance/audit-ring.ts
+++ b/src/governance/audit-ring.ts
@@ -1,0 +1,45 @@
+/**
+ * Audit Ring Buffer - Runtime-only audit surface
+ * No payload bodies, only hashes + meta
+ */
+import { createHash } from 'crypto';
+
+export interface AuditEntry {
+  evt: string;
+  route: string;
+  id: string;
+  seed?: number;
+  inference_mode?: string;
+  bma_hash?: string;
+  response_hash?: string;
+  status: number;
+  ts: string;
+}
+
+// Ring buffer with max size
+const MAX_ENTRIES = 100;
+const auditRing: AuditEntry[] = [];
+
+export function recordAuditEvent(entry: AuditEntry): void {
+  if (auditRing.length >= MAX_ENTRIES) {
+    auditRing.shift(); // Remove oldest
+  }
+  auditRing.push(entry);
+}
+
+export function getRecentAuditEvents(limit: number = 50): AuditEntry[] {
+  return auditRing.slice(-limit);
+}
+
+export function clearAuditEvents(): void {
+  auditRing.length = 0;
+}
+
+export function getAuditStats() {
+  return {
+    total_entries: auditRing.length,
+    max_entries: MAX_ENTRIES,
+    oldest_ts: auditRing.length > 0 ? auditRing[0].ts : null,
+    newest_ts: auditRing.length > 0 ? auditRing[auditRing.length - 1].ts : null
+  };
+}

--- a/src/routes/test/audit.ts
+++ b/src/routes/test/audit.ts
@@ -1,0 +1,26 @@
+/**
+ * Test-only audit endpoint
+ * Exposes recent audit events for CI verification
+ */
+import type { FastifyInstance } from 'fastify';
+import { getRecentAuditEvents, getAuditStats } from '../../governance/audit-ring.js';
+
+export async function registerAuditTestRoute(app: FastifyInstance) {
+  // Only available when TEST_ROUTES=1
+  if (process.env.TEST_ROUTES !== '1') {
+    return;
+  }
+
+  app.get('/__audit__/recent', async (req, reply) => {
+    const limit = parseInt(String((req.query as any).limit || '50'), 10);
+    const events = getRecentAuditEvents(Math.min(limit, 100));
+    const stats = getAuditStats();
+    
+    return reply.code(200).send({
+      schema: 'audit.v1',
+      events,
+      stats,
+      note: 'TEST_ROUTES=1 only. No payloads/PII logged - only hashes and meta.'
+    });
+  });
+}

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -128,7 +128,8 @@ export async function registerV1Routes(app: FastifyInstance) {
   await registerInspectRoute(app);
   await registerScoreRoute(app);
   await registerInterveneRoute(app);
-  await registerEvidenceRoute(app);  
+  await registerEvidenceRoute(app);
+  await registerAuditTestRoute(app);  
   // P1: Register enhanced stream route if enabled, otherwise use legacy
   if (process.env.STREAM_PARITY_ENABLE === '1') {
     await registerStreamRouteEnhanced(app);
@@ -228,3 +229,4 @@ import { registerInspectRoute } from './inspect.js';
 import { registerScoreRoute } from './score.js';
 import { registerInterveneRoute } from './intervene.js';
 import { registerEvidenceRoute } from './evidence.js';
+import { registerAuditTestRoute } from '../test/audit.js';

--- a/src/routes/v1/score.ts
+++ b/src/routes/v1/score.ts
@@ -3,6 +3,7 @@
  */
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createHash } from 'crypto';
+import { recordAuditEvent } from '../../governance/audit-ring.js';
 
 interface ScoreRequest {
   graph: { nodes: any[]; edges: any[] };
@@ -102,7 +103,7 @@ export async function registerScoreRoute(app: FastifyInstance) {
       duration_ms: duration 
     }, 'score completed');
     
-    return reply.code(200).send({
+    const response = {
       schema: 'score.v1',
       result: {
         options,
@@ -110,6 +111,21 @@ export async function registerScoreRoute(app: FastifyInstance) {
       },
       top_drivers: topDrivers,
       meta: { seed, inference_mode: 'model_based' }
+    };
+    
+    // Record audit event (no payload bodies, only hashes + meta)
+    const responseHash = createHash('sha256').update(JSON.stringify(response)).digest('hex').slice(0, 16);
+    recordAuditEvent({
+      evt: 'score',
+      route: '/v1/score',
+      id: req.id,
+      seed,
+      inference_mode: 'model_based',
+      response_hash: responseHash,
+      status: 200,
+      ts: new Date().toISOString()
     });
+    
+    return reply.code(200).send(response);
   });
 }

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnServer, type ServerHandle } from './utils.js';
+
+describe('Audit Surface', () => {
+  let server: ServerHandle;
+
+  beforeAll(async () => { 
+    // Spawn with TEST_ROUTES=1 to enable audit endpoint
+    server = await spawnServer({ env: { TEST_ROUTES: '1' } }); 
+  });
+  afterAll(async () => { await server.kill(); });
+
+  it('exposes /__audit__/recent when TEST_ROUTES=1', async () => {
+    const res = await fetch(`${server.baseUrl}/__audit__/recent`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.schema).toBe('audit.v1');
+    expect(data.events).toBeDefined();
+    expect(data.stats).toBeDefined();
+    expect(Array.isArray(data.events)).toBe(true);
+  });
+
+  it('records audit events with hashes only (no payloads)', async () => {
+    // Make a request to score endpoint
+    await fetch(`${server.baseUrl}/v1/score`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        graph: {
+          nodes: [{ id: 'A', label: 'A' }],
+          edges: []
+        },
+        utilities: {
+          type: 'linear',
+          weights: { A: 1.0 }
+        }
+      })
+    });
+    
+    // Check audit log
+    const res = await fetch(`${server.baseUrl}/__audit__/recent`);
+    const data = await res.json();
+    
+    const scoreEvents = data.events.filter((e: any) => e.route === '/v1/score');
+    expect(scoreEvents.length).toBeGreaterThan(0);
+    
+    const event = scoreEvents[scoreEvents.length - 1];
+    expect(event.evt).toBe('score');
+    expect(event.route).toBe('/v1/score');
+    expect(event.id).toBeDefined();
+    expect(event.response_hash).toBeDefined();
+    expect(event.status).toBe(200);
+    expect(event.ts).toBeDefined();
+    
+    // Ensure no payload bodies are present
+    expect(event).not.toHaveProperty('graph');
+    expect(event).not.toHaveProperty('utilities');
+    expect(event).not.toHaveProperty('result');
+  });
+
+  it('includes seed and inference_mode in audit', async () => {
+    await fetch(`${server.baseUrl}/v1/score`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        graph: {
+          nodes: [{ id: 'X', label: 'X' }],
+          edges: []
+        },
+        seed: 9999,
+        utilities: {
+          type: 'linear',
+          weights: { X: 0.5 }
+        }
+      })
+    });
+    
+    const res = await fetch(`${server.baseUrl}/__audit__/recent`);
+    const data = await res.json();
+    
+    const scoreEvents = data.events.filter((e: any) => e.route === '/v1/score');
+    const event = scoreEvents[scoreEvents.length - 1];
+    
+    expect(event.seed).toBe(9999);
+    expect(event.inference_mode).toBe('model_based');
+  });
+
+  it('provides audit stats', async () => {
+    const res = await fetch(`${server.baseUrl}/__audit__/recent`);
+    const data = await res.json();
+    
+    expect(data.stats).toBeDefined();
+    expect(data.stats.total_entries).toBeGreaterThanOrEqual(0);
+    expect(data.stats.max_entries).toBe(100);
+  });
+
+  it('respects limit parameter', async () => {
+    const res = await fetch(`${server.baseUrl}/__audit__/recent?limit=5`);
+    const data = await res.json();
+    
+    expect(data.events.length).toBeLessThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## Summary
Implements Feature I: Minimal immutable audit surface for governance.

## Features
- **In-memory audit ring buffer** (max 100 entries)
- Records hashes + metadata only (no payloads/PII)
- Test-only  endpoint (TEST_ROUTES=1)
- Audit recording integrated in score endpoint (example)
- Ephemeral (cleared on restart)

## Audit Fields
- evt, route, id, seed, inference_mode
- response_hash (SHA-256, first 16 chars)
- status, ts

## Tests
- ✅ 5/5 passing
- Endpoint availability check
- No payloads/PII in logs
- Audit stats verification
- Limit parameter

## Documentation
- ✅ README section on Governance & Audit Surfaces
- ✅ Compliance notes

## Acceptance
ACCEPT:GOV audit_surface=added pii_logged=0 tests_pass=true