### PR TITLE
feat(plot): plot_unified_v3 — blend ISL continuous bootstrap confidence

### DIFF
--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -6,15 +6,25 @@
  *
  * Scientific Approach:
  * - Influence = Sum of path effects (product of strength.mean along each path)
- * - Confidence = Unified formula (plot_unified_v2):
- *   0.5 × attribution_stability_band_score
- *   + 0.5 × mean(exists_probability of incoming edges)
+ * - Confidence = Unified formula. Two formula versions:
+ *     plot_unified_v3 (preferred when ISL emits a continuous bootstrap
+ *       confidence alongside a non-null `attribution_stability`):
+ *         0.5 × ISL_continuous_bootstrap_confidence + 0.5 × mean(exists_probability)
+ *     plot_unified_v2 (fallback for all other paths):
+ *         0.5 × attribution_stability_band_score + 0.5 × mean(exists_probability)
+ *     v3 replaces v2's 4-bucket band collapse {0, 0.25, 0.5, 1.0} with the
+ *     continuous stability-derived confidence ISL already computes (see
+ *     `src/config/stability_thresholds.py:140` on the ISL side). The 50/50
+ *     blend with the edge component is preserved across both versions.
  * - Direction = Sign of total influence (positive/negative effect on goal)
  *
  * Confidence honesty (audit A1-PRIMARY): the public `confidence_source` field
- * uses the new `ConfidenceSource` enum which honestly tags PLoT-recomputed
- * values. ISL's own `confidence` and `confidence_source` are dropped on
- * receipt — see truth-table row A1-PRIMARY (audit 2026-05-truth-table).
+ * uses the `ConfidenceSource` enum which honestly tags PLoT-recomputed values.
+ * Under v2 ISL's `confidence` is dropped entirely; under v3 it is consumed as
+ * one input to the blend but never emitted verbatim — the 50/50 step, clamp,
+ * and provenance tag are PLoT's. ISL's own `confidence_source` label (e.g.
+ * `"bootstrap_sampling"`) is always discarded. See truth-table row A1-PRIMARY
+ * (audit 2026-05-truth-table).
  *
  * @see Schema D.5 - Factor influence derived from edge-level data
  */
@@ -28,6 +38,7 @@ import type {
   ConfidenceSource,
   ConfidenceInputQuality,
   ConfidenceProvenance,
+  ConfidenceFormulaVersion,
 } from '../types/engine-v3.js';
 import { ATTRIBUTION_STABILITY_BAND_SCORES } from '../review-pass/evidence-priority.js';
 
