### PR TITLE
Add FactObjectV1 schema and assembly for structured inference facts

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -3068,6 +3068,65 @@ paths:
                           type: object
                           description: 'Additional context data (e.g., affected edge IDs)'
                           additionalProperties: true
+                  facts:
+                    type: object
+                    description: 'Optional FactObjectV1 envelope. Present when ENABLE_FACTS_ASSEMBLY=1 (Stream D). Backward-compatible — omitted when disabled.'
+                    properties:
+                      facts_schema_version:
+                        type: integer
+                        description: 'Schema version for FactObjectV1 (currently 1)'
+                        example: 1
+                      facts:
+                        type: array
+                        description: 'Array of structured fact objects'
+                        items:
+                          type: object
+                          required: [fact_id, fact_key, fact_type, data, lineage, content_hash]
+                          properties:
+                            fact_id:
+                              type: string
+                              pattern: '^[0-9a-f]{16}$'
+                              description: 'Deterministic ID: hash(fact_key + lineage)'
+                            fact_key:
+                              type: object
+                              description: 'Structured key for content-addressable identification'
+                              required: [type]
+                              properties:
+                                type:
+                                  type: string
+                                  enum: [probability, factor_sensitivity, critique, robustness]
+                                node_id: { type: string }
+                                edge_id: { type: string }
+                                option_id: { type: string }
+                                metric: { type: string }
+                            fact_type:
+                              type: string
+                              enum: [probability, factor_sensitivity, critique, robustness]
+                            data:
+                              type: object
+                              description: 'Raw data from inference. Shape varies by fact_type.'
+                              properties:
+                                type: { type: string }
+                              additionalProperties: true
+                            lineage:
+                              type: object
+                              description: 'Lineage for reproducibility'
+                              required: [graph_hash, seed, config_version, isl_request_id]
+                              properties:
+                                graph_hash: { type: string }
+                                seed: { type: integer }
+                                config_version: { type: string }
+                                isl_request_id: { type: string }
+                                plan_id: { type: string }
+                                plan_hash: { type: string }
+                            content_hash:
+                              type: string
+                              pattern: '^[0-9a-f]{16}$'
+                              description: 'Hash of canonical JSON of data payload'
+                      analysis_status:
+                        type: string
+                        enum: [computed, partial, failed]
+                        description: 'Status of the analysis that produced these facts'
                   # baseline_label moved to meta (single source of truth)
                   model_card:
                     type: object

--- a/fixtures/facts/computed.golden.json
+++ b/fixtures/facts/computed.golden.json
@@ -1,0 +1,79 @@
+{
+  "description": "Golden fixture: full ISL response (computed) → expected FactsEnvelope",
+  "input": {
+    "isl_response": {
+      "analysis_status": "computed",
+      "options": [
+        {
+          "option_id": "opt_low_price",
+          "label": "Low Price",
+          "outcome": { "p10": 80, "p50": 100, "p90": 120, "mean": 100 }
+        },
+        {
+          "option_id": "opt_high_price",
+          "label": "High Price",
+          "outcome": { "p10": 90, "p50": 110, "p90": 140, "mean": 113.3 }
+        }
+      ],
+      "factor_sensitivity": [
+        {
+          "node_id": "market_demand",
+          "label": "Market Demand",
+          "sensitivity_score": 0.85,
+          "importance_score": 0.85,
+          "importance_rank": 1,
+          "elasticity": 0.72,
+          "direction": "positive",
+          "confidence": 0.9,
+          "attribution_stability": "high"
+        },
+        {
+          "node_id": "competitor_price",
+          "label": "Competitor Price",
+          "sensitivity_score": 0.65,
+          "importance_score": 0.65,
+          "importance_rank": 2,
+          "elasticity": -0.45,
+          "direction": "negative",
+          "confidence": 0.8,
+          "attribution_stability": "moderate"
+        }
+      ],
+      "critiques": [
+        {
+          "id": "crit_001",
+          "code": "MISSING_EVIDENCE",
+          "severity": "warning",
+          "message": "No evidence provided for market_demand node",
+          "suggestion": "Add market research data as evidence",
+          "affected_node_ids": ["market_demand"]
+        }
+      ],
+      "robustness": {
+        "label": "moderate",
+        "score": 0.65
+      }
+    },
+    "lineage": {
+      "graph_hash": "a1b2c3d4e5f6a7b8",
+      "seed": 4242,
+      "config_version": "1",
+      "isl_request_id": "req-golden-001"
+    }
+  },
+  "expected": {
+    "facts_schema_version": 1,
+    "analysis_status": "computed",
+    "fact_count": 6,
+    "fact_types": ["probability", "probability", "factor_sensitivity", "factor_sensitivity", "critique", "robustness"],
+    "fact_type_counts": {
+      "probability": 2,
+      "factor_sensitivity": 2,
+      "critique": 1,
+      "robustness": 1
+    },
+    "ordering_stable": true,
+    "all_fact_ids_unique": true,
+    "all_content_hashes_present": true
+  }
+}

--- a/fixtures/facts/failed.golden.json
+++ b/fixtures/facts/failed.golden.json
@@ -1,0 +1,62 @@
+{
+  "description": "Golden fixture: failed analysis → critiques only",
+  "input": {
+    "isl_response": {
+      "analysis_status": "failed",
+      "options": [
+        {
+          "option_id": "opt_x",
+          "label": "Option X",
+          "outcome": { "p10": 0, "p50": 0, "p90": 0, "mean": 0 }
+        }
+      ],
+      "factor_sensitivity": [
+        {
+          "node_id": "node_1",
+          "label": "Node 1",
+          "sensitivity_score": 0.5,
+          "importance_rank": 1,
+          "direction": "positive"
+        }
+      ],
+      "critiques": [
+        {
+          "id": "crit_fail_001",
+          "code": "GRAPH_CYCLE",
+          "severity": "blocker",
+          "message": "Cycle detected in graph: A -> B -> C -> A",
+          "affected_node_ids": ["A", "B", "C"]
+        },
+        {
+          "id": "crit_fail_002",
+          "code": "NO_OUTCOME_NODE",
+          "severity": "error",
+          "message": "No outcome node identified in graph"
+        }
+      ],
+      "robustness": {
+        "label": "fragile",
+        "score": 0.2
+      }
+    },
+    "lineage": {
+      "graph_hash": "c3d4e5f6a7b8c9d0",
+      "seed": 4242,
+      "config_version": "1",
+      "isl_request_id": "req-golden-003"
+    }
+  },
+  "expected": {
+    "facts_schema_version": 1,
+    "analysis_status": "failed",
+    "fact_count": 2,
+    "fact_types": ["critique", "critique"],
+    "fact_type_counts": {
+      "critique": 2
+    },
+    "ordering_stable": true,
+    "all_fact_ids_unique": true,
+    "all_content_hashes_present": true,
+    "note": "Failed analysis: options, factor_sensitivity, and robustness are NOT emitted — only critiques"
+  }
+}

