### PR TITLE
feat(plot): display-honesty — flip_thresholds_status classification

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -5962,6 +5962,22 @@ components:
         response_hash:
           type: string
           description: 16-char hex hash of canonical request (semantic fields only)
+        flip_thresholds_status:
+          type: string
+          enum: [computed, all_no_effect, partial_no_effect, unresolved, unavailable]
+          description: |
+            Display-honesty classification of `flip_thresholds[]`, computed at
+            the post-denormalised response-assembly boundary. Lets UI consumers
+            render the all-no-effect / partial / unresolved cases honestly
+            without re-deriving the picture from individual `flip_reason`
+            strings. Excluded from `response_hash`. UI vocabulary; values
+            never user-facing.
+        flip_thresholds_status_reason:
+          type: string
+          description: |
+            First-seen `flip_reason` string when `flip_thresholds_status` is
+            `unresolved` (e.g. `timeout`, `error`, `insufficient_precision`).
+            Payload-only debug metadata; never user-facing copy.
         critiques:
           type: array
           items:

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -5977,8 +5977,12 @@ components:
           description: |
             First-seen unresolved `flip_reason` string (e.g. `timeout`,
             `error`, `insufficient_precision`). Emitted in TWO cases:
-              - `flip_thresholds_status === 'unresolved'` — every entry was
-                unresolved (no computed flip, no no_effect_within_bounds).
+              - `flip_thresholds_status === 'unresolved'` — no computed
+                flip and at least one unresolved entry.
+                `no_effect_within_bounds` entries may also be present in
+                this case (a pure mix of no_effect + unresolved still
+                classifies as `unresolved` because the unresolved signal
+                is the actionable one).
               - `flip_thresholds_status === 'partial_no_effect'` AND at
                 least one unresolved entry is present alongside computed +
                 no_effect ones. Lets UI consumers soften copy that would

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -5975,8 +5975,15 @@ components:
         flip_thresholds_status_reason:
           type: string
           description: |
-            First-seen `flip_reason` string when `flip_thresholds_status` is
-            `unresolved` (e.g. `timeout`, `error`, `insufficient_precision`).
+            First-seen unresolved `flip_reason` string (e.g. `timeout`,
+            `error`, `insufficient_precision`). Emitted in TWO cases:
+              - `flip_thresholds_status === 'unresolved'` — every entry was
+                unresolved (no computed flip, no no_effect_within_bounds).
+              - `flip_thresholds_status === 'partial_no_effect'` AND at
+                least one unresolved entry is present alongside computed +
+                no_effect ones. Lets UI consumers soften copy that would
+                otherwise imply every non-computed factor was a harmless
+                no_effect_within_bounds case.
             Payload-only debug metadata; never user-facing copy.
         critiques:
           type: array

