### PR TITLE
chore(plot): remove dead V1 extractParameterUncertainties helper

### DIFF
--- a/src/routes/v1/run.ts
+++ b/src/routes/v1/run.ts
@@ -31,7 +31,7 @@ import { generateInsights } from '../../trust/insights.js';
 import { analyseEvidence } from '../../trust/evidence-analysis.js';
 import { computeFullSensitivity } from '../../trust/sensitivity-full.js';
 import { calculateCalibratedConfidence, compareConfidence } from '../../trust/confidence-calibrated.js';
-import { getISLService, type PLoTValidationResult, type PLoTSensitivityResult, type PLoTFactorSensitivityResult, type ISLParameterUncertainty } from '../../integrations/isl/index.js';
+import { getISLService, type PLoTValidationResult, type PLoTSensitivityResult, type PLoTFactorSensitivityResult } from '../../integrations/isl/index.js';
 import { recordEngineComputeMs } from '../../metrics.js';
 import { CEE_TIMEOUT_MS } from '../../config/timeouts.js';
 import {
@@ -146,35 +146,6 @@ function transformSensitivityToEnrichment(
     fragile_edges: fragileEdges.length > 0 ? fragileEdges : undefined,
     recommendations: sensitivity.recommendations.length > 0 ? sensitivity.recommendations : undefined,
   };
-}
-
-/**
- * Extract parameter uncertainties from graph factor nodes.
- *
- * NOTE: this helper is currently **dead code**. The result is assigned to a
- * local `parameterUncertainties` in the `/v1/run` handler but is never passed
- * into `islService.analyseRobustness(...)`. Active V1 outbound
- * `parameter_uncertainties` is built inside `islService.analyseRobustness`
- * (see `src/integrations/isl/index.ts`) via the preflight builder
- * `buildParameterUncertainties`, which honours user-supplied
- * `observed_state.std`. (The V3 translator `buildParameterUncertaintiesV3`
- * services a separate path — direct ISL request construction by V2 — and
- * uses the same shared bounds module, so behaviour is identical across
- * paths.)
- *
- * Kept for now to avoid widening this PR's scope. Slated for removal (or
- * replacement with a call to `buildParameterUncertainties`) in a follow-up.
- */
-function extractParameterUncertainties(graph: { nodes: any[]; edges: any[] }): ISLParameterUncertainty[] {
-  return graph.nodes
-    .filter((n: any) => n.kind === 'factor' && n.observed_state?.value !== undefined && Number.isFinite(n.observed_state.value))
-    .map((n: any) => ({
-      node_id: n.id,
-      distribution: 'normal' as const,
-      mean: n.observed_state.value,
-      // Default uncertainty: ±20% of value, minimum 0.1
-      std: Math.max(Math.abs(n.observed_state.value) * 0.2, 0.1),
-    }));
 }
 
 /**
@@ -964,8 +935,6 @@ export async function registerRunRoute(app: FastifyInstance) {
     if (islService.isEnabled() && detail_level !== 'quick') {
       const islStartTime = Date.now();
       try {
-        // Extract parameter uncertainties for factor sensitivity analysis
-        const parameterUncertainties = extractParameterUncertainties(graph);
         const optionNodes = extractOptionNodes(graph);
 
         // Run ISL calls in parallel for efficiency

--- a/tests/factor-sensitivity.test.ts
+++ b/tests/factor-sensitivity.test.ts
@@ -359,34 +359,3 @@ describe('POST /v1/run factor sensitivity enrichment', () => {
   });
 });
 
-describe('Parameter Uncertainties Extraction', () => {
-  /**
-   * Test the extractParameterUncertainties helper function
-   */
-  it('extracts parameter uncertainties from factor nodes', async () => {
-    // We test this indirectly by checking that the ISL call receives correct data
-    // when run against a real server (the extraction happens in run.ts)
-
-    const graph = {
-      nodes: [
-        { id: 'factor_a', kind: 'factor', observed_state: { value: 100 } },
-        { id: 'factor_b', kind: 'factor', observed_state: { value: 50 } },
-        { id: 'factor_c', kind: 'factor' }, // No observed_state - should be excluded
-        { id: 'option_1', kind: 'option', observed_state: { value: 10 } }, // Not a factor
-        { id: 'goal', kind: 'goal' },
-      ],
-      edges: [
-        { from: 'factor_a', to: 'goal', weight: 1 },
-        { from: 'factor_b', to: 'goal', weight: 0.5 },
-      ],
-    };
-
-    // The helper function should extract only factor nodes with observed_state.value
-    // Each should get distribution: 'normal', mean: value, std: max(|value|*0.2, 0.1)
-
-    // We can test this by importing the function directly
-    // Note: This is an integration test - the function is in run.ts but we test via the endpoint
-
-    expect(graph.nodes.filter((n) => n.kind === 'factor' && n.observed_state?.value !== undefined)).toHaveLength(2);
-  });
-});


### PR DESCRIPTION
## Summary

Pure dead-code cleanup. The `/v1/run` handler computed a `parameterUncertainties` local on every non-quick request via `extractParameterUncertainties(graph)` but never passed it into `islService.analyseRobustness(...)`. Active V1 outbound `parameter_uncertainties` is built inside the ISL service via the preflight builder `buildParameterUncertainties` ([src/integrations/isl/index.ts](src/integrations/isl/index.ts), inside `analyseRobustness`) — which already honours user-supplied `observed_state.std` per PR #168.

This cleanup was deferred from PR #168 to keep that PR's diff focused on the silent-widening bug fix.

## Files changed (2)

- `src/routes/v1/run.ts`:
  - Delete the dead `extractParameterUncertainties` helper (and its `ISLParameterUncertainty` return type).
  - Delete the dead `const parameterUncertainties = ...` local in the handler.
  - Drop the now-unused `ISLParameterUncertainty` import.
  - `hasParameterUncertainties` is **preserved** — it is still live, used at the `factor_sensitivity_status` mapping in this same file.
- `tests/factor-sensitivity.test.ts`:
  - Delete the vestigial `Parameter Uncertainties Extraction` describe block. Its body only filtered the local fixture (`.toHaveLength(2)`) and never imported or invoked the helper; the surrounding comments referenced the now-removed function by name and would otherwise decay into stale documentation.

Net diff: **2 files changed, 1 insertion(+), 50 deletions(-)**.

## No production behaviour change

V1 continues to call `islService.analyseRobustness`, and that call constructs `parameter_uncertainties` via the shared preflight builder — exactly as before this commit. The deleted helper was orphaned.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run --changed --bail=1` — 700 passed, 1 skipped, 0 fail
- [x] `npx vitest run tests/factor-sensitivity.test.ts` — 8 passed
- [x] `bash scripts/pre-push-validate.sh` — **4705 passed | 25 skipped**, all 6 checks green (typecheck, full suite, stale-.js, dep audit, spectral lint, branch guard)

## Deployment

Target: **staging only**. **Do not merge or deploy without explicit human approval.**

## Coordination with PR #168

PR #168 (`fix(plot): honour user-supplied observed_state.std (no silent widening)`) touches a comment block on the helper this PR removes. Order of merge does not matter for correctness:
- If this PR merges first, PR #168's comment edit becomes irrelevant (the helper is gone) — a rebase/merge will drop those comment lines cleanly.
- If PR #168 merges first, this PR's removal will also delete those updated comments. Either order is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)