### PR TITLE
fix(coaching): address review feedback on trust pipeline hardening

### DIFF
--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -323,7 +323,7 @@ function buildWarnings(input: BriefAssemblyInput, isPartial: boolean): BriefWarn
       warnings.push({
         code: mc.type,
         message: mc.challenge_question,
-        severity: mc.severity === 'blocker' ? 'warning' : mc.severity === 'warn' ? 'warning' : 'info',
+        severity: mc.severity === 'blocker' ? 'error' : mc.severity === 'warn' ? 'warning' : 'info',
       });
     }
   }

--- a/src/cee/decision-review-request.ts
+++ b/src/cee/decision-review-request.ts
@@ -10,6 +10,7 @@
 import { createHash } from 'node:crypto';
 import type { EngineGraphV3, OptionV3 } from '../types/engine-v3.js';
 import type { M1Coaching, EvidenceGap, Critique } from '../coaching/types.js';
+import { filterInterventionOverrides } from '../coaching/sensitivity-filter.js';
 import type {
   DecisionReviewRequest,
   DecisionReviewNode,
@@ -233,13 +234,11 @@ function extractOptionComparison(
 /**
  * Extract factor sensitivity data from ISL result.
  */
-function extractFactorSensitivity(islResult: ISLResultInput): FactorSensitivityData[] {
+export function extractFactorSensitivity(islResult: ISLResultInput): FactorSensitivityData[] {
   const factorSensitivity = islResult.factor_sensitivity ?? [];
 
-  // Task 2: Filter out intervention_override factors — decision levers, not uncertainty drivers
-  return factorSensitivity
-    .filter((f) => f.zero_reason !== 'intervention_override')
-    .map((f) => ({
+  // Task 2: Filter out intervention_override factors (decision levers, not uncertainty drivers)
+  return filterInterventionOverrides(factorSensitivity).map((f) => ({
       factor_id: f.factor_id,
       factor_label: f.factor_label ?? f.factor_id,
       elasticity: f.elasticity ?? 0,

--- a/src/coaching/m1-coaching.ts
+++ b/src/coaching/m1-coaching.ts
@@ -241,8 +241,9 @@ function applyJointProbabilityGate(
   thresholds: { readiness_joint_prob_floor: number; readiness_joint_prob_close_call: number },
   modelCritiques: Critique[]
 ): Readiness {
-  // Extract per-option joint probabilities from ISL constraint_analysis
-  const islOptions: any[] = islResult?.options ?? [];
+  // Extract per-option joint probabilities from ISL constraint_analysis.
+  // Read from options ?? results for V1/legacy ISL payload compatibility.
+  const islOptions: any[] = islResult?.options ?? islResult?.results ?? [];
   const jointProbs: number[] = [];
   for (const opt of islOptions) {
     const jp = opt?.constraint_analysis?.joint_probability
@@ -258,24 +259,31 @@ function applyJointProbabilityGate(
   const maxJointProb = Math.max(...jointProbs);
   let readiness = currentReadiness;
 
+  // Dedupe: only emit GOAL_FEASIBILITY_LOW if not already present
+  const alreadyEmitted = modelCritiques.some((c) => c.type === 'GOAL_FEASIBILITY_LOW');
+
   if (maxJointProb < thresholds.readiness_joint_prob_floor) {
     // Very low joint probability — cap at needs_evidence
     readiness = capReadiness(readiness, 'needs_evidence');
-    modelCritiques.push({
-      type: 'GOAL_FEASIBILITY_LOW',
-      severity: 'warn',
-      challenge_question: 'No option has a strong probability of meeting all stated constraints. The best available option may not achieve the target.',
-      suggested_action: 'Review whether your constraints are realistic, or gather more evidence on the factors that most affect feasibility.',
-    });
+    if (!alreadyEmitted) {
+      modelCritiques.push({
+        type: 'GOAL_FEASIBILITY_LOW',
+        severity: 'warn',
+        challenge_question: 'No option has a strong probability of meeting all stated constraints. The best available option may not achieve the target.',
+        suggested_action: 'Review whether your constraints are realistic, or gather more evidence on the factors that most affect feasibility.',
+      });
+    }
   } else if (maxJointProb < thresholds.readiness_joint_prob_close_call) {
     // Moderate joint probability — cap at close_call
     readiness = capReadiness(readiness, 'close_call');
-    modelCritiques.push({
-      type: 'GOAL_FEASIBILITY_LOW',
-      severity: 'warn',
-      challenge_question: 'No option has a strong probability of meeting all stated constraints. The best available option may not achieve the target.',
-      suggested_action: 'Review whether your constraints are realistic, or gather more evidence on the factors that most affect feasibility.',
-    });
+    if (!alreadyEmitted) {
+      modelCritiques.push({
+        type: 'GOAL_FEASIBILITY_LOW',
+        severity: 'warn',
+        challenge_question: 'No option has a strong probability of meeting all stated constraints. The best available option may not achieve the target.',
+        suggested_action: 'Review whether your constraints are realistic, or gather more evidence on the factors that most affect feasibility.',
+      });
+    }
   }
 
   return readiness;

--- a/src/coaching/sensitivity-filter.ts
+++ b/src/coaching/sensitivity-filter.ts
@@ -1,0 +1,23 @@
+/**
+ * Sensitivity Filter — intervention_override exclusion
+ *
+ * Factors with zero_reason === 'intervention_override' are decision levers,
+ * not uncertainty drivers. They should not appear in sensitivity output sent
+ * to the review prompt or the UI.
+ *
+ * This is a PLoT output filter only — ISL request/response is not mutated.
+ */
+
+/**
+ * Filter out factor sensitivity entries that represent intervention overrides.
+ * These are decision levers (elasticity=0 because the user controls them),
+ * not uncertainty drivers.
+ *
+ * @param factors Array of factor sensitivity entries with optional zero_reason
+ * @returns Filtered array excluding intervention_override entries
+ */
+export function filterInterventionOverrides<T extends { zero_reason?: string | null }>(
+  factors: T[]
+): T[] {
+  return factors.filter((f) => f.zero_reason !== 'intervention_override');
+}

--- a/src/coaching/thresholds.ts
+++ b/src/coaching/thresholds.ts
@@ -110,6 +110,8 @@ export const DEFAULT_THRESHOLDS: CoachingThresholds = {
  * - M1_THRESHOLD_ACTION_HIGH_VOI
  * - M1_THRESHOLD_READINESS_HIGH_GAP_COUNT
  * - M1_THRESHOLD_READINESS_HIGH_VOI
+ * - READINESS_JOINT_PROB_FLOOR (default: 0.05 — joint probability below this caps readiness at needs_evidence)
+ * - READINESS_JOINT_PROB_CLOSE_CALL (default: 0.30 — joint probability below this caps readiness at close_call)
  *
  * @returns CoachingThresholds object with resolved values
  */

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -106,6 +106,7 @@ import { factorReviewV2, type CEESchemaV2Config } from '../../cee/client.js';
 import { FLAGS } from '../../config/flags.js';
 import { getAllFeatureFlags } from '../../config/feature-flags.js';
 import { generateM1Coaching } from '../../coaching/m1-coaching.js';
+import { filterInterventionOverrides } from '../../coaching/sensitivity-filter.js';
 import type { M1Review } from '../../cee/validation/m1-review-types.js';
 import type { ReviewStatus } from '../../cee/validation/m1-review-constants.js';
 import { ReviewSkipReasons, type ReviewSkipReason } from '../../cee/validation/m1-review-constants.js';
@@ -185,11 +186,9 @@ function transformEdgeSensitivity(islSensitivity: unknown): EdgeSensitivityResul
  */
 function transformFactorSensitivity(islFactorSensitivity: unknown): FactorSensitivityResultV3[] | undefined {
   if (!hasNonEmptyArray(islFactorSensitivity)) return undefined;
-  // Task 2: Filter out intervention_override factors — these are decision levers,
-  // not uncertainty drivers, and should not appear in sensitivity output.
-  return (islFactorSensitivity as any[])
-    .filter((f: any) => f.zero_reason !== 'intervention_override')
-    .map((f: any) => {
+  // Task 2: Filter out intervention_override factors (decision levers, not uncertainty drivers)
+  const filtered = filterInterventionOverrides(islFactorSensitivity as any[]);
+  return filtered.map((f: any) => {
     // Schema v2.6 canonical field is 'sensitivity_score'; legacy used 'sensitivity'
     // Support both for backward compatibility
     const sensitivityValue = f.sensitivity_score ?? f.sensitivity;

--- a/tests/coaching/sensitivity-filter.test.ts
+++ b/tests/coaching/sensitivity-filter.test.ts
@@ -1,22 +1,19 @@
 /**
  * Task 2: Sensitivity Filter — exclude intervention_override factors
  *
- * Tests the filtering of factors with zero_reason === 'intervention_override'
- * from both the API response and review prompt paths.
+ * Tests the production filter utility (filterInterventionOverrides) used by both:
+ * - transformFactorSensitivity (API response assembly in routes/v2/run.ts)
+ * - extractFactorSensitivity (CEE review prompt input in decision-review-request.ts)
  */
 
 import { describe, it, expect } from 'vitest';
+import { filterInterventionOverrides } from '../../src/coaching/sensitivity-filter.js';
 
-// We test the filter logic directly rather than importing the private function.
-// The filter rule: exclude entries where zero_reason === 'intervention_override'.
+// =============================================================================
+// filterInterventionOverrides — shared production filter
+// =============================================================================
 
-function filterInterventionOverride<T extends { zero_reason?: string | null }>(
-  factors: T[]
-): T[] {
-  return factors.filter((f) => f.zero_reason !== 'intervention_override');
-}
-
-describe('Task 2: Sensitivity Filter — intervention_override', () => {
+describe('filterInterventionOverrides', () => {
   it('filters out factor with zero_reason "intervention_override"', () => {
     const factors = [
       { factor_id: 'f1', sensitivity_score: 0.5, zero_reason: undefined },
@@ -24,7 +21,7 @@ describe('Task 2: Sensitivity Filter — intervention_override', () => {
       { factor_id: 'f3', sensitivity_score: 0.3, zero_reason: 'no_path_to_goal' },
     ];
 
-    const result = filterInterventionOverride(factors);
+    const result = filterInterventionOverrides(factors);
     expect(result).toHaveLength(2);
     expect(result.map(f => f.factor_id)).toEqual(['f1', 'f3']);
   });
@@ -35,7 +32,7 @@ describe('Task 2: Sensitivity Filter — intervention_override', () => {
       { factor_id: 'f2', sensitivity_score: 0.0, zero_reason: 'intervention_override' },
     ];
 
-    const result = filterInterventionOverride(factors);
+    const result = filterInterventionOverrides(factors);
     expect(result).toHaveLength(0);
   });
 
@@ -45,7 +42,7 @@ describe('Task 2: Sensitivity Filter — intervention_override', () => {
       { factor_id: 'f2', sensitivity_score: 0.3 },
     ];
 
-    const result = filterInterventionOverride(factors);
+    const result = filterInterventionOverrides(factors);
     expect(result).toHaveLength(2);
     expect(result).toEqual(factors);
   });
@@ -57,7 +54,7 @@ describe('Task 2: Sensitivity Filter — intervention_override', () => {
       { factor_id: 'f3', zero_reason: null },
     ];
 
-    const result = filterInterventionOverride(factors);
+    const result = filterInterventionOverrides(factors);
     expect(result).toHaveLength(3);
   });
 
@@ -67,7 +64,36 @@ describe('Task 2: Sensitivity Filter — intervention_override', () => {
       { factor_id: 'f2', zero_reason: 'intervention_override' },
     ];
 
-    const result = filterInterventionOverride(factors);
+    const result = filterInterventionOverrides(factors);
+    expect(result).toHaveLength(1);
+    expect(result[0].factor_id).toBe('f1');
+  });
+
+  it('handles empty array', () => {
+    const result = filterInterventionOverrides([]);
+    expect(result).toHaveLength(0);
+  });
+
+  // Simulate the shapes used by both production call sites
+  it('works with ISL factor_sensitivity shape (run.ts path)', () => {
+    const islFactors = [
+      { node_id: 'f1', sensitivity_score: 0.5, elasticity: 0.3, direction: 'positive', zero_reason: null },
+      { node_id: 'f2', sensitivity_score: 0.0, elasticity: 0, direction: 'positive', zero_reason: 'intervention_override' },
+      { node_id: 'f3', sensitivity_score: 0.2, elasticity: -0.1, direction: 'negative' },
+    ];
+
+    const result = filterInterventionOverrides(islFactors);
+    expect(result).toHaveLength(2);
+    expect(result.map(f => f.node_id)).toEqual(['f1', 'f3']);
+  });
+
+  it('works with ISLResultInput factor_sensitivity shape (decision-review-request.ts path)', () => {
+    const factors = [
+      { factor_id: 'f1', factor_label: 'Cost', elasticity: 0.5, confidence: 0.8 },
+      { factor_id: 'f2', factor_label: 'Speed', elasticity: 0.0, confidence: 0.5, zero_reason: 'intervention_override' },
+    ];
+
+    const result = filterInterventionOverrides(factors);
     expect(result).toHaveLength(1);
     expect(result[0].factor_id).toBe('f1');
   });


### PR DESCRIPTION
P0 fixes:
- Joint-probability gate now reads islResult.options ?? islResult.results for V1/legacy ISL payload compatibility
- Task 2 tests now exercise the production filterInterventionOverrides utility (extracted to src/coaching/sensitivity-filter.ts) instead of a local test-only helper
- blocker coaching critiques now map to 'error' (not 'warning') in decision-brief warnings, preserving high-severity signal downstream

P1 fixes:
- Added dedupe guard: GOAL_FEASIBILITY_LOW critique is only emitted once per coaching call regardless of future code paths
- Documented READINESS_JOINT_PROB_FLOOR and READINESS_JOINT_PROB_CLOSE_CALL in getThresholds() env-var mapping comments

https://claude.ai/code/session_01GkcmfVufhh8EM9jyrA1gND

### What
- 

### How to verify
- `npm test` → green
- (optional) `npm run replay` → All fixtures match

### Risk
- 

### Checklist
- [ ] No `parse_text` in logs
- [ ] Determinism preserved (fixtures unchanged)