--- a/fixtures/facts/partial.golden.json
+++ b/fixtures/facts/partial.golden.json
@@ -1,0 +1,44 @@
+{
+  "description": "Golden fixture: partial analysis → subset of facts (options + critiques, no robustness)",
+  "input": {
+    "isl_response": {
+      "analysis_status": "partial",
+      "options": [
+        {
+          "option_id": "opt_a",
+          "label": "Option A",
+          "outcome": { "p10": 50, "p50": 70, "p90": 90, "mean": 70 }
+        }
+      ],
+      "factor_sensitivity": [],
+      "critiques": [
+        {
+          "id": "crit_partial_001",
+          "code": "PARTIAL_ANALYSIS",
+          "severity": "info",
+          "message": "Analysis completed partially due to timeout"
+        }
+      ],
+      "robustness": null
+    },
+    "lineage": {
+      "graph_hash": "b2c3d4e5f6a7b8c9",
+      "seed": 4242,
+      "config_version": "1",
+      "isl_request_id": "req-golden-002"
+    }
+  },
+  "expected": {
+    "facts_schema_version": 1,
+    "analysis_status": "partial",
+    "fact_count": 2,
+    "fact_types": ["probability", "critique"],
+    "fact_type_counts": {
+      "probability": 1,
+      "critique": 1
+    },
+    "ordering_stable": true,
+    "all_fact_ids_unique": true,
+    "all_content_hashes_present": true
+  }
+}

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -48,6 +48,8 @@ export const KNOWN_FEATURE_FLAGS = [
   'CEE_ORCHESTRATOR_ENABLE',
   'CEE_ORCHESTRATOR_ENABLED',
   'DECISION_REVIEW_ENABLE',
+  // Stream D: FactObject assembly
+  'ENABLE_FACTS_ASSEMBLY',
 ] as const;
 
 export function validateFeatureFlags(logger?: any): void {

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -76,4 +76,14 @@ export const FLAGS = {
   get DECISION_REVIEW_ENABLE() {
     return process.env.DECISION_REVIEW_ENABLE === '1' || process.env.DECISION_REVIEW_ENABLE === 'true';
   },
+
+  // Stream D: FactObject assembly
+  /** Enable FactObjectV1 facts assembly in run_bundle response (default: true for staging/test) */
+  get ENABLE_FACTS_ASSEMBLY() {
+    const raw = process.env.ENABLE_FACTS_ASSEMBLY;
+    if (raw === '0' || raw === 'false') return false;
+    // Default on for test/staging, off for production unless explicitly enabled
+    if (raw === '1' || raw === 'true') return true;
+    return process.env.NODE_ENV === 'test' || process.env.RENDER_SERVICE_NAME?.includes('staging') === true;
+  },
 } as const;

--- a/src/facts/hash.ts
+++ b/src/facts/hash.ts
@@ -1,0 +1,55 @@
+/**
+ * Deterministic hashing for FactObjectV1.
+ *
+ * - fact_id: hash(fact_key + lineage) — content-addressable, stable per analysis run
+ * - content_hash: hash(canonical JSON of data payload)
+ *
+ * Uses SHA-256 truncated to 16 hex chars for compact IDs.
+ */
+
+import { createHash } from 'node:crypto';
+import type { FactKey, FactLineage, FactData } from './types.js';
+
+/**
+ * Produce canonical JSON: keys sorted recursively, no whitespace.
+ * Ensures deterministic serialisation regardless of property insertion order.
+ */
+export function canonicalJson(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) => {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(value).sort()) {
+        sorted[k] = value[k];
+      }
+      return sorted;
+    }
+    return value;
+  });
+}
+
+/**
+ * SHA-256 of an arbitrary string, returned as full hex digest.
+ */
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * Generate a deterministic fact_id from fact_key + lineage.
+ *
+ * Uses `canonicalJson(factKey) + ":" + lineage fields` as the pre-image,
+ * then SHA-256 truncated to 16 hex chars.
+ */
+export function generateFactId(factKey: FactKey, lineage: FactLineage): string {
+  const keyPayload = canonicalJson(factKey);
+  const lineagePayload = `${lineage.graph_hash}:${lineage.seed}:${lineage.config_version}:${lineage.isl_request_id}`;
+  return sha256(`${keyPayload}:${lineagePayload}`).slice(0, 16);
+}
+
+/**
+ * Generate content_hash from the canonical JSON of a fact's data payload.
+ * SHA-256 truncated to 16 hex chars.
+ */
+export function generateContentHash(data: FactData): string {
+  return sha256(canonicalJson(data)).slice(0, 16);
+}

--- a/src/facts/index.ts
+++ b/src/facts/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Facts module — structured FactObjectV1 assembly from inference results.
+ *
+ * Public API:
+ *  - assembleFactObjects()           — generic ISL-style input
+ *  - assembleFactsFromBundleResults() — run_bundle-specific input
+ *  - Types: FactObjectV1, FactsEnvelope, FactKey, FactLineage, etc.
+ */
+
+export {
+  FACTS_SCHEMA_VERSION,
+  type FactKey,
+  type FactType,
+  type FactObjectV1,
+  type FactData,
+  type ProbabilityFactData,
+  type FactorSensitivityFactData,
+  type CritiqueFactData,
+  type RobustnessFactData,
+  type FactLineage,
+  type FactsEnvelope,
+} from './types.js';
+
+export {
+  assembleFactObjects,
+  assembleFactsFromBundleResults,
+  compareFactKeys,
+  type ISLResponseInput,
+  type BundleResultInput,
+  type OptionResultInput,
+  type FactorSensitivityInput,
+  type CritiqueInput,
+  type RobustnessInput,
+} from './mapper.js';
+
+export {
+  generateFactId,
+  generateContentHash,
+  canonicalJson,
+} from './hash.js';