@@ -112,26 +123,32 @@ interface RichEdgeInfo {
  * `input_quality` preserves the audit trail of the legacy
  * `'fallback_degenerate'` source-tag (now moved into provenance metadata so
  * it doesn't pollute the source-of-computation enum).
+ * `formula_version` records which branch of the unified formula fired
+ * (`plot_unified_v3` when ISL continuous bootstrap confidence was used as the
+ * stability input; `plot_unified_v2` for all other branches). Carried through
+ * to `confidence_provenance.formula_version` on the public response.
  */
 export interface UnifiedConfidence {
   confidence: number;
   source: ConfidenceSource;
   input_quality: ConfidenceInputQuality;
+  formula_version: ConfidenceFormulaVersion;
 }
 
 /**
  * Build a complete `ConfidenceProvenance` object for emission alongside a
- * computed confidence value. All four metadata fields are populated from
- * single-valued enums at this tranche; future Jinghui calibration extends
- * `formula_version` and `calibration_status` without payload reshape.
+ * computed confidence value. `formula_version` is supplied by the caller so
+ * each branch of `computeUnifiedConfidence` can declare its own (v3 for the
+ * ISL-continuous-bootstrap path; v2 for the band fallback and graph paths).
  */
 export function buildConfidenceProvenance(
   source: ConfidenceSource,
   inputQuality: ConfidenceInputQuality,
+  formulaVersion: ConfidenceFormulaVersion = 'plot_unified_v2',
 ): ConfidenceProvenance {
   return {
     computation_source: source,
-    formula_version: 'plot_unified_v2',
+    formula_version: formulaVersion,
     is_provisional: true,
     calibration_status: 'provisional_pending_pilot_calibration',
     input_quality: inputQuality,
@@ -141,26 +158,49 @@ export function buildConfidenceProvenance(
 /**
  * Compute unified confidence for a factor.
  *
- * When ISL bootstrap data IS available (attributionStability is not null):
- *   confidence = 0.5 × band_score(attributionStability) + 0.5 × mean(exists_probability)
- *   → source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard'
+ * Branch order:
  *
- * When ISL bootstrap data is NOT available and rich edge data IS available:
- *   confidence = mean(exists_probability) × (1 - mean_cv)
- *   where mean_cv = mean of |strength.std / strength.mean| across inbound edges
- *   → source: 'plot_unified_from_graph', input_quality: 'standard'
+ * 1. ISL continuous-bootstrap (formula_version `plot_unified_v3`) —
+ *    fires when `islContinuousConfidence` is finite and in [0, 1] AND
+ *    `attributionStability` is non-null (the gate ensures the value is
+ *    bootstrap-derived, not the VOI fallback inserted by `mapIslFactorEntry`):
+ *      confidence = 0.5 × islContinuousConfidence + 0.5 × mean(exists_probability)
+ *    → source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard'
+ *    Replaces the 4-bucket band collapse of v2 with ISL's already-continuous
+ *    stability-derived confidence (`compute_factor_confidence` in
+ *    `src/config/stability_thresholds.py:140`, rounded to 4 decimals). The
+ *    50/50 blend with the edge component is preserved; PLoT remains the
+ *    computer of the final value (audit A1-PRIMARY honesty intact).
  *
- * When neither is available: falls through to the 50/50 formula with defaults.
- *   → source: 'plot_unified_from_graph', input_quality: 'degenerate_fallback'
- *   The numeric value is not differentiating in this case.
+ * 2. ISL band fallback (formula_version `plot_unified_v2`) —
+ *    fires when bootstrap ran (`attributionStability` non-null) but
+ *    ISL's continuous confidence is absent or out-of-range:
+ *      confidence = 0.5 × band_score(attributionStability) + 0.5 × mean(exists_probability)
+ *    → source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard'
+ *
+ * 3. Graph CV fallback (formula_version `plot_unified_v2`) —
+ *    fires when no bootstrap but rich edge data is available:
+ *      confidence = mean(exists_probability) × (1 - mean_cv)
+ *    where mean_cv = mean of |strength.std / strength.mean| across inbound edges
+ *    → source: 'plot_unified_from_graph', input_quality: 'standard'
+ *
+ * 4. Degenerate fallback (formula_version `plot_unified_v2`) —
+ *    neither bootstrap nor rich edges; 50/50 with defaults.
+ *    → source: 'plot_unified_from_graph', input_quality: 'degenerate_fallback'
  *
  * @param attributionStability ISL attribution_stability category, or null if absent
  * @param incomingEdges Edges where edge.to === factor_id
- * @returns { confidence: [0, 1], source, input_quality }
+ * @param islContinuousConfidence ISL's continuous bootstrap confidence
+ *   (`FactorSensitivityV2.confidence` from `compute_factor_confidence`).
+ *   Optional. Used as the stability component only when finite, in [0, 1],
+ *   AND `attributionStability` is non-null. When absent or invalid, the
+ *   function falls through to the v2 band path unchanged.
+ * @returns { confidence: [0, 1], source, input_quality, formula_version }
  */
 export function computeUnifiedConfidence(
   attributionStability: string | null | undefined,
-  incomingEdges: Array<RichEdgeInfo> | undefined | null
+  incomingEdges: Array<RichEdgeInfo> | undefined | null,
+  islContinuousConfidence?: number | null,
 ): UnifiedConfidence {
   const hasBootstrap = attributionStability != null;
 
@@ -170,19 +210,38 @@ export function computeUnifiedConfidence(
     meanExistsProb = sum / incomingEdges.length;
   }
 
+  // Branch 1: ISL continuous-bootstrap path (plot_unified_v3).
+  // Gated on attribution_stability != null so we never consume the VOI value
+  // that `mapIslFactorEntry` falls back to when ISL omits `confidence`.
+  if (
+    hasBootstrap &&
+    typeof islContinuousConfidence === 'number' &&
+    Number.isFinite(islContinuousConfidence) &&
+    islContinuousConfidence >= 0 &&
+    islContinuousConfidence <= 1
+  ) {
+    const raw = 0.5 * islContinuousConfidence + 0.5 * meanExistsProb;
+    return {
+      confidence: Math.max(0, Math.min(1, raw)),
+      source: 'plot_unified_from_isl_bootstrap',
+      input_quality: 'standard',
+      formula_version: 'plot_unified_v3',
+    };
+  }
+
+  // Branch 2: ISL band fallback (plot_unified_v2).
   if (hasBootstrap) {
-    // ISL bootstrap path (formula_version plot_unified_v2).
     const bandScore = ATTRIBUTION_STABILITY_BAND_SCORES[attributionStability!] ?? DEFAULT_STABILITY_BAND_SCORE;
     const raw = 0.5 * bandScore + 0.5 * meanExistsProb;
     return {
       confidence: Math.max(0, Math.min(1, raw)),
       source: 'plot_unified_from_isl_bootstrap',
       input_quality: 'standard',
+      formula_version: 'plot_unified_v2',
     };
   }
 
-  // Graph fallback: when no bootstrap, use edge strength variation
-  // to differentiate confidence instead of uniform 0.5 default.
+  // Branch 3: Graph CV fallback (plot_unified_v2).
   if (incomingEdges && incomingEdges.length > 0) {
     const cvValues: number[] = [];
     for (const e of incomingEdges) {
@@ -201,10 +260,12 @@ export function computeUnifiedConfidence(
         confidence: Math.max(0, Math.min(1, raw)),
         source: 'plot_unified_from_graph',
         input_quality: 'standard',
+        formula_version: 'plot_unified_v2',
       };
     }
   }
 
+  // Branch 4: Degenerate fallback (plot_unified_v2).
   // No bootstrap, no rich edges: uniform 50/50 default — not differentiating.
   // Tagged via input_quality so telemetry can still surface this branch.
   const raw = 0.5 * DEFAULT_STABILITY_BAND_SCORE + 0.5 * meanExistsProb;
@@ -212,6 +273,7 @@ export function computeUnifiedConfidence(
     confidence: Math.max(0, Math.min(1, raw)),
     source: 'plot_unified_from_graph',
     input_quality: 'degenerate_fallback',
+    formula_version: 'plot_unified_v2',
   };
 }
 
@@ -669,9 +731,11 @@ export function computeFactorSensitivityFromGraph(
 
   // Map to FactorSensitivityResultV3 format
   return influences.map((f, index) => {
-    // Unified confidence: no ISL data at this stage (null stability), use incoming edges
+    // Unified confidence: no ISL data at this stage (null stability), use incoming edges.
+    // formulaVersion will resolve to plot_unified_v2 here (no ISL bootstrap input
+    // is available pre-merge; the v3 branch can only fire after the merge step).
     const incomingEdges = incomingEdgesMap.get(f.factor_id);
-    const { confidence, source: confidenceSource, input_quality: inputQuality } =
+    const { confidence, source: confidenceSource, input_quality: inputQuality, formula_version: formulaVersion } =
       computeUnifiedConfidence(null, incomingEdges);
 
     return {
@@ -707,13 +771,15 @@ export function computeFactorSensitivityFromGraph(
         fragileEdges
       ),
 
-      // Unified confidence (formula_version plot_unified_v2):
-      //   0.5 × stability_band + 0.5 × mean(incoming edge exists_probability).
-      // No ISL data at graph stage → confidence_source is plot_unified_from_graph.
-      // input_quality flags the uniform-default branch when it fires.
+      // Unified confidence: pre-merge value (always plot_unified_v2 here — no
+      // ISL bootstrap input available yet). May be overwritten by
+      // mergeIslConfidenceIntoGraphFactors with a v3 value when ISL data
+      // arrives. No ISL data at graph stage → confidence_source is
+      // plot_unified_from_graph; input_quality flags the uniform-default
+      // branch when it fires.
       confidence,
       confidence_source: confidenceSource,
-      confidence_provenance: buildConfidenceProvenance(confidenceSource, inputQuality),
+      confidence_provenance: buildConfidenceProvenance(confidenceSource, inputQuality, formulaVersion),
 
       // Progressive disclosure: raw confidence components
       confidence_components: {
@@ -742,17 +808,28 @@ export function computeFactorSensitivityFromGraph(
  * Merge ISL bootstrap data into graph-based factor sensitivity entries
  * and recompute unified confidence.
  *
- * Graph-based entries are primary for influence/sensitivity scores.
- * When ISL provides `attribution_stability`, the unified confidence formula
- * blends it with incoming edge exists_probability:
+ * Graph-based entries are primary for influence/sensitivity scores. When
+ * ISL provides both `attribution_stability` and a finite continuous
+ * `confidence`, the v3 branch of the unified formula fires:
+ *
+ *   confidence = 0.5 × ISL_continuous_bootstrap_confidence + 0.5 × mean(incoming edge exists_probability)
+ *
+ * If ISL omits or returns an out-of-range `confidence`, the v2 band fallback
+ * is used instead:
  *
  *   confidence = 0.5 × band_score(attribution_stability) + 0.5 × mean(incoming edge exists_probability)
  *
- * Confidence honesty (audit row A1-PRIMARY): ISL's own `confidence` and
- * `confidence_source` are dropped explicitly here. They never reach the
- * public `factor_sensitivity[]` response. ISL's *diagnostic* bootstrap
- * fields (`attribution_stability`, `elasticity_std`, `rank_flip_rate`,
- * `stability_method`) are preserved.
+ * Both versions clamp to [0, 1]; both label `confidence_source` as
+ * `plot_unified_from_isl_bootstrap`. The active version is recorded on
+ * `confidence_provenance.formula_version` (`plot_unified_v3` vs
+ * `plot_unified_v2`).
+ *
+ * Confidence honesty (audit row A1-PRIMARY): ISL's own `confidence_source`
+ * label is dropped explicitly here. ISL's `confidence` value is consumed as
+ * an input to the v3 formula but never emitted verbatim — the 50/50 blend,
+ * clamp, and honest provenance tag are PLoT's contribution. ISL's
+ * *diagnostic* bootstrap fields (`attribution_stability`, `elasticity_std`,
+ * `rank_flip_rate`, `stability_method`) are preserved on the merged entry.
  *
  * @param graphFactors Graph-based factor sensitivity entries (with confidence_components.structural_certainty)
  * @param islFactors ISL factor sensitivity entries (with attribution_stability)
@@ -808,9 +885,18 @@ export function mergeIslConfidenceIntoGraphFactors(
       ? richIncoming
       : [{ exists_probability: structuralCertainty }];
 
-    // Recompute unified confidence with ISL attribution_stability
-    const { confidence, source: confidenceSource, input_quality: inputQuality } =
-      computeUnifiedConfidence(attrStability, incomingEdgesForFormula);
+    // Pass ISL's continuous bootstrap confidence (when present) so the v3
+    // branch can replace the 4-bucket band collapse with the continuous
+    // stability-derived value. Gating on `attrStability != null` inside
+    // computeUnifiedConfidence ensures we don't pick up the VOI-fallback
+    // value `mapIslFactorEntry` inserts when ISL omits `confidence`.
+    const islContinuousConfidence = typeof islMatch.confidence === 'number'
+      ? islMatch.confidence
+      : null;
+
+    // Recompute unified confidence with ISL attribution_stability + continuous confidence
+    const { confidence, source: confidenceSource, input_quality: inputQuality, formula_version: formulaVersion } =
+      computeUnifiedConfidence(attrStability, incomingEdgesForFormula, islContinuousConfidence);
 
     // Band score for progressive disclosure
     const bandScore = hasIslData
@@ -821,7 +907,7 @@ export function mergeIslConfidenceIntoGraphFactors(
       ...gf,
       confidence,
       confidence_source: confidenceSource,
-      confidence_provenance: buildConfidenceProvenance(confidenceSource, inputQuality),
+      confidence_provenance: buildConfidenceProvenance(confidenceSource, inputQuality, formulaVersion),
       // Progressive disclosure: update with ISL sampling_stability
       confidence_components: {
         structural_certainty: structuralCertainty,
@@ -854,10 +940,20 @@ export function mergeIslConfidenceIntoGraphFactors(
         }));
 
       const attrStability = islF.attribution_stability ?? null;
-      const { confidence, source: confidenceSource, input_quality: inputQuality } =
+      // ISL's continuous bootstrap confidence — consumed as the v3 stability
+      // input. The branch only activates when `attrStability != null` inside
+      // computeUnifiedConfidence, so a VOI-fallback value (when ISL omits
+      // `confidence` entirely) is rejected by the gate. The local `islF.confidence`
+      // value, whatever it is, is also discarded in the destructure below
+      // (`_islDiscardConfidence`) — PLoT's recomputed value replaces it.
+      const islFContinuousConfidence = typeof islF.confidence === 'number'
+        ? islF.confidence
+        : null;
+      const { confidence, source: confidenceSource, input_quality: inputQuality, formula_version: formulaVersion } =
         computeUnifiedConfidence(
           attrStability,
           incoming.length > 0 ? incoming : undefined,
+          islFContinuousConfidence,
         );
       const structuralCertainty = incoming.length > 0
         ? incoming.reduce((acc, e) => acc + e.exists_probability, 0) / incoming.length
@@ -869,7 +965,10 @@ export function mergeIslConfidenceIntoGraphFactors(
       // Strip ISL's `confidence` and `confidence_source` explicitly before
       // spreading. Belt-and-braces against ISL labels (e.g.
       // `confidence_source: "bootstrap_sampling"`) leaking into the public
-      // response. PLoT's recomputed values follow.
+      // response. PLoT's recomputed values follow. (Under v3, ISL's continuous
+      // `confidence` is consumed as an input to the formula above but never
+      // emitted verbatim — the 50/50 blend with the edge component and the
+      // honest provenance tag are the PLoT-side contribution.)
       const {
         confidence: _islDiscardConfidence,
         confidence_source: _islDiscardSource,
@@ -882,7 +981,7 @@ export function mergeIslConfidenceIntoGraphFactors(
         ...islFCleaned,
         confidence,
         confidence_source: confidenceSource,
-        confidence_provenance: buildConfidenceProvenance(confidenceSource, inputQuality),
+        confidence_provenance: buildConfidenceProvenance(confidenceSource, inputQuality, formulaVersion),
         confidence_components: {
           structural_certainty: structuralCertainty,
           sampling_stability: bandScore,

--- a/src/review-pass/evidence-priority.ts
+++ b/src/review-pass/evidence-priority.ts
@@ -70,6 +70,13 @@ export const EVIDENCE_PRIORITY_SUPPRESSION_THRESHOLD = 0.05;
  * keeps `negligible` at 0.0 (no information loss). High and moderate are
  * unchanged. See truth-table row A1-SECONDARY for evidence.
  *
+ * v3 (formula_version `plot_unified_v3`): the unified formula prefers ISL's
+ * continuous bootstrap confidence to the band collapse; this table is used
+ * only as the v2 fallback when ISL's continuous confidence is absent or
+ * out-of-range. Sampling_stability progressive disclosure still derives
+ * from this table on every entry where ISL emits `attribution_stability`,
+ * regardless of which formula version produced the public `confidence`.
+ *
  * Coefficients are still operational defaults pending pilot calibration
  * (Neil gate 1, Jinghui calibration brief).
  */

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -558,11 +558,16 @@ function mapIslFactorEntry(f: any, normContext?: NormalisationContext): FactorSe
   // different from "this factor has zero influence". Let undefined pass through.
   //
   // Confidence honesty (audit A1-PRIMARY): the `confidence` value emitted here
-  // is ISL's own value — it MUST NOT reach the public response. The merge
-  // step (`mergeIslConfidenceIntoGraphFactors` in factor-influence.ts) strips
-  // both `confidence` and `confidence_source` from every ISL entry before
-  // forming the public `factor_sensitivity[]`. ISL's labels (e.g.
-  // `confidence_source: "bootstrap_sampling"`) likewise never propagate.
+  // is ISL's own value — it MUST NOT reach the public response as the final
+  // displayed confidence. The merge step (`mergeIslConfidenceIntoGraphFactors`
+  // in factor-influence.ts) always recomputes the public value:
+  //   - Under v3, ISL's `confidence` is consumed as the stability input to a
+  //     50/50 blend with the edge component; PLoT's blend + clamp + provenance
+  //     tag are what reach the response.
+  //   - Under v2, ISL's `confidence` is dropped entirely and the 4-bucket
+  //     band of `attribution_stability` is used instead.
+  // Either way, ISL's `confidence_source` label (e.g. `"bootstrap_sampling"`)
+  // is stripped before merge.
   //
   // `confidence_source` and `confidence_provenance` are TYPE-REQUIRED on the
   // public type. We populate placeholder values here purely so the

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1460,11 +1460,22 @@ export type ConfidenceSource =
 
 /**
  * Formula-version tag for the unified confidence computation.
- * v2 distinguishes `low` from `negligible` in the band-score table — see
- * truth-table row A1-SECONDARY. Single-valued at this tranche; future
- * Jinghui-led calibration may extend.
+ *
+ * - `'plot_unified_v2'` — 0.5 × attribution_stability_band_score + 0.5 × mean(exists_probability).
+ *   The band score is a 4-bucket map of ISL's `attribution_stability` category.
+ * - `'plot_unified_v3'` — 0.5 × ISL_continuous_bootstrap_confidence + 0.5 × mean(exists_probability).
+ *   Replaces the 4-bucket band with ISL's already-continuous bootstrap-derived
+ *   confidence value (rounded to 4 decimals on the ISL side). Used when ISL
+ *   emits a finite confidence in [0, 1] alongside a non-null
+ *   `attribution_stability`. Falls back to v2 when ISL confidence is absent
+ *   or invalid. Preserves `confidence_source` and the 50/50 blend; the
+ *   only material difference is the granularity of the stability term.
+ *
+ * Future Jinghui-led calibration may extend further. DGAI's debug hook
+ * validates this field with `/^plot_unified_v\d+$/` — extensions must keep
+ * to that family.
  */
-export type ConfidenceFormulaVersion = 'plot_unified_v2';
+export type ConfidenceFormulaVersion = 'plot_unified_v2' | 'plot_unified_v3';
 
 /**
  * Calibration status for the confidence formula. Single-valued at this tranche
@@ -1613,9 +1624,22 @@ export interface FactorSensitivityResultV3 {
   evpi_method?: 'heuristic' | 'counterfactual';
   /**
    * Confidence in the sensitivity score (0-1).
-   * Unified formula (plot_unified_v2): 0.5 × attribution_stability_band_score
-   *   + 0.5 × mean(exists_probability of incoming edges).
-   * Always PLoT-recomputed — ISL's own `confidence` is dropped on receipt.
+   *
+   * Always PLoT-recomputed; never a raw passthrough of ISL's own `confidence`
+   * label. The merge step writes one of:
+   *
+   * - `plot_unified_v3` (when ISL emits a finite continuous `confidence` and a
+   *   non-null `attribution_stability`):
+   *     0.5 × ISL_continuous_bootstrap_confidence + 0.5 × mean(exists_probability)
+   *   ISL's continuous value is consumed as the stability input; the public
+   *   value remains PLoT-computed (the 50/50 blend + clamp is the PLoT step).
+   *
+   * - `plot_unified_v2` (fallback when ISL continuous confidence is absent or
+   *   invalid):
+   *     0.5 × band_score(attribution_stability) + 0.5 × mean(exists_probability)
+   *   The 4-bucket band collapses ISL's stability category to {0, 0.25, 0.5, 1.0}.
+   *
+   * The active formula is disclosed via `confidence_provenance.formula_version`.
    * @see truth-table row A1-PRIMARY (audit 2026-05-truth-table)
    */
   confidence?: number;

--- a/tests/factor-influence.test.ts
+++ b/tests/factor-influence.test.ts
@@ -1024,13 +1024,13 @@ describe('computeUnifiedConfidence', () => {
     // Source remains 'plot_unified_from_graph' (audit A1-PRIMARY: source enum
     // tags COMPUTATION origin; degeneracy moved to input_quality).
     expect(computeUnifiedConfidence(null, undefined)).toEqual({
-      confidence: 0.5, source: 'plot_unified_from_graph', input_quality: 'degenerate_fallback',
+      confidence: 0.5, source: 'plot_unified_from_graph', input_quality: 'degenerate_fallback', formula_version: 'plot_unified_v2',
     });
     expect(computeUnifiedConfidence(undefined, null)).toEqual({
-      confidence: 0.5, source: 'plot_unified_from_graph', input_quality: 'degenerate_fallback',
+      confidence: 0.5, source: 'plot_unified_from_graph', input_quality: 'degenerate_fallback', formula_version: 'plot_unified_v2',
     });
     expect(computeUnifiedConfidence(null, [])).toEqual({
-      confidence: 0.5, source: 'plot_unified_from_graph', input_quality: 'degenerate_fallback',
+      confidence: 0.5, source: 'plot_unified_from_graph', input_quality: 'degenerate_fallback', formula_version: 'plot_unified_v2',
     });
     // Plain exists_probability without strength data also hits degenerate branch
     // (graph branch requires strength_mean/std to activate CV path).
@@ -1038,6 +1038,7 @@ describe('computeUnifiedConfidence', () => {
       confidence: 0.7, // 0.5 × 0.5 + 0.5 × 0.9
       source: 'plot_unified_from_graph',
       input_quality: 'degenerate_fallback',
+      formula_version: 'plot_unified_v2',
     });
   });
 
@@ -1050,25 +1051,27 @@ describe('computeUnifiedConfidence', () => {
   });
 
   it('returns source: plot_unified_from_isl_bootstrap (bootstrap-dominated) when edges absent', () => {
-    // moderate (0.5), no edges → 0.5 × 0.5 + 0.5 × 0.5 = 0.5
+    // moderate (0.5), no edges, no ISL continuous confidence → v2 band path:
+    //   0.5 × 0.5 + 0.5 × 0.5 = 0.5
     expect(computeUnifiedConfidence('moderate', undefined)).toEqual({
-      confidence: 0.5, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard',
+      confidence: 0.5, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard', formula_version: 'plot_unified_v2',
     });
     // high (1.0), no edges → 0.5 × 1.0 + 0.5 × 0.5 = 0.75
     expect(computeUnifiedConfidence('high', undefined)).toEqual({
-      confidence: 0.75, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard',
+      confidence: 0.75, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard', formula_version: 'plot_unified_v2',
     });
   });
 
-  it('distinguishes low and negligible at root factors (audit A1-SECONDARY, plot_unified_v2)', () => {
+  it('distinguishes low and negligible at root factors (audit A1-SECONDARY, plot_unified_v2 fallback)', () => {
+    // No ISL continuous confidence supplied → falls through to v2 band path.
     // Under v2 band table {high:1.0, moderate:0.5, low:0.25, negligible:0.0}:
     // low (0.25), no edges → 0.5 × 0.25 + 0.5 × 0.5 = 0.375
     expect(computeUnifiedConfidence('low', undefined)).toEqual({
-      confidence: 0.375, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard',
+      confidence: 0.375, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard', formula_version: 'plot_unified_v2',
     });
     // negligible (0.0), no edges → 0.5 × 0.0 + 0.5 × 0.5 = 0.25
     expect(computeUnifiedConfidence('negligible', undefined)).toEqual({
-      confidence: 0.25, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard',
+      confidence: 0.25, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard', formula_version: 'plot_unified_v2',
     });
     // Critical regression: outputs MUST be distinct (was 0.25 for both pre-v2)
     const lowOut = computeUnifiedConfidence('low', undefined).confidence;
@@ -1090,10 +1093,10 @@ describe('computeUnifiedConfidence', () => {
 
   it('clamps confidence to [0, 1]', () => {
     expect(computeUnifiedConfidence('high', [{ exists_probability: 1.0 }])).toEqual({
-      confidence: 1.0, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard',
+      confidence: 1.0, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard', formula_version: 'plot_unified_v2',
     });
     expect(computeUnifiedConfidence('negligible', [{ exists_probability: 0.0 }])).toEqual({
-      confidence: 0.0, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard',
+      confidence: 0.0, source: 'plot_unified_from_isl_bootstrap', input_quality: 'standard', formula_version: 'plot_unified_v2',
     });
   });
 

--- a/tests/isl-confidence-merge.test.ts
+++ b/tests/isl-confidence-merge.test.ts
@@ -1,11 +1,17 @@
 /**
  * ISL Confidence Merge Tests
  *
- * Verifies mergeIslConfidenceIntoGraphFactors with unified confidence formula
- * (formula_version plot_unified_v2, audit row A1-PRIMARY).
+ * Verifies mergeIslConfidenceIntoGraphFactors with unified confidence formula.
+ *
+ * Default test path (formula_version plot_unified_v3): when `makeIslFactor`
+ * supplies a finite continuous ISL `confidence` (default 0.72) together with
+ * a non-null `attribution_stability`, the merge fires the v3 branch:
+ *   confidence = 0.5 × ISL_continuous_bootstrap_confidence + 0.5 × mean(exists_probability)
+ * The 4-bucket band fallback (plot_unified_v2) is exercised by tests that
+ * explicitly set `confidence: null` on the ISL factor (V3-T3).
  *
  * T1: Merge by node_id — graph A,B,C + ISL A,B → A,B get unified confidence; C keeps graph
- * T2: Unified confidence blends ISL attribution_stability with incoming edge mean
+ * T2: Unified confidence blends ISL continuous confidence with incoming edge mean
  * T3: ISL-only factors preserved (appended with new honest source enum)
  * T4: ISL entry without attribution_stability — degenerate fallback flagged via input_quality
  * T5: No ISL results — all factors retain graph confidence
@@ -14,8 +20,11 @@
  * T8: confidence_components populated correctly
  * T9: ISL-only factors get unified confidence from graph edges
  * T10: intervention_override updates but doesn't append
- * T11 (audit A1-PRIMARY): ISL's own `confidence` and ISL-style `confidence_source`
- *      values (e.g. "bootstrap_sampling") never reach the merged public response.
+ * T11 (audit A1-PRIMARY): ISL's own `confidence` literal and ISL-style
+ *      `confidence_source` (e.g. "bootstrap_sampling") never reach the
+ *      merged public response. Under v3, ISL's confidence value is consumed
+ *      as a 50/50 input to the blend but never emitted verbatim.
+ * V3-T1..V3-T6: plot_unified_v3 invariants (see new `plot_unified_v3` describe block).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -86,56 +95,61 @@ const LEGACY_FORBIDDEN_SOURCES = ['isl', 'graph', 'fallback_degenerate', 'bootst
 // ---------------------------------------------------------------------------
 
 describe('mergeIslConfidenceIntoGraphFactors', () => {
-  it('T1: merges ISL attribution_stability into matching graph factors and recomputes unified confidence', () => {
+  it('T1: merges ISL attribution_stability + continuous confidence into matching graph factors and recomputes unified confidence', () => {
     const graph = [
       makeGraphFactor('fac_a', { confidence: 0.5, confidence_components: { structural_certainty: 0.5, sampling_stability: null } }),
       makeGraphFactor('fac_b', { confidence: 0.7, confidence_components: { structural_certainty: 0.9, sampling_stability: null } }),
       makeGraphFactor('fac_c', { confidence: 0.5, confidence_components: { structural_certainty: 0.5, sampling_stability: null } }),
     ];
     const isl = [
-      makeIslFactor('fac_a', { attribution_stability: 'high' }),   // v2 band_score = 1.0
-      makeIslFactor('fac_b', { attribution_stability: 'low' }),    // v2 band_score = 0.25 (was 0.0)
+      // makeIslFactor default `confidence: 0.72` activates plot_unified_v3.
+      makeIslFactor('fac_a', { attribution_stability: 'high' }),   // isl_conf = 0.72
+      makeIslFactor('fac_b', { attribution_stability: 'low' }),    // isl_conf = 0.72
     ];
 
     const result = mergeIslConfidenceIntoGraphFactors(graph, isl);
 
     expect(result).toHaveLength(3);
 
-    // A: unified = 0.5 × 1.0 + 0.5 × 0.5 = 0.75
+    // A (v3): unified = 0.5 × 0.72 + 0.5 × 0.5 = 0.61
     const a = result.find(f => f.factor_id === 'fac_a')!;
-    expect(a.confidence).toBeCloseTo(0.75, 5);
+    expect(a.confidence).toBeCloseTo(0.61, 5);
     expect(a.confidence_source).toBe(SRC_ISL_BOOTSTRAP);
+    expect(a.confidence_provenance?.formula_version).toBe('plot_unified_v3');
     expect(a.sensitivity_score).toBe(0.5); // Graph influence preserved
     expect(a.source).toBe('graph'); // Still graph-based entry
 
-    // B: v2 — unified = 0.5 × 0.25 + 0.5 × 0.9 = 0.575 (pre-v2: 0.45)
+    // B (v3): unified = 0.5 × 0.72 + 0.5 × 0.9 = 0.81
     const b = result.find(f => f.factor_id === 'fac_b')!;
-    expect(b.confidence).toBeCloseTo(0.575, 5);
+    expect(b.confidence).toBeCloseTo(0.81, 5);
     expect(b.confidence_source).toBe(SRC_ISL_BOOTSTRAP);
+    expect(b.confidence_provenance?.formula_version).toBe('plot_unified_v3');
 
     // C retains graph confidence (no ISL match)
     const c = result.find(f => f.factor_id === 'fac_c')!;
     expect(c.confidence).toBe(0.5);
     expect(c.confidence_source).toBe(SRC_GRAPH);
+    expect(c.confidence_provenance?.formula_version).toBe('plot_unified_v2');
   });
 
-  it('T2: unified confidence blends both ISL and edge signals', () => {
+  it('T2: unified confidence blends both ISL continuous confidence and edge signals', () => {
     // Graph factor with incoming edges (structural_certainty = 0.8)
     const graph = [makeGraphFactor('fac_a', {
       confidence: 0.65, // graph-stage: 0.5×0.5 + 0.5×0.8 = 0.65
       confidence_components: { structural_certainty: 0.8, sampling_stability: null },
     })];
-    // ISL provides moderate stability
-    const isl = [makeIslFactor('fac_a', { attribution_stability: 'moderate' })]; // band_score = 0.5
+    // ISL provides moderate stability + default continuous confidence 0.72
+    const isl = [makeIslFactor('fac_a', { attribution_stability: 'moderate' })]; // isl_conf = 0.72
 
     const result = mergeIslConfidenceIntoGraphFactors(graph, isl);
 
-    // unified = 0.5 × 0.5 + 0.5 × 0.8 = 0.65
-    expect(result[0].confidence).toBeCloseTo(0.65, 5);
+    // v3 unified = 0.5 × 0.72 + 0.5 × 0.8 = 0.76
+    expect(result[0].confidence).toBeCloseTo(0.76, 5);
     expect(result[0].confidence_source).toBe(SRC_ISL_BOOTSTRAP);
+    expect(result[0].confidence_provenance?.formula_version).toBe('plot_unified_v3');
     expect(result[0].confidence_components).toEqual({
       structural_certainty: 0.8,
-      sampling_stability: 0.5, // moderate → 0.5
+      sampling_stability: 0.5, // band-table derived for progressive disclosure; moderate → 0.5
     });
   });
 
@@ -158,11 +172,12 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
     expect(d).toBeDefined();
     expect(d.source).toBe('isl');
     expect(d.confidence_source).toBe(SRC_ISL_BOOTSTRAP);
-    // unified = 0.5 × 0.5 + 0.5 × 0.85 = 0.675
-    expect(d.confidence).toBeCloseTo(0.675, 5);
+    expect(d.confidence_provenance?.formula_version).toBe('plot_unified_v3');
+    // v3 unified = 0.5 × 0.72 + 0.5 × 0.85 = 0.785
+    expect(d.confidence).toBeCloseTo(0.785, 5);
     expect(d.confidence_components).toEqual({
       structural_certainty: 0.85,
-      sampling_stability: 0.5, // moderate → 0.5
+      sampling_stability: 0.5, // band-table derived for progressive disclosure; moderate → 0.5
     });
   });
 
@@ -259,11 +274,12 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
     const result = mergeIslConfidenceIntoGraphFactors(graph, isl);
 
     const d = result.find(f => f.factor_id === 'fac_d')!;
-    // v2 — unified = 0.5 × 0.25 + 0.5 × 0.5 = 0.375 (pre-v2: 0.25)
-    expect(d.confidence).toBeCloseTo(0.375, 5);
+    // v3 unified = 0.5 × 0.72 + 0.5 × 0.5 = 0.61
+    expect(d.confidence).toBeCloseTo(0.61, 5);
+    expect(d.confidence_provenance?.formula_version).toBe('plot_unified_v3');
     expect(d.confidence_components).toEqual({
       structural_certainty: 0.5,
-      sampling_stability: 0.25, // v2: low → 0.25 (was 0.0)
+      sampling_stability: 0.25, // band-table derived for progressive disclosure; low → 0.25
     });
   });
 
@@ -290,9 +306,9 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
     const graphFactor = result.find(f => f.factor_id === 'fac_graph')!;
     const islFactor = result.find(f => f.factor_id === 'fac_isl_only')!;
 
-    // Both: 0.5 × 0.5 + 0.5 × 0.7 = 0.6
-    expect(graphFactor.confidence).toBeCloseTo(0.6, 5);
-    expect(islFactor.confidence).toBeCloseTo(0.6, 5);
+    // Both v3: 0.5 × 0.72 + 0.5 × 0.7 = 0.71
+    expect(graphFactor.confidence).toBeCloseTo(0.71, 5);
+    expect(islFactor.confidence).toBeCloseTo(0.71, 5);
     expect(graphFactor.confidence).toBe(islFactor.confidence);
   });
 
@@ -323,11 +339,12 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
     expect(result).toHaveLength(2);
     expect(result.map(f => f.factor_id).sort()).toEqual(['fac_a', 'fac_b']);
 
-    // fac_a should have updated confidence from ISL attribution_stability: negligible
-    // negligible band score = 0.0, mean_ep = 0.5 (default) → 0.5×0.0 + 0.5×0.5 = 0.25
+    // fac_a should have updated confidence from ISL bootstrap inputs.
+    // v3: ISL continuous conf 0.72, mean_ep = 0.5 (default) → 0.5×0.72 + 0.5×0.5 = 0.61
     const facA = result.find(f => f.factor_id === 'fac_a')!;
-    expect(facA.confidence).toBeCloseTo(0.25, 5);
+    expect(facA.confidence).toBeCloseTo(0.61, 5);
     expect(facA.confidence_source).toBe(SRC_ISL_BOOTSTRAP);
+    expect(facA.confidence_provenance?.formula_version).toBe('plot_unified_v3');
     expect(facA.attribution_stability).toBe('negligible');
 
     // fac_b has no ISL match — keeps default 0.5
@@ -340,15 +357,19 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
   // T11 — heart-of-the-fix regression (audit row A1-PRIMARY)
   // -------------------------------------------------------------------------
 
-  it('T11: ISL own confidence and confidence_source ("bootstrap_sampling") never reach the public response', () => {
+  it('T11: ISL own confidence-source label and verbatim confidence value never reach the public response', () => {
     const graph = [makeGraphFactor('fac_a')];
-    // makeIslFactor() helper sets confidence: 0.72, confidence_source: 'bootstrap_sampling'.
-    // After merge, neither must surface in the output object.
+    // makeIslFactor() helper sets confidence_source: 'bootstrap_sampling'.
+    // Set ISL `confidence` to 0.99 — under v3 the value is consumed as the
+    // stability input to the blend, but the literal 0.99 must NOT surface
+    // verbatim. The emitted value is the PLoT-computed blend.
     const isl = [makeIslFactor('fac_a', { attribution_stability: 'high', confidence: 0.99 as any })];
 
     const result = mergeIslConfidenceIntoGraphFactors(graph, isl);
 
-    expect(result[0].confidence).not.toBe(0.99); // ISL's value dropped
+    // v3: 0.5 × 0.99 + 0.5 × 0.5 = 0.745 ≠ 0.99
+    expect(result[0].confidence).not.toBe(0.99);
+    expect(result[0].confidence).toBeCloseTo(0.745, 5);
     expect(result[0].confidence_source).not.toBe('bootstrap_sampling');
     // Belt-and-braces: forbid every legacy or upstream-ISL source label.
     for (const forbidden of LEGACY_FORBIDDEN_SOURCES) {
@@ -356,10 +377,10 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
     }
     // And the new honest label is what we get instead.
     expect(result[0].confidence_source).toBe(SRC_ISL_BOOTSTRAP);
-    // Provenance metadata populated.
+    // Provenance metadata populated; v3 because ISL emitted a finite continuous confidence.
     expect(result[0].confidence_provenance).toEqual({
       computation_source: SRC_ISL_BOOTSTRAP,
-      formula_version: 'plot_unified_v2',
+      formula_version: 'plot_unified_v3',
       is_provisional: true,
       calibration_status: 'provisional_pending_pilot_calibration',
       input_quality: 'standard',
@@ -386,9 +407,195 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
       }
       // Source is one of the honest enum values.
       expect([SRC_ISL_BOOTSTRAP, SRC_GRAPH]).toContain(f.confidence_source);
-      // Provenance present and well-formed.
-      expect(f.confidence_provenance?.formula_version).toBe('plot_unified_v2');
+      // Provenance present and well-formed. ISL factors fire v3 (finite continuous
+      // confidence supplied by makeIslFactor default 0.72); graph-only factors stay on v2.
+      const expectedVersion = f.confidence_source === SRC_ISL_BOOTSTRAP ? 'plot_unified_v3' : 'plot_unified_v2';
+      expect(f.confidence_provenance?.formula_version).toBe(expectedVersion);
       expect(f.confidence_provenance?.is_provisional).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// plot_unified_v3 invariants (continuous bootstrap confidence path)
+//
+// V3-T1: ISL continuous confidence used as the stability component when present.
+// V3-T2: Edge-confidence component still blended in.
+// V3-T3: Missing / invalid ISL confidence falls back to the v2 banded formula.
+// V3-T4: Default-edge case no longer collapses to {0.25, 0.375, 0.5, 0.75}.
+// V3-T5: Fixture with at least 5 factors produces ≥ 5 distinct confidence values.
+// V3-T6: Unrelated outputs (3C diagnostic fields, source/provenance shape,
+//        importance_rank ordering, attribution_stability passthrough) unchanged.
+// ---------------------------------------------------------------------------
+
+describe('plot_unified_v3 (continuous bootstrap confidence)', () => {
+  it('V3-T1: ISL continuous confidence is used as the stability component (50/50 with edge mean)', () => {
+    const graph = [makeGraphFactor('fac_a', {
+      confidence_components: { structural_certainty: 0.5, sampling_stability: null },
+    })];
+    // Default makeIslFactor confidence is 0.72; override to a specific value
+    // representative of ISL's `compute_factor_confidence` output for moderate
+    // stability with mild CV refinement: 0.6694 (≈ 0.7×0.6 + 0.3×(1/(1+0.2))).
+    const isl = [makeIslFactor('fac_a', {
+      attribution_stability: 'moderate',
+      confidence: 0.6694 as any,
+    })];
+
+    const result = mergeIslConfidenceIntoGraphFactors(graph, isl);
+
+    // 0.5 × 0.6694 + 0.5 × 0.5 = 0.5847
+    expect(result[0].confidence).toBeCloseTo(0.5847, 6);
+    expect(result[0].confidence_source).toBe(SRC_ISL_BOOTSTRAP);
+    expect(result[0].confidence_provenance?.formula_version).toBe('plot_unified_v3');
+  });
+
+  it('V3-T2: edge-confidence component is still blended in (confidence varies with edge mean)', () => {
+    const graphLowEdge = [makeGraphFactor('fac_a', {
+      confidence_components: { structural_certainty: 0.5, sampling_stability: null },
+    })];
+    const graphHighEdge = [makeGraphFactor('fac_a', {
+      confidence_components: { structural_certainty: 0.9, sampling_stability: null },
+    })];
+    const isl = [makeIslFactor('fac_a', {
+      attribution_stability: 'moderate',
+      confidence: 0.6694 as any,
+    })];
+
+    const resultLow = mergeIslConfidenceIntoGraphFactors(graphLowEdge, isl);
+    const resultHigh = mergeIslConfidenceIntoGraphFactors(graphHighEdge, isl);
+
+    // Low edges: 0.5 × 0.6694 + 0.5 × 0.5 = 0.5847
+    // High edges: 0.5 × 0.6694 + 0.5 × 0.9 = 0.7847
+    // Difference proves the edge component is not dropped.
+    expect(resultLow[0].confidence).toBeCloseTo(0.5847, 6);
+    expect(resultHigh[0].confidence).toBeCloseTo(0.7847, 6);
+    expect(resultHigh[0].confidence).toBeGreaterThan(resultLow[0].confidence);
+  });
+
+  it('V3-T3: missing or invalid ISL continuous confidence falls back to v2 banded formula', () => {
+    const graph = [makeGraphFactor('fac_a', {
+      confidence_components: { structural_certainty: 0.5, sampling_stability: null },
+    })];
+    // Three sub-cases — each MUST produce the v2 band result (low band 0.25
+    // → 0.5 × 0.25 + 0.5 × 0.5 = 0.375) and tag formula_version v2.
+    const subCases: Array<[string, unknown]> = [
+      ['undefined confidence', undefined],
+      ['NaN confidence', Number.NaN],
+      ['out-of-range confidence (1.5)', 1.5],
+      ['out-of-range confidence (-0.1)', -0.1],
+      ['null confidence', null],
+    ];
+    for (const [label, badConfidence] of subCases) {
+      const isl = [makeIslFactor('fac_a', {
+        attribution_stability: 'low',
+        confidence: badConfidence as any,
+      })];
+      const result = mergeIslConfidenceIntoGraphFactors(graph, isl);
+      expect(result[0].confidence, `case=${label}`).toBeCloseTo(0.375, 6);
+      expect(result[0].confidence_source, `case=${label}`).toBe(SRC_ISL_BOOTSTRAP);
+      expect(result[0].confidence_provenance?.formula_version, `case=${label}`).toBe('plot_unified_v2');
+    }
+  });
+
+  it('V3-T4: default-edge case no longer collapses to the {0.25, 0.375, 0.5, 0.625, 0.75} lattice', () => {
+    // Five factors, all with default-edge mean (0.5), each with a distinct
+    // ISL continuous confidence. The pre-v3 formula would have produced
+    // values in {0.25, 0.375, 0.5, 0.75} regardless of CV refinement; v3
+    // produces continuous values reflecting ISL's actual confidence.
+    const graphFactors = ['fac_a', 'fac_b', 'fac_c', 'fac_d', 'fac_e'].map(id =>
+      makeGraphFactor(id, {
+        confidence_components: { structural_certainty: 0.5, sampling_stability: null },
+      })
+    );
+    const islFactors = [
+      makeIslFactor('fac_a', { attribution_stability: 'high', confidence: 0.87 as any }),
+      makeIslFactor('fac_b', { attribution_stability: 'moderate', confidence: 0.66 as any }),
+      makeIslFactor('fac_c', { attribution_stability: 'low', confidence: 0.31 as any }),
+      makeIslFactor('fac_d', { attribution_stability: 'negligible', confidence: 0.12 as any }),
+      makeIslFactor('fac_e', { attribution_stability: 'low', confidence: 0.42 as any }),
+    ];
+
+    const result = mergeIslConfidenceIntoGraphFactors(graphFactors, islFactors);
+    const values = result.map(f => f.confidence!);
+
+    const LATTICE = new Set([0.25, 0.375, 0.5, 0.625, 0.75]);
+    for (const v of values) {
+      // Round to 5 decimals so 0.685 doesn't accidentally match 0.685000…01.
+      const rounded = Math.round(v * 1e5) / 1e5;
+      expect(LATTICE.has(rounded), `value ${v} fell on the legacy v2 lattice`).toBe(false);
+    }
+    // All factors are on the v3 path.
+    for (const f of result) {
+      expect(f.confidence_provenance?.formula_version).toBe('plot_unified_v3');
+    }
+  });
+
+  it('V3-T5: fixture with at least 5 factors produces 5+ distinct confidence values', () => {
+    const ids = ['fac_a', 'fac_b', 'fac_c', 'fac_d', 'fac_e', 'fac_f'];
+    const graphFactors = ids.map(id =>
+      makeGraphFactor(id, {
+        confidence_components: { structural_certainty: 0.5, sampling_stability: null },
+      })
+    );
+    // ISL confidences chosen so the 50/50 blend with mean_edge=0.5 produces
+    // six distinct values: 0.685, 0.580, 0.500, 0.405, 0.310, 0.235.
+    const islConfidences = [0.87, 0.66, 0.50, 0.31, 0.12, 0.47];
+    const islFactors = ids.map((id, i) =>
+      makeIslFactor(id, {
+        attribution_stability: 'moderate',
+        confidence: islConfidences[i] as any,
+      })
+    );
+
+    const result = mergeIslConfidenceIntoGraphFactors(graphFactors, islFactors);
+    const confidences = result.map(f => f.confidence!);
+    // Round to 6 decimals to suppress floating-point hash collisions.
+    const distinct = new Set(confidences.map(v => Math.round(v * 1e6) / 1e6));
+    expect(distinct.size).toBeGreaterThanOrEqual(5);
+  });
+
+  it('V3-T6: unrelated outputs unchanged — 3C diagnostic fields, importance_rank ordering, attribution_stability passthrough', () => {
+    const graph = [
+      makeGraphFactor('fac_a', { importance_rank: 1, confidence_components: { structural_certainty: 0.5, sampling_stability: null } }),
+      makeGraphFactor('fac_b', { importance_rank: 2, confidence_components: { structural_certainty: 0.7, sampling_stability: null } }),
+    ];
+    const isl = [
+      makeIslFactor('fac_a', {
+        attribution_stability: 'moderate',
+        confidence: 0.6694 as any,
+        elasticity_std: 0.05,
+        rank_flip_rate: 0.05,
+        stability_method: 'bootstrap_20',
+      }),
+      makeIslFactor('fac_b', {
+        attribution_stability: 'high',
+        confidence: 0.92 as any,
+        elasticity_std: 0.02,
+        rank_flip_rate: 0.0,
+        stability_method: 'bootstrap_20',
+      }),
+    ];
+
+    const result = mergeIslConfidenceIntoGraphFactors(graph, isl);
+
+    // importance_rank ordering preserved (graph-side input)
+    expect(result.find(f => f.factor_id === 'fac_a')!.importance_rank).toBe(1);
+    expect(result.find(f => f.factor_id === 'fac_b')!.importance_rank).toBe(2);
+
+    // 3C diagnostic fields passed through verbatim from ISL
+    const a = result.find(f => f.factor_id === 'fac_a')!;
+    expect(a.attribution_stability).toBe('moderate');
+    expect(a.elasticity_std).toBe(0.05);
+    expect(a.rank_flip_rate).toBe(0.05);
+    expect(a.stability_method).toBe('bootstrap_20');
+
+    // confidence_source / shape unchanged (v3 keeps the bootstrap source label)
+    for (const f of result) {
+      expect(f.confidence_source).toBe(SRC_ISL_BOOTSTRAP);
+      expect(f.confidence_provenance?.computation_source).toBe(SRC_ISL_BOOTSTRAP);
+      expect(f.confidence_provenance?.is_provisional).toBe(true);
+      expect(f.confidence_provenance?.calibration_status).toBe('provisional_pending_pilot_calibration');
+      expect(f.confidence_provenance?.input_quality).toBe('standard');
     }
   });
 });


### PR DESCRIPTION
## Summary

- New `formula_version: 'plot_unified_v3'` for the unified confidence formula. The stability term now uses ISL's already-continuous bootstrap-derived `confidence` (rounded to 4 decimals on the ISL side) instead of the 4-bucket band collapse of `attribution_stability`. The 50/50 blend with the existing edge-confidence component is preserved.
- The v2 band fallback is retained and fires when ISL omits or emits an out-of-range `confidence`. Gated on `attribution_stability != null` so a VOI-fallback value from `mapIslFactorEntry` cannot reach the formula.
- Public response shape is unchanged: `confidence_source` remains `plot_unified_from_isl_bootstrap`; the active formula is disclosed only via `confidence_provenance.formula_version`. DGAI's regex families (`/^plot_unified_from_[a-z0-9_]+$/`, `/^plot_unified_v\d+$/`) continue to match — no DGAI changes needed.

## Why

Recent staging bundles show `factor_sensitivity[].confidence` clustering on **{0.25, 0.375, 0.5, 0.625, 0.75}**. Root cause: `computeUnifiedConfidence` was collapsing ISL's stability evidence to 4 buckets `{0, 0.25, 0.5, 1.0}` and 50/50-blending with `mean(exists_probability)`, which defaults to 0.5 on edges without explicit probability. Combined, the formula reduced to `0.5 × band + 0.25`, exactly the observed lattice. Investigation report: `~/.claude/plans/isl-bootstrap-confidence-pure-wozniak.md`. Bootstrap count is NOT changed — investigation showed the granularity bottleneck was PLoT's band reduction, not the n=10/20 ISL sample size.

## Before / after distribution (default-edge factors, `mean(exists_probability)=0.5`)

Old v2 formula, `confidence = 0.5 × band + 0.5 × 0.5`:

| attribution_stability | band | confidence |
|---|---:|---:|
| `negligible` | 0.0 | **0.25** |
| `low` | 0.25 | **0.375** |
| `moderate` | 0.5 | **0.5** |
| `high` | 1.0 | **0.75** |

New v3 formula, `confidence = 0.5 × ISL_continuous + 0.5 × 0.5`, where ISL emits `round(0.7 × cat_score + 0.3 × cv_score, 4)` with `cv_score = 1/(1+CV)`:

| attribution_stability | category | example CV | ISL continuous | v3 confidence |
|---|---|---:|---:|---:|
| `negligible` | 0.1 | 0.0 (cv=∞) | 0.1 + 0.3·0 = 0.10 | **0.300** |
| `negligible` | 0.1 | 1.0 (cv=0) | 0.07 + 0.30 = 0.37 | **0.435** |
| `low` | 0.3 | 0.667 (cv=0.5) | 0.21 + 0.20 = 0.41 | **0.455** |
| `low` | 0.3 | 1.0 | 0.21 + 0.30 = 0.51 | **0.505** |
| `moderate` | 0.6 | 0.5 | 0.42 + 0.15 = 0.57 | **0.535** |
| `moderate` | 0.6 | 1.0 | 0.42 + 0.30 = 0.72 | **0.610** |
| `high` | 0.9 | 0.667 | 0.63 + 0.20 = 0.83 | **0.665** |
| `high` | 0.9 | 1.0 | 0.63 + 0.30 = 0.93 | **0.715** |

Confidence values become continuous and bounded `[0, 1]`. No values land on the legacy lattice (V3-T4 asserts this). With ≥ 5 distinct ISL inputs, ≥ 5 distinct outputs (V3-T5 asserts this).

## Pre-coding checks (per investigation plan)

| Check | Result |
|---|---|
| A1 audit reason still valid? | **No** — D3 keeps PLoT authoritative; honesty goal preserved (ISL's `confidence_source` label still stripped; ISL's `confidence` consumed as input but not emitted verbatim; new `formula_version` makes the policy change auditable). |
| DGAI / contracts hardcode `confidence_source`? | **No** — DGAI uses regex families. Picked `plot_unified_v3` (not `plot_unified_v3_continuous_bootstrap` as initially specced) so the value matches DGAI's `/^plot_unified_v\d+$/` anchor. Continuous-bootstrap intent is captured in JSDoc, provenance comments, tests, and this PR body. |
| ISL emits finite continuous confidence reliably? | **Yes** — `compute_factor_confidence` in `src/config/stability_thresholds.py:140` returns `round(clamp01(x), 4)` whenever `attribution_stability != null`. Gating on `attribution_stability != null` in PLoT excludes the VOI-fallback value `mapIslFactorEntry` substitutes when ISL omits `confidence`. |

## Files changed

- `src/lib/factor-influence.ts` — new branch (a) in `computeUnifiedConfidence`, ISL continuous confidence plumbed through `mergeIslConfidenceIntoGraphFactors` (both loops), `buildConfidenceProvenance` takes `formulaVersion`, JSDoc and audit-comment block updated.
- `src/types/engine-v3.ts` — `ConfidenceFormulaVersion` extended to `'plot_unified_v2' | 'plot_unified_v3'`; `UnifiedConfidence` and `FactorSensitivityResultV3.confidence` JSDoc updated.
- `src/routes/v2/run.ts` — `mapIslFactorEntry` audit comment updated (ISL `confidence` consumed but not emitted verbatim under v3).
- `src/review-pass/evidence-priority.ts` — `ATTRIBUTION_STABILITY_BAND_SCORES` comment notes v3 fallback usage.
- `tests/factor-influence.test.ts` — `formula_version` field added to existing `.toEqual` literals (the unit tests still pass undefined for `islContinuousConfidence` so v2 path is exercised).
- `tests/isl-confidence-merge.test.ts` — existing T1/T2/T3/T9/T10/T11 expected confidence values updated to v3 (makeIslFactor's default `confidence: 0.72` now activates v3); new `describe('plot_unified_v3')` block adds V3-T1 (continuous input used), V3-T2 (edge component still blended), V3-T3 (5 invalid-confidence sub-cases fall back to v2), V3-T4 (no value lands on the {0.25, 0.375, 0.5, 0.625, 0.75} lattice), V3-T5 (≥ 5 distinct values from 6 factors), V3-T6 (3C diagnostic fields, importance_rank, source/provenance shape unchanged).

## Stop-conditions (per investigation plan)

| Condition | Result |
|---|---|
| A1 audit forbids ISL confidence for a still-valid reason? | No — see check above. |
| ISL confidence not continuous / missing on common paths? | No. |
| DGAI / contracts hardcode `confidence_source` in a breaking way? | No. |
| Formula change breaks evidence gaps / EVPI / factor ordering? | No — V3-T6 + full suite (439 files, 4761 passing tests) green. |

## Test plan

- [x] `pnpm test` — 439 test files, 4761 passing, 25 skipped, 0 failures.
- [x] `pnpm build` — tsc clean on both `tsconfig.json` and `tsconfig.tools.json`; no stale `.js`.
- [x] `bash scripts/pre-push-validate.sh` — 6/6 checks passed (branch guard, tsc, full test suite, no stale .js, no file: deps, spectral OpenAPI lint).
- [ ] Manual replay against a recorded staging bundle — Paul/ChatGPT to verify in review (analytical demo above + V3-T4/T5 tests pin the lattice break).

## Out of scope / follow-ups

- ISL bootstrap count remains at the adaptive 10→20 schedule. Investigation showed this is **not** the cluster cause. Separate review if a higher count is wanted for bucket-stability reasons.
- Scientific recalibration of ISL's 70/30 cat/CV blend and CV bucket boundaries (`high≤0.1`, `moderate≤0.3`) — still provisional pending Jinghui input. This PR does not change the calibration.
- `EXISTS_PROBABILITY_DEFAULT` warnings on edges are not yet surfaced on the factor — worth doing in a separate PR so users see when confidence is being computed from defaulted edge data.

## Pause for review

Do not merge. Do not deploy. Awaiting Paul + ChatGPT review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)