### PR TITLE
fix(plot): honour user-supplied observed_state.std (no silent widening)

### DIFF
--- a/docs/Olumi_Decision_Model_Schema_v2_6.md
+++ b/docs/Olumi_Decision_Model_Schema_v2_6.md
@@ -90,7 +90,7 @@ type NodeKind =
 
 interface ObservedState {
   value: number;                           // Current observed value (required)
-  std?: number;                            // Uncertainty in observed value (PoC: not consumed)
+  std?: number;                            // Uncertainty in observed value — propagated to ISL parameter_uncertainties (V3+); see §D.5
   baseline?: number;                       // Reference value for comparison
   unit?: string;                           // Display unit ('£', '%', 'users')
   source?: string;                         // Data provenance (free text, e.g., "Q3 Analytics Report")
@@ -736,7 +736,7 @@ const std = Math.max(0.001, cv * Math.abs(strength_mean));
 
 ## D.5 Factor Sensitivity (PoC)
 
-**PoC Mechanism:** Factor sensitivity is derived from **edge uncertainty** parameters (`strength.std`, `exists_probability`), not node-level parameter uncertainties. This is an edge-uncertainty-driven proxy — true factor/parameter uncertainty analysis requires explicit `parameter_uncertainties` input (post-PoC scope).
+**PoC Mechanism:** Factor sensitivity is derived from **edge uncertainty** parameters (`strength.std`, `exists_probability`) **and**, when supplied, node-level `observed_state.std`. The V3 translator (`buildParameterUncertaintiesV3`) propagates user-supplied `observed_state.std` into ISL `parameter_uncertainties`, so explicit node-level uncertainty now feeds sensitivity / EVPI / robustness. See "Node-level uncertainty" below for the propagation rules.
 
 | Condition | `drivers_status` | UI Treatment |
 |-----------|------------------|--------------|
@@ -746,7 +746,7 @@ const std = Math.max(0.001, cv * Math.abs(strength_mean));
 
 **Note:** `skipped` is not a computation failure — it indicates the preconditions for factor sensitivity were not met. Values of zero are valid when computed; do not treat zeros as failures.
 
-**Node-level uncertainty:** `observed_state.std`, if present, is **not consumed** by inference or sensitivity in PoC. Uncertainty modelling is edge-level only. Future use of node-level uncertainty must apply normalisation consistently.
+**Node-level uncertainty:** `observed_state.std`, when finite and positive, **is consumed**: it is propagated into ISL `parameter_uncertainties[].std` by the V3 translator and the V2 preflight builder, clamped to `[1e-4, 2.0]` for numerical safety. Synthesised defaults (binary / value-based / fallback) are floored at `0.1`, but user-supplied values are honoured below that floor — small user stds (e.g. `0.001`) reach ISL unchanged and tighten sensitivity / EVPI / robustness estimates accordingly. Zero, negative, and non-finite `observed_state.std` are treated as missing.
 
 ---
 
@@ -853,6 +853,7 @@ const STRUCTURAL_INVARIANTS = [
 | v2.4 | 15 Jan 2026 | Added Option ID consistency invariant, `OPTION_ID_MISMATCH` critique code, ISL/PLoT enrichment architecture note, and D.5 Factor Sensitivity (PoC) clarification |
 | v2.5 | 15 Jan 2026 | Clarified D.5: factor sensitivity is edge-uncertainty-driven proxy (not node-level parameter uncertainty); zeros are valid computed values |
 | **v2.6** | **15 Jan 2026** | Added `observed_state.std` to schema (PoC: not consumed); clarified node-level uncertainty is not used in PoC inference/sensitivity |
+| **v2.6.1** | **17 May 2026** | `observed_state.std` is now consumed: V3 translator and V2 preflight propagate it into ISL `parameter_uncertainties` (clamped to `[1e-4, 2.0]`); synthesised defaults still floored at `0.1`. Supersedes the v2.6 "not consumed" statement in §D.5 and the `ObservedState` interface comment. |
 
 ---
 

--- a/src/integrations/isl/constraint-pu-injection.ts
+++ b/src/integrations/isl/constraint-pu-injection.ts
@@ -18,8 +18,14 @@ import type { GoalConstraint, EngineNodeV3 } from '../../types/engine-v3.js';
  * Pins constrained node to its observed value for constraint evaluation.
  * Not modelling real uncertainty — prevents ISL base=0.0 default.
  *
- * Distinct from translator std floors (≥0.1 for factors, ≥0.01 for
- * external priors) which represent genuine inference uncertainty.
+ * Distinct from the translator's user-uncertainty and default paths:
+ *   - User-supplied `observed_state.std` is clamped to [MIN_USER_STD, MAX_USER_STD]
+ *     (see `parameter-uncertainty-bounds.ts`).
+ *   - Synthesised defaults (binary / value-based / fallback) are floored at
+ *     DEFAULT_STD_FLOOR.
+ *   - External priors are floored at 0.01.
+ * This constant only applies to constrained nodes that arrive at the injection
+ * step without an existing PU entry.
  */
 export const CONSTRAINT_PINNED_STD = 0.001;
 

--- a/src/integrations/isl/parameter-uncertainty-bounds.ts
+++ b/src/integrations/isl/parameter-uncertainty-bounds.ts
@@ -38,3 +38,26 @@ export const VALUE_BASED_STD_FRACTION = 0.15;
 
 /** Fallback std when no user value, not binary, and value is exactly 0. */
 export const FALLBACK_STD = 0.5;
+
+/**
+ * Returns the resolved user-supplied std, or `null` if `observedStd` is not a
+ * meaningful user value (missing, zero, negative, NaN, Infinity, non-numeric).
+ *
+ * Finite positive values are clamped to `[MIN_USER_STD, MAX_USER_STD]`:
+ *   - `0 < std < MIN_USER_STD` → `MIN_USER_STD`
+ *   - `std > MAX_USER_STD`     → `MAX_USER_STD`
+ *   - otherwise                → `std` unchanged
+ *
+ * Callers must fall back to synthesised defaults (DEFAULT_STD_FLOOR /
+ * BINARY_DEFAULT_STD / VALUE_BASED_STD_FRACTION / FALLBACK_STD) when this
+ * returns `null`. Centralising the rule here keeps `translator-v3.ts` and
+ * `preflight.ts` from drifting.
+ */
+export function resolveUserSuppliedStd(observedStd: unknown): number | null {
+  if (typeof observedStd !== 'number') return null;
+  if (!Number.isFinite(observedStd)) return null;
+  if (observedStd <= 0) return null;
+  if (observedStd < MIN_USER_STD) return MIN_USER_STD;
+  if (observedStd > MAX_USER_STD) return MAX_USER_STD;
+  return observedStd;
+}

--- a/src/integrations/isl/parameter-uncertainty-bounds.ts
+++ b/src/integrations/isl/parameter-uncertainty-bounds.ts
@@ -1,0 +1,40 @@
+/**
+ * Bounds and defaults for `parameter_uncertainties[].std` emitted to ISL.
+ *
+ * Shared by the V3 translator (`buildParameterUncertaintiesV3`) and the
+ * V1/V2 preflight builder (`buildParameterUncertainties`) so the two paths
+ * stay in lockstep.
+ *
+ * Priority order (both paths):
+ *   1. User-supplied `observed_state.std` (clamped to [MIN_USER_STD, MAX_USER_STD]).
+ *   2. Binary-factor default (BINARY_DEFAULT_STD).
+ *   3. Value-based default for non-zero continuous factors
+ *      (|value| × VALUE_BASED_STD_FRACTION, floored at DEFAULT_STD_FLOOR).
+ *   4. Fallback for zero-valued continuous factors (FALLBACK_STD).
+ *
+ * The DEFAULT_STD_FLOOR applies ONLY to synthesised defaults (priorities
+ * 2–4). User-supplied values are honoured down to MIN_USER_STD; the floor
+ * never silently widens what the user told us.
+ *
+ * Distinct from CONSTRAINT_PINNED_STD in `constraint-pu-injection.ts`,
+ * which is a constraint-evaluation safety net for nodes that arrive at the
+ * injection step without a PU entry.
+ */
+
+/** Hard lower bound for user-supplied std. Prevents literal-zero degeneracy in ISL Monte Carlo. */
+export const MIN_USER_STD = 1e-4;
+
+/** Hard upper cap for user-supplied std. Prevents extreme values from destabilising ISL. */
+export const MAX_USER_STD = 2.0;
+
+/** Floor applied to synthesised default std (priorities 2–4). Ensures meaningful sensitivity. */
+export const DEFAULT_STD_FLOOR = 0.1;
+
+/** Default std for binary factors (range [0, 1] or labelled yes/no). */
+export const BINARY_DEFAULT_STD = 0.3;
+
+/** Fraction of |value| used as the synthesised default for non-zero continuous factors. */
+export const VALUE_BASED_STD_FRACTION = 0.15;
+
+/** Fallback std when no user value, not binary, and value is exactly 0. */
+export const FALLBACK_STD = 0.5;

--- a/src/integrations/isl/preflight.ts
+++ b/src/integrations/isl/preflight.ts
@@ -11,12 +11,11 @@ import type { ISLPreflightResult } from './types/plot-types.js';
 import type { ISLParameterUncertainty } from './types/isl-types.js';
 import { DEFAULT_EXISTS_PROBABILITY } from '../../constants/limits.js';
 import {
-  MIN_USER_STD,
-  MAX_USER_STD,
   DEFAULT_STD_FLOOR,
   BINARY_DEFAULT_STD,
   VALUE_BASED_STD_FRACTION,
   FALLBACK_STD,
+  resolveUserSuppliedStd,
 } from './parameter-uncertainty-bounds.js';
 
 /**
@@ -87,15 +86,14 @@ export function buildParameterUncertainties(graph: Graph): ISLParameterUncertain
   for (const node of graph.nodes) {
     if (isFactorWithValue(node)) {
       const value = node.observed_state!.value;
-      const observedStd = node.observed_state!.std;
-      const hasUserStd =
-        observedStd !== undefined && Number.isFinite(observedStd) && observedStd > 0;
+      const userStd = resolveUserSuppliedStd(node.observed_state!.std);
 
       let std: number;
 
-      if (hasUserStd) {
-        // Priority 1: honour user-supplied std, clamped to safe numerical bounds.
-        std = Math.min(Math.max(observedStd as number, MIN_USER_STD), MAX_USER_STD);
+      if (userStd !== null) {
+        // Priority 1: honour user-supplied std (already clamped to
+        // [MIN_USER_STD, MAX_USER_STD] by the shared helper).
+        std = userStd;
       } else {
         // Priorities 2–4: synthesised defaults, with DEFAULT_STD_FLOOR applied.
         const isBinary = isBinaryFactorNode(node);

--- a/src/integrations/isl/preflight.ts
+++ b/src/integrations/isl/preflight.ts
@@ -10,6 +10,14 @@ import type { Graph, GraphEdge, GraphNode } from '../../trust/types.js';
 import type { ISLPreflightResult } from './types/plot-types.js';
 import type { ISLParameterUncertainty } from './types/isl-types.js';
 import { DEFAULT_EXISTS_PROBABILITY } from '../../constants/limits.js';
+import {
+  MIN_USER_STD,
+  MAX_USER_STD,
+  DEFAULT_STD_FLOOR,
+  BINARY_DEFAULT_STD,
+  VALUE_BASED_STD_FRACTION,
+  FALLBACK_STD,
+} from './parameter-uncertainty-bounds.js';
 
 /**
  * Check if an edge has uncertainty data for sensitivity analysis
@@ -57,18 +65,21 @@ function isFactorWithValue(node: GraphNode): boolean {
 }
 
 /**
- * Build parameter uncertainties from graph factor nodes
+ * Build parameter uncertainties from graph factor nodes.
  *
- * Creates uncertainty specifications for factor nodes that have observed_state.
- * This enables ISL to compute factor_sensitivity scores.
+ * Mirrors `buildParameterUncertaintiesV3` in translator-v3.ts. Shared bounds
+ * and defaults live in `./parameter-uncertainty-bounds.ts`.
  *
  * Standard deviation calculation priority:
- * 1. Use observed_state.std if present and > 0
- * 2. For binary factors (0/1 range): use 0.3
- * 3. Use 15% of |observed_state.value| if value != 0
- * 4. Fallback: 0.5
+ * 1. Finite positive `observed_state.std` → clamped to [MIN_USER_STD, MAX_USER_STD].
+ *    User value is honoured down to MIN_USER_STD; the default floor does NOT apply.
+ * 2. Binary factors → BINARY_DEFAULT_STD.
+ * 3. Non-zero continuous factors → |value| × VALUE_BASED_STD_FRACTION.
+ * 4. Zero-valued continuous factors → FALLBACK_STD.
  *
- * All std values have a floor of 0.1 to ensure meaningful sensitivity.
+ * DEFAULT_STD_FLOOR is applied ONLY to priorities 2–4. Small user-supplied
+ * values (e.g. 0.001) propagate to ISL as-is — fixed: previously the floor
+ * silently widened them.
  */
 export function buildParameterUncertainties(graph: Graph): ISLParameterUncertainty[] {
   const uncertainties: ISLParameterUncertainty[] = [];
@@ -77,35 +88,26 @@ export function buildParameterUncertainties(graph: Graph): ISLParameterUncertain
     if (isFactorWithValue(node)) {
       const value = node.observed_state!.value;
       const observedStd = node.observed_state!.std;
-
-      // Detect binary factors using strong signals only
-      const isBinary = isBinaryFactorNode(node);
+      const hasUserStd =
+        observedStd !== undefined && Number.isFinite(observedStd) && observedStd > 0;
 
       let std: number;
 
-      // Priority 1: Use observed_state.std if present and meaningful
-      // Cap at 2.0 to prevent extreme values from destabilizing ISL
-      if (observedStd !== undefined && observedStd > 0) {
-        std = Math.min(observedStd, 2.0);
-        if (observedStd > 2.0) {
-          console.warn(`[PARAMETER_UNCERTAINTY] node_id=${node.id} observed_state.std=${observedStd} capped to 2.0`);
+      if (hasUserStd) {
+        // Priority 1: honour user-supplied std, clamped to safe numerical bounds.
+        std = Math.min(Math.max(observedStd as number, MIN_USER_STD), MAX_USER_STD);
+      } else {
+        // Priorities 2–4: synthesised defaults, with DEFAULT_STD_FLOOR applied.
+        const isBinary = isBinaryFactorNode(node);
+        if (isBinary) {
+          std = BINARY_DEFAULT_STD;
+        } else if (value !== 0) {
+          std = Math.abs(value) * VALUE_BASED_STD_FRACTION;
+        } else {
+          std = FALLBACK_STD;
         }
+        std = Math.max(DEFAULT_STD_FLOOR, std);
       }
-      // Priority 2: Binary factors get std = 0.3
-      else if (isBinary) {
-        std = 0.3;
-      }
-      // Priority 3: 15% of absolute value for non-zero values
-      else if (value !== 0) {
-        std = Math.abs(value) * 0.15;
-      }
-      // Priority 4: Fallback for zero-valued continuous factors
-      else {
-        std = 0.5;
-      }
-
-      // Floor at 0.1 to ensure meaningful sensitivity
-      std = Math.max(0.1, std);
 
       uncertainties.push({
         node_id: node.id,

--- a/src/integrations/isl/translator-v3.ts
+++ b/src/integrations/isl/translator-v3.ts
@@ -16,12 +16,11 @@ import type {
   GoalConstraint,
 } from '../../types/engine-v3.js';
 import {
-  MIN_USER_STD,
-  MAX_USER_STD,
   DEFAULT_STD_FLOOR,
   BINARY_DEFAULT_STD,
   VALUE_BASED_STD_FRACTION,
   FALLBACK_STD,
+  resolveUserSuppliedStd,
 } from './parameter-uncertainty-bounds.js';
 
 // -----------------------------------------------------------------------------
@@ -241,17 +240,15 @@ export function buildParameterUncertaintiesV3(
   for (const node of nodes) {
     if (node.kind === 'factor' && node.observed_state?.value !== undefined && Number.isFinite(node.observed_state.value)) {
       const value = node.observed_state.value;
-      const observedStd = node.observed_state.std;
-      const hasUserStd = observedStd !== undefined && Number.isFinite(observedStd) && observedStd > 0;
+      const userStd = resolveUserSuppliedStd(node.observed_state.std);
 
       let std: number;
 
-      if (hasUserStd) {
-        // Priority 1: Honour user-supplied std, clamped to safe numerical bounds.
-        // The DEFAULT_STD_FLOOR is intentionally NOT applied here — small user
-        // values (e.g. 0.001) must propagate to ISL as-is so sensitivity / EVPI /
-        // robustness reflect what the user actually told us.
-        std = Math.min(Math.max(observedStd as number, MIN_USER_STD), MAX_USER_STD);
+      if (userStd !== null) {
+        // Priority 1: honour user-supplied std (already clamped to
+        // [MIN_USER_STD, MAX_USER_STD]). DEFAULT_STD_FLOOR intentionally does
+        // not apply — small user values must reach ISL as-is.
+        std = userStd;
       } else {
         // Priorities 2–4: synthesised defaults, with DEFAULT_STD_FLOOR applied.
         const isBinary = isBinaryFactor(node);

--- a/src/integrations/isl/translator-v3.ts
+++ b/src/integrations/isl/translator-v3.ts
@@ -15,6 +15,14 @@ import type {
   InterventionValueV3,
   GoalConstraint,
 } from '../../types/engine-v3.js';
+import {
+  MIN_USER_STD,
+  MAX_USER_STD,
+  DEFAULT_STD_FLOOR,
+  BINARY_DEFAULT_STD,
+  VALUE_BASED_STD_FRACTION,
+  FALLBACK_STD,
+} from './parameter-uncertainty-bounds.js';
 
 // -----------------------------------------------------------------------------
 // ISL Wire Format Types
@@ -208,12 +216,19 @@ export function toISLOption(option: OptionV3): ISLOptionV3 {
  * specification for ISL. This enables ISL to compute factor_sensitivity scores.
  *
  * Standard deviation calculation priority:
- * 1. Use observed_state.std if present and > 0
- * 2. For binary factors (0/1 range): use 0.3
- * 3. Use 15% of |observed_state.value| if value != 0
- * 4. Fallback: 0.5
+ * 1. Finite positive `observed_state.std` → clamped to [MIN_USER_STD, MAX_USER_STD].
+ *    The user value is honoured down to MIN_USER_STD; the default floor below
+ *    does NOT apply.
+ * 2. Binary factors (0/1 range or labelled yes/no) → BINARY_DEFAULT_STD.
+ * 3. Non-zero continuous factors → |value| × VALUE_BASED_STD_FRACTION.
+ * 4. Zero-valued continuous factors → FALLBACK_STD.
  *
- * All std values have a floor of 0.1 to ensure meaningful sensitivity.
+ * The DEFAULT_STD_FLOOR is applied ONLY to priorities 2–4 (synthesised defaults),
+ * never to user-supplied values. This is the fix for the silent-widening bug
+ * where `observed_state.std = 0.001` was being floored to 0.1.
+ *
+ * Non-finite, zero, and negative `observed_state.std` are treated as missing
+ * and fall through to default synthesis.
  *
  * @param nodes Graph nodes
  * @returns Parameter uncertainties for ISL
@@ -227,36 +242,28 @@ export function buildParameterUncertaintiesV3(
     if (node.kind === 'factor' && node.observed_state?.value !== undefined && Number.isFinite(node.observed_state.value)) {
       const value = node.observed_state.value;
       const observedStd = node.observed_state.std;
-      const range = node.state_space?.range;
-
-      // Detect binary factors using strong signals only
-      const isBinary = isBinaryFactor(node);
+      const hasUserStd = observedStd !== undefined && Number.isFinite(observedStd) && observedStd > 0;
 
       let std: number;
 
-      // Priority 1: Use observed_state.std if present and meaningful
-      // Cap at 2.0 to prevent extreme values from destabilizing ISL
-      if (observedStd !== undefined && observedStd > 0) {
-        std = Math.min(observedStd, 2.0);
-        if (observedStd > 2.0) {
-          console.warn(`[PARAMETER_UNCERTAINTY] node_id=${node.id} observed_state.std=${observedStd} capped to 2.0`);
+      if (hasUserStd) {
+        // Priority 1: Honour user-supplied std, clamped to safe numerical bounds.
+        // The DEFAULT_STD_FLOOR is intentionally NOT applied here — small user
+        // values (e.g. 0.001) must propagate to ISL as-is so sensitivity / EVPI /
+        // robustness reflect what the user actually told us.
+        std = Math.min(Math.max(observedStd as number, MIN_USER_STD), MAX_USER_STD);
+      } else {
+        // Priorities 2–4: synthesised defaults, with DEFAULT_STD_FLOOR applied.
+        const isBinary = isBinaryFactor(node);
+        if (isBinary) {
+          std = BINARY_DEFAULT_STD;
+        } else if (value !== 0) {
+          std = Math.abs(value) * VALUE_BASED_STD_FRACTION;
+        } else {
+          std = FALLBACK_STD;
         }
+        std = Math.max(DEFAULT_STD_FLOOR, std);
       }
-      // Priority 2: Binary factors get std = 0.3
-      else if (isBinary) {
-        std = 0.3;
-      }
-      // Priority 3: 15% of absolute value for non-zero values
-      else if (value !== 0) {
-        std = Math.abs(value) * 0.15;
-      }
-      // Priority 4: Fallback for zero-valued continuous factors
-      else {
-        std = 0.5;
-      }
-
-      // Floor at 0.1 to ensure meaningful sensitivity
-      std = Math.max(0.1, std);
 
       uncertainties.push({
         node_id: node.id,

--- a/src/routes/v1/run.ts
+++ b/src/routes/v1/run.ts
@@ -152,16 +152,18 @@ function transformSensitivityToEnrichment(
  * Extract parameter uncertainties from graph factor nodes.
  *
  * NOTE: this helper is currently **dead code**. The result is assigned to a
- * local `parameterUncertainties` in the `/v1/run` handler but is not passed
- * into `islService.analyseRobustness(...)`; the ISL service builds its own
- * `parameter_uncertainties` via the shared V3 translator
- * (`buildParameterUncertaintiesV3`) and V2 preflight builder
- * (`buildParameterUncertainties`) — both of which honour user-supplied
- * `observed_state.std`. Active V1 outbound behaviour is therefore governed
- * by the shared preflight/translator path, not by this helper.
+ * local `parameterUncertainties` in the `/v1/run` handler but is never passed
+ * into `islService.analyseRobustness(...)`. Active V1 outbound
+ * `parameter_uncertainties` is built inside `islService.analyseRobustness`
+ * (see `src/integrations/isl/index.ts`) via the preflight builder
+ * `buildParameterUncertainties`, which honours user-supplied
+ * `observed_state.std`. (The V3 translator `buildParameterUncertaintiesV3`
+ * services a separate path — direct ISL request construction by V2 — and
+ * uses the same shared bounds module, so behaviour is identical across
+ * paths.)
  *
  * Kept for now to avoid widening this PR's scope. Slated for removal (or
- * replacement with a call to the shared builders) in a follow-up cleanup.
+ * replacement with a call to `buildParameterUncertainties`) in a follow-up.
  */
 function extractParameterUncertainties(graph: { nodes: any[]; edges: any[] }): ISLParameterUncertainty[] {
   return graph.nodes

--- a/src/routes/v1/run.ts
+++ b/src/routes/v1/run.ts
@@ -149,16 +149,19 @@ function transformSensitivityToEnrichment(
 }
 
 /**
- * Extract parameter uncertainties from graph factor nodes
- * Used for ISL /robustness/analyze/v2 factor sensitivity call
+ * Extract parameter uncertainties from graph factor nodes.
  *
- * NOTE: This V1 path is frozen and does NOT honour user-supplied
- * `observed_state.std`. It always synthesises std from the value magnitude.
- * User-uncertainty propagation is implemented only in the V3 translator
- * (`buildParameterUncertaintiesV3`) and the V2 preflight builder
- * (`buildParameterUncertainties`). If V1 still receives production traffic
- * and needs to honour user uncertainty, migrate callers to V3 or port the
- * priority logic from `src/integrations/isl/translator-v3.ts`.
+ * NOTE: this helper is currently **dead code**. The result is assigned to a
+ * local `parameterUncertainties` in the `/v1/run` handler but is not passed
+ * into `islService.analyseRobustness(...)`; the ISL service builds its own
+ * `parameter_uncertainties` via the shared V3 translator
+ * (`buildParameterUncertaintiesV3`) and V2 preflight builder
+ * (`buildParameterUncertainties`) — both of which honour user-supplied
+ * `observed_state.std`. Active V1 outbound behaviour is therefore governed
+ * by the shared preflight/translator path, not by this helper.
+ *
+ * Kept for now to avoid widening this PR's scope. Slated for removal (or
+ * replacement with a call to the shared builders) in a follow-up cleanup.
  */
 function extractParameterUncertainties(graph: { nodes: any[]; edges: any[] }): ISLParameterUncertainty[] {
   return graph.nodes

--- a/src/routes/v1/run.ts
+++ b/src/routes/v1/run.ts
@@ -151,6 +151,14 @@ function transformSensitivityToEnrichment(
 /**
  * Extract parameter uncertainties from graph factor nodes
  * Used for ISL /robustness/analyze/v2 factor sensitivity call
+ *
+ * NOTE: This V1 path is frozen and does NOT honour user-supplied
+ * `observed_state.std`. It always synthesises std from the value magnitude.
+ * User-uncertainty propagation is implemented only in the V3 translator
+ * (`buildParameterUncertaintiesV3`) and the V2 preflight builder
+ * (`buildParameterUncertainties`). If V1 still receives production traffic
+ * and needs to honour user uncertainty, migrate callers to V3 or port the
+ * priority logic from `src/integrations/isl/translator-v3.ts`.
  */
 function extractParameterUncertainties(graph: { nodes: any[]; edges: any[] }): ISLParameterUncertainty[] {
   return graph.nodes

--- a/tests/boundary-plot-to-isl.contract.test.ts
+++ b/tests/boundary-plot-to-isl.contract.test.ts
@@ -330,12 +330,43 @@ describe('ISL request contract — golden-path (T5a)', () => {
     expect(puGoal).toBeUndefined();
   });
 
-  // std floor: min 0.1 for factor nodes
-  it('parameter_uncertainties std is at least 0.1 for all factor entries', () => {
+  // std contract:
+  //   - User-supplied observed_state.std is honoured, clamped to [1e-4, 2.0].
+  //   - Synthesised defaults (binary / value-based / fallback) are floored at 0.1.
+  // The fixture for this `req` uses fac-a (value=0.7, no std) and fac-b (value=0.4, no std),
+  // both of which go through default synthesis, so every entry here is >= 0.1.
+  it('parameter_uncertainties std respects bounds (defaults floored at 0.1; absolute bounds [1e-4, 2.0])', () => {
     expect(req.parameter_uncertainties).toBeDefined();
     for (const pu of req.parameter_uncertainties!) {
+      // Default synthesis path → floor at 0.1.
       expect(pu.std).toBeGreaterThanOrEqual(0.1);
+      // Absolute upper bound for all paths.
+      expect(pu.std).toBeLessThanOrEqual(2.0);
     }
+  });
+
+  it('user-supplied observed_state.std below 0.1 is preserved (not silently widened)', () => {
+    // Separate fixture: small user-supplied std must propagate to ISL as-is.
+    const graphWithSmallStd: EngineGraphV3 = {
+      nodes: [
+        { id: 'goal', kind: 'goal', label: 'Goal', observed_state: { value: 100 } },
+        { id: 'fac-small', kind: 'factor', label: 'Small Std', observed_state: { value: 0.6, std: 0.001 } },
+      ],
+      edges: [
+        { from: 'fac-small', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
+      ],
+    };
+    const reqSmall = toISLRobustnessRequest(
+      graphWithSmallStd,
+      [{ id: 'o1', label: 'O1', interventions: { 'fac-small': { value: 0.5, source: 'user_specified' } } }],
+      'goal',
+      'req-small-std',
+      500
+    );
+    const pu = reqSmall.parameter_uncertainties!.find((p: any) => p.node_id === 'fac-small');
+    expect(pu).toBeDefined();
+    // The fix: user-supplied std must NOT be floored to 0.1.
+    expect(pu!.std).toBe(0.001);
   });
 
   // analysis_types hardcoded to all three required values

--- a/tests/boundary-plot-to-isl.contract.test.ts
+++ b/tests/boundary-plot-to-isl.contract.test.ts
@@ -367,6 +367,15 @@ describe('ISL request contract — golden-path (T5a)', () => {
     expect(pu).toBeDefined();
     // The fix: user-supplied std must NOT be floored to 0.1.
     expect(pu!.std).toBe(0.001);
+
+    // Outbound shape unchanged: exactly one entry (only the factor with an
+    // observed_state.value is emitted — the goal node never appears) and each
+    // entry has only the four contract fields. Asserts the change is purely
+    // additive to `std`, not the entry count or field set.
+    expect(reqSmall.parameter_uncertainties!.length).toBe(1);
+    for (const entry of reqSmall.parameter_uncertainties!) {
+      expect(Object.keys(entry).sort()).toEqual(['distribution', 'mean', 'node_id', 'std']);
+    }
   });
 
   // analysis_types hardcoded to all three required values

--- a/tests/cil-constraint-auto-pu.test.ts
+++ b/tests/cil-constraint-auto-pu.test.ts
@@ -5,7 +5,9 @@
  * a ParameterUncertainty entry in the ISL request. Two layers provide this:
  *
  * 1. Translator: buildParameterUncertaintiesV3 generates PU for all factor
- *    nodes with observed_state.value (std >= 0.1 floor).
+ *    nodes with observed_state.value. Synthesised default std is floored at 0.1;
+ *    user-supplied observed_state.std is honoured (clamped to [1e-4, 2.0]) and
+ *    may legitimately be below 0.1.
  * 2. Phase 4b+ safety net: for constrained nodes the translator misses,
  *    auto-generates { distribution: 'normal', mean: observed_value, std: 0.001 }.
  *
@@ -198,8 +200,10 @@ describe('CIL: Constraint auto-PU integration (Phase 4b+)', () => {
     expect(capturedISLRequestBody).not.toBeNull();
 
     // The constrained node (factor-b) MUST have a PU entry in the ISL request.
-    // The translator generates it with mean=observed_state.value and std>=0.1.
-    // Phase 4b+ acts as a safety net for nodes the translator might miss.
+    // The translator generates it from observed_state.value. Here factor-b has
+    // no user-supplied std, so it goes through the synthesised default path
+    // (value-based, floored at 0.1). Phase 4b+ acts as a safety net for nodes
+    // the translator might miss.
     const puArray = capturedISLRequestBody.parameter_uncertainties ?? [];
     const factorBPU = puArray.find((p: any) => p.node_id === 'factor-b');
 

--- a/tests/golden/constraint-pipeline.integration.test.ts
+++ b/tests/golden/constraint-pipeline.integration.test.ts
@@ -253,14 +253,18 @@ describe('Constraint Pipeline Integration', () => {
     expect(res.status).toBe(200);
     expect(capturedISLRequestBody).not.toBeNull();
 
-    // factor-b is kind='factor' with observed_state.value=0.5.
-    // The translator (buildParameterUncertaintiesV3) creates PU with std >= 0.1.
+    // factor-b is kind='factor' with observed_state.value=0.5 and no user-supplied
+    // std, so the translator (buildParameterUncertaintiesV3) creates an existing PU
+    // via the synthesised default path (floored at 0.1).
     // Phase 4b+ should see the existing PU entry and SKIP (inject-only-when-missing).
+    // (If factor-b had observed_state.std < 0.1, the translator would honour it and
+    // the entry could legitimately be below 0.1 — this fixture deliberately omits std
+    // to exercise the synthesised-default branch.)
     const puArray = capturedISLRequestBody.parameter_uncertainties ?? [];
     const factorBPU = puArray.find((p: any) => p.node_id === 'factor-b');
 
     expect(factorBPU).toBeDefined();
-    // std should be from translator (>= 0.1), NOT from Phase 4b+ (0.001)
+    // std comes from the synthesised default (floored at 0.1), NOT from Phase 4b+ (0.001).
     expect(factorBPU.std).toBeGreaterThanOrEqual(0.1);
     expect(factorBPU.std).not.toBe(CONSTRAINT_PINNED_STD);
 

--- a/tests/parameter-uncertainty-propagation.test.ts
+++ b/tests/parameter-uncertainty-propagation.test.ts
@@ -95,6 +95,23 @@ describe('buildParameterUncertaintiesV3 — user-supplied std propagation', () =
       const result = buildParameterUncertaintiesV3([factor('f', 50, 2.0)])!;
       expect(result[0].std).toBe(2.0);
     });
+
+    // Exact MIN_USER_STD boundary trio — pins the clamp inflection point.
+    it('user std = MIN_USER_STD (1e-4) passes through unchanged', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5, 1e-4)])!;
+      expect(result[0].std).toBe(1e-4);
+    });
+
+    it('user std = 0.99e-4 (just below MIN) is clamped up to 1e-4', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5, 0.99e-4)])!;
+      expect(result[0].std).toBe(MIN_USER_STD);
+      expect(result[0].std).toBe(1e-4);
+    });
+
+    it('user std = 1.01e-4 (just above MIN) passes through unchanged', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5, 1.01e-4)])!;
+      expect(result[0].std).toBe(1.01e-4);
+    });
   });
 
   describe('invalid / missing user std falls through to default synthesis', () => {
@@ -209,6 +226,22 @@ describe('buildParameterUncertainties (preflight) — mirrors V3 translator', ()
     expect(result[0].std).toBe(MAX_USER_STD);
   });
 
+  // Exact MIN_USER_STD boundary trio (mirrors translator block above).
+  it('std = MIN_USER_STD (1e-4) → unchanged', () => {
+    const result = buildParameterUncertainties(buildGraph(0.5, 1e-4));
+    expect(result[0].std).toBe(1e-4);
+  });
+
+  it('std = 0.99e-4 → clamped up to MIN_USER_STD', () => {
+    const result = buildParameterUncertainties(buildGraph(0.5, 0.99e-4));
+    expect(result[0].std).toBe(MIN_USER_STD);
+  });
+
+  it('std = 1.01e-4 → unchanged', () => {
+    const result = buildParameterUncertainties(buildGraph(0.5, 1.01e-4));
+    expect(result[0].std).toBe(1.01e-4);
+  });
+
   it('std = 0 treated as missing → value-based default, floored', () => {
     const result = buildParameterUncertainties(buildGraph(0.5, 0));
     expect(result[0].std).toBe(DEFAULT_STD_FLOOR);
@@ -237,6 +270,9 @@ describe('translator vs preflight parity for std derivation', () => {
     { name: 'medium user std', value: 0.5, std: 0.05 },
     { name: 'large user std', value: 50, std: 1.5 },
     { name: 'sub-min user std', value: 0.5, std: 1e-8 },
+    { name: 'at-min user std (1e-4)', value: 0.5, std: 1e-4 },
+    { name: 'just-below-min user std (0.99e-4)', value: 0.5, std: 0.99e-4 },
+    { name: 'just-above-min user std (1.01e-4)', value: 0.5, std: 1.01e-4 },
     { name: 'over-max user std', value: 50, std: 3.0 },
     { name: 'zero user std', value: 0.5, std: 0 },
     { name: 'negative user std', value: 10, std: -0.1 },

--- a/tests/parameter-uncertainty-propagation.test.ts
+++ b/tests/parameter-uncertainty-propagation.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for user-supplied factor uncertainty propagation into ISL
+ * `parameter_uncertainties`.
+ *
+ * Fixes the silent-widening bug: prior to this change, `observed_state.std`
+ * values below 0.1 were floored to 0.1 by `Math.max(0.1, std)` applied after
+ * Priority 1. User-supplied small stds (e.g. 0.001, 0.003) were therefore
+ * never reaching ISL.
+ *
+ * Covers:
+ *   - V3 translator: `buildParameterUncertaintiesV3`
+ *   - V2 preflight: `buildParameterUncertainties`
+ *   - Numerical safety bounds (MIN_USER_STD, MAX_USER_STD)
+ *   - Synthesised defaults preserved
+ *   - Boundary contract (graph in → ISL request out)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildParameterUncertaintiesV3,
+  toISLRobustnessRequest,
+} from '../src/integrations/isl/translator-v3.js';
+import { buildParameterUncertainties } from '../src/integrations/isl/preflight.js';
+import {
+  MIN_USER_STD,
+  MAX_USER_STD,
+  DEFAULT_STD_FLOOR,
+  BINARY_DEFAULT_STD,
+  FALLBACK_STD,
+} from '../src/integrations/isl/parameter-uncertainty-bounds.js';
+import type { EngineGraphV3, EngineNodeV3, OptionV3 } from '../src/types/engine-v3.js';
+
+// ---------------------------------------------------------------------------
+// V3 translator: buildParameterUncertaintiesV3
+// ---------------------------------------------------------------------------
+
+describe('buildParameterUncertaintiesV3 — user-supplied std propagation', () => {
+  function factor(id: string, value: number, std?: number): EngineNodeV3 {
+    return {
+      id,
+      kind: 'factor',
+      label: id,
+      observed_state: std === undefined ? { value } : { value, std },
+    };
+  }
+
+  describe('user-supplied std is honoured (no silent widening)', () => {
+    it('observed_state.std = 0.001 → outbound std = 0.001', () => {
+      const result = buildParameterUncertaintiesV3([factor('fac_task_coverage', 0.6, 0.001)])!;
+      expect(result).toHaveLength(1);
+      expect(result[0].std).toBe(0.001);
+    });
+
+    it('observed_state.std = 0.003 → outbound std = 0.003', () => {
+      const result = buildParameterUncertaintiesV3([factor('fac_team_structure', 0.4, 0.003)])!;
+      expect(result).toHaveLength(1);
+      expect(result[0].std).toBe(0.003);
+    });
+
+    it('observed_state.std = 0.05 → outbound std = 0.05 (sub-floor value preserved)', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5, 0.05)])!;
+      expect(result[0].std).toBe(0.05);
+    });
+
+    it('observed_state.std = 0.1 → outbound std = 0.1', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5, 0.1)])!;
+      expect(result[0].std).toBe(0.1);
+    });
+
+    it('observed_state.std = 0.5 → outbound std = 0.5', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5, 0.5)])!;
+      expect(result[0].std).toBe(0.5);
+    });
+
+    it('observed_state.std = 1.5 → outbound std = 1.5 (existing behaviour preserved)', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 50, 1.5)])!;
+      expect(result[0].std).toBe(1.5);
+    });
+  });
+
+  describe('numerical safety bounds clamp extreme user values', () => {
+    it('very small user std (1e-8) is clamped up to MIN_USER_STD (1e-4)', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5, 1e-8)])!;
+      expect(result[0].std).toBe(MIN_USER_STD);
+      expect(result[0].std).toBe(1e-4);
+    });
+
+    it('user std above MAX_USER_STD (3.0) is capped at 2.0', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 50, 3.0)])!;
+      expect(result[0].std).toBe(MAX_USER_STD);
+      expect(result[0].std).toBe(2.0);
+    });
+
+    it('user std = MAX_USER_STD passes through unchanged', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 50, 2.0)])!;
+      expect(result[0].std).toBe(2.0);
+    });
+  });
+
+  describe('invalid / missing user std falls through to default synthesis', () => {
+    it('missing std with non-zero value uses value-based default (floored)', () => {
+      // value = 0.5 → 0.5 × 0.15 = 0.075 → floored to 0.1
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5)])!;
+      expect(result[0].std).toBe(DEFAULT_STD_FLOOR);
+    });
+
+    it('missing std with non-zero value above floor uses unfloored value-based default', () => {
+      // value = 10 → 10 × 0.15 = 1.5 (above floor)
+      const result = buildParameterUncertaintiesV3([factor('f', 10)])!;
+      expect(result[0].std).toBeCloseTo(1.5, 10);
+    });
+
+    it('missing std with value = 0 uses FALLBACK_STD = 0.5', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0)])!;
+      expect(result[0].std).toBe(FALLBACK_STD);
+    });
+
+    it('std = 0 is treated as missing (falls through to defaults)', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 0.5, 0)])!;
+      // value = 0.5 → 0.5 × 0.15 = 0.075 → floored to 0.1
+      expect(result[0].std).toBe(DEFAULT_STD_FLOOR);
+    });
+
+    it('negative std is treated as missing (falls through to defaults)', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 10, -0.1)])!;
+      expect(result[0].std).toBeCloseTo(1.5, 10);
+    });
+
+    it('NaN std is treated as missing (falls through to defaults)', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 10, NaN)])!;
+      expect(result[0].std).toBeCloseTo(1.5, 10);
+    });
+
+    it('Infinity std is treated as missing (falls through to defaults)', () => {
+      const result = buildParameterUncertaintiesV3([factor('f', 10, Infinity)])!;
+      expect(result[0].std).toBeCloseTo(1.5, 10);
+    });
+  });
+
+  describe('binary factor defaults preserved', () => {
+    it('binary factor (range [0,1]) without user std → BINARY_DEFAULT_STD = 0.3', () => {
+      const node: EngineNodeV3 = {
+        id: 'bin',
+        kind: 'factor',
+        label: 'Binary',
+        observed_state: { value: 1 },
+        state_space: { range: { min: 0, max: 1 } },
+      };
+      const result = buildParameterUncertaintiesV3([node])!;
+      expect(result[0].std).toBe(BINARY_DEFAULT_STD);
+    });
+
+    it('binary factor WITH user std = 0.05 → user value honoured (overrides binary default)', () => {
+      const node: EngineNodeV3 = {
+        id: 'bin',
+        kind: 'factor',
+        label: 'Binary',
+        observed_state: { value: 1, std: 0.05 },
+        state_space: { range: { min: 0, max: 1 } },
+      };
+      const result = buildParameterUncertaintiesV3([node])!;
+      expect(result[0].std).toBe(0.05);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V2 preflight: buildParameterUncertainties (must mirror translator)
+// ---------------------------------------------------------------------------
+
+describe('buildParameterUncertainties (preflight) — mirrors V3 translator', () => {
+  function buildGraph(value: number, std?: number) {
+    return {
+      nodes: [
+        {
+          id: 'f1',
+          kind: 'factor' as const,
+          label: 'F1',
+          observed_state: std === undefined ? { value } : { value, std },
+        },
+        { id: 'goal', kind: 'goal' as const, label: 'Goal' },
+      ],
+      edges: [{ from: 'f1', to: 'goal' }],
+    };
+  }
+
+  it('observed_state.std = 0.001 → outbound std = 0.001', () => {
+    const result = buildParameterUncertainties(buildGraph(0.6, 0.001));
+    expect(result[0].std).toBe(0.001);
+  });
+
+  it('observed_state.std = 0.003 → outbound std = 0.003', () => {
+    const result = buildParameterUncertainties(buildGraph(0.4, 0.003));
+    expect(result[0].std).toBe(0.003);
+  });
+
+  it('observed_state.std = 0.5 → outbound std = 0.5', () => {
+    const result = buildParameterUncertainties(buildGraph(0.5, 0.5));
+    expect(result[0].std).toBe(0.5);
+  });
+
+  it('very small std (1e-8) → clamped to MIN_USER_STD = 1e-4', () => {
+    const result = buildParameterUncertainties(buildGraph(0.5, 1e-8));
+    expect(result[0].std).toBe(MIN_USER_STD);
+  });
+
+  it('std above MAX_USER_STD (3.0) → capped at 2.0', () => {
+    const result = buildParameterUncertainties(buildGraph(50, 3.0));
+    expect(result[0].std).toBe(MAX_USER_STD);
+  });
+
+  it('std = 0 treated as missing → value-based default, floored', () => {
+    const result = buildParameterUncertainties(buildGraph(0.5, 0));
+    expect(result[0].std).toBe(DEFAULT_STD_FLOOR);
+  });
+
+  it('negative std treated as missing → value-based default', () => {
+    const result = buildParameterUncertainties(buildGraph(10, -0.5));
+    expect(result[0].std).toBeCloseTo(1.5, 10);
+  });
+
+  it('value = 0 with no user std → FALLBACK_STD = 0.5', () => {
+    const result = buildParameterUncertainties(buildGraph(0));
+    expect(result[0].std).toBe(FALLBACK_STD);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Translator <-> preflight parity (sanity check that both paths emit the same
+// std for the same input). The pipelines diverge in many places, but the
+// std-derivation logic must remain in lockstep.
+// ---------------------------------------------------------------------------
+
+describe('translator vs preflight parity for std derivation', () => {
+  const cases: Array<{ name: string; value: number; std?: number }> = [
+    { name: 'small user std', value: 0.6, std: 0.001 },
+    { name: 'medium user std', value: 0.5, std: 0.05 },
+    { name: 'large user std', value: 50, std: 1.5 },
+    { name: 'sub-min user std', value: 0.5, std: 1e-8 },
+    { name: 'over-max user std', value: 50, std: 3.0 },
+    { name: 'zero user std', value: 0.5, std: 0 },
+    { name: 'negative user std', value: 10, std: -0.1 },
+    { name: 'NaN user std', value: 10, std: NaN },
+    { name: 'no std, value 10', value: 10 },
+    { name: 'no std, value 0', value: 0 },
+    { name: 'no std, value 0.5', value: 0.5 },
+  ];
+
+  for (const { name, value, std } of cases) {
+    it(`parity: ${name}`, () => {
+      const v3 = buildParameterUncertaintiesV3([
+        {
+          id: 'f',
+          kind: 'factor',
+          label: 'F',
+          observed_state: std === undefined ? { value } : { value, std },
+        },
+      ])!;
+      const preflight = buildParameterUncertainties({
+        nodes: [
+          {
+            id: 'f',
+            kind: 'factor',
+            label: 'F',
+            observed_state: std === undefined ? { value } : { value, std },
+          },
+          { id: 'goal', kind: 'goal', label: 'Goal' },
+        ],
+        edges: [{ from: 'f', to: 'goal' }],
+      });
+      expect(v3[0].std).toBe(preflight[0].std);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Boundary contract: graph → ISL request preserves user-supplied std
+// (regression test for the original symptom — small user values reaching ISL)
+// ---------------------------------------------------------------------------
+
+describe('PLoT → ISL boundary: user-supplied std reaches ISL request', () => {
+  it('outbound parameter_uncertainties preserves small user-supplied stds', () => {
+    const graph: EngineGraphV3 = {
+      nodes: [
+        { id: 'goal', kind: 'goal', label: 'Revenue', observed_state: { value: 100 } },
+        {
+          id: 'fac_task_coverage',
+          kind: 'factor',
+          label: 'Task Coverage',
+          observed_state: { value: 0.6, std: 0.001 },
+        },
+        {
+          id: 'fac_team_structure',
+          kind: 'factor',
+          label: 'Team Structure',
+          observed_state: { value: 0.4, std: 0.003 },
+        },
+      ],
+      edges: [
+        { from: 'fac_task_coverage', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
+        { from: 'fac_team_structure', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
+      ],
+    };
+    const options: OptionV3[] = [
+      { id: 'opt1', label: 'Option 1', interventions: {} },
+    ];
+
+    const req = toISLRobustnessRequest(graph, options, 'goal', 'req-test', 1000);
+
+    const pus = req.parameter_uncertainties ?? [];
+    const tc = pus.find((p) => p.node_id === 'fac_task_coverage');
+    const ts = pus.find((p) => p.node_id === 'fac_team_structure');
+
+    expect(tc).toBeDefined();
+    expect(ts).toBeDefined();
+    // The fix: small user-supplied stds must propagate to the ISL payload as-is.
+    expect(tc!.std).toBe(0.001);
+    expect(ts!.std).toBe(0.003);
+  });
+
+  it('low- vs high-uncertainty fixture: outbound stds differ as supplied', () => {
+    const makeGraph = (std: number): EngineGraphV3 => ({
+      nodes: [
+        { id: 'goal', kind: 'goal', label: 'Goal', observed_state: { value: 100 } },
+        { id: 'f', kind: 'factor', label: 'F', observed_state: { value: 0.6, std } },
+      ],
+      edges: [
+        { from: 'f', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
+      ],
+    });
+
+    const low = toISLRobustnessRequest(makeGraph(0.001), [], 'goal', 'req-low', 1000);
+    const high = toISLRobustnessRequest(makeGraph(0.5), [], 'goal', 'req-high', 1000);
+
+    const lowStd = low.parameter_uncertainties!.find((p) => p.node_id === 'f')!.std;
+    const highStd = high.parameter_uncertainties!.find((p) => p.node_id === 'f')!.std;
+
+    expect(lowStd).toBe(0.001);
+    expect(highStd).toBe(0.5);
+    expect(lowStd).toBeLessThan(highStd);
+  });
+});

--- a/tests/v2-run-user-uncertainty-route.test.ts
+++ b/tests/v2-run-user-uncertainty-route.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Route-level integration test for user-supplied uncertainty propagation.
+ *
+ * Pins the production path: a `/v2/run` request with `observed_state.std = 0.001`
+ * on a factor node must result in `parameter_uncertainties[].std = 0.001` in the
+ * outbound ISL request body. Complements the direct-translator boundary tests
+ * by exercising the full route pipeline (normalisation, route handler, translator,
+ * Phase 4b+ injection).
+ *
+ * Uses vi.mock to intercept the ISL service and capture the request body,
+ * mirroring the established pattern in tests/golden/constraint-pipeline.integration.test.ts
+ * and tests/cil-constraint-auto-pu.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// ISL mock — captures the outbound request body for assertion
+// ---------------------------------------------------------------------------
+
+let capturedISLRequestBody: any = null;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      options: options.map((opt: any, idx: number) => ({
+        option_id: opt.id,
+        outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+        rank: idx + 1,
+      })),
+      edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [], value_of_information: [],
+      factors_provenance: 'unavailable' as const,
+      factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.8,
+      fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    capturedISLRequestBody = body;
+    const options = body.options || [];
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+          rank: idx + 1,
+        })),
+        edges: [], factors: [], value_of_information: [],
+        overall_robustness: 'robust', robustness_score: 0.8,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('/v2/run — user-supplied observed_state.std propagates to ISL', () => {
+  let app: FastifyInstance;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+
+    app = await createServer();
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const addr = app.server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    capturedISLRequestBody = null;
+  });
+
+  it('observed_state.std = 0.001 on a factor reaches ISL parameter_uncertainties as 0.001', async () => {
+    capturedISLRequestBody = null;
+
+    const payload = {
+      graph: {
+        nodes: [
+          { id: 'goal', kind: 'goal', label: 'Revenue' },
+          {
+            id: 'fac_task_coverage',
+            kind: 'factor',
+            label: 'Task Coverage',
+            observed_state: { value: 0.6, std: 0.001 },
+          },
+          {
+            id: 'fac_team_structure',
+            kind: 'factor',
+            label: 'Team Structure',
+            observed_state: { value: 0.4, std: 0.003 },
+          },
+        ],
+        edges: [
+          { from: 'fac_task_coverage', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+          { from: 'fac_team_structure', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+        ],
+      },
+      options: [
+        { id: 'opt1', label: 'A', interventions: { 'fac_task_coverage': 0.7 } },
+        { id: 'opt2', label: 'B', interventions: { 'fac_team_structure': 0.5 } },
+      ],
+      goal_node_id: 'goal',
+      seed: '42',
+    };
+
+    const res = await fetch(`${baseUrl}/v2/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedISLRequestBody).not.toBeNull();
+
+    const pus = capturedISLRequestBody.parameter_uncertainties ?? [];
+    const tc = pus.find((p: any) => p.node_id === 'fac_task_coverage');
+    const ts = pus.find((p: any) => p.node_id === 'fac_team_structure');
+
+    expect(tc).toBeDefined();
+    expect(ts).toBeDefined();
+
+    // The fix: small user-supplied stds must propagate through the full
+    // /v2/run pipeline (normalisation → route → translator → Phase 4b+)
+    // to the outbound ISL request body unchanged.
+    expect(tc!.std).toBe(0.001);
+    expect(ts!.std).toBe(0.003);
+  });
+});


### PR DESCRIPTION
## Summary

- The `parameter_uncertainties` builders (V3 translator + V2 preflight) applied `Math.max(0.1, std)` **after** Priority 1, silently widening every user-supplied `observed_state.std` below `0.1` up to `0.1`. So `0.001` and `0.003` reached ISL as `0.1`, weakening sensitivity, EVPI / evidence-gaps, robustness, and confidence quality.
- This PR honours user-supplied values, clamped only to a numerical safety range `[MIN_USER_STD = 1e-4, MAX_USER_STD = 2.0]`. The `0.1` default floor now applies only to synthesised defaults (binary / value-based / fallback).
- Targeted bug fix — **not** a broader uncertainty-architecture redesign.

## Files changed (6)

- `src/integrations/isl/parameter-uncertainty-bounds.ts` — **new**, shared constants module: `MIN_USER_STD`, `MAX_USER_STD`, `DEFAULT_STD_FLOOR`, `BINARY_DEFAULT_STD`, `VALUE_BASED_STD_FRACTION`, `FALLBACK_STD`.
- `src/integrations/isl/translator-v3.ts` — `buildParameterUncertaintiesV3` refactor; floor applied only to defaults. Removed unused `range` local and per-factor `console.warn` over-cap log.
- `src/integrations/isl/preflight.ts` — `buildParameterUncertainties` mirror of the translator refactor.
- `src/integrations/isl/constraint-pu-injection.ts` — comment-only: `CONSTRAINT_PINNED_STD` docstring updated to reflect new floor semantics.
- `src/routes/v1/run.ts` — comment-only: note that V1 `extractParameterUncertainties` is frozen and does **not** honour `observed_state.std`. **⚠ V1 routes (`POST /v1/run`) are still registered in `createServer.ts`** — flagged for reviewer to confirm whether V1 still receives production traffic. If yes, a follow-up should port the V3 priority logic.
- `tests/parameter-uncertainty-propagation.test.ts` — **new**, 39 tests.

## Behaviour change — before / after

| `observed_state.std` | value | before (outbound `std`) | after (outbound `std`) |
|---:|---:|---:|---:|
| `0.001` | `0.6` | `0.1` (silently widened ⚠) | `0.001` (preserved) |
| `0.003` | `0.4` | `0.1` (silently widened ⚠) | `0.003` (preserved) |
| `0.05` | `0.5` | `0.1` (silently widened ⚠) | `0.05` (preserved) |
| `0.5` | `0.5` | `0.5` | `0.5` (unchanged) |
| `1.5` | `50` | `1.5` | `1.5` (unchanged) |
| `3.0` | `50` | `2.0` (cap, unchanged) | `2.0` (cap, unchanged) |
| `1e-8` | `0.5` | `0.1` | `1e-4` (clamped to MIN_USER_STD) |
| missing | `0.5` | `0.1` | `0.1` (unchanged — value-based default) |
| missing | `0` | `0.5` | `0.5` (unchanged — FALLBACK_STD) |
| `0` | `0.5` | `0.1` | `0.1` (treated as missing → unchanged) |
| `-0.1` | `10` | `1.5` | `1.5` (treated as missing → unchanged) |
| `NaN` / `Infinity` | `10` | undefined | `1.5` (treated as missing → unchanged) |

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` for changed area (5 files, 122 tests) — all pass
- [x] Auto-noise / golden / constraint regressions (9 files, 149 tests) — all pass
- [x] `bash scripts/pre-push-validate.sh` — full suite **4745 passed | 25 skipped**, branch guard, stale-.js, dep audit, spectral lint all pass
- [ ] Manual: trigger a `/v2/run` against a fixture with `fac_*.observed_state.std = 0.001` and confirm `event: 'isl_request_parameter_uncertainties'` log shows `std: 0.001` outbound (instead of `0.1`)
- [ ] Scientific review: sensitivity / EVPI / robustness shift in the expected direction on a controlled low-std vs high-std fixture

## Out of scope (deferred)

- Provenance / disclosure fields (`parameter_uncertainty_provenance`).
- New response fields.
- OpenAPI / schema changes — none required (`observed_state.std` already typed).
- Auto-noise scaling, intervention-target changes, distribution-family support.
- DGAI / CEE / prompt changes.
- V1 path fix (commented out, not implemented — see above).

## Open questions for reviewer

1. **Is V1 (`POST /v1/run`) still receiving production traffic?** If yes, do we want a follow-up to honour `observed_state.std` there too?
2. **Is `MIN_USER_STD = 1e-4` the right hard lower bound?** Symmetric rationale to the existing `MAX_USER_STD = 2.0` cap. Open to tuning per Neil's preference.
3. **Disclosure.** Worth adding `parameter_uncertainty_provenance` per node so the UI can show "user-supplied std = 0.001 (honoured)" vs "default 0.1 (floored)"? Plan file lists this as deferred Option B work.

## Deployment

Target: **staging only**. **Do not merge or deploy without explicit human approval.** Per CLAUDE.md, `main` is auto-deploy to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)