### PR TITLE
fix(plot): clamp evpi_percentage_points to >= 0 (Howard 1966 non-negativity)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -6065,16 +6065,22 @@ components:
                 minimum: 0
                 description: >-
                   Estimated EVPI in percentage points of win probability.
-                  Heuristic approximation: VOI × win-probability spread × 100,
-                  clamped to ≥ 0. Present only when both VOI and win
-                  probabilities are available. EVPI is non-negative by
-                  definition (information cannot harm a rational decision-
-                  maker on average — Howard 1966); negative values returned
-                  by Monte Carlo VOI estimators are sampling artefacts, not
-                  meaningful decision signals, and are collapsed to 0 here
-                  so consumers never see a negative percentage that would
-                  falsely imply learning more about the factor worsens the
-                  decision.
+                  Heuristic approximation: VOI × win-probability spread × 100.
+                  Present only when both VOI and win probabilities are
+                  available. EVPI is non-negative by definition
+                  (information cannot harm a rational decision-maker on
+                  average — Howard 1966); negative values returned by Monte
+                  Carlo VOI estimators are sampling artefacts, not
+                  meaningful decision signals.
+                  Two-tier enforcement: (1) negative upstream VOI is
+                  treated as unavailable at the integration boundary, so
+                  `evpi_percentage_points` is OMITTED entirely for the
+                  affected factor (preserving the missing-vs-zero
+                  distinction the rest of the response contract relies
+                  on); (2) any negative computed EVPI that nevertheless
+                  reaches the emitter is defensively clamped to `0`
+                  (belt-and-braces for future producers using a different
+                  VOI formula). When present, this field is always ≥ 0.
               evpi_method:
                 type: string
                 enum: [heuristic, counterfactual]

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -6065,8 +6065,16 @@ components:
                 minimum: 0
                 description: >-
                   Estimated EVPI in percentage points of win probability.
-                  Heuristic approximation: VOI × win probability spread × 100.
-                  Present only when both VOI and win probabilities are available.
+                  Heuristic approximation: VOI × win-probability spread × 100,
+                  clamped to ≥ 0. Present only when both VOI and win
+                  probabilities are available. EVPI is non-negative by
+                  definition (information cannot harm a rational decision-
+                  maker on average — Howard 1966); negative values returned
+                  by Monte Carlo VOI estimators are sampling artefacts, not
+                  meaningful decision signals, and are collapsed to 0 here
+                  so consumers never see a negative percentage that would
+                  falsely imply learning more about the factor worsens the
+                  decision.
               evpi_method:
                 type: string
                 enum: [heuristic, counterfactual]

--- a/src/coaching/evidence-gaps.ts
+++ b/src/coaching/evidence-gaps.ts
@@ -7,6 +7,7 @@
 import type { CoachingInputs, EvidenceGap } from './types.js';
 import { computeNormalisedImpact } from './normalise-inputs.js';
 import { getThresholds } from './thresholds.js';