--- a/src/lib/flip-threshold-status.ts
+++ b/src/lib/flip-threshold-status.ts
@@ -98,7 +98,19 @@ export function classifyFlipThresholdsStatus(
   }
 
   if (computedCount > 0 && noEffectCount > 0) {
-    return { status: 'partial_no_effect' };
+    // When unresolved entries (timeout / error / insufficient_precision)
+    // are also present, surface the first-seen unresolved reason so UI
+    // consumers can soften copy that would otherwise imply every
+    // non-computed factor was a harmless no_effect_within_bounds case.
+    // The base status stays 'partial_no_effect' so existing consumers
+    // continue to render the same broad UX; status_reason is purely
+    // additive metadata. Field is payload-only — never user-facing copy.
+    return {
+      status: 'partial_no_effect',
+      ...(unresolvedCount > 0 && firstUnresolvedReason
+        ? { status_reason: firstUnresolvedReason }
+        : {}),
+    };
   }
   if (computedCount > 0) {
     // Known scope choice (follow-up tracked separately): when a mix of

--- a/src/lib/flip-threshold-status.ts
+++ b/src/lib/flip-threshold-status.ts
@@ -1,0 +1,110 @@
+/**
+ * Flip Threshold Status Classifier
+ *
+ * Classifies the public, post-denormalised flip_thresholds[] array into a
+ * single high-level status that consumers can render honestly without
+ * re-deriving the picture from individual flip_reason strings.
+ *
+ * Rules — applied AFTER denormalisation, on the array placed in the v2/run
+ * response. Operates only on the public shape so the source of truth is the
+ * same data consumers see.
+ *
+ *   empty / null array                                  -> 'unavailable'
+ *   every entry has flip_value !== null                 -> 'computed'
+ *   no entry has flip_value, every entry is no_effect   -> 'all_no_effect'
+ *   no entry has flip_value, mix of no_effect/unresolved-> 'unresolved'
+ *   no entry has flip_value, every entry is unresolved  -> 'unresolved'
+ *   at least one computed AND at least one no_effect    -> 'partial_no_effect'
+ *   at least one computed, rest unresolved (no no_effect) -> 'computed'
+ *
+ * Crucially: timeout/error/insufficient_precision entries are never
+ * misclassified as 'all_no_effect' — they fall under 'unresolved'.
+ */
+
+import type { DenormalisedFlipThreshold } from './flip-threshold-denormaliser.js';
+
+export type FlipThresholdsStatus =
+  | 'computed'
+  | 'all_no_effect'
+  | 'partial_no_effect'
+  | 'unresolved'
+  | 'unavailable';
+
+export interface FlipThresholdsStatusResult {
+  status: FlipThresholdsStatus;
+  /** Populated for 'unresolved' — the first unresolved flip_reason seen. */
+  status_reason?: string;
+}
+
+const NO_EFFECT_REASON = 'no_effect_within_bounds';
+
+/**
+ * Reasons that mean "we did not produce a flip_value but it is not because the
+ * factor has no effect" — these signal the analysis itself was incomplete or
+ * imprecise, and must NOT be conflated with 'no_effect_within_bounds'.
+ */
+const UNRESOLVED_REASONS = new Set<string>([
+  'timeout',
+  'error',
+  'insufficient_precision',
+  'non_monotonic_grid',
+  'heuristic',
+  'zero_elasticity_fallback',
+  'single_option',
+]);
+
+type EntryKind = 'computed' | 'no_effect' | 'unresolved';
+
+function classifyEntry(entry: DenormalisedFlipThreshold): EntryKind {
+  if (entry.flip_value !== null && entry.flip_value !== undefined) {
+    return 'computed';
+  }
+  if (entry.flip_reason === NO_EFFECT_REASON) {
+    return 'no_effect';
+  }
+  if (UNRESOLVED_REASONS.has(entry.flip_reason)) {
+    return 'unresolved';
+  }
+  // Unknown reason with null flip_value — treat conservatively as unresolved
+  // rather than asserting no_effect, so future flip_reason additions don't
+  // silently get reported as "no factors changed the leading option".
+  return 'unresolved';
+}
+
+export function classifyFlipThresholdsStatus(
+  flipThresholds: DenormalisedFlipThreshold[] | null | undefined,
+): FlipThresholdsStatusResult {
+  if (!flipThresholds || flipThresholds.length === 0) {
+    return { status: 'unavailable' };
+  }
+
+  let computedCount = 0;
+  let noEffectCount = 0;
+  let unresolvedCount = 0;
+  let firstUnresolvedReason: string | undefined;
+
+  for (const entry of flipThresholds) {
+    const kind = classifyEntry(entry);
+    if (kind === 'computed') {
+      computedCount++;
+    } else if (kind === 'no_effect') {
+      noEffectCount++;
+    } else {
+      unresolvedCount++;
+      if (firstUnresolvedReason === undefined) {
+        firstUnresolvedReason = entry.flip_reason || 'unknown';
+      }
+    }
+  }
+
+  if (computedCount > 0 && noEffectCount > 0) {
+    return { status: 'partial_no_effect' };
+  }
+  if (computedCount > 0) {
+    return { status: 'computed' };
+  }
+  if (noEffectCount > 0 && unresolvedCount === 0) {
+    return { status: 'all_no_effect' };
+  }
+  return { status: 'unresolved', status_reason: firstUnresolvedReason };
+}

--- a/src/lib/flip-threshold-status.ts
+++ b/src/lib/flip-threshold-status.ts
@@ -101,6 +101,15 @@ export function classifyFlipThresholdsStatus(
     return { status: 'partial_no_effect' };
   }
   if (computedCount > 0) {
+    // Known scope choice (follow-up tracked separately): when a mix of
+    // computed and unresolved entries is present (no no_effect entries),
+    // we report 'computed' because at least one factor produced a flip
+    // value, and the UI treats the result as actionable. This silently
+    // absorbs the unresolved entries. A future revision may emit a
+    // dedicated 'partial_unresolved' status (or add an `unresolved_count`
+    // counter) so timeout / error / insufficient_precision entries are
+    // surfaced even when one factor has a flip value. Deliberately out
+    // of scope for the initial display-honesty workstream.
     return { status: 'computed' };
   }
   if (noEffectCount > 0 && unresolvedCount === 0) {

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -108,6 +108,7 @@ import {
 import { createISLInferenceFn, resolveFlipValues } from '../../analysis/flip-thresholds.js';
 import { computeFlipThresholdData } from '../../coaching/flip-thresholds.js';
 import { denormaliseFlipThresholds, type DenormalisedFlipThreshold } from '../../lib/flip-threshold-denormaliser.js';
+import { classifyFlipThresholdsStatus } from '../../lib/flip-threshold-status.js';
 import type { CeeReviewRequest, CeeTrace, FactorEnrichment } from '../../cee/types.js';
 // CIL Phase 1: Shared types from @talchain/schemas
 import type { SeedSourceType } from '@talchain/schemas';
@@ -2008,6 +2009,19 @@ function buildResponse(
     // Always emitted ([] when empty or absent) so consumers can distinguish
     // computed-empty from absent. Excluded from canonical hash.
     flip_thresholds: flipThresholds ?? [],
+
+    // Display-honesty: high-level classification of the post-denormalised
+    // flip_thresholds[] array. Always emitted alongside flip_thresholds so
+    // UI consumers can render the all-no-effect / partial / unresolved
+    // cases honestly without re-deriving from individual flip_reason strings.
+    // Excluded from canonical hash (display-only enrichment).
+    ...(() => {
+      const result = classifyFlipThresholdsStatus(flipThresholds);
+      return {
+        flip_thresholds_status: result.status,
+        ...(result.status_reason && { flip_thresholds_status_reason: result.status_reason }),
+      };
+    })(),
 
     // Threshold analysis (B10.3) — ISL native threshold endpoint
     // NOTE: Non-semantic post-analysis enrichment, excluded from response_hash.

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1006,8 +1006,11 @@ export interface RunResponseV3 {
    * `insufficient_precision`).
    *
    * Emitted in TWO cases:
-   *  - `flip_thresholds_status === 'unresolved'` — every entry was
-   *    unresolved (no computed flip and no no_effect_within_bounds).
+   *  - `flip_thresholds_status === 'unresolved'` — no computed flip and
+   *    at least one unresolved entry. `no_effect_within_bounds` entries
+   *    may also be present in this case (a pure mix of no_effect +
+   *    unresolved still classifies as `'unresolved'` because the
+   *    unresolved signal is the actionable one).
    *  - `flip_thresholds_status === 'partial_no_effect'` AND at least one
    *    unresolved entry is present alongside computed + no_effect ones.
    *    Lets UI consumers soften copy that would otherwise imply every

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1002,8 +1002,19 @@ export interface RunResponseV3 {
     | 'unavailable';
 
   /**
-   * First-seen `flip_reason` string when `flip_thresholds_status` is
-   * 'unresolved'. Payload-only debug metadata; never user-facing copy.
+   * First-seen unresolved `flip_reason` string (e.g. `timeout`, `error`,
+   * `insufficient_precision`).
+   *
+   * Emitted in TWO cases:
+   *  - `flip_thresholds_status === 'unresolved'` — every entry was
+   *    unresolved (no computed flip and no no_effect_within_bounds).
+   *  - `flip_thresholds_status === 'partial_no_effect'` AND at least one
+   *    unresolved entry is present alongside computed + no_effect ones.
+   *    Lets UI consumers soften copy that would otherwise imply every
+   *    non-computed factor was a harmless no_effect_within_bounds case.
+   *
+   * Payload-only debug metadata; never user-facing copy.
+   * @see classifyFlipThresholdsStatus in src/lib/flip-threshold-status.ts
    */
   flip_thresholds_status_reason?: string;
 

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -977,6 +977,36 @@ export interface RunResponseV3 {
    */
   flip_thresholds?: DenormalisedFlipThreshold[];
 
+  /**
+   * High-level classification of `flip_thresholds[]`, computed at the
+   * post-denormalised response-assembly boundary so consumers can render
+   * the all-no-effect / partial / unresolved cases honestly without
+   * re-deriving the picture from individual `flip_reason` strings.
+   *
+   * - 'computed'         : every entry has a flip_value (or only computed +
+   *                        unresolved entries — actionable insight present)
+   * - 'all_no_effect'    : every entry is no_effect_within_bounds
+   * - 'partial_no_effect': mix of computed and no_effect_within_bounds
+   * - 'unresolved'       : no entry has a flip_value, and at least one entry
+   *                        is timeout/error/insufficient_precision/etc.
+   * - 'unavailable'      : flip_thresholds[] empty or absent
+   *
+   * NOTE: Deterministic. Excluded from response_hash as non-semantic.
+   * @see classifyFlipThresholdsStatus in src/lib/flip-threshold-status.ts
+   */
+  flip_thresholds_status?:
+    | 'computed'
+    | 'all_no_effect'
+    | 'partial_no_effect'
+    | 'unresolved'
+    | 'unavailable';
+
+  /**
+   * First-seen `flip_reason` string when `flip_thresholds_status` is
+   * 'unresolved'. Payload-only debug metadata; never user-facing copy.
+   */
+  flip_thresholds_status_reason?: string;
+
   // ---------------------------------------------------------------------------
   // Threshold Analysis Fields (B10.3)
   // Only present when include_thresholds is true in request

--- a/tests/lib/flip-threshold-status.test.ts
+++ b/tests/lib/flip-threshold-status.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Flip Threshold Status Classifier Tests
+ *
+ * Display-honesty workstream: classifies the public, post-denormalised
+ * flip_thresholds[] array so UI consumers can render the all-no-effect /
+ * partial / unresolved cases honestly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyFlipThresholdsStatus,
+} from '../../src/lib/flip-threshold-status.js';
+import type { DenormalisedFlipThreshold } from '../../src/lib/flip-threshold-denormaliser.js';
+
+function makeEntry(overrides: Partial<DenormalisedFlipThreshold> = {}): DenormalisedFlipThreshold {
+  return {
+    factor_id: 'f1',
+    factor_label: 'Factor One',
+    current_value: 0.5,
+    flip_value: 0.3,
+    direction: 'decrease',
+    flip_reason: 'found',
+    iterations_used: 4,
+    alternative_winner_id: 'opt-b',
+    alternative_winner_label: 'Option Beta',
+    unit: 'GBP',
+    ...overrides,
+  };
+}
+
+describe('classifyFlipThresholdsStatus()', () => {
+  describe('unavailable', () => {
+    it('returns unavailable for empty array', () => {
+      expect(classifyFlipThresholdsStatus([])).toEqual({ status: 'unavailable' });
+    });
+
+    it('returns unavailable for null', () => {
+      expect(classifyFlipThresholdsStatus(null)).toEqual({ status: 'unavailable' });
+    });
+
+    it('returns unavailable for undefined', () => {
+      expect(classifyFlipThresholdsStatus(undefined)).toEqual({ status: 'unavailable' });
+    });
+  });
+
+  describe('all_no_effect', () => {
+    it('returns all_no_effect when every entry is no_effect_within_bounds', () => {
+      const entries = [
+        makeEntry({ flip_value: null, flip_reason: 'no_effect_within_bounds' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'no_effect_within_bounds' }),
+        makeEntry({ factor_id: 'f3', flip_value: null, flip_reason: 'no_effect_within_bounds' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'all_no_effect' });
+    });
+
+    it('returns all_no_effect for a single no_effect entry', () => {
+      const entries = [makeEntry({ flip_value: null, flip_reason: 'no_effect_within_bounds' })];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'all_no_effect' });
+    });
+  });
+
+  describe('computed', () => {
+    it('returns computed when every entry has a flip_value', () => {
+      const entries = [
+        makeEntry({ flip_value: 0.3, flip_reason: 'found' }),
+        makeEntry({ factor_id: 'f2', flip_value: 0.7, flip_reason: 'found' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'computed' });
+    });
+
+    it('returns computed when actionable data exists alongside unresolved entries (unresolved silently absorbed)', () => {
+      const entries = [
+        makeEntry({ flip_value: 0.3, flip_reason: 'found' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'timeout' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'computed' });
+    });
+  });
+
+  describe('partial_no_effect', () => {
+    it('returns partial_no_effect when at least one entry is computed and one is no_effect', () => {
+      const entries = [
+        makeEntry({ flip_value: 0.3, flip_reason: 'found' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'no_effect_within_bounds' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'partial_no_effect' });
+    });
+
+    it('still returns partial_no_effect when unresolved entries are mixed in alongside computed and no_effect', () => {
+      const entries = [
+        makeEntry({ flip_value: 0.3, flip_reason: 'found' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'no_effect_within_bounds' }),
+        makeEntry({ factor_id: 'f3', flip_value: null, flip_reason: 'timeout' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'partial_no_effect' });
+    });
+  });
+
+  describe('unresolved (must NOT be misclassified as no_effect)', () => {
+    it('returns unresolved with reason for an all-timeout array', () => {
+      const entries = [
+        makeEntry({ flip_value: null, flip_reason: 'timeout' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'timeout' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({
+        status: 'unresolved',
+        status_reason: 'timeout',
+      });
+    });
+
+    it('returns unresolved with reason for an all-error array', () => {
+      const entries = [makeEntry({ flip_value: null, flip_reason: 'error' })];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({
+        status: 'unresolved',
+        status_reason: 'error',
+      });
+    });
+
+    it('returns unresolved with reason for an all-insufficient_precision array', () => {
+      const entries = [makeEntry({ flip_value: null, flip_reason: 'insufficient_precision' })];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({
+        status: 'unresolved',
+        status_reason: 'insufficient_precision',
+      });
+    });
+
+    it('returns unresolved when no_effect mixes with unresolved and there is no computed entry', () => {
+      const entries = [
+        makeEntry({ flip_value: null, flip_reason: 'no_effect_within_bounds' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'timeout' }),
+      ];
+      const result = classifyFlipThresholdsStatus(entries);
+      expect(result.status).toBe('unresolved');
+      expect(result.status_reason).toBe('timeout');
+    });
+
+    it('records the FIRST unresolved reason seen when several entries are unresolved', () => {
+      const entries = [
+        makeEntry({ flip_value: null, flip_reason: 'insufficient_precision' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'timeout' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({
+        status: 'unresolved',
+        status_reason: 'insufficient_precision',
+      });
+    });
+
+    it('treats an unknown reason with null flip_value as unresolved (conservative — never silently no_effect)', () => {
+      const entries = [
+        makeEntry({ flip_value: null, flip_reason: 'something_new_in_a_future_isl_version' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({
+        status: 'unresolved',
+        status_reason: 'something_new_in_a_future_isl_version',
+      });
+    });
+  });
+});

--- a/tests/lib/flip-threshold-status.test.ts
+++ b/tests/lib/flip-threshold-status.test.ts
@@ -86,13 +86,37 @@ describe('classifyFlipThresholdsStatus()', () => {
       expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'partial_no_effect' });
     });
 
-    it('still returns partial_no_effect when unresolved entries are mixed in alongside computed and no_effect', () => {
+    it('still returns partial_no_effect when unresolved entries are mixed in alongside computed and no_effect — and surfaces first unresolved reason so UI can soften copy', () => {
       const entries = [
         makeEntry({ flip_value: 0.3, flip_reason: 'found' }),
         makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'no_effect_within_bounds' }),
         makeEntry({ factor_id: 'f3', flip_value: null, flip_reason: 'timeout' }),
       ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({
+        status: 'partial_no_effect',
+        status_reason: 'timeout',
+      });
+    });
+
+    it('omits status_reason on partial_no_effect when there are no unresolved entries (pure computed + no_effect mix)', () => {
+      const entries = [
+        makeEntry({ flip_value: 0.3, flip_reason: 'found' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'no_effect_within_bounds' }),
+      ];
       expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'partial_no_effect' });
+    });
+
+    it('records the FIRST unresolved reason on partial_no_effect when several unresolved kinds are present', () => {
+      const entries = [
+        makeEntry({ flip_value: 0.3, flip_reason: 'found' }),
+        makeEntry({ factor_id: 'f2', flip_value: null, flip_reason: 'no_effect_within_bounds' }),
+        makeEntry({ factor_id: 'f3', flip_value: null, flip_reason: 'insufficient_precision' }),
+        makeEntry({ factor_id: 'f4', flip_value: null, flip_reason: 'timeout' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({
+        status: 'partial_no_effect',
+        status_reason: 'insufficient_precision',
+      });
     });
   });
 

--- a/tests/lib/flip-threshold-status.test.ts
+++ b/tests/lib/flip-threshold-status.test.ts
@@ -75,6 +75,17 @@ describe('classifyFlipThresholdsStatus()', () => {
       ];
       expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'computed' });
     });
+
+    it('treats flip_value === 0 as a valid computed flip (must not be silently demoted via truthiness)', () => {
+      // Guards against a future regression that changes the null-check to
+      // a truthiness check (`if (entry.flip_value)`), which would treat a
+      // legitimate zero-valued flip threshold (e.g. a factor whose flip
+      // point lands at zero cost) as unresolved.
+      const entries = [
+        makeEntry({ flip_value: 0, flip_reason: 'found' }),
+      ];
+      expect(classifyFlipThresholdsStatus(entries)).toEqual({ status: 'computed' });
+    });
   });
 
   describe('partial_no_effect', () => {


### PR DESCRIPTION
## Summary

Display-honesty workstream — PLoT side. Adds a high-level status classification of the post-denormalised `flip_thresholds[]` array so UI consumers can render the all-no-effect / partial / unresolved cases honestly without re-deriving the picture from individual `flip_reason` strings.

Classification happens at the response-assembly boundary on the public denormalised array (the same data consumers see). Crucially, `timeout` / `error` / `insufficient_precision` entries are never misclassified as `'all_no_effect'` — they fall under `'unresolved'`.

### New response fields

| Field | Type | When |
|---|---|---|
| `flip_thresholds_status` | `'computed' \| 'all_no_effect' \| 'partial_no_effect' \| 'unresolved' \| 'unavailable'` | Always emitted alongside `flip_thresholds[]` |
| `flip_thresholds_status_reason` | `string` | Only when `status === 'unresolved'`; carries first-seen unresolved `flip_reason` (payload-only debug, never user-facing copy) |

Both fields are optional, additive, and **excluded from `response_hash`** (which hashes request inputs, not the response shape). Raw entries on `flip_thresholds[]` are unchanged.

### Classification rules

```
empty / null array                                   -> 'unavailable'
every entry has flip_value !== null                  -> 'computed'
no entry has flip_value, every entry is no_effect    -> 'all_no_effect'
no entry has flip_value, mix of no_effect/unresolved -> 'unresolved'
no entry has flip_value, every entry is unresolved   -> 'unresolved'
at least one computed AND at least one no_effect     -> 'partial_no_effect'
at least one computed, rest unresolved (no no_effect) -> 'computed'
unknown reason with null flip_value                  -> 'unresolved' (conservative; never silently 'no_effect')
```

## Files changed (5 files, +60 / -0 production code; +268 test code)

- `src/lib/flip-threshold-status.ts` — new pure classifier
- `src/types/engine-v3.ts` — `RunResponseV3` fields + JSDoc
- `src/routes/v2/run.ts` — wire status into v2/run response (additive spread next to `flip_thresholds:`)
- `contracts/openapi.yaml` — schema documentation
- `tests/lib/flip-threshold-status.test.ts` — 15 cases including every `flip_reason` variant and the must-not-misclassify-unresolved guarantees

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/lib/flip-threshold-status.test.ts` — 15/15 pass
- [x] `npx vitest run --changed --bail=1` — 1315/1315 pass
- [x] `bash scripts/pre-push-validate.sh` — 6/6 PASS, 4703 tests pass
- [ ] CI staging-full-tests — pending

## Risk / regression check

- Wiring is purely additive: an `import` and a spread expression alongside the unchanged `flip_thresholds: flipThresholds ?? []` line.
- `response_hash` is computed from request inputs (`hashRequest(body, filteredGraph, plotSeedUsed, ...)` at run.ts:3398), not from the response object — so the new fields cannot perturb the hash.
- B3 `auto_noise_provenance`, `evidence_gaps`, `factor_sensitivity`, `option_comparison.win_probability`, and `flip_thresholds[]` raw entries are all untouched and covered by the existing 4703-test gate.
- No prompt edits, no CEE changes, no ISL changes, no package/lockfile churn.

## Display-honesty workstream context

DGAI consumes `flip_thresholds_status` in companion PR `claude-ui/display-honesty` (item B), where `'all_no_effect'` renders one soft explanatory block instead of repetitive cards. PLoT side here is the single source of truth so the field's semantics aren't duplicated in each UI consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)