--- a/src/facts/mapper.ts
+++ b/src/facts/mapper.ts
@@ -1,0 +1,346 @@
+/**
+ * ISL / Inference → FactObject mapping.
+ *
+ * Converts raw inference results into structured FactObjectV1 instances.
+ * Respects analysis_status — only emits what's valid.
+ *
+ * Two entry points:
+ *  1. assembleFactObjects() — generic mapper for ISL-style responses
+ *  2. assembleFactsFromBundleResults() — run_bundle-specific mapper
+ */
+
+import type {
+  FactObjectV1,
+  FactKey,
+  FactType,
+  FactData,
+  FactLineage,
+  FactsEnvelope,
+  ProbabilityFactData,
+  FactorSensitivityFactData,
+  CritiqueFactData,
+  RobustnessFactData,
+} from './types.js';
+import { FACTS_SCHEMA_VERSION } from './types.js';
+import { generateFactId, generateContentHash } from './hash.js';
+
+// ---------------------------------------------------------------------------
+// Input interfaces — decouple from ISL types to avoid import cycles
+// ---------------------------------------------------------------------------
+
+/** Minimal option result shape for probability facts. */
+export interface OptionResultInput {
+  option_id: string;
+  label?: string;
+  outcome?: {
+    p10?: number;
+    p50?: number;
+    p90?: number;
+    mean?: number;
+  };
+}
+
+/** Minimal factor sensitivity shape. */
+export interface FactorSensitivityInput {
+  node_id: string;
+  label?: string;
+  sensitivity_score?: number;
+  importance_score?: number;
+  importance_rank: number;
+  elasticity?: number;
+  direction?: 'positive' | 'negative' | 'mixed';
+  confidence?: number;
+  attribution_stability?: 'high' | 'moderate' | 'low' | 'negligible';
+}
+
+/** Minimal critique shape. */
+export interface CritiqueInput {
+  id: string;
+  code: string;
+  severity: 'info' | 'warning' | 'error' | 'blocker';
+  message: string;
+  suggestion?: string;
+  affected_option_ids?: string[];
+  affected_node_ids?: string[];
+}
+
+/** Minimal robustness shape. */
+export interface RobustnessInput {
+  label?: 'robust' | 'moderate' | 'fragile';
+  score?: number;
+}
+
+/** Generic ISL-style response for assembleFactObjects. */
+export interface ISLResponseInput {
+  analysis_status: 'computed' | 'partial' | 'failed';
+  options?: OptionResultInput[];
+  factor_sensitivity?: FactorSensitivityInput[];
+  critiques?: CritiqueInput[];
+  robustness?: RobustnessInput;
+}
+
+// ---------------------------------------------------------------------------
+// run_bundle–specific input shape
+// ---------------------------------------------------------------------------
+
+/** A single scenario result from run_bundle. */
+export interface BundleResultInput {
+  label: string;
+  summary: { p10: number; p50: number; p90: number } | null;
+  sensitivity_by_node?: Array<{
+    node_id: string;
+    node_label: string;
+    contribution_pct: number;
+    edge_count: number;
+  }>;
+  error?: { code: string; message: string };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: build a single FactObjectV1
+// ---------------------------------------------------------------------------
+
+function buildFact(
+  factKey: FactKey,
+  factType: FactType,
+  data: FactData,
+  lineage: FactLineage,
+): FactObjectV1 {
+  return {
+    fact_id: generateFactId(factKey, lineage),
+    fact_key: factKey,
+    fact_type: factType,
+    data,
+    lineage,
+    content_hash: generateContentHash(data),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+function mapOptionResults(
+  options: OptionResultInput[],
+  lineage: FactLineage,
+): FactObjectV1[] {
+  return options
+    .filter((o) => o.outcome)
+    .map((o) => {
+      const data: ProbabilityFactData = {
+        type: 'probability',
+        option_id: o.option_id,
+        option_label: o.label ?? o.option_id,
+        p10: o.outcome!.p10 ?? 0,
+        p50: o.outcome!.p50 ?? 0,
+        p90: o.outcome!.p90 ?? 0,
+        mean: o.outcome!.mean ?? o.outcome!.p50 ?? 0,
+      };
+      const key: FactKey = { type: 'probability', option_id: o.option_id };
+      return buildFact(key, 'probability', data, lineage);
+    });
+}
+
+function mapFactorSensitivity(
+  factors: FactorSensitivityInput[],
+  lineage: FactLineage,
+): FactObjectV1[] {
+  return factors.map((f, idx) => {
+    const data: FactorSensitivityFactData = {
+      type: 'factor_sensitivity',
+      node_id: f.node_id,
+      label: f.label ?? f.node_id,
+      sensitivity_score: f.sensitivity_score ?? 0,
+      importance_score: f.importance_score ?? f.sensitivity_score ?? 0,
+      importance_rank: f.importance_rank ?? idx + 1,
+      elasticity: f.elasticity ?? f.sensitivity_score ?? 0,
+      direction: f.direction === 'mixed' ? 'positive' : (f.direction ?? 'positive'),
+      confidence: f.confidence ?? 0.5,
+      attribution_stability: f.attribution_stability ?? 'moderate',
+    };
+    const key: FactKey = {
+      type: 'factor_sensitivity',
+      node_id: f.node_id,
+      metric: 'sensitivity_score',
+    };
+    return buildFact(key, 'factor_sensitivity', data, lineage);
+  });
+}
+
+function mapCritiques(
+  critiques: CritiqueInput[],
+  lineage: FactLineage,
+): FactObjectV1[] {
+  return critiques.map((c) => {
+    const data: CritiqueFactData = {
+      type: 'critique',
+      id: c.id,
+      code: c.code,
+      severity: c.severity,
+      message: c.message,
+      ...(c.suggestion !== undefined && { suggestion: c.suggestion }),
+      ...(c.affected_option_ids?.length && { affected_option_ids: c.affected_option_ids }),
+      ...(c.affected_node_ids?.length && { affected_node_ids: c.affected_node_ids }),
+    };
+    const key: FactKey = { type: 'critique', node_id: c.id, metric: c.code };
+    return buildFact(key, 'critique', data, lineage);
+  });
+}
+
+function mapRobustness(
+  robustness: RobustnessInput,
+  lineage: FactLineage,
+): FactObjectV1 {
+  const data: RobustnessFactData = {
+    type: 'robustness',
+    robustness_level: robustness.label ?? 'moderate',
+    robustness_score: robustness.score ?? 0.5,
+  };
+  const key: FactKey = { type: 'robustness', metric: 'robustness_score' };
+  return buildFact(key, 'robustness', data, lineage);
+}
+
+// ---------------------------------------------------------------------------
+// Fact key comparison for deterministic ordering
+// ---------------------------------------------------------------------------
+
+const TYPE_ORDER: Record<FactType, number> = {
+  probability: 0,
+  factor_sensitivity: 1,
+  critique: 2,
+  robustness: 3,
+};
+
+/**
+ * Compare two fact keys for deterministic sort:
+ * type → option_id → node_id → edge_id → metric
+ */
+export function compareFactKeys(a: FactKey, b: FactKey): number {
+  const typeA = TYPE_ORDER[a.type] ?? 99;
+  const typeB = TYPE_ORDER[b.type] ?? 99;
+  if (typeA !== typeB) return typeA - typeB;
+
+  const cmpOption = (a.option_id ?? '').localeCompare(b.option_id ?? '');
+  if (cmpOption !== 0) return cmpOption;
+
+  const cmpNode = (a.node_id ?? '').localeCompare(b.node_id ?? '');
+  if (cmpNode !== 0) return cmpNode;
+
+  const cmpEdge = (a.edge_id ?? '').localeCompare(b.edge_id ?? '');
+  if (cmpEdge !== 0) return cmpEdge;
+
+  return (a.metric ?? '').localeCompare(b.metric ?? '');
+}
+
+// ---------------------------------------------------------------------------
+// Primary entry point: generic ISL-style response → FactsEnvelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble FactObjectV1 instances from an ISL-style response.
+ *
+ * Respects analysis_status:
+ * - failed  → critiques only
+ * - partial → critiques + whatever data is available
+ * - computed → full assembly
+ */
+export function assembleFactObjects(
+  islResponse: ISLResponseInput,
+  lineage: FactLineage,
+): FactsEnvelope {
+  const facts: FactObjectV1[] = [];
+
+  // Always try critiques (available even on partial/failed)
+  if (islResponse.critiques?.length) {
+    facts.push(...mapCritiques(islResponse.critiques, lineage));
+  }
+
+  // Only on computed/partial
+  if (islResponse.analysis_status !== 'failed') {
+    if (islResponse.options?.length) {
+      facts.push(...mapOptionResults(islResponse.options, lineage));
+    }
+
+    if (islResponse.factor_sensitivity?.length) {
+      // Top N drivers (start with top 5)
+      const topN = [...islResponse.factor_sensitivity]
+        .sort((a, b) => (a.importance_rank ?? 999) - (b.importance_rank ?? 999))
+        .slice(0, 5);
+      facts.push(...mapFactorSensitivity(topN, lineage));
+    }
+
+    if (islResponse.robustness) {
+      facts.push(mapRobustness(islResponse.robustness, lineage));
+    }
+  }
+
+  // Stable sort by fact_key for deterministic ordering
+  facts.sort((a, b) => compareFactKeys(a.fact_key, b.fact_key));
+
+  return {
+    facts_schema_version: FACTS_SCHEMA_VERSION,
+    facts,
+    analysis_status: islResponse.analysis_status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// run_bundle–specific entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble facts from run_bundle results.
+ *
+ * run_bundle produces local SCM-Lite inference results:
+ * - Each scenario has label + summary (p10/p50/p90)
+ * - Optional sensitivity_by_node
+ * - No critiques/robustness from ISL (those are V2 /run path)
+ *
+ * Maps scenario results → probability facts.
+ */
+export function assembleFactsFromBundleResults(
+  results: BundleResultInput[],
+  lineage: FactLineage,
+): FactsEnvelope {
+  const facts: FactObjectV1[] = [];
+
+  // Determine analysis status from results
+  const failedCount = results.filter((r) => r.error).length;
+  let analysisStatus: 'computed' | 'partial' | 'failed';
+  if (results.length === 0) {
+    analysisStatus = 'computed'; // No results to fail
+  } else if (failedCount === results.length) {
+    analysisStatus = 'failed';
+  } else if (failedCount > 0) {
+    analysisStatus = 'partial';
+  } else {
+    analysisStatus = 'computed';
+  }
+
+  // Only emit probability facts for successful results
+  for (const result of results) {
+    if (!result.summary || result.error) continue;
+
+    const data: ProbabilityFactData = {
+      type: 'probability',
+      option_id: result.label,
+      option_label: result.label,
+      p10: result.summary.p10,
+      p50: result.summary.p50,
+      p90: result.summary.p90,
+      mean: (result.summary.p10 + result.summary.p50 + result.summary.p90) / 3,
+    };
+
+    const key: FactKey = { type: 'probability', option_id: result.label };
+    facts.push(buildFact(key, 'probability', data, lineage));
+  }
+
+  // Stable sort
+  facts.sort((a, b) => compareFactKeys(a.fact_key, b.fact_key));
+
+  return {
+    facts_schema_version: FACTS_SCHEMA_VERSION,
+    facts,
+    analysis_status: analysisStatus,
+  };
+}

--- a/src/facts/types.ts
+++ b/src/facts/types.ts
@@ -1,0 +1,127 @@
+/**
+ * FactObjectV1 Schema — Structured facts from ISL/inference for UI rendering.
+ *
+ * Design principles:
+ * - Raw data, not formatted strings — UI renders templates
+ * - Content-addressable fact keys — not rank-based IDs that churn
+ * - Explicit lineage — graph_hash, seed, config_version, isl_request_id
+ * - Deterministic ordering — sort by fact_key before hashing
+ *
+ * @see Stream D — FactObjectV1 Schema + ISL→FactObject Assembly
+ */
+
+export const FACTS_SCHEMA_VERSION = 1;
+
+/**
+ * Structured key for content-addressable fact identification.
+ * Stable across re-runs with same inputs.
+ */
+export interface FactKey {
+  type: FactType;
+  node_id?: string;
+  /** For edge-related facts: "{from}_{to}" */
+  edge_id?: string;
+  option_id?: string;
+  /** e.g., 'sensitivity_score', 'importance_rank' */
+  metric?: string;
+}
+
+export type FactType =
+  | 'probability'        // OptionResultV2.outcome_distribution
+  | 'factor_sensitivity' // FactorSensitivityV2 (align with ISL naming)
+  | 'critique'           // CritiqueV2 (align with ISL naming)
+  | 'robustness';        // RobustnessResultV2
+  // Future: 'fragile_edge', 'constraint' — add when UI needs them
+
+export interface FactObjectV1 {
+  /**
+   * Deterministic ID: hash(fact_key + lineage).
+   * Stable for same content + same analysis run.
+   */
+  fact_id: string;
+
+  /** Structured key for identification. Content-addressable. */
+  fact_key: FactKey;
+
+  fact_type: FactType;
+
+  /**
+   * Raw data from ISL/inference. UI renders display format.
+   * Shape varies by fact_type — see FactData union.
+   */
+  data: FactData;
+
+  /** Lineage for reproducibility. */
+  lineage: FactLineage;
+
+  /** Hash of canonical JSON of this fact's data payload. */
+  content_hash: string;
+}
+
+/**
+ * Union of data shapes by fact_type. Raw fields, no formatting.
+ */
+export type FactData =
+  | ProbabilityFactData
+  | FactorSensitivityFactData
+  | CritiqueFactData
+  | RobustnessFactData;
+
+export interface ProbabilityFactData {
+  type: 'probability';
+  option_id: string;
+  option_label: string;
+  p10: number;
+  p50: number;
+  p90: number;
+  mean: number;
+}
+
+export interface FactorSensitivityFactData {
+  type: 'factor_sensitivity';
+  node_id: string;
+  label: string;
+  sensitivity_score: number;      // 0-1
+  importance_score: number;       // 0-1
+  importance_rank: number;
+  elasticity: number;
+  direction: 'positive' | 'negative';
+  confidence: number;             // 0-1
+  attribution_stability: 'high' | 'moderate' | 'low' | 'negligible';
+}
+
+export interface CritiqueFactData {
+  type: 'critique';
+  /** Original critique ID */
+  id: string;
+  /** Original critique code */
+  code: string;
+  severity: 'info' | 'warning' | 'error' | 'blocker';
+  message: string;
+  suggestion?: string;
+  affected_option_ids?: string[];
+  affected_node_ids?: string[];
+}
+
+export interface RobustnessFactData {
+  type: 'robustness';
+  robustness_level: 'robust' | 'moderate' | 'fragile';
+  robustness_score: number;
+}
+
+export interface FactLineage {
+  graph_hash: string;
+  seed: number;
+  config_version: string;
+  isl_request_id: string;
+  /** From CEE checkpoint, if available */
+  plan_id?: string;
+  plan_hash?: string;
+}
+
+export interface FactsEnvelope {
+  /** Always FACTS_SCHEMA_VERSION */
+  facts_schema_version: number;
+  facts: FactObjectV1[];
+  analysis_status: 'computed' | 'partial' | 'failed';
+}

--- a/src/routes/v1/run-bundle.ts
+++ b/src/routes/v1/run-bundle.ts
@@ -45,6 +45,9 @@ import {
   shouldAnalyzeEdgeFunctionSensitivity,
 } from '../../engine/edge-function-sensitivity.js';
 import { MAX_NODES, MAX_EDGES, MAX_OPTIONS } from '../../constants/limits.js';
+import { FLAGS } from '../../config/flags.js';
+import { assembleFactsFromBundleResults } from '../../facts/index.js';
+import type { FactsEnvelope, FactLineage } from '../../facts/types.js';
 
 interface GraphDelta {
   label: string;
@@ -745,6 +748,24 @@ export async function registerRunBundleRoute(app: FastifyInstance) {
       });
     }
 
+    // Stream D: FactObjectV1 assembly (feature-flagged, backward-compatible)
+    let factsEnvelope: FactsEnvelope | undefined;
+    if (FLAGS.ENABLE_FACTS_ASSEMBLY) {
+      const graphHashForLineage = createHash('sha256')
+        .update(JSON.stringify({ nodes: body.base_graph.nodes, edges: baseEdges }))
+        .digest('hex')
+        .slice(0, 16);
+
+      const lineage: FactLineage = {
+        graph_hash: graphHashForLineage,
+        seed,
+        config_version: '1',
+        isl_request_id: String(req.id),
+      };
+
+      factsEnvelope = assembleFactsFromBundleResults(results, lineage);
+    }
+
     const response: any = {
       schema: 'run_bundle.v1',
       results,
@@ -762,6 +783,8 @@ export async function registerRunBundleRoute(app: FastifyInstance) {
       ...(coherenceWarnings.length > 0 && { coherence_warnings: coherenceWarnings }),
       // Phase 3: Edge function sensitivity warnings (separate from coherence for schema clarity)
       ...(edgeFunctionWarnings.length > 0 && { edge_function_warnings: edgeFunctionWarnings }),
+      // Stream D: Optional FactObjectV1 envelope (backward-compatible)
+      ...(factsEnvelope && { facts: factsEnvelope }),
       // baseline_label in meta only (single source of truth)
       model_card: {
         seed,

--- a/tests/facts.mapper.test.ts
+++ b/tests/facts.mapper.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Unit tests for FactObjectV1 mapper and hash functions.
+ *
+ * Covers:
+ * - fact_id determinism (same inputs → same fact_id)
+ * - fact_key sorting (verify stable order)
+ * - Empty inputs: no crash, empty facts array
+ * - Missing optional fields: graceful handling
+ * - Golden fixture validation (computed / partial / failed)
+ * - Content hash consistency
+ * - assembleFactsFromBundleResults (run_bundle path)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  assembleFactObjects,
+  assembleFactsFromBundleResults,
+  compareFactKeys,
+  generateFactId,
+  generateContentHash,
+  canonicalJson,
+  FACTS_SCHEMA_VERSION,
+} from '../src/facts/index.js';
+import type {
+  FactKey,
+  FactLineage,
+  FactsEnvelope,
+  ISLResponseInput,
+  BundleResultInput,
+} from '../src/facts/index.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const LINEAGE: FactLineage = {
+  graph_hash: 'a1b2c3d4e5f6a7b8',
+  seed: 4242,
+  config_version: '1',
+  isl_request_id: 'req-test-001',
+};
+
+function loadGolden(name: string): any {
+  const filePath = resolve(__dirname, '..', 'fixtures', 'facts', `${name}.golden.json`);
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+}
+
+// ---------------------------------------------------------------------------
+// canonicalJson
+// ---------------------------------------------------------------------------
+
+describe('canonicalJson', () => {
+  it('sorts object keys deterministically', () => {
+    const a = { z: 1, a: 2, m: 3 };
+    const b = { a: 2, m: 3, z: 1 };
+    expect(canonicalJson(a)).toBe(canonicalJson(b));
+  });
+
+  it('handles nested objects', () => {
+    const a = { outer: { z: 1, a: 2 } };
+    expect(canonicalJson(a)).toBe('{"outer":{"a":2,"z":1}}');
+  });
+
+  it('preserves arrays in order', () => {
+    const a = { items: [3, 1, 2] };
+    expect(canonicalJson(a)).toBe('{"items":[3,1,2]}');
+  });
+
+  it('handles null and primitives', () => {
+    expect(canonicalJson(null)).toBe('null');
+    expect(canonicalJson(42)).toBe('42');
+    expect(canonicalJson('hello')).toBe('"hello"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateFactId — determinism
+// ---------------------------------------------------------------------------
+
+describe('generateFactId', () => {
+  it('same inputs produce same fact_id', () => {
+    const key: FactKey = { type: 'probability', option_id: 'opt_a' };
+    const id1 = generateFactId(key, LINEAGE);
+    const id2 = generateFactId(key, LINEAGE);
+    expect(id1).toBe(id2);
+  });
+
+  it('different keys produce different fact_ids', () => {
+    const keyA: FactKey = { type: 'probability', option_id: 'opt_a' };
+    const keyB: FactKey = { type: 'probability', option_id: 'opt_b' };
+    expect(generateFactId(keyA, LINEAGE)).not.toBe(generateFactId(keyB, LINEAGE));
+  });
+
+  it('different lineage produces different fact_ids', () => {
+    const key: FactKey = { type: 'probability', option_id: 'opt_a' };
+    const lineage2: FactLineage = { ...LINEAGE, seed: 9999 };
+    expect(generateFactId(key, LINEAGE)).not.toBe(generateFactId(key, lineage2));
+  });
+
+  it('produces 16 hex character string', () => {
+    const key: FactKey = { type: 'robustness', metric: 'robustness_score' };
+    const id = generateFactId(key, LINEAGE);
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateContentHash
+// ---------------------------------------------------------------------------
+
+describe('generateContentHash', () => {
+  it('same data produces same hash', () => {
+    const data = { type: 'probability' as const, option_id: 'a', option_label: 'A', p10: 1, p50: 2, p90: 3, mean: 2 };
+    expect(generateContentHash(data)).toBe(generateContentHash(data));
+  });
+
+  it('different data produces different hash', () => {
+    const a = { type: 'probability' as const, option_id: 'a', option_label: 'A', p10: 1, p50: 2, p90: 3, mean: 2 };
+    const b = { type: 'probability' as const, option_id: 'b', option_label: 'B', p10: 1, p50: 2, p90: 3, mean: 2 };
+    expect(generateContentHash(a)).not.toBe(generateContentHash(b));
+  });
+
+  it('produces 16 hex character string', () => {
+    const data = { type: 'robustness' as const, robustness_level: 'moderate' as const, robustness_score: 0.5 };
+    expect(generateContentHash(data)).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compareFactKeys — deterministic sort
+// ---------------------------------------------------------------------------
+
+describe('compareFactKeys', () => {
+  it('sorts by type first', () => {
+    const a: FactKey = { type: 'probability' };
+    const b: FactKey = { type: 'robustness' };
+    expect(compareFactKeys(a, b)).toBeLessThan(0);
+  });
+
+  it('sorts by option_id within same type', () => {
+    const a: FactKey = { type: 'probability', option_id: 'alpha' };
+    const b: FactKey = { type: 'probability', option_id: 'beta' };
+    expect(compareFactKeys(a, b)).toBeLessThan(0);
+  });
+
+  it('sorts by node_id when option_id matches', () => {
+    const a: FactKey = { type: 'factor_sensitivity', node_id: 'a_node' };
+    const b: FactKey = { type: 'factor_sensitivity', node_id: 'b_node' };
+    expect(compareFactKeys(a, b)).toBeLessThan(0);
+  });
+
+  it('identical keys return 0', () => {
+    const a: FactKey = { type: 'critique', node_id: 'crit1', metric: 'MISSING' };
+    const b: FactKey = { type: 'critique', node_id: 'crit1', metric: 'MISSING' };
+    expect(compareFactKeys(a, b)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assembleFactObjects — ISL-style input
+// ---------------------------------------------------------------------------
+
+describe('assembleFactObjects', () => {
+  it('computed: emits all fact types', () => {
+    const input: ISLResponseInput = {
+      analysis_status: 'computed',
+      options: [
+        { option_id: 'opt_a', label: 'A', outcome: { p10: 80, p50: 100, p90: 120, mean: 100 } },
+      ],
+      factor_sensitivity: [
+        { node_id: 'n1', label: 'N1', sensitivity_score: 0.8, importance_rank: 1, direction: 'positive' },
+      ],
+      critiques: [
+        { id: 'c1', code: 'WARN', severity: 'warning', message: 'Test warning' },
+      ],
+      robustness: { label: 'moderate', score: 0.6 },
+    };
+
+    const result = assembleFactObjects(input, LINEAGE);
+
+    expect(result.facts_schema_version).toBe(FACTS_SCHEMA_VERSION);
+    expect(result.analysis_status).toBe('computed');
+    expect(result.facts.length).toBe(4);
+
+    const types = result.facts.map((f) => f.fact_type);
+    expect(types).toContain('probability');
+    expect(types).toContain('factor_sensitivity');
+    expect(types).toContain('critique');
+    expect(types).toContain('robustness');
+  });
+
+  it('failed: emits critiques only', () => {
+    const input: ISLResponseInput = {
+      analysis_status: 'failed',
+      options: [{ option_id: 'opt_x', label: 'X', outcome: { p10: 0, p50: 0, p90: 0 } }],
+      factor_sensitivity: [{ node_id: 'n1', label: 'N1', sensitivity_score: 0.5, importance_rank: 1 }],
+      critiques: [
+        { id: 'c1', code: 'BLOCKER', severity: 'blocker', message: 'Blocked' },
+      ],
+      robustness: { label: 'fragile', score: 0.2 },
+    };
+
+    const result = assembleFactObjects(input, LINEAGE);
+
+    expect(result.analysis_status).toBe('failed');
+    expect(result.facts.length).toBe(1);
+    expect(result.facts[0].fact_type).toBe('critique');
+  });
+
+  it('partial: emits critiques + options (no robustness when null)', () => {
+    const input: ISLResponseInput = {
+      analysis_status: 'partial',
+      options: [{ option_id: 'opt_a', label: 'A', outcome: { p10: 50, p50: 70, p90: 90 } }],
+      critiques: [{ id: 'c1', code: 'PARTIAL', severity: 'info', message: 'Partial' }],
+    };
+
+    const result = assembleFactObjects(input, LINEAGE);
+
+    expect(result.analysis_status).toBe('partial');
+    expect(result.facts.length).toBe(2);
+    const types = result.facts.map((f) => f.fact_type);
+    expect(types).toContain('probability');
+    expect(types).toContain('critique');
+    expect(types).not.toContain('robustness');
+  });
+
+  it('empty inputs: no crash, empty facts array', () => {
+    const input: ISLResponseInput = {
+      analysis_status: 'computed',
+      options: [],
+      factor_sensitivity: [],
+      critiques: [],
+    };
+
+    const result = assembleFactObjects(input, LINEAGE);
+
+    expect(result.facts_schema_version).toBe(1);
+    expect(result.facts).toEqual([]);
+    expect(result.analysis_status).toBe('computed');
+  });
+
+  it('deterministic ordering: same input → same order', () => {
+    const input: ISLResponseInput = {
+      analysis_status: 'computed',
+      options: [
+        { option_id: 'opt_b', label: 'B', outcome: { p10: 1, p50: 2, p90: 3 } },
+        { option_id: 'opt_a', label: 'A', outcome: { p10: 4, p50: 5, p90: 6 } },
+      ],
+      critiques: [{ id: 'c1', code: 'WARN', severity: 'warning', message: 'W' }],
+    };
+
+    const r1 = assembleFactObjects(input, LINEAGE);
+    const r2 = assembleFactObjects(input, LINEAGE);
+
+    expect(r1.facts.map((f) => f.fact_id)).toEqual(r2.facts.map((f) => f.fact_id));
+  });
+
+  it('fact_ids are unique within envelope', () => {
+    const input: ISLResponseInput = {
+      analysis_status: 'computed',
+      options: [
+        { option_id: 'opt_a', label: 'A', outcome: { p10: 1, p50: 2, p90: 3 } },
+        { option_id: 'opt_b', label: 'B', outcome: { p10: 4, p50: 5, p90: 6 } },
+      ],
+      factor_sensitivity: [
+        { node_id: 'n1', label: 'N1', sensitivity_score: 0.8, importance_rank: 1 },
+      ],
+      critiques: [
+        { id: 'c1', code: 'WARN', severity: 'warning', message: 'W' },
+      ],
+      robustness: { label: 'robust', score: 0.9 },
+    };
+
+    const result = assembleFactObjects(input, LINEAGE);
+    const ids = result.facts.map((f) => f.fact_id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('content_hash present on all facts', () => {
+    const input: ISLResponseInput = {
+      analysis_status: 'computed',
+      options: [{ option_id: 'opt_a', label: 'A', outcome: { p10: 1, p50: 2, p90: 3 } }],
+      robustness: { label: 'robust', score: 0.9 },
+    };
+
+    const result = assembleFactObjects(input, LINEAGE);
+    for (const fact of result.facts) {
+      expect(fact.content_hash).toMatch(/^[0-9a-f]{16}$/);
+    }
+  });
+
+  it('limits factor_sensitivity to top 5', () => {
+    const factors = Array.from({ length: 10 }, (_, i) => ({
+      node_id: `n${i}`,
+      label: `Node ${i}`,
+      sensitivity_score: 1 - i * 0.1,
+      importance_rank: i + 1,
+    }));
+    const input: ISLResponseInput = {
+      analysis_status: 'computed',
+      factor_sensitivity: factors,
+    };
+
+    const result = assembleFactObjects(input, LINEAGE);
+    const sensitivityFacts = result.facts.filter((f) => f.fact_type === 'factor_sensitivity');
+    expect(sensitivityFacts.length).toBe(5);
+  });
+
+  it('handles missing optional critique fields', () => {
+    const input: ISLResponseInput = {
+      analysis_status: 'computed',
+      critiques: [
+        {
+          id: 'c1',
+          code: 'SIMPLE',
+          severity: 'info',
+          message: 'Minimal critique',
+          // no suggestion, no affected_*
+        },
+      ],
+    };
+
+    const result = assembleFactObjects(input, LINEAGE);
+    expect(result.facts.length).toBe(1);
+    const data = result.facts[0].data as any;
+    expect(data.suggestion).toBeUndefined();
+    expect(data.affected_option_ids).toBeUndefined();
+    expect(data.affected_node_ids).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assembleFactsFromBundleResults — run_bundle path
+// ---------------------------------------------------------------------------
+
+describe('assembleFactsFromBundleResults', () => {
+  it('maps successful results to probability facts', () => {
+    const results: BundleResultInput[] = [
+      { label: 'Low Price', summary: { p10: 80, p50: 100, p90: 120 } },
+      { label: 'High Price', summary: { p10: 90, p50: 110, p90: 140 } },
+    ];
+
+    const envelope = assembleFactsFromBundleResults(results, LINEAGE);
+
+    expect(envelope.facts_schema_version).toBe(1);
+    expect(envelope.analysis_status).toBe('computed');
+    expect(envelope.facts.length).toBe(2);
+    expect(envelope.facts.every((f) => f.fact_type === 'probability')).toBe(true);
+  });
+
+  it('skips errored results', () => {
+    const results: BundleResultInput[] = [
+      { label: 'Good', summary: { p10: 80, p50: 100, p90: 120 } },
+      { label: 'Bad', summary: { p10: 0, p50: 0, p90: 0 }, error: { code: 'FAIL', message: 'failed' } },
+    ];
+
+    const envelope = assembleFactsFromBundleResults(results, LINEAGE);
+
+    expect(envelope.analysis_status).toBe('partial');
+    expect(envelope.facts.length).toBe(1);
+    expect(envelope.facts[0].data).toMatchObject({ option_label: 'Good' });
+  });
+
+  it('all errors → failed status', () => {
+    const results: BundleResultInput[] = [
+      { label: 'A', summary: null, error: { code: 'FAIL', message: 'err' } },
+      { label: 'B', summary: null, error: { code: 'FAIL', message: 'err' } },
+    ];
+
+    const envelope = assembleFactsFromBundleResults(results, LINEAGE);
+
+    expect(envelope.analysis_status).toBe('failed');
+    expect(envelope.facts.length).toBe(0);
+  });
+
+  it('empty results → computed with no facts', () => {
+    const envelope = assembleFactsFromBundleResults([], LINEAGE);
+    expect(envelope.analysis_status).toBe('computed');
+    expect(envelope.facts).toEqual([]);
+  });
+
+  it('computes mean from p10/p50/p90', () => {
+    const results: BundleResultInput[] = [
+      { label: 'Test', summary: { p10: 30, p50: 60, p90: 90 } },
+    ];
+
+    const envelope = assembleFactsFromBundleResults(results, LINEAGE);
+    const data = envelope.facts[0].data as any;
+    expect(data.mean).toBe(60); // (30 + 60 + 90) / 3
+  });
+
+  it('fact_ids are deterministic across calls', () => {
+    const results: BundleResultInput[] = [
+      { label: 'A', summary: { p10: 10, p50: 20, p90: 30 } },
+    ];
+
+    const e1 = assembleFactsFromBundleResults(results, LINEAGE);
+    const e2 = assembleFactsFromBundleResults(results, LINEAGE);
+
+    expect(e1.facts[0].fact_id).toBe(e2.facts[0].fact_id);
+    expect(e1.facts[0].content_hash).toBe(e2.facts[0].content_hash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden fixture validation
+// ---------------------------------------------------------------------------
+
+describe('golden fixtures', () => {
+  it('computed.golden.json validates', () => {
+    const golden = loadGolden('computed');
+    const { isl_response, lineage } = golden.input;
+    const result = assembleFactObjects(isl_response, lineage);
+
+    expect(result.facts_schema_version).toBe(golden.expected.facts_schema_version);
+    expect(result.analysis_status).toBe(golden.expected.analysis_status);
+    expect(result.facts.length).toBe(golden.expected.fact_count);
+
+    // Check type distribution
+    const typeCounts: Record<string, number> = {};
+    for (const fact of result.facts) {
+      typeCounts[fact.fact_type] = (typeCounts[fact.fact_type] || 0) + 1;
+    }
+    expect(typeCounts).toEqual(golden.expected.fact_type_counts);
+
+    // All IDs unique
+    const ids = result.facts.map((f) => f.fact_id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    // All content hashes present
+    for (const fact of result.facts) {
+      expect(fact.content_hash).toMatch(/^[0-9a-f]{16}$/);
+    }
+
+    // Ordering stable
+    const result2 = assembleFactObjects(isl_response, lineage);
+    expect(result.facts.map((f) => f.fact_id)).toEqual(result2.facts.map((f) => f.fact_id));
+  });
+
+  it('partial.golden.json validates', () => {
+    const golden = loadGolden('partial');
+    const { isl_response, lineage } = golden.input;
+    const result = assembleFactObjects(isl_response, lineage);
+
+    expect(result.facts_schema_version).toBe(golden.expected.facts_schema_version);
+    expect(result.analysis_status).toBe(golden.expected.analysis_status);
+    expect(result.facts.length).toBe(golden.expected.fact_count);
+
+    const typeCounts: Record<string, number> = {};
+    for (const fact of result.facts) {
+      typeCounts[fact.fact_type] = (typeCounts[fact.fact_type] || 0) + 1;
+    }
+    expect(typeCounts).toEqual(golden.expected.fact_type_counts);
+  });
+
+  it('failed.golden.json validates', () => {
+    const golden = loadGolden('failed');
+    const { isl_response, lineage } = golden.input;
+    const result = assembleFactObjects(isl_response, lineage);
+
+    expect(result.facts_schema_version).toBe(golden.expected.facts_schema_version);
+    expect(result.analysis_status).toBe(golden.expected.analysis_status);
+    expect(result.facts.length).toBe(golden.expected.fact_count);
+
+    // Failed analysis should only have critiques
+    for (const fact of result.facts) {
+      expect(fact.fact_type).toBe('critique');
+    }
+  });
+});

--- a/tests/run-bundle-facts.test.ts
+++ b/tests/run-bundle-facts.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration tests: FactObjectV1 in run_bundle response.
+ *
+ * Verifies:
+ * - facts field present when ENABLE_FACTS_ASSEMBLY=1
+ * - facts field absent when ENABLE_FACTS_ASSEMBLY=0
+ * - FactsEnvelope structure and content
+ * - Backward compatibility: existing fields unchanged
+ * - Contract: facts validates against expected shape
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnServer, type ServerHandle } from './utils.js';
+
+const BASIC_PAYLOAD = {
+  base_graph: {
+    nodes: [
+      { id: 'demand', label: 'Demand', value: 0.7 },
+      { id: 'price', label: 'Price', value: 0.5 },
+      { id: 'revenue', label: 'Revenue', value: 0.6 },
+    ],
+    edges: [
+      { from: 'demand', to: 'revenue', weight: 0.8 },
+      { from: 'price', to: 'revenue', weight: 0.6 },
+    ],
+  },
+  deltas: [
+    { label: 'Low Price', nodes: [{ id: 'price', value: 0.3 }] },
+    { label: 'High Price', nodes: [{ id: 'price', value: 0.8 }] },
+  ],
+  seed: 4242,
+};
+
+describe('run_bundle facts integration (ENABLE_FACTS_ASSEMBLY=1)', () => {
+  let server: ServerHandle;
+
+  beforeAll(async () => {
+    server = await spawnServer({ env: { ENABLE_FACTS_ASSEMBLY: '1' } });
+  });
+  afterAll(async () => { await server.kill(); });
+
+  it('response includes facts envelope', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/run_bundle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASIC_PAYLOAD),
+    });
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.facts).toBeDefined();
+    expect(data.facts.facts_schema_version).toBe(1);
+    expect(data.facts.analysis_status).toBe('computed');
+    expect(Array.isArray(data.facts.facts)).toBe(true);
+  });
+
+  it('facts contain probability facts for each scenario', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/run_bundle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASIC_PAYLOAD),
+    });
+    const data = await res.json();
+
+    const probFacts = data.facts.facts.filter((f: any) => f.fact_type === 'probability');
+    expect(probFacts.length).toBe(2); // Two scenarios
+
+    // Verify structure of each probability fact
+    for (const fact of probFacts) {
+      expect(fact.fact_id).toMatch(/^[0-9a-f]{16}$/);
+      expect(fact.fact_key.type).toBe('probability');
+      expect(fact.data.type).toBe('probability');
+      expect(typeof fact.data.p10).toBe('number');
+      expect(typeof fact.data.p50).toBe('number');
+      expect(typeof fact.data.p90).toBe('number');
+      expect(typeof fact.data.mean).toBe('number');
+      expect(fact.lineage).toBeDefined();
+      expect(fact.lineage.graph_hash).toMatch(/^[0-9a-f]{16}$/);
+      expect(fact.lineage.seed).toBe(4242);
+      expect(fact.content_hash).toMatch(/^[0-9a-f]{16}$/);
+    }
+  });
+
+  it('content_hashes are deterministic across identical requests', async () => {
+    const body = JSON.stringify(BASIC_PAYLOAD);
+    const [res1, res2] = await Promise.all([
+      fetch(`${server.baseUrl}/v1/run_bundle`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      }),
+      fetch(`${server.baseUrl}/v1/run_bundle`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      }),
+    ]);
+    const data1 = await res1.json();
+    const data2 = await res2.json();
+
+    // Same payload → same content_hashes (derived from data only, not lineage)
+    const hashes1 = data1.facts.facts.map((f: any) => f.content_hash).sort();
+    const hashes2 = data2.facts.facts.map((f: any) => f.content_hash).sort();
+    expect(hashes1).toEqual(hashes2);
+
+    // Same fact_key structure (same option_ids / types)
+    const keys1 = data1.facts.facts.map((f: any) => JSON.stringify(f.fact_key)).sort();
+    const keys2 = data2.facts.facts.map((f: any) => JSON.stringify(f.fact_key)).sort();
+    expect(keys1).toEqual(keys2);
+  });
+
+  it('existing response fields unchanged (backward compatible)', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/run_bundle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASIC_PAYLOAD),
+    });
+    const data = await res.json();
+
+    // Core fields unchanged
+    expect(data.schema).toBe('run_bundle.v1');
+    expect(data.results).toHaveLength(2);
+    expect(data.model_card).toBeDefined();
+    expect(data.meta).toBeDefined();
+    expect(data.meta.total_scenarios).toBe(2);
+  });
+
+  it('facts field NOT included in response_hash (stable hash)', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/run_bundle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASIC_PAYLOAD),
+    });
+    const data = await res.json();
+
+    // response_hash should be the same whether facts are present or not
+    // (it's based on results, not facts)
+    expect(data.model_card.response_hash).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe('run_bundle facts integration (ENABLE_FACTS_ASSEMBLY=0)', () => {
+  let server: ServerHandle;
+
+  beforeAll(async () => {
+    server = await spawnServer({ env: { ENABLE_FACTS_ASSEMBLY: '0' } });
+  });
+  afterAll(async () => { await server.kill(); });
+
+  it('response does NOT include facts when disabled', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/run_bundle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASIC_PAYLOAD),
+    });
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.facts).toBeUndefined();
+    // Existing fields still present
+    expect(data.schema).toBe('run_bundle.v1');
+    expect(data.results).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
### What
Implements Stream D: FactObjectV1 schema and assembly pipeline for structured facts from inference results.

**New modules:**
- `src/facts/types.ts` — FactObjectV1 schema (fact_id, fact_key, lineage, content_hash)
- `src/facts/hash.ts` — Deterministic hashing (SHA-256 truncated to 16 hex chars)
- `src/facts/mapper.ts` — ISL→FactObject and run_bundle→FactObject mappers
- `src/facts/index.ts` — Public API exports

**Integration:**
- `run_bundle` response now includes optional `facts` envelope when `ENABLE_FACTS_ASSEMBLY=1`
- Backward-compatible: facts field omitted when flag disabled
- Respects analysis_status: failed→critiques only, partial→available data, computed→full assembly

**Key design:**
- Content-addressable fact_ids: `hash(fact_key + lineage)` — stable per analysis run
- Deterministic ordering: facts sorted by fact_key before serialization
- Raw data payloads: UI renders display format, not pre-formatted strings
- Explicit lineage: graph_hash, seed, config_version, isl_request_id for reproducibility

### How to verify
- `npm test` → all unit tests pass (473 lines of test coverage)
- Golden fixtures validate: computed/partial/failed analysis scenarios
- Integration tests verify facts envelope structure in run_bundle response
- Backward compatibility: existing response fields unchanged when flag disabled

### Risk
- Low: feature-flagged (ENABLE_FACTS_ASSEMBLY), backward-compatible
- Facts field is optional in OpenAPI schema
- No changes to existing inference logic or response structure

### Checklist
- [x] No `parse_text` in logs
- [x] Determinism preserved (fact_ids/content_hashes stable across identical inputs)
- [x] Golden fixtures included for computed/partial/failed scenarios

https://claude.ai/code/session_01TEayjgWvc97eXXfaSE4hq2