+import { computeEvpiPercentagePoints } from '../lib/evpi-emission.js';
 
 export function computeEvidenceGaps(inputs: CoachingInputs): EvidenceGap[] {
   const { factorSensitivity } = inputs;
@@ -51,9 +52,11 @@ export function computeEvidenceGaps(inputs: CoachingInputs): EvidenceGap[] {
   return gaps.map((f) => {
     const node = inputs.graph.nodes.find(n => n.id === f.node_id);
     const os = node?.observed_state;
-    const evpiPp = winProbSpread > 0
-      ? Math.round(f.voi * winProbSpread * 100 * 10) / 10
-      : undefined;
+    // Non-negative EVPI contract — see `src/lib/evpi-emission.ts` for the
+    // shared helper and the Howard-1966 rationale. The helper returns
+    // `undefined` when either input is missing or non-finite, matching the
+    // pre-existing conditional-inclusion pattern below.
+    const evpiPp = computeEvpiPercentagePoints(f.voi, winProbSpread);
     return {
       factor_id: f.node_id,
       factor_label: f.label,

--- a/src/lib/evpi-emission.ts
+++ b/src/lib/evpi-emission.ts
@@ -52,10 +52,11 @@ export function sanitiseIslVoi(value: unknown): number | undefined {
  * the result is the rounded product clamped to `>= 0`.
  *
  * The `Math.max(0, ...)` is belt-and-braces: when `sanitiseIslVoi` has run
- * at the boundary, `voi` should already be non-negative or `null`, but
- * defensive clamping here keeps the contract intact if a future producer
- * slips a negative past the boundary (e.g. PLoT-side compute path that
- * derives VOI by a different formula).
+ * at the boundary, `voi` should already be non-negative or `undefined`,
+ * but defensive clamping here keeps the contract intact if a future
+ * producer slips a negative past the boundary (e.g. a PLoT-side compute
+ * path that derives VOI by a different formula, like the coaching
+ * surface's `normalisedImpact × (1 - confidence)`).
  */
 export function computeEvpiPercentagePoints(
   voi: number | null | undefined,

--- a/src/lib/evpi-emission.ts
+++ b/src/lib/evpi-emission.ts
@@ -1,0 +1,68 @@
+/**
+ * EVPI (Expected Value of Perfect Information) emission helpers.
+ *
+ * Centralises the non-negative contract for `evpi_percentage_points` so it
+ * is enforced consistently across every site that emits the field. EVPI is
+ * non-negative by definition (Howard 1966; Felli & Hazen 1998 — information
+ * cannot harm a rational decision-maker on average), so Monte Carlo
+ * estimates that drift slightly negative are sampling artefacts, not
+ * meaningful decision signals. Surfacing a negative percentage to users
+ * would falsely imply "learning more about this factor would make the
+ * decision worse" and violates the OpenAPI declared `minimum: 0`.
+ *
+ * Used by:
+ * - `src/routes/v2/run.ts` — `mapIslFactorEntry` (boundary sanitisation of
+ *   ISL `value_of_information`) and the EVPI enrichment loop in the route
+ *   handler.
+ * - `src/coaching/evidence-gaps.ts` — the parallel coaching surface that
+ *   emits `m1_coaching.evidence_gaps[].evpi_percentage_points`.
+ */
+
+/**
+ * Sanitise an ISL-emitted `value_of_information` value to satisfy PLoT's
+ * non-negative VOI contract. ISL emits VOI via a Monte Carlo estimator which
+ * can drift slightly negative from sampling noise around zero — a
+ * well-known artefact, not a real signal. Mirrors the existing convention
+ * in `src/integrations/isl/adapters/factor-sensitivity.ts:49` which already
+ * filters CEE-facing ISL VOI by `>= 0`.
+ *
+ * Returns the value verbatim when it is a finite non-negative number;
+ * returns `undefined` for negatives, non-finite (NaN / Infinity), and any
+ * non-number type. `undefined` aligns with `FactorSensitivityResultV3.value_of_information`
+ * (typed `number | undefined`, an optional field) and causes the downstream
+ * EVPI emitter to skip the field entirely rather than emit zero —
+ * preserving the missing-vs-zero distinction the rest of the response
+ * contract relies on.
+ */
+export function sanitiseIslVoi(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Compute the EVPI percentage-points value to emit on a factor sensitivity
+ * entry, enforcing the non-negative contract.
+ *
+ * Returns `undefined` (rather than `0`) when either input is missing or
+ * non-finite, so the caller can conditionally include the field rather
+ * than emitting a confident `0` that conflates "no measurable value of
+ * information" with "we couldn't compute it". When both inputs are valid,
+ * the result is the rounded product clamped to `>= 0`.
+ *
+ * The `Math.max(0, ...)` is belt-and-braces: when `sanitiseIslVoi` has run
+ * at the boundary, `voi` should already be non-negative or `null`, but
+ * defensive clamping here keeps the contract intact if a future producer
+ * slips a negative past the boundary (e.g. PLoT-side compute path that
+ * derives VOI by a different formula).
+ */
+export function computeEvpiPercentagePoints(
+  voi: number | null | undefined,
+  winProbSpread: number,
+): number | undefined {
+  if (typeof voi !== 'number' || !Number.isFinite(voi)) return undefined;
+  if (!Number.isFinite(winProbSpread) || winProbSpread <= 0) return undefined;
+  const raw = voi * winProbSpread * 100;
+  return Math.max(0, Math.round(raw * 10) / 10);
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -122,6 +122,7 @@ import { ReviewSkipReasons, type ReviewSkipReason } from '../../cee/validation/m
 import { getDownstreamCallsForLog } from '../../util/downstream-tracker.js';
 import { computeFactorSensitivityFromGraph, buildFactorStability, mergeIslConfidenceIntoGraphFactors } from '../../lib/factor-influence.js';
 import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagMissingFromIsl } from '../../lib/auto-noise.js';
+import { sanitiseIslVoi, computeEvpiPercentagePoints } from '../../lib/evpi-emission.js';
 import { NEAR_TIE_THRESHOLD } from '../../trust/result-coherence.js';
 import { assessGraphIdentifiability, toIdentifiabilityResponse, detectUnmeasuredConfounding } from '../../trust/identifiability-v2.js';
 import { classifyEdgeSeverity } from '../../trust/edge-severity.js';
@@ -570,6 +571,13 @@ function mapIslFactorEntry(f: any, normContext?: NormalisationContext): FactorSe
   // going through the merge, these placeholders would surface — that's a bug
   // and the integration test in tests/b8-8-3c-field-segregation.test.ts pins
   // the boundary contract.
+  //
+  // Pre-computed once so the VOI guard logic lives in one place and is
+  // reused for both the `value_of_information` field and the `confidence`
+  // fallback chain below. See `src/lib/evpi-emission.ts` for the full
+  // contract rationale (Howard 1966 non-negativity, MC sampling artefacts).
+  const sanitisedVoi = sanitiseIslVoi(f.value_of_information);
+
   const entry: FactorSensitivityResultV3 = {
     factor_id: factorId,
     factor_label: f.label ?? null,
@@ -583,8 +591,23 @@ function mapIslFactorEntry(f: any, normContext?: NormalisationContext): FactorSe
     // VOI is a dimensionless decision-readiness score (EVPI proxy, clamped [0,1]).
     // It does NOT require denormalisation — it measures "how valuable would perfect
     // information about this factor be" as a normalised fraction, not outcome-space units.
-    value_of_information: f.value_of_information ?? null,
-    confidence: f.confidence ?? f.value_of_information ?? null,
+    //
+    // Boundary guard (Howard 1966 EVPI non-negativity): ISL emits VOI via a
+    // Monte Carlo estimator which can drift slightly negative from sampling
+    // noise around zero — a well-known artefact, not a real signal. Negative
+    // and non-finite values are filtered to null here so downstream
+    // `evpi_percentage_points` emission (`run.ts` near line 4060) honours the
+    // OpenAPI `minimum: 0` contract and never surfaces "learning more would
+    // make the decision worse" to the user. Mirrors the existing convention
+    // in the sibling ISL adapter at
+    // `src/integrations/isl/adapters/factor-sensitivity.ts:49` which already
+    // filters `value_of_information` by `>= 0` on the CEE-facing surface.
+    value_of_information: sanitisedVoi,
+    // Confidence retains the legacy passthrough fallback chain. Use the
+    // already-sanitised VOI so the fallback path can't surface a negative /
+    // non-finite value that the boundary guard explicitly rejected for the
+    // VOI field itself.
+    confidence: f.confidence ?? sanitisedVoi,
     zero_reason: f.zero_reason ?? null,
     source: 'isl' as const,
     // Placeholder — overwritten by mergeIslConfidenceIntoGraphFactors. If this
@@ -4045,9 +4068,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         }
 
         // Enrich factor sensitivity with EVPI percentage points heuristic.
-        // Heuristic approximation: VOI × win probability spread × 100.
-        // Not true counterfactual EVPI. To be replaced when ISL supports
-        // per-factor counterfactual EVPI.
+        // Heuristic approximation: VOI × win probability spread × 100,
+        // clamped to ≥ 0. Not true counterfactual EVPI. To be replaced
+        // when ISL supports per-factor counterfactual EVPI. See
+        // `src/lib/evpi-emission.ts` for the non-negative contract
+        // rationale (Howard 1966; OpenAPI `evpi_percentage_points.minimum: 0`).
         if (factorSensitivity) {
           const islOptions = processedIslResult?.options ?? processedIslResult?.results ?? [];
           const winProbs = (islOptions as any[])
@@ -4057,8 +4082,9 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           const winProbSpread = winProbs.length >= 2 ? winProbs[0] - winProbs[1] : 0;
           if (winProbSpread > 0) {
             for (const f of factorSensitivity) {
-              if (f.value_of_information != null) {
-                f.evpi_percentage_points = Math.round(f.value_of_information * winProbSpread * 100 * 10) / 10;
+              const evpiPp = computeEvpiPercentagePoints(f.value_of_information, winProbSpread);
+              if (evpiPp !== undefined) {
+                f.evpi_percentage_points = evpiPp;
                 f.evpi_method = 'heuristic';
               }
             }

--- a/tests/evpi-emission.test.ts
+++ b/tests/evpi-emission.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for `src/lib/evpi-emission.ts` — the centralised non-negative
+ * contract for `evpi_percentage_points` and the boundary guard for ISL-
+ * emitted `value_of_information`.
+ *
+ * Pins the Howard-1966 contract end-to-end: EVPI is non-negative by
+ * definition, Monte Carlo estimators produce small negative artefacts from
+ * sampling noise, and PLoT must never surface a negative percentage to
+ * users (it would falsely imply "learning more would make the decision
+ * worse"). Both helpers are tested in isolation so the contract is
+ * locked at the source-of-truth, not just downstream consumers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sanitiseIslVoi, computeEvpiPercentagePoints } from '../src/lib/evpi-emission.js';
+
+describe('sanitiseIslVoi — boundary guard for ISL value_of_information', () => {
+  describe('accepts valid non-negative finite numbers verbatim', () => {
+    it('returns zero unchanged', () => {
+      expect(sanitiseIslVoi(0)).toBe(0);
+    });
+
+    it('returns positive numbers in (0, 1] unchanged', () => {
+      expect(sanitiseIslVoi(0.42)).toBe(0.42);
+      expect(sanitiseIslVoi(1)).toBe(1);
+    });
+
+    it('returns positive numbers > 1 unchanged (no upper clamp at this layer)', () => {
+      // Upper clamping is the producer's responsibility (e.g. computeValueOfInformation
+      // clamps to [0,1]). This layer only enforces the non-negative contract.
+      expect(sanitiseIslVoi(1.5)).toBe(1.5);
+    });
+  });
+
+  describe('rejects values that violate the EVPI non-negativity contract', () => {
+    it('returns undefined for small negatives (Monte Carlo sampling artefacts)', () => {
+      expect(sanitiseIslVoi(-0.001)).toBeUndefined();
+      expect(sanitiseIslVoi(-0.07)).toBeUndefined();
+    });
+
+    it('returns undefined for large negatives', () => {
+      expect(sanitiseIslVoi(-1)).toBeUndefined();
+      expect(sanitiseIslVoi(-100)).toBeUndefined();
+    });
+
+    it('returns undefined for NaN', () => {
+      expect(sanitiseIslVoi(Number.NaN)).toBeUndefined();
+    });
+
+    it('returns undefined for ±Infinity', () => {
+      expect(sanitiseIslVoi(Number.POSITIVE_INFINITY)).toBeUndefined();
+      expect(sanitiseIslVoi(Number.NEGATIVE_INFINITY)).toBeUndefined();
+    });
+  });
+
+  describe('rejects non-number types', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['empty string', ''],
+      ['number-like string', '0.5'],
+      ['object', { value_of_information: 0.5 }],
+      ['array', [0.5]],
+      ['boolean true', true],
+      ['boolean false', false],
+    ])('returns undefined for %s', (_label, input) => {
+      expect(sanitiseIslVoi(input)).toBeUndefined();
+    });
+  });
+});
+
+describe('computeEvpiPercentagePoints — non-negative contract on emission', () => {
+  describe('happy path: returns rounded clamped product', () => {
+    it('emits a positive percentage for a positive VOI and positive spread', () => {
+      // 0.5 * 0.4 * 100 = 20 — exact one-decimal rounded value
+      expect(computeEvpiPercentagePoints(0.5, 0.4)).toBe(20);
+    });
+
+    it('emits 0 when VOI is 0 (no measurable value of information)', () => {
+      expect(computeEvpiPercentagePoints(0, 0.4)).toBe(0);
+    });
+
+    it('rounds to one decimal place', () => {
+      // 0.123 * 0.456 * 100 = 5.6088 → rounds to 5.6
+      expect(computeEvpiPercentagePoints(0.123, 0.456)).toBeCloseTo(5.6, 5);
+    });
+  });
+
+  describe('clamps negative computed values to 0 (EVPI non-negativity)', () => {
+    it('clamps a small negative MC artefact to 0', () => {
+      // Although sanitiseIslVoi at the boundary should have already
+      // filtered this, defence-in-depth: if a negative VOI reaches the
+      // emitter directly (e.g. a future producer bypasses the boundary),
+      // the percentage still honours the contract.
+      expect(computeEvpiPercentagePoints(-0.001, 0.5)).toBe(0);
+    });
+
+    it('clamps a large negative VOI to 0', () => {
+      expect(computeEvpiPercentagePoints(-1, 0.5)).toBe(0);
+    });
+  });
+
+  describe('returns undefined when inputs cannot produce a meaningful percentage', () => {
+    it('returns undefined when VOI is null', () => {
+      expect(computeEvpiPercentagePoints(null, 0.4)).toBeUndefined();
+    });
+
+    it('returns undefined when VOI is undefined', () => {
+      expect(computeEvpiPercentagePoints(undefined, 0.4)).toBeUndefined();
+    });
+
+    it('returns undefined when VOI is NaN', () => {
+      expect(computeEvpiPercentagePoints(Number.NaN, 0.4)).toBeUndefined();
+    });
+
+    it('returns undefined when VOI is ±Infinity', () => {
+      expect(computeEvpiPercentagePoints(Number.POSITIVE_INFINITY, 0.4)).toBeUndefined();
+      expect(computeEvpiPercentagePoints(Number.NEGATIVE_INFINITY, 0.4)).toBeUndefined();
+    });
+
+    it('returns undefined when winProbSpread is 0 (no discriminating choice)', () => {
+      // Spread of 0 means all options have the same win probability —
+      // there is no decision to inform, so EVPI is not meaningful.
+      expect(computeEvpiPercentagePoints(0.5, 0)).toBeUndefined();
+    });
+
+    it('returns undefined when winProbSpread is negative (malformed input)', () => {
+      // winProbSpread is always max - second_max, so should be >= 0; a
+      // negative value indicates upstream bug — fail closed rather than
+      // emit a sign-flipped percentage.
+      expect(computeEvpiPercentagePoints(0.5, -0.1)).toBeUndefined();
+    });
+
+    it('returns undefined when winProbSpread is non-finite', () => {
+      expect(computeEvpiPercentagePoints(0.5, Number.NaN)).toBeUndefined();
+      expect(computeEvpiPercentagePoints(0.5, Number.POSITIVE_INFINITY)).toBeUndefined();
+    });
+  });
+
+  describe('boundary + emitter compose correctly (Howard 1966 contract end-to-end)', () => {
+    it('sanitised (undefined) VOI → undefined percentage (field is then omitted by callers)', () => {
+      const sanitised = sanitiseIslVoi(-0.05);
+      expect(sanitised).toBeUndefined();
+      expect(computeEvpiPercentagePoints(sanitised, 0.4)).toBeUndefined();
+    });
+
+    it('sanitised positive VOI → positive percentage', () => {
+      const sanitised = sanitiseIslVoi(0.5);
+      expect(sanitised).toBe(0.5);
+      expect(computeEvpiPercentagePoints(sanitised, 0.4)).toBe(20);
+    });
+
+    it('sanitised zero VOI → zero percentage', () => {
+      const sanitised = sanitiseIslVoi(0);
+      expect(sanitised).toBe(0);
+      expect(computeEvpiPercentagePoints(sanitised, 0.4)).toBe(0);
+    });
+
+    it('all Monte Carlo negative artefacts (NaN, ±Inf, small/large negatives) collapse to undefined', () => {
+      const mcArtefacts = [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, -0.001, -0.07, -1, -100];
+      for (const artefact of mcArtefacts) {
+        const sanitised = sanitiseIslVoi(artefact);
+        expect(sanitised).toBeUndefined();
+        expect(computeEvpiPercentagePoints(sanitised, 0.4)).toBeUndefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Live PLoT staging was emitting **negative `evpi_percentage_points`** for some factor sensitivity entries, surfacing through DGAI as a negative percentage on factor cards — violating PLoT's own OpenAPI contract (`evpi_percentage_points.minimum: 0`) and falsely implying "learning more about this factor would worsen the decision".

Root cause: `mapIslFactorEntry` in `src/routes/v2/run.ts` passed ISL's `value_of_information` through with no clamp, no sign check, no finite check. The emission site computed `round(voi * spread * 100) / 10` with no defensive clamp. Negative values are Monte Carlo sampling artefacts from ISL's VOI estimator drifting around zero — well-documented in the literature (Howard 1966; Felli & Hazen 1998 — EVPI is non-negative by definition because information cannot harm a rational decision-maker on average), not real decision signals.

## Implementation

- **New module `src/lib/evpi-emission.ts`** centralising the non-negative contract:
  - `sanitiseIslVoi(value: unknown): number | undefined` — boundary guard returning the value verbatim for finite non-negative numbers, `undefined` otherwise. Mirrors the existing convention in `src/integrations/isl/adapters/factor-sensitivity.ts:49`.
  - `computeEvpiPercentagePoints(voi, winProbSpread): number | undefined` — rounded product clamped to `Math.max(0, ...)`. Returns `undefined` for missing inputs so callers conditionally include the field rather than emitting confident `0`.
- **3 call sites refactored** to use the helpers: `mapIslFactorEntry` (boundary), v2/run emission loop, coaching `m1_coaching.evidence_gaps` parallel surface.
- **OpenAPI description** updated to document the clamp + Howard-1966 rationale.
- **31 unit tests** in `tests/evpi-emission.test.ts` covering positive/zero/negative/NaN/Infinity VOI, win-spread edge cases, and boundary+emitter composition.

## Verification

| Gate | Result |
|---|---|
| `npx vitest run tests/evpi-emission.test.ts` | **31/31 pass** |
| `npx vitest run tests/factor-influence.test.ts tests/v2-run.integration.test.ts` | **112/112 pass** (no regression) |
| `npx tsc --noEmit` | **clean** |
| Spectral OpenAPI lint | **clean** |
| `bash scripts/pre-push-validate.sh` (full gate) at `3fdde1d` | **ALL CHECKS PASSED — 4666 individual tests passed / 25 skipped / 0 failed** |

## Branch state — important

- This PR's head is at **`3fdde1d`** (the safely-pushed, clean-gate state).
- A doc-only follow-up `95222ba` (5-line JSDoc clarification: tightens wording from "non-negative or `null`" to "non-negative or `undefined`" matching the actual return type) was created locally but **was NOT pushed** because the pre-push hook subsequently flagged unrelated flaky tests (see below). The JSDoc commit can be applied later when the gate is healthy; it does not change behaviour or tests.

## Pre-push gate flake (unrelated to EVPI)

The pre-push gate **passed cleanly on this commit (`3fdde1d`)** when originally pushed. Subsequent re-runs (against the local doc-only follow-up) failed intermittently:

- **Run 1** (against `3fdde1d`): PASSED — 4666 individual tests passed / 25 skipped / 0 failed.
- **Run 2** (against `95222ba`): FAILED — `tests/inflight.plugin.test.ts` failed at the file level (env-leak detected: `TEST_ROUTES=1`, `FEATURE_STREAM=1` polluted from a prior test in suite order) + `afterAll` hook timed out at 10000ms. All 4666 individual tests still passed.
- **Run 3** (against `95222ba`): FAILED — 3 tests in `tests/counterfactual.zero-baseline.test.ts` failed with `ECONNREFUSED 127.0.0.1:4353` (server-spawn race or port collision). 4663/4666 individual tests passed.

Diagnostic:
- **Different test files fail each run** (`inflight.plugin.test.ts`, `counterfactual.zero-baseline.test.ts`). Both are server-spawning tests prone to env-isolation + port-collision races.
- **Running `inflight.plugin.test.ts` in isolation** passed cleanly (7/7).
- **No EVPI-touched files are implicated**. The flaky tests neither import `src/lib/evpi-emission.ts` nor reference the changed sites in `src/routes/v2/run.ts:586` / `4061` or `src/coaching/evidence-gaps.ts:54`.
- The local `95222ba` follow-up is doc-only (5 lines of JSDoc text); it cannot affect test behaviour.

**These are pre-existing test-infrastructure flakes**, not introduced by this PR. They should be tracked as a separate test-infrastructure follow-up — investigation deliberately out of scope for the EVPI fix per workstream brief.

## Merge gating

Do **not** merge this PR until either:
1. The full local pre-push gate passes cleanly again on the target commit, **or**
2. CI on this PR (GitHub Actions full-suite) passes deterministically, **and**
3. Paul explicitly authorises the merge via the PR route.

No `--no-verify` bypass has been used. The branch was pushed normally through a clean gate run.

## Scope guard

Files changed (5):

```
contracts/openapi.yaml          | 12 ++- (description only)
src/coaching/evidence-gaps.ts   |  9 ++-
src/lib/evpi-emission.ts        | 68 +++ (new)
src/routes/v2/run.ts            | 40 ++-
tests/evpi-emission.test.ts     | 168 +++ (new)
```

No touches to: ISL, CEE, DGAI, prompts, schemas, OpenAPI shape (description only), or PLoT request/response field shape. No new wire fields. No semantic change to valid non-negative VOI values.

## Test plan

- [x] `npx vitest run tests/evpi-emission.test.ts` — 31/31 pass
- [x] `npx vitest run tests/factor-influence.test.ts tests/v2-run.integration.test.ts` — 112/112 pass
- [x] `npx tsc --noEmit` — clean
- [x] Spectral OpenAPI lint — clean
- [x] `bash scripts/pre-push-validate.sh` — passed at `3fdde1d`
- [ ] CI full-suite on this PR (deterministic re-run of the gate)
- [ ] Paul authorisation to merge
- [ ] Post-deploy: live `/v2/run` smoke confirms no negative `evpi_percentage_points` on factor_sensitivity[] entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)