### PR TITLE
feat(plot): margin-sensitivity diagnostic for flip thresholds (additive)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -5989,6 +5989,57 @@ components:
                 otherwise imply every non-computed factor was a harmless
                 no_effect_within_bounds case.
             Payload-only debug metadata; never user-facing copy.
+        flip_thresholds_margin_status:
+          type: string
+          enum: [computed, partial_movement, all_none, unavailable]
+          description: |
+            Additive lead-margin classification across `flip_thresholds[]`.
+            Distinct from `flip_thresholds_status` (which is strict-flip
+            oriented). Surfaces whether the tested factor range
+            materially weakens, strengthens, or flips the leading
+            option's lead margin, even when no strict winner flip
+            occurs. Diagnostic only; PR exposes for future DGAI /
+            debug consumption. Excluded from `response_hash`. UI
+            vocabulary; values never user-facing.
+
+            Classification:
+              - `computed`         : ≥1 entry has movement ∈
+                                     {flipped, weakened, strengthened},
+                                     no entry-with-margin has movement
+                                     === 'none'
+              - `partial_movement` : ≥1 entry has movement, ≥1 entry
+                                     -with-margin has movement === 'none'
+              - `all_none`         : every entry-with-margin has movement
+                                     === 'none'
+              - `unavailable`      : no entry carries `margin_sensitivity`
+                                     (or array empty)
+
+            Entries lacking `margin_sensitivity` are excluded from the
+            classification — see `flip_thresholds_margin_coverage` for
+            honest counts.
+        flip_thresholds_margin_coverage:
+          type: object
+          description: |
+            Honest counters for `margin_sensitivity` coverage across
+            `flip_thresholds[]`. Some entries (pre-probe timeout,
+            non-finite baseline, heuristic-only) lack margin evidence;
+            this object surfaces that explicitly so consumers do not
+            assume universal margin coverage. Excluded from
+            `response_hash`. Diagnostic only.
+          properties:
+            total:
+              type: integer
+              minimum: 0
+              description: Total entries in `flip_thresholds[]`.
+            with_margin:
+              type: integer
+              minimum: 0
+              description: Entries that carry `margin_sensitivity`.
+            without_margin:
+              type: integer
+              minimum: 0
+              description: Entries that do not carry `margin_sensitivity`.
+          required: [total, with_margin, without_margin]
         critiques:
           type: array
           items:

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -16,6 +16,7 @@
  */
 
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
+import { computeMarginSensitivity, type MarginSensitivity } from './margin-sensitivity.js';
 
 // =============================================================================
 // Types
@@ -87,6 +88,12 @@ export interface FlipDiagnostics {
   flip_reason: string;
   flip_value: number | null;
   alternative_winner_id: string | null;
+  /**
+   * Additive lead-margin diagnostic computed from the Step-0 probes.
+   * Omitted on entries where probes did not complete (pre-probe timeout,
+   * non-finite baseline, or exception during the parallel probe phase).
+   */
+  margin_sensitivity?: MarginSensitivity;
 }
 
 // =============================================================================
@@ -210,12 +217,24 @@ async function searchFlipForFactor(
     diag.winner_at_min = W_min;
     diag.winner_at_max = W_max;
 
+    // Margin-sensitivity diagnostic — computed once from the three already-fetched
+    // probe results. Strict-flip detected iff either bound's argmax differs from
+    // baseline's argmax. Attached to every probe-completed return below.
+    const strictFlipDetected = W_min !== W0 || W_max !== W0;
+    const marginSensitivity = computeMarginSensitivity({
+      baseline: baselineResult,
+      min: minResult,
+      max: maxResult,
+      strictFlipDetected,
+    });
+    diag.margin_sensitivity = marginSensitivity;
+
     // Step 1: If winner is the same at baseline and both bounds → factor cannot flip
     if (W_min === W0 && W_max === W0) {
       diag.flip_reason = 'no_effect_within_bounds';
       diag.iterations_used = 0;
       return {
-        result: { ...candidate, flip_value: null, flip_reason: 'no_effect_within_bounds', iterations_used: 0, alternative_winner_id: null },
+        result: { ...candidate, flip_value: null, flip_reason: 'no_effect_within_bounds', iterations_used: 0, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
         diagnostics: diag,
       };
     }
@@ -276,7 +295,7 @@ async function searchFlipForFactor(
         diag.flip_value = flipValue;
         diag.alternative_winner_id = farWinner;
         return {
-          result: { ...candidate, flip_value: flipValue, flip_reason: 'timeout', iterations_used: iterations, alternative_winner_id: farWinner },
+          result: { ...candidate, flip_value: flipValue, flip_reason: 'timeout', iterations_used: iterations, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
           diagnostics: diag,
         };
       }
@@ -300,7 +319,7 @@ async function searchFlipForFactor(
       } else {
         // Non-monotonic: a third option became the winner. Fall back to grid scan.
         return await gridFallback(
-          candidate, inferenceFn, originalWinnerId, 0, 1, config, factorDeadline, iterations, diag
+          candidate, inferenceFn, originalWinnerId, 0, 1, config, factorDeadline, iterations, diag, marginSensitivity
         );
       }
     }
@@ -317,14 +336,14 @@ async function searchFlipForFactor(
     if (precisionAchieved > config.precisionTarget) {
       diag.flip_reason = 'insufficient_precision';
       return {
-        result: { ...candidate, flip_value: flipValue, flip_reason: 'insufficient_precision', iterations_used: iterations, alternative_winner_id: farWinner },
+        result: { ...candidate, flip_value: flipValue, flip_reason: 'insufficient_precision', iterations_used: iterations, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
         diagnostics: diag,
       };
     }
 
     diag.flip_reason = 'found';
     return {
-      result: { ...candidate, flip_value: flipValue, flip_reason: 'found', iterations_used: iterations, alternative_winner_id: farWinner },
+      result: { ...candidate, flip_value: flipValue, flip_reason: 'found', iterations_used: iterations, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
       diagnostics: diag,
     };
   } catch (err) {
@@ -353,7 +372,8 @@ async function gridFallback(
   config: FlipSearchConfig,
   deadline: number,
   iterationsSoFar: number,
-  diag: FlipDiagnostics
+  diag: FlipDiagnostics,
+  marginSensitivity: MarginSensitivity
 ): Promise<{ result: FlipThresholdInputData; diagnostics: FlipDiagnostics }> {
   let iterations = iterationsSoFar;
   const step = (high - low) / (config.maxGridPoints - 1);
@@ -363,7 +383,7 @@ async function gridFallback(
       diag.iterations_used = iterations;
       diag.flip_reason = 'timeout';
       return {
-        result: { ...candidate, flip_value: null, flip_reason: 'timeout', iterations_used: iterations, alternative_winner_id: null },
+        result: { ...candidate, flip_value: null, flip_reason: 'timeout', iterations_used: iterations, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
         diagnostics: diag,
       };
     }
@@ -382,7 +402,7 @@ async function gridFallback(
         diag.flip_value = flipValue;
         diag.alternative_winner_id = winner;
         return {
-          result: { ...candidate, flip_value: flipValue, flip_reason: 'non_monotonic_grid', iterations_used: iterations, alternative_winner_id: winner },
+          result: { ...candidate, flip_value: flipValue, flip_reason: 'non_monotonic_grid', iterations_used: iterations, alternative_winner_id: winner, margin_sensitivity: marginSensitivity },
           diagnostics: diag,
         };
       }
@@ -396,7 +416,7 @@ async function gridFallback(
   diag.iterations_used = iterations;
   diag.flip_reason = 'no_effect_within_bounds';
   return {
-    result: { ...candidate, flip_value: null, flip_reason: 'no_effect_within_bounds', iterations_used: iterations, alternative_winner_id: null },
+    result: { ...candidate, flip_value: null, flip_reason: 'no_effect_within_bounds', iterations_used: iterations, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
     diagnostics: diag,
   };
 }

--- a/src/analysis/margin-sensitivity.ts
+++ b/src/analysis/margin-sensitivity.ts
@@ -10,6 +10,29 @@
  *
  * Probability convention: decimals in [0, 1]. `MARGIN_MOVEMENT_THRESHOLD` is
  * provisional (5 percentage points, decimal 0.05) — not calibrated.
+ *
+ * ## Display-ready fields (architecture principle)
+ *
+ * DGAI is a thin display layer. PLoT owns scientific meaning. To stop DGAI
+ * deriving percentage-point copy from raw `min_probe_delta` / `max_probe_delta`,
+ * PLoT emits four display-ready fields directly:
+ *
+ *  - `strongest_delta`                    — signed decimal of the selected delta
+ *  - `strongest_delta_abs`                — absolute value of the above
+ *  - `strongest_delta_percentage_points`  — `abs * 100`, what DGAI shows
+ *  - `display_value_available`            — true ONLY when `strongest_probe_value`
+ *                                           is finite and has been denormalised
+ *                                           to display units (value_scale ===
+ *                                           'display'). DGAI must not render
+ *                                           `strongest_probe_value` unless true.
+ *
+ * `min_probe_delta` and `max_probe_delta` remain for diagnostics; they are NOT
+ * the field DGAI should display.
+ *
+ * Important: `strongest_probe_value` is the tested bound (or null when the
+ * strict flip was found inside the interval by binary search). It is NOT the
+ * exact flip threshold. The exact flip threshold remains `flip_value` on the
+ * surrounding `flip_thresholds[]` entry.
  */
 
 import type { FlipInferenceResult } from './flip-thresholds.js';
@@ -31,13 +54,44 @@ export interface MarginSensitivity {
   baseline_leading_option_id: string | null;
   baseline_runner_up_option_id: string | null;
   baseline_margin: number | null;
+  /** Raw diagnostic: lead margin at min bound. NOT for direct UI display. */
   min_probe_margin: number | null;
+  /** Raw diagnostic: lead margin at max bound. NOT for direct UI display. */
   max_probe_margin: number | null;
+  /** Raw diagnostic: min_probe_margin - baseline_margin. NOT for direct UI display. */
   min_probe_delta: number | null;
+  /** Raw diagnostic: max_probe_margin - baseline_margin. NOT for direct UI display. */
   max_probe_delta: number | null;
   strongest_direction: MarginStrongestDirection;
+  /**
+   * Tested bound (or null) corresponding to `strongest_direction`. NOT the
+   * exact flip threshold — that lives on `flip_value`. In normalised [0, 1]
+   * until the denormaliser converts it to display units.
+   */
   strongest_probe_value: number | null;
   value_scale: MarginValueScale;
+
+  /**
+   * Signed decimal margin delta corresponding to the selected strongest probe.
+   * Negative ⇒ baseline leading option's margin weakened.
+   * Positive ⇒ baseline leading option's margin strengthened.
+   * Null when `movement === 'none'` or no finite delta is available.
+   */
+  strongest_delta: number | null;
+  /** Absolute value of `strongest_delta`. Null when above is null. */
+  strongest_delta_abs: number | null;
+  /**
+   * `strongest_delta_abs * 100`. The display-ready percentage-point value
+   * DGAI should render. Finite or null. Not aggressively rounded here —
+   * UI house style does the rounding.
+   */
+  strongest_delta_percentage_points: number | null;
+  /**
+   * True ONLY when `strongest_probe_value` is finite AND `value_scale ===
+   * 'display'` (i.e. the denormaliser converted it against a valid factor
+   * context). DGAI must not render `strongest_probe_value` unless true.
+   */
+  display_value_available: boolean;
 }
 
 export interface ComputeMarginSensitivityArgs {
@@ -117,21 +171,117 @@ function marginAtProbeForLeader(
   return { margin: leaderProb - strongestOtherProb, leaderProb, strongestOtherId };
 }
 
-function emptyResult(): MarginSensitivity {
+/**
+ * Select the signed strongest delta given movement, direction, and the raw
+ * min/max deltas. Returns null when no finite signal exists.
+ *
+ * Selection rules (mirrors `strongest_direction` / `strongest_probe_value`):
+ *  - 'none'        → null  (movement is 'none')
+ *  - 'towards_min' → min_probe_delta when finite, else null
+ *  - 'towards_max' → max_probe_delta when finite, else null
+ *  - 'both'        → side with the larger |delta| (ties → min for determinism)
+ *
+ * For `movement === 'flipped'` with `strongest_direction === 'none'` (strict
+ * flip found inside the interval by binary search — neither bound probe
+ * flipped on its own), still pick the larger-|delta| finite bound if any, so
+ * DGAI has a useful magnitude. This does NOT imply the exact flip threshold.
+ */
+function selectStrongestSignedDelta(
+  movement: MarginMovement,
+  direction: MarginStrongestDirection,
+  minDelta: number | null,
+  maxDelta: number | null,
+): number | null {
+  if (movement === 'none') return null;
+
+  const haveMin = isFiniteNumber(minDelta);
+  const haveMax = isFiniteNumber(maxDelta);
+
+  if (direction === 'towards_min') return haveMin ? minDelta : null;
+  if (direction === 'towards_max') return haveMax ? maxDelta : null;
+
+  if (direction === 'both') {
+    if (haveMin && haveMax) {
+      return Math.abs(minDelta as number) >= Math.abs(maxDelta as number)
+        ? (minDelta as number)
+        : (maxDelta as number);
+    }
+    if (haveMin) return minDelta;
+    if (haveMax) return maxDelta;
+    return null;
+  }
+
+  // direction === 'none' — only reachable for movement === 'flipped' via
+  // interior binary-search strict flip. Pick the larger-|delta| finite bound.
+  if (movement === 'flipped') {
+    if (haveMin && haveMax) {
+      return Math.abs(minDelta as number) >= Math.abs(maxDelta as number)
+        ? (minDelta as number)
+        : (maxDelta as number);
+    }
+    if (haveMin) return minDelta;
+    if (haveMax) return maxDelta;
+  }
+  return null;
+}
+
+function buildResult(args: {
+  movement: MarginMovement;
+  leaderId: string | null;
+  runnerUpId: string | null;
+  baselineMargin: number | null;
+  minMargin: number | null;
+  maxMargin: number | null;
+  minDelta: number | null;
+  maxDelta: number | null;
+  direction: MarginStrongestDirection;
+  probeValue: number | null;
+}): MarginSensitivity {
+  const strongestDelta = selectStrongestSignedDelta(
+    args.movement,
+    args.direction,
+    args.minDelta,
+    args.maxDelta,
+  );
+  const strongestDeltaAbs = strongestDelta !== null ? Math.abs(strongestDelta) : null;
+  const strongestDeltaPp = strongestDeltaAbs !== null ? strongestDeltaAbs * 100 : null;
+
   return {
-    movement: 'none',
+    movement: args.movement,
     threshold: MARGIN_MOVEMENT_THRESHOLD,
-    baseline_leading_option_id: null,
-    baseline_runner_up_option_id: null,
-    baseline_margin: null,
-    min_probe_margin: null,
-    max_probe_margin: null,
-    min_probe_delta: null,
-    max_probe_delta: null,
-    strongest_direction: 'none',
-    strongest_probe_value: null,
+    baseline_leading_option_id: args.leaderId,
+    baseline_runner_up_option_id: args.runnerUpId,
+    baseline_margin: args.baselineMargin,
+    min_probe_margin: args.minMargin,
+    max_probe_margin: args.maxMargin,
+    min_probe_delta: args.minDelta,
+    max_probe_delta: args.maxDelta,
+    strongest_direction: args.direction,
+    strongest_probe_value: args.probeValue,
+    // The helper always emits 'normalised'. The denormaliser may stamp
+    // 'display' (and set display_value_available=true) if it converts
+    // strongest_probe_value against a valid factor context.
     value_scale: 'normalised',
+    strongest_delta: strongestDelta,
+    strongest_delta_abs: strongestDeltaAbs,
+    strongest_delta_percentage_points: strongestDeltaPp,
+    display_value_available: false,
   };
+}
+
+function emptyResult(movementOverride?: MarginMovement): MarginSensitivity {
+  return buildResult({
+    movement: movementOverride ?? 'none',
+    leaderId: null,
+    runnerUpId: null,
+    baselineMargin: null,
+    minMargin: null,
+    maxMargin: null,
+    minDelta: null,
+    maxDelta: null,
+    direction: 'none',
+    probeValue: null,
+  });
 }
 
 /**
@@ -152,9 +302,7 @@ export function computeMarginSensitivity(args: ComputeMarginSensitivityArgs): Ma
   if (!baselineTop) {
     // Cannot identify a baseline leader / runner-up. Still surface flip status
     // (when known) so downstream classifier behaves correctly.
-    const out = emptyResult();
-    if (args.strictFlipDetected) out.movement = 'flipped';
-    return out;
+    return emptyResult(args.strictFlipDetected ? 'flipped' : 'none');
   }
 
   const leaderId = baselineTop.leader.id;
@@ -191,23 +339,22 @@ export function computeMarginSensitivity(args: ComputeMarginSensitivityArgs): Ma
     } else {
       // strictFlipDetected set by caller (binary-search/grid-fallback path).
       // Direction is recorded elsewhere on the FlipDiagnostics; leave 'none'.
+      // strongest_delta still populated from larger-|delta| bound below.
       direction = 'none';
       probeValue = null;
     }
-    return {
+    return buildResult({
       movement: 'flipped',
-      threshold: MARGIN_MOVEMENT_THRESHOLD,
-      baseline_leading_option_id: leaderId,
-      baseline_runner_up_option_id: runnerUpId,
-      baseline_margin: baselineMargin,
-      min_probe_margin: minMargin,
-      max_probe_margin: maxMargin,
-      min_probe_delta: minDelta,
-      max_probe_delta: maxDelta,
-      strongest_direction: direction,
-      strongest_probe_value: probeValue,
-      value_scale: 'normalised',
-    };
+      leaderId,
+      runnerUpId,
+      baselineMargin,
+      minMargin,
+      maxMargin,
+      minDelta,
+      maxDelta,
+      direction,
+      probeValue,
+    });
   }
 
   // Non-flip classification: compare |min_delta|, |max_delta| against threshold.
@@ -244,18 +391,16 @@ export function computeMarginSensitivity(args: ComputeMarginSensitivityArgs): Ma
     }
   }
 
-  return {
+  return buildResult({
     movement,
-    threshold: MARGIN_MOVEMENT_THRESHOLD,
-    baseline_leading_option_id: leaderId,
-    baseline_runner_up_option_id: runnerUpId,
-    baseline_margin: baselineMargin,
-    min_probe_margin: minMargin,
-    max_probe_margin: maxMargin,
-    min_probe_delta: minDelta,
-    max_probe_delta: maxDelta,
-    strongest_direction: direction,
-    strongest_probe_value: probeValue,
-    value_scale: 'normalised',
-  };
+    leaderId,
+    runnerUpId,
+    baselineMargin,
+    minMargin,
+    maxMargin,
+    minDelta,
+    maxDelta,
+    direction,
+    probeValue,
+  });
 }

--- a/src/analysis/margin-sensitivity.ts
+++ b/src/analysis/margin-sensitivity.ts
@@ -1,0 +1,261 @@
+/**
+ * Margin Sensitivity — Lead-margin diagnostic for flip-threshold probes.
+ *
+ * Computed from the same baseline/min/max probe results that the flip-threshold
+ * binary search already fetches. No additional ISL calls.
+ *
+ * "Lead margin" = baseline leading option's win probability minus the strongest
+ * alternative's win probability. Movement classifies whether the tested factor
+ * range materially weakens, strengthens, flips, or fails to move the lead.
+ *
+ * Probability convention: decimals in [0, 1]. `MARGIN_MOVEMENT_THRESHOLD` is
+ * provisional (5 percentage points, decimal 0.05) — not calibrated.
+ */
+
+import type { FlipInferenceResult } from './flip-thresholds.js';
+
+/**
+ * Provisional minimum signed lead-margin movement, in probability decimals,
+ * required to classify a probe as material. 0.05 = 5 percentage points.
+ * Documented as provisional; not empirically calibrated.
+ */
+export const MARGIN_MOVEMENT_THRESHOLD = 0.05;
+
+export type MarginMovement = 'none' | 'weakened' | 'strengthened' | 'flipped';
+export type MarginStrongestDirection = 'towards_min' | 'towards_max' | 'both' | 'none';
+export type MarginValueScale = 'normalised' | 'display';
+
+export interface MarginSensitivity {
+  movement: MarginMovement;
+  threshold: number;
+  baseline_leading_option_id: string | null;
+  baseline_runner_up_option_id: string | null;
+  baseline_margin: number | null;
+  min_probe_margin: number | null;
+  max_probe_margin: number | null;
+  min_probe_delta: number | null;
+  max_probe_delta: number | null;
+  strongest_direction: MarginStrongestDirection;
+  strongest_probe_value: number | null;
+  value_scale: MarginValueScale;
+}
+
+export interface ComputeMarginSensitivityArgs {
+  baseline: FlipInferenceResult;
+  min: FlipInferenceResult;
+  max: FlipInferenceResult;
+  /**
+   * True if the binary search (or a bound probe) already established a strict
+   * winner flip for this factor. Forces `movement: 'flipped'`.
+   */
+  strictFlipDetected: boolean;
+}
+
+function isFiniteNumber(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+
+/**
+ * Identify leading option and strongest alternative from a probe.
+ * Returns null pair if probe has <2 valid options.
+ */
+function topTwo(
+  options: ReadonlyArray<{ option_id: string; win_probability: number }>,
+): { leader: { id: string; p: number }; runnerUp: { id: string; p: number } } | null {
+  const valid = options.filter(
+    (o) => typeof o.option_id === 'string' && o.option_id.length > 0 && isFiniteNumber(o.win_probability),
+  );
+  if (valid.length < 2) return null;
+
+  // Deterministic ordering: primary by win_probability desc, secondary by option_id asc.
+  const sorted = [...valid].sort((a, b) => {
+    if (b.win_probability !== a.win_probability) return b.win_probability - a.win_probability;
+    return a.option_id < b.option_id ? -1 : a.option_id > b.option_id ? 1 : 0;
+  });
+  return {
+    leader: { id: sorted[0].option_id, p: sorted[0].win_probability },
+    runnerUp: { id: sorted[1].option_id, p: sorted[1].win_probability },
+  };
+}
+
+/**
+ * Margin at a probe for a fixed baseline-leading option.
+ * = baseline_leading.win_probability_at_probe - max(other options' win_probability_at_probe)
+ * Returns null if data is missing/invalid. Negative when the baseline leader is
+ * no longer the strongest at this probe (a bound-level flip).
+ */
+function marginAtProbeForLeader(
+  probe: FlipInferenceResult,
+  baselineLeadingOptionId: string,
+): { margin: number; leaderProb: number; strongestOtherId: string | null } | null {
+  if (!probe || !Array.isArray(probe.options)) return null;
+
+  let leaderProb: number | undefined;
+  let strongestOtherProb = -Infinity;
+  let strongestOtherId: string | null = null;
+
+  for (const opt of probe.options) {
+    if (!opt || typeof opt.option_id !== 'string' || !isFiniteNumber(opt.win_probability)) {
+      continue;
+    }
+    if (opt.option_id === baselineLeadingOptionId) {
+      leaderProb = opt.win_probability;
+    } else if (
+      opt.win_probability > strongestOtherProb ||
+      (opt.win_probability === strongestOtherProb &&
+        strongestOtherId !== null &&
+        opt.option_id < strongestOtherId)
+    ) {
+      strongestOtherProb = opt.win_probability;
+      strongestOtherId = opt.option_id;
+    }
+  }
+
+  if (!isFiniteNumber(leaderProb) || strongestOtherId === null || !isFiniteNumber(strongestOtherProb)) {
+    return null;
+  }
+  return { margin: leaderProb - strongestOtherProb, leaderProb, strongestOtherId };
+}
+
+function emptyResult(): MarginSensitivity {
+  return {
+    movement: 'none',
+    threshold: MARGIN_MOVEMENT_THRESHOLD,
+    baseline_leading_option_id: null,
+    baseline_runner_up_option_id: null,
+    baseline_margin: null,
+    min_probe_margin: null,
+    max_probe_margin: null,
+    min_probe_delta: null,
+    max_probe_delta: null,
+    strongest_direction: 'none',
+    strongest_probe_value: null,
+    value_scale: 'normalised',
+  };
+}
+
+/**
+ * Classify lead-margin movement across the three Step-0 probes.
+ *
+ * Rules:
+ *  - If `strictFlipDetected` is true, or either probe margin is negative (a
+ *    bound-level flip already happened), movement is 'flipped'.
+ *  - Otherwise, with both deltas finite: pick the larger |delta|. If it is
+ *    below `MARGIN_MOVEMENT_THRESHOLD`, movement is 'none'; if the larger-
+ *    |delta| direction has negative sign, movement is 'weakened'; positive
+ *    sign, 'strengthened'.
+ *  - `strongest_direction` is 'both' when both bounds exceed threshold with
+ *    opposite signs, else the side that exceeds threshold, else 'none'.
+ */
+export function computeMarginSensitivity(args: ComputeMarginSensitivityArgs): MarginSensitivity {
+  const baselineTop = topTwo(args.baseline?.options ?? []);
+  if (!baselineTop) {
+    // Cannot identify a baseline leader / runner-up. Still surface flip status
+    // (when known) so downstream classifier behaves correctly.
+    const out = emptyResult();
+    if (args.strictFlipDetected) out.movement = 'flipped';
+    return out;
+  }
+
+  const leaderId = baselineTop.leader.id;
+  const runnerUpId = baselineTop.runnerUp.id;
+  const baselineMargin = baselineTop.leader.p - baselineTop.runnerUp.p;
+
+  const minAt = marginAtProbeForLeader(args.min, leaderId);
+  const maxAt = marginAtProbeForLeader(args.max, leaderId);
+
+  const minMargin = minAt ? minAt.margin : null;
+  const maxMargin = maxAt ? maxAt.margin : null;
+  const minDelta = minMargin !== null ? minMargin - baselineMargin : null;
+  const maxDelta = maxMargin !== null ? maxMargin - baselineMargin : null;
+
+  // Strict flip path: caller already detected a winner change, or a bound
+  // probe shows the baseline leader is no longer the strongest there.
+  const minIsBoundFlip = minMargin !== null && minMargin < 0;
+  const maxIsBoundFlip = maxMargin !== null && maxMargin < 0;
+  if (args.strictFlipDetected || minIsBoundFlip || maxIsBoundFlip) {
+    let direction: MarginStrongestDirection = 'none';
+    let probeValue: number | null = null;
+    if (minIsBoundFlip && maxIsBoundFlip) {
+      direction = 'both';
+      // Pick the side with the larger absolute delta when both flip.
+      const absMin = minDelta !== null ? Math.abs(minDelta) : -Infinity;
+      const absMax = maxDelta !== null ? Math.abs(maxDelta) : -Infinity;
+      probeValue = absMin >= absMax ? 0 : 1;
+    } else if (minIsBoundFlip) {
+      direction = 'towards_min';
+      probeValue = 0;
+    } else if (maxIsBoundFlip) {
+      direction = 'towards_max';
+      probeValue = 1;
+    } else {
+      // strictFlipDetected set by caller (binary-search/grid-fallback path).
+      // Direction is recorded elsewhere on the FlipDiagnostics; leave 'none'.
+      direction = 'none';
+      probeValue = null;
+    }
+    return {
+      movement: 'flipped',
+      threshold: MARGIN_MOVEMENT_THRESHOLD,
+      baseline_leading_option_id: leaderId,
+      baseline_runner_up_option_id: runnerUpId,
+      baseline_margin: baselineMargin,
+      min_probe_margin: minMargin,
+      max_probe_margin: maxMargin,
+      min_probe_delta: minDelta,
+      max_probe_delta: maxDelta,
+      strongest_direction: direction,
+      strongest_probe_value: probeValue,
+      value_scale: 'normalised',
+    };
+  }
+
+  // Non-flip classification: compare |min_delta|, |max_delta| against threshold.
+  const minMaterial = minDelta !== null && Math.abs(minDelta) >= MARGIN_MOVEMENT_THRESHOLD;
+  const maxMaterial = maxDelta !== null && Math.abs(maxDelta) >= MARGIN_MOVEMENT_THRESHOLD;
+
+  let movement: MarginMovement = 'none';
+  let direction: MarginStrongestDirection = 'none';
+  let probeValue: number | null = null;
+
+  if (minMaterial || maxMaterial) {
+    const absMin = minDelta !== null ? Math.abs(minDelta) : -Infinity;
+    const absMax = maxDelta !== null ? Math.abs(maxDelta) : -Infinity;
+    // Use sign of the larger-|delta| side for movement classification.
+    const dominantDelta = absMin >= absMax ? minDelta : maxDelta;
+    movement = (dominantDelta ?? 0) < 0 ? 'weakened' : 'strengthened';
+
+    if (minMaterial && maxMaterial) {
+      const sameSign =
+        minDelta !== null && maxDelta !== null && Math.sign(minDelta) === Math.sign(maxDelta);
+      if (sameSign) {
+        direction = absMin >= absMax ? 'towards_min' : 'towards_max';
+        probeValue = absMin >= absMax ? 0 : 1;
+      } else {
+        direction = 'both';
+        probeValue = absMin >= absMax ? 0 : 1;
+      }
+    } else if (minMaterial) {
+      direction = 'towards_min';
+      probeValue = 0;
+    } else {
+      direction = 'towards_max';
+      probeValue = 1;
+    }
+  }
+
+  return {
+    movement,
+    threshold: MARGIN_MOVEMENT_THRESHOLD,
+    baseline_leading_option_id: leaderId,
+    baseline_runner_up_option_id: runnerUpId,
+    baseline_margin: baselineMargin,
+    min_probe_margin: minMargin,
+    max_probe_margin: maxMargin,
+    min_probe_delta: minDelta,
+    max_probe_delta: maxDelta,
+    strongest_direction: direction,
+    strongest_probe_value: probeValue,
+    value_scale: 'normalised',
+  };
+}

--- a/src/cee/validation/m1-review-types.ts
+++ b/src/cee/validation/m1-review-types.ts
@@ -12,6 +12,7 @@
 
 import { z } from 'zod';
 import { M1_REVIEW_LIMITS, type ReviewStatus, type ReviewSkipReason } from './m1-review-constants.js';
+import type { MarginSensitivity } from '../../analysis/margin-sensitivity.js';
 
 // =============================================================================
 // M1Review — What CEE Returns
@@ -295,6 +296,12 @@ export interface FlipThresholdInputData {
   alternative_winner_id?: string | null;
   /** Factor unit from observed_state (e.g., "GBP", "%") */
   unit?: string;
+  /**
+   * Additive lead-margin diagnostic computed from the Step-0 flip-search probes.
+   * Optional — omitted on entries that did not complete the probe phase
+   * (pre-probe timeout, non-finite baseline, probe exception, heuristic path).
+   */
+  margin_sensitivity?: MarginSensitivity;
 }
 
 /**

--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -131,21 +131,28 @@ function enrichWithLabels(
 
 /**
  * Denormalise `strongest_probe_value` against the factor's range and stamp
- * `value_scale: 'display'`. Probability fields (margins, deltas) are
- * scale-independent and pass through.
+ * `value_scale: 'display'`. Sets `display_value_available` = true ONLY when
+ * the denormalised probe value is itself finite — so DGAI can render
+ * `strongest_probe_value` exactly when this boolean is true.
+ *
+ * Probability fields (margins, deltas, percentage-points) are scale-
+ * independent and pass through unchanged.
  */
 function denormaliseMarginSensitivity(
   margin: MarginSensitivity,
   range: NormalisationRange,
 ): MarginSensitivity {
-  const denormProbe =
-    margin.strongest_probe_value !== null && Number.isFinite(margin.strongest_probe_value)
-      ? denormaliseValue(margin.strongest_probe_value, range)
-      : null;
+  const probeIsFinite =
+    margin.strongest_probe_value !== null && Number.isFinite(margin.strongest_probe_value);
+  const denormProbe = probeIsFinite
+    ? denormaliseValue(margin.strongest_probe_value as number, range)
+    : null;
+  const denormProbeFinite = denormProbe !== null && Number.isFinite(denormProbe);
   return {
     ...margin,
-    strongest_probe_value: denormProbe,
+    strongest_probe_value: denormProbeFinite ? denormProbe : null,
     value_scale: 'display',
+    display_value_available: denormProbeFinite,
   };
 }
 

--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -9,8 +9,9 @@
  */
 
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
-import type { NormalisationContext } from './intervention-normaliser.js';
+import type { NormalisationContext, NormalisationRange } from './intervention-normaliser.js';
 import { denormaliseValue } from './intervention-normaliser.js';
+import type { MarginSensitivity } from '../analysis/margin-sensitivity.js';
 
 // =============================================================================
 // Types
@@ -38,6 +39,16 @@ export interface DenormalisedFlipThreshold {
   flip_reason: string;
   /** Number of ISL inference iterations used */
   iterations_used?: number;
+  /**
+   * Additive lead-margin diagnostic. Omitted on entries whose flip-search
+   * Step-0 probes did not complete (pre-probe timeout, non-finite baseline,
+   * exception during probe phase, heuristic-only entries).
+   *
+   * `value_scale` is `'display'` only when `strongest_probe_value` has been
+   * denormalised here against a valid factor context. Otherwise it stays
+   * `'normalised'` and the value is preserved as emitted by the helper.
+   */
+  margin_sensitivity?: MarginSensitivity;
 }
 
 // =============================================================================
@@ -82,6 +93,9 @@ export function denormaliseFlipThresholds(
       alternative_winner_label: resolveLabel(flip.alternative_winner_id, options),
       flip_reason: flip.flip_reason ?? 'heuristic',
       iterations_used: flip.iterations_used,
+      ...(flip.margin_sensitivity
+        ? { margin_sensitivity: denormaliseMarginSensitivity(flip.margin_sensitivity, factorContext.range) }
+        : {}),
     };
   });
 }
@@ -109,6 +123,29 @@ function enrichWithLabels(
     alternative_winner_label: resolveLabel(flip.alternative_winner_id, options),
     flip_reason: flip.flip_reason ?? 'heuristic',
     iterations_used: flip.iterations_used,
+    // No factor context for denormalisation. Pass margin_sensitivity through
+    // untouched: `value_scale` stays `'normalised'` for honesty.
+    ...(flip.margin_sensitivity ? { margin_sensitivity: flip.margin_sensitivity } : {}),
+  };
+}
+
+/**
+ * Denormalise `strongest_probe_value` against the factor's range and stamp
+ * `value_scale: 'display'`. Probability fields (margins, deltas) are
+ * scale-independent and pass through.
+ */
+function denormaliseMarginSensitivity(
+  margin: MarginSensitivity,
+  range: NormalisationRange,
+): MarginSensitivity {
+  const denormProbe =
+    margin.strongest_probe_value !== null && Number.isFinite(margin.strongest_probe_value)
+      ? denormaliseValue(margin.strongest_probe_value, range)
+      : null;
+  return {
+    ...margin,
+    strongest_probe_value: denormProbe,
+    value_scale: 'display',
   };
 }
 

--- a/src/lib/flip-thresholds-margin-status.ts
+++ b/src/lib/flip-thresholds-margin-status.ts
@@ -1,0 +1,90 @@
+/**
+ * Flip-Thresholds Margin-Status Classifier
+ *
+ * Aggregate status for the additive margin-sensitivity diagnostic across
+ * `flip_thresholds[]`. Distinct from `flip_thresholds_status` (PR #167) which
+ * is strict-flip oriented and remains untouched.
+ *
+ * Rules — operate on the public denormalised flip_thresholds[] array:
+ *
+ *   empty / null / undefined                                           -> 'unavailable'
+ *   no entry carries margin_sensitivity                                -> 'unavailable'
+ *   at least one entry has movement ∈ {flipped, weakened, strengthened},
+ *     AND at least one entry-with-margin has movement === 'none'       -> 'partial_movement'
+ *   every entry-with-margin has movement === 'none'                    -> 'all_none'
+ *   every entry-with-margin has movement ≠ 'none'                      -> 'computed'
+ *
+ * Entries without `margin_sensitivity` are excluded from classification:
+ * they do NOT count toward `all_none`. The companion coverage object
+ * (`flip_thresholds_margin_coverage`) surfaces honest counts.
+ */
+
+import type { DenormalisedFlipThreshold } from './flip-threshold-denormaliser.js';
+
+export type FlipThresholdsMarginStatus =
+  | 'computed'
+  | 'partial_movement'
+  | 'all_none'
+  | 'unavailable';
+
+export interface FlipThresholdsMarginStatusResult {
+  status: FlipThresholdsMarginStatus;
+}
+
+export interface FlipThresholdsMarginCoverage {
+  total: number;
+  with_margin: number;
+  without_margin: number;
+}
+
+export function classifyFlipThresholdsMarginStatus(
+  flipThresholds: DenormalisedFlipThreshold[] | null | undefined,
+): FlipThresholdsMarginStatusResult {
+  if (!flipThresholds || flipThresholds.length === 0) {
+    return { status: 'unavailable' };
+  }
+
+  let withMargin = 0;
+  let movementCount = 0;
+  let noneCount = 0;
+
+  for (const entry of flipThresholds) {
+    const ms = entry.margin_sensitivity;
+    if (!ms) continue;
+    withMargin++;
+    if (ms.movement === 'none') {
+      noneCount++;
+    } else {
+      // 'flipped' | 'weakened' | 'strengthened'
+      movementCount++;
+    }
+  }
+
+  if (withMargin === 0) {
+    return { status: 'unavailable' };
+  }
+  if (movementCount > 0 && noneCount > 0) {
+    return { status: 'partial_movement' };
+  }
+  if (movementCount > 0) {
+    return { status: 'computed' };
+  }
+  return { status: 'all_none' };
+}
+
+export function computeFlipThresholdsMarginCoverage(
+  flipThresholds: DenormalisedFlipThreshold[] | null | undefined,
+): FlipThresholdsMarginCoverage {
+  const total = flipThresholds?.length ?? 0;
+  let withMargin = 0;
+  if (flipThresholds) {
+    for (const entry of flipThresholds) {
+      if (entry.margin_sensitivity) withMargin++;
+    }
+  }
+  return {
+    total,
+    with_margin: withMargin,
+    without_margin: total - withMargin,
+  };
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -109,6 +109,10 @@ import { createISLInferenceFn, resolveFlipValues } from '../../analysis/flip-thr
 import { computeFlipThresholdData } from '../../coaching/flip-thresholds.js';
 import { denormaliseFlipThresholds, type DenormalisedFlipThreshold } from '../../lib/flip-threshold-denormaliser.js';
 import { classifyFlipThresholdsStatus } from '../../lib/flip-threshold-status.js';
+import {
+  classifyFlipThresholdsMarginStatus,
+  computeFlipThresholdsMarginCoverage,
+} from '../../lib/flip-thresholds-margin-status.js';
 import type { CeeReviewRequest, CeeTrace, FactorEnrichment } from '../../cee/types.js';
 // CIL Phase 1: Shared types from @talchain/schemas
 import type { SeedSourceType } from '@talchain/schemas';
@@ -2025,6 +2029,20 @@ function buildResponse(
       return {
         flip_thresholds_status: result.status,
         ...(result.status_reason && { flip_thresholds_status_reason: result.status_reason }),
+      };
+    })(),
+
+    // Additive margin-sensitivity classification + coverage counters.
+    // Separate from flip_thresholds_status (PR #167). Diagnostic only;
+    // excluded from response_hash by normaliseReport(). Surfaces lead-
+    // margin movement (weakened / strengthened / flipped) without
+    // changing PR #167's strict-flip semantics.
+    ...(() => {
+      const marginStatus = classifyFlipThresholdsMarginStatus(flipThresholds);
+      const marginCoverage = computeFlipThresholdsMarginCoverage(flipThresholds);
+      return {
+        flip_thresholds_margin_status: marginStatus.status,
+        flip_thresholds_margin_coverage: marginCoverage,
       };
     })(),
 

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1021,6 +1021,48 @@ export interface RunResponseV3 {
    */
   flip_thresholds_status_reason?: string;
 
+  /**
+   * Aggregate margin-sensitivity classification across `flip_thresholds[]`.
+   * Additive diagnostic, separate from `flip_thresholds_status`.
+   *
+   * - 'computed'         : at least one entry has movement ∈
+   *                        {flipped, weakened, strengthened}
+   * - 'partial_movement' : at least one entry has movement, at least one
+   *                        entry has movement === 'none'
+   * - 'all_none'         : every entry that carries margin_sensitivity has
+   *                        movement === 'none'
+   * - 'unavailable'      : no entry carries margin_sensitivity (or array
+   *                        empty/absent)
+   *
+   * Entries missing `margin_sensitivity` do NOT count toward `all_none`;
+   * they are excluded from classification.
+   *
+   * NOTE: Deterministic. Excluded from `response_hash` as non-semantic.
+   * @see classifyFlipThresholdsMarginStatus in src/lib/flip-thresholds-margin-status.ts
+   */
+  flip_thresholds_margin_status?:
+    | 'computed'
+    | 'partial_movement'
+    | 'all_none'
+    | 'unavailable';
+
+  /**
+   * Per-array coverage counters for margin-sensitivity. Honest counter so
+   * downstream consumers can tell when only a subset of flip-threshold
+   * entries carry margin evidence.
+   *
+   *  - total          : total entries in `flip_thresholds[]`
+   *  - with_margin    : entries that carry `margin_sensitivity`
+   *  - without_margin : total - with_margin
+   *
+   * Excluded from `response_hash`. Additive diagnostic.
+   */
+  flip_thresholds_margin_coverage?: {
+    total: number;
+    with_margin: number;
+    without_margin: number;
+  };
+
   // ---------------------------------------------------------------------------
   // Threshold Analysis Fields (B10.3)
   // Only present when include_thresholds is true in request

--- a/src/util/canonical-json.ts
+++ b/src/util/canonical-json.ts
@@ -104,9 +104,10 @@ export function normaliseReport(report: unknown): unknown {
   if (Array.isArray(flipThresholds)) {
     normalised.flip_thresholds = flipThresholds.map((entry) => {
       if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
-        const copy = { ...(entry as Record<string, unknown>) };
-        delete copy.margin_sensitivity;
-        return copy;
+        // Destructure-discard is idiomatic and avoids the `delete` operator,
+        // which deoptimises object shape in V8.
+        const { margin_sensitivity: _omitted, ...rest } = entry as Record<string, unknown>;
+        return rest;
       }
       return entry;
     });

--- a/src/util/canonical-json.ts
+++ b/src/util/canonical-json.ts
@@ -93,12 +93,30 @@ export function normaliseReport(report: unknown): unknown {
 
   // Remove request_id at root level (varies per-request, not deterministic)
   delete normalised.request_id;
-  
+
+  // Additive margin-sensitivity diagnostic — excluded from response_hash so
+  // that adding this enrichment does not perturb existing canonical hashes.
+  //  - Top-level: flip_thresholds_margin_status, flip_thresholds_margin_coverage
+  //  - Per-entry: flip_thresholds[].margin_sensitivity
+  delete normalised.flip_thresholds_margin_status;
+  delete normalised.flip_thresholds_margin_coverage;
+  const flipThresholds = normalised.flip_thresholds;
+  if (Array.isArray(flipThresholds)) {
+    normalised.flip_thresholds = flipThresholds.map((entry) => {
+      if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+        const copy = { ...(entry as Record<string, unknown>) };
+        delete copy.margin_sensitivity;
+        return copy;
+      }
+      return entry;
+    });
+  }
+
   // Normalize critique to array
   if ('critique' in normalised) {
     normalised.critique = normaliseCritique(normalised.critique);
   }
-  
+
   return normalised;
 }
 

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -627,3 +627,112 @@ describe('createISLInferenceFn()', () => {
     expect(originalPU[0].mean).toBe(0.7);
   });
 });
+
+// =============================================================================
+// Margin Sensitivity Integration
+// =============================================================================
+
+describe('resolveFlipValues() margin_sensitivity integration', () => {
+  /**
+   * Mock that keeps the same winner at every probe but compresses the lead
+   * margin at the lower bound. baseline: a=0.65 b=0.30 c=0.05 (margin 0.35),
+   * min (factor=0): a=0.55 b=0.40 c=0.05 (margin 0.15 → delta -0.20),
+   * max (factor=1): a=0.66 b=0.29 c=0.05 (margin 0.37 → delta +0.02).
+   */
+  function createMarginCompressionAtMinMock(): ISLInferenceFn {
+    return async (_factorId: string, overrideMean: number): Promise<FlipInferenceResult> => {
+      if (overrideMean <= 0) {
+        return {
+          options: [
+            { option_id: 'opt-a', win_probability: 0.55 },
+            { option_id: 'opt-b', win_probability: 0.40 },
+            { option_id: 'opt-c', win_probability: 0.05 },
+          ],
+        };
+      }
+      if (overrideMean >= 1) {
+        return {
+          options: [
+            { option_id: 'opt-a', win_probability: 0.66 },
+            { option_id: 'opt-b', win_probability: 0.29 },
+            { option_id: 'opt-c', win_probability: 0.05 },
+          ],
+        };
+      }
+      return {
+        options: [
+          { option_id: 'opt-a', win_probability: 0.65 },
+          { option_id: 'opt-b', win_probability: 0.30 },
+          { option_id: 'opt-c', win_probability: 0.05 },
+        ],
+      };
+    };
+  }
+
+  it("emits margin_sensitivity 'weakened' alongside flip_reason 'no_effect_within_bounds' (iterations_used: 0 can coexist with non-none margin movement)", async () => {
+    const mock = createMarginCompressionAtMinMock();
+    const candidate = makeCandidate({ current_value: 0.5, direction: 'decrease' });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results).toHaveLength(1);
+    expect(results[0].flip_reason).toBe('no_effect_within_bounds');
+    expect(results[0].iterations_used).toBe(0);
+    expect(results[0].flip_value).toBeNull();
+    expect(results[0].alternative_winner_id).toBeNull();
+
+    expect(results[0].margin_sensitivity).toBeDefined();
+    const ms = results[0].margin_sensitivity!;
+    expect(ms.movement).toBe('weakened');
+    expect(ms.baseline_leading_option_id).toBe('opt-a');
+    expect(ms.baseline_runner_up_option_id).toBe('opt-b');
+    expect(ms.strongest_direction).toBe('towards_min');
+    expect(ms.strongest_probe_value).toBe(0);
+    expect(ms.value_scale).toBe('normalised');
+  });
+
+  it("emits margin_sensitivity 'flipped' alongside found flip without disturbing existing fields", async () => {
+    const mock = createMonotonicMock(0.35, 'opt-a', 'opt-b', 'decrease');
+    const candidate = makeCandidate({ current_value: 0.7, direction: 'decrease' });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('found');
+    expect(results[0].flip_value).not.toBeNull();
+    expect(results[0].alternative_winner_id).toBe('opt-b');
+    expect(results[0].margin_sensitivity?.movement).toBe('flipped');
+  });
+
+  it("emits margin_sensitivity 'none' for a genuinely flat factor", async () => {
+    const mock = createNeverFlipMock('opt-a');
+    const candidate = makeCandidate({ current_value: 0.5 });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('no_effect_within_bounds');
+    expect(results[0].margin_sensitivity).toBeDefined();
+    expect(results[0].margin_sensitivity!.movement).toBe('none');
+    expect(results[0].margin_sensitivity!.strongest_direction).toBe('none');
+    expect(results[0].margin_sensitivity!.strongest_probe_value).toBeNull();
+  });
+
+  it('omits margin_sensitivity when the probe phase fails with an exception', async () => {
+    const mock = createErrorMock();
+    const candidate = makeCandidate({ current_value: 0.5 });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('error');
+    expect(results[0].margin_sensitivity).toBeUndefined();
+  });
+
+  it('omits margin_sensitivity when current_value is non-finite (skips probes entirely)', async () => {
+    const mock = createNeverFlipMock();
+    const candidate = makeCandidate({ current_value: Number.NaN });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('error');
+    expect(results[0].margin_sensitivity).toBeUndefined();
+  });
+});

--- a/tests/analysis/margin-sensitivity.test.ts
+++ b/tests/analysis/margin-sensitivity.test.ts
@@ -185,4 +185,147 @@ describe('computeMarginSensitivity()', () => {
       expect(out.value_scale).toBe('normalised');
     });
   });
+
+  // ===========================================================================
+  // Display-ready fields — PLoT emits them so DGAI stays a thin display layer.
+  // DGAI must NOT compute these from raw min_probe_delta / max_probe_delta.
+  // ===========================================================================
+
+  describe('display-ready fields (strongest_delta family)', () => {
+    it('weakened by -20pp at min: strongest_delta = -0.20, abs = 0.20, pp = 20', () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]);
+      const min = probe(['a', 0.5], ['b', 0.4], ['c', 0.1]); // margin 0.1 → delta -0.20
+      const max = probe(['a', 0.61], ['b', 0.29], ['c', 0.1]); // ~unchanged
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+
+      expect(out.movement).toBe('weakened');
+      expect(out.strongest_direction).toBe('towards_min');
+      expect(out.strongest_delta).toBeCloseTo(-0.20, 10);
+      expect(out.strongest_delta_abs).toBeCloseTo(0.20, 10);
+      expect(out.strongest_delta_percentage_points).toBeCloseTo(20, 6);
+    });
+
+    it('strengthened by +7pp at max: strongest_delta = +0.07, pp = 7', () => {
+      // baseline margin 0.10 → max margin 0.17 → delta +0.07
+      const baseline = probe(['a', 0.55], ['b', 0.45]);
+      const min = probe(['a', 0.55], ['b', 0.45]); // unchanged
+      const max = probe(['a', 0.585], ['b', 0.415]); // margin 0.17, delta +0.07
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+
+      expect(out.movement).toBe('strengthened');
+      expect(out.strongest_direction).toBe('towards_max');
+      expect(out.strongest_delta).toBeCloseTo(0.07, 10);
+      expect(out.strongest_delta_abs).toBeCloseTo(0.07, 10);
+      expect(out.strongest_delta_percentage_points).toBeCloseTo(7, 6);
+    });
+
+    it("'both' opposite signs (min -8pp, max +6pp): strongest_delta = -0.08, pp = 8, direction = 'both'", () => {
+      // baseline margin 0.15
+      // min: a=0.51, b=0.44, c=0.05 → margin 0.07 → delta -0.08
+      // max: a=0.58, b=0.37, c=0.05 → margin 0.21 → delta +0.06
+      const baseline = probe(['a', 0.55], ['b', 0.40], ['c', 0.05]);
+      const min = probe(['a', 0.51], ['b', 0.44], ['c', 0.05]);
+      const max = probe(['a', 0.58], ['b', 0.37], ['c', 0.05]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+
+      expect(out.movement).toBe('weakened');
+      expect(out.strongest_direction).toBe('both');
+      expect(out.strongest_delta).toBeCloseTo(-0.08, 10);
+      expect(out.strongest_delta_abs).toBeCloseTo(0.08, 10);
+      expect(out.strongest_delta_percentage_points).toBeCloseTo(8, 6);
+    });
+
+    it("'none' movement: all three new delta fields null, display_value_available false", () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3]);
+      const min = probe(['a', 0.59], ['b', 0.31]); // sub-threshold
+      const max = probe(['a', 0.62], ['b', 0.29]); // sub-threshold
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+
+      expect(out.movement).toBe('none');
+      expect(out.strongest_delta).toBeNull();
+      expect(out.strongest_delta_abs).toBeNull();
+      expect(out.strongest_delta_percentage_points).toBeNull();
+      expect(out.display_value_available).toBe(false);
+    });
+
+    it("'flipped' (bound-level): strongest_delta populated from bound-level evidence", () => {
+      const baseline = probe(['a', 0.55], ['b', 0.35], ['c', 0.10]);
+      const min = probe(['a', 0.30], ['b', 0.60], ['c', 0.10]); // bound flip
+      const max = probe(['a', 0.56], ['b', 0.34], ['c', 0.10]); // unchanged
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+
+      expect(out.movement).toBe('flipped');
+      expect(out.strongest_direction).toBe('towards_min');
+      // baseline margin 0.20; min margin = 0.30 - 0.60 = -0.30; delta = -0.50.
+      expect(out.strongest_delta).toBeCloseTo(-0.50, 10);
+      expect(out.strongest_delta_abs).toBeCloseTo(0.50, 10);
+      expect(out.strongest_delta_percentage_points).toBeCloseTo(50, 6);
+    });
+
+    it("'flipped' via interior strict flip (no bound flip): strongest_delta still populated from larger-|delta| bound", () => {
+      // Both bounds keep the baseline winner; the binary search caller signals
+      // strictFlipDetected. Use larger-|delta| bound for strongest_delta even
+      // though strongest_direction stays 'none'.
+      const baseline = probe(['a', 0.55], ['b', 0.40], ['c', 0.05]); // margin 0.15
+      const min = probe(['a', 0.52], ['b', 0.43], ['c', 0.05]); // margin 0.09 → delta -0.06
+      const max = probe(['a', 0.50], ['b', 0.45], ['c', 0.05]); // margin 0.05 → delta -0.10
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: true });
+
+      expect(out.movement).toBe('flipped');
+      expect(out.strongest_direction).toBe('none'); // not a bound-level flip
+      expect(out.strongest_probe_value).toBeNull(); // not the exact flip threshold
+      // Larger |delta| is max's -0.10
+      expect(out.strongest_delta).toBeCloseTo(-0.10, 10);
+      expect(out.strongest_delta_abs).toBeCloseTo(0.10, 10);
+      expect(out.strongest_delta_percentage_points).toBeCloseTo(10, 6);
+    });
+
+    it("'flipped' preserves the diagnostic: strongest_probe_value is NOT the exact flip threshold", () => {
+      // Documented invariant: flip_value (on the surrounding flip_thresholds[]
+      // entry) is the exact threshold from binary search. strongest_probe_value
+      // is the tested BOUND that drove margin movement, not the same thing.
+      const baseline = probe(['a', 0.55], ['b', 0.35], ['c', 0.10]);
+      const min = probe(['a', 0.30], ['b', 0.60], ['c', 0.10]);
+      const max = probe(['a', 0.56], ['b', 0.34], ['c', 0.10]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      // strongest_probe_value = 0 (the min bound), NOT a precise flip point.
+      expect(out.strongest_probe_value).toBe(0);
+    });
+
+    it('display_value_available is false by default (helper always emits normalised)', () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3]);
+      const min = probe(['a', 0.5], ['b', 0.4]);
+      const max = probe(['a', 0.6], ['b', 0.3]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.value_scale).toBe('normalised');
+      expect(out.display_value_available).toBe(false);
+    });
+
+    it('NaN/Infinity inputs → new fields remain finite-or-null only', () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]);
+      const minBad: FlipInferenceResult = {
+        options: [
+          { option_id: 'a', win_probability: NaN },
+          { option_id: 'b', win_probability: 0.5 },
+          { option_id: 'c', win_probability: Number.POSITIVE_INFINITY },
+        ],
+      };
+      const max = probe(['a', 0.61], ['b', 0.29], ['c', 0.1]);
+      const out = computeMarginSensitivity({ baseline, min: minBad, max, strictFlipDetected: false });
+
+      for (const v of [out.strongest_delta, out.strongest_delta_abs, out.strongest_delta_percentage_points]) {
+        if (v !== null) expect(Number.isFinite(v)).toBe(true);
+      }
+      expect(out.display_value_available).toBe(false);
+    });
+
+    it('threshold dampening: 0.20 decimal delta → exactly 20 percentage points (no aggressive rounding)', () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3]);
+      const min = probe(['a', 0.5], ['b', 0.4]); // delta = -0.20
+      const max = probe(['a', 0.6], ['b', 0.3]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      // Allow for the IEEE-754 floating-point representation of 0.2 * 100.
+      expect(out.strongest_delta_percentage_points).toBeCloseTo(20, 9);
+    });
+  });
 });

--- a/tests/analysis/margin-sensitivity.test.ts
+++ b/tests/analysis/margin-sensitivity.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Pure-helper tests for margin-sensitivity classification.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeMarginSensitivity,
+  MARGIN_MOVEMENT_THRESHOLD,
+} from '../../src/analysis/margin-sensitivity.js';
+import type { FlipInferenceResult } from '../../src/analysis/flip-thresholds.js';
+
+function probe(...pairs: Array<[string, number]>): FlipInferenceResult {
+  return { options: pairs.map(([option_id, win_probability]) => ({ option_id, win_probability })) };
+}
+
+describe('computeMarginSensitivity()', () => {
+  describe('strict flip precedence', () => {
+    it("returns 'flipped' when caller signals a strict flip", () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]);
+      const min = probe(['a', 0.55], ['b', 0.35], ['c', 0.1]); // still leader
+      const max = probe(['a', 0.5], ['b', 0.4], ['c', 0.1]); // still leader
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: true });
+      expect(out.movement).toBe('flipped');
+      expect(out.baseline_leading_option_id).toBe('a');
+      expect(out.baseline_runner_up_option_id).toBe('b');
+    });
+
+    it("treats bound-level flip (probe margin negative) as 'flipped' even without strictFlipDetected", () => {
+      const baseline = probe(['a', 0.55], ['b', 0.35], ['c', 0.1]);
+      const min = probe(['a', 0.3], ['b', 0.6], ['c', 0.1]); // 'a' lost the lead at min
+      const max = probe(['a', 0.55], ['b', 0.35], ['c', 0.1]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.movement).toBe('flipped');
+      expect(out.strongest_direction).toBe('towards_min');
+      expect(out.strongest_probe_value).toBe(0);
+      expect(out.min_probe_margin).toBeLessThan(0);
+    });
+  });
+
+  describe('weakened lead', () => {
+    it("classifies a 10pp lead-margin compression at min bound as 'weakened'", () => {
+      // baseline margin 0.6 - 0.3 = 0.3. min: 0.5 - 0.4 = 0.1 → delta = -0.2 (≥ 0.05).
+      const baseline = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]);
+      const min = probe(['a', 0.5], ['b', 0.4], ['c', 0.1]);
+      const max = probe(['a', 0.61], ['b', 0.29], ['c', 0.1]); // ~unchanged
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.movement).toBe('weakened');
+      expect(out.strongest_direction).toBe('towards_min');
+      expect(out.strongest_probe_value).toBe(0);
+      expect(out.baseline_margin).toBeCloseTo(0.3, 10);
+      expect(out.min_probe_delta).toBeLessThan(0);
+    });
+  });
+
+  describe('strengthened lead', () => {
+    it("classifies a 7pp lead-margin growth at max bound as 'strengthened'", () => {
+      const baseline = probe(['a', 0.5], ['b', 0.4], ['c', 0.1]);
+      const min = probe(['a', 0.5], ['b', 0.4], ['c', 0.1]); // unchanged
+      const max = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]); // margin 0.1 → 0.3 ; delta +0.2
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.movement).toBe('strengthened');
+      expect(out.strongest_direction).toBe('towards_max');
+      expect(out.strongest_probe_value).toBe(1);
+      expect(out.max_probe_delta).toBeGreaterThan(0);
+    });
+  });
+
+  describe('no movement below threshold', () => {
+    it("returns 'none' and direction 'none' when both deltas are sub-threshold", () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]);
+      const min = probe(['a', 0.59], ['b', 0.31], ['c', 0.1]); // delta ~-0.02
+      const max = probe(['a', 0.62], ['b', 0.29], ['c', 0.09]); // delta ~+0.03
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.movement).toBe('none');
+      expect(out.strongest_direction).toBe('none');
+      expect(out.strongest_probe_value).toBeNull();
+    });
+  });
+
+  describe('threshold boundary', () => {
+    it('classifies movement at exactly the threshold (>= behaviour, not strictly >)', () => {
+      // Engineer min delta = exactly -MARGIN_MOVEMENT_THRESHOLD
+      // baseline 0.6 - 0.3 = 0.3 ; min: a=0.575, b=0.325, c=0.1 → margin 0.25 → delta -0.05
+      const baseline = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]);
+      const min = probe(['a', 0.575], ['b', 0.325], ['c', 0.1]);
+      const max = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.threshold).toBe(MARGIN_MOVEMENT_THRESHOLD);
+      expect(Math.abs(out.min_probe_delta as number)).toBeCloseTo(MARGIN_MOVEMENT_THRESHOLD, 10);
+      expect(out.movement).toBe('weakened');
+    });
+  });
+
+  describe('both directions material', () => {
+    it("picks larger |delta| sign for movement and sets strongest_direction to 'both' on opposite signs", () => {
+      // baseline 0.55 - 0.4 = 0.15
+      // min compresses by 0.08 (delta -0.08), max grows by 0.06 (delta +0.06).
+      const baseline = probe(['a', 0.55], ['b', 0.4], ['c', 0.05]);
+      const min = probe(['a', 0.51], ['b', 0.44], ['c', 0.05]); // margin 0.07 → delta -0.08
+      const max = probe(['a', 0.58], ['b', 0.37], ['c', 0.05]); // margin 0.21 → delta +0.06
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.movement).toBe('weakened');
+      expect(out.strongest_direction).toBe('both');
+      expect(out.strongest_probe_value).toBe(0);
+    });
+
+    it("uses larger |delta| side for strongest_direction when both same-sign material", () => {
+      // both deltas negative; max is larger
+      const baseline = probe(['a', 0.55], ['b', 0.4], ['c', 0.05]);
+      const min = probe(['a', 0.51], ['b', 0.44], ['c', 0.05]); // delta -0.08
+      const max = probe(['a', 0.48], ['b', 0.47], ['c', 0.05]); // margin 0.01 → delta -0.14
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.movement).toBe('weakened');
+      expect(out.strongest_direction).toBe('towards_max');
+      expect(out.strongest_probe_value).toBe(1);
+    });
+  });
+
+  describe('runner-up tie handling', () => {
+    it('deterministically picks lexicographically-smallest option_id for the runner-up tie', () => {
+      const baseline = probe(['a', 0.6], ['c', 0.2], ['b', 0.2]); // b and c tie for runner-up
+      const min = probe(['a', 0.6], ['b', 0.2], ['c', 0.2]);
+      const max = probe(['a', 0.6], ['b', 0.2], ['c', 0.2]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.baseline_leading_option_id).toBe('a');
+      expect(out.baseline_runner_up_option_id).toBe('b'); // 'b' < 'c'
+    });
+  });
+
+  describe('numeric safety', () => {
+    it('returns all-null and movement none when probe has <2 valid options', () => {
+      const baseline = probe(['a', 0.9]); // only one option
+      const min = probe(['a', 0.9]);
+      const max = probe(['a', 0.9]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.movement).toBe('none');
+      expect(out.baseline_leading_option_id).toBeNull();
+      expect(out.baseline_runner_up_option_id).toBeNull();
+      expect(out.baseline_margin).toBeNull();
+      expect(out.min_probe_margin).toBeNull();
+      expect(out.max_probe_margin).toBeNull();
+    });
+
+    it('still surfaces flipped for strictFlipDetected even when baseline lacks 2 valid options', () => {
+      const baseline = probe(['a', 0.9]);
+      const min = probe(['a', 0.9]);
+      const max = probe(['a', 0.9]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: true });
+      expect(out.movement).toBe('flipped');
+    });
+
+    it('filters NaN/Infinity win_probability and treats probe as missing those options', () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3], ['c', 0.1]);
+      const minBad: FlipInferenceResult = {
+        options: [
+          { option_id: 'a', win_probability: NaN },
+          { option_id: 'b', win_probability: 0.5 },
+          { option_id: 'c', win_probability: Number.POSITIVE_INFINITY },
+        ],
+      };
+      const max = probe(['a', 0.61], ['b', 0.29], ['c', 0.1]);
+      const out = computeMarginSensitivity({ baseline, min: minBad, max, strictFlipDetected: false });
+      // The leader 'a' has no finite probe at min → min_probe_margin is null
+      expect(out.min_probe_margin).toBeNull();
+      expect(out.min_probe_delta).toBeNull();
+      // All remaining numeric outputs are finite or null — never NaN/Infinity.
+      const numerics: Array<number | null> = [
+        out.baseline_margin,
+        out.min_probe_margin,
+        out.max_probe_margin,
+        out.min_probe_delta,
+        out.max_probe_delta,
+        out.strongest_probe_value,
+      ];
+      for (const v of numerics) {
+        if (v !== null) expect(Number.isFinite(v)).toBe(true);
+      }
+    });
+
+    it('stamps value_scale "normalised" by default', () => {
+      const baseline = probe(['a', 0.6], ['b', 0.3]);
+      const min = probe(['a', 0.6], ['b', 0.3]);
+      const max = probe(['a', 0.6], ['b', 0.3]);
+      const out = computeMarginSensitivity({ baseline, min, max, strictFlipDetected: false });
+      expect(out.value_scale).toBe('normalised');
+    });
+  });
+});

--- a/tests/lib/flip-threshold-denormaliser.test.ts
+++ b/tests/lib/flip-threshold-denormaliser.test.ts
@@ -196,4 +196,87 @@ describe('denormaliseFlipThresholds()', () => {
       expect(result[0].alternative_winner_label).toBeNull();
     });
   });
+
+  // ===========================================================================
+  // Margin sensitivity — display_value_available reflects whether
+  // strongest_probe_value has actually been denormalised.
+  // ===========================================================================
+
+  describe('margin_sensitivity display_value_available', () => {
+    function makeMarginInput(strongestProbeValue: number | null) {
+      return {
+        movement: 'weakened' as const,
+        threshold: 0.05,
+        baseline_leading_option_id: 'opt-a',
+        baseline_runner_up_option_id: 'opt-b',
+        baseline_margin: 0.3,
+        min_probe_margin: 0.1,
+        max_probe_margin: 0.32,
+        min_probe_delta: -0.2,
+        max_probe_delta: 0.02,
+        strongest_direction: 'towards_min' as const,
+        strongest_probe_value: strongestProbeValue,
+        value_scale: 'normalised' as const,
+        strongest_delta: -0.2,
+        strongest_delta_abs: 0.2,
+        strongest_delta_percentage_points: 20,
+        display_value_available: false,
+      };
+    }
+
+    it('sets display_value_available=true and value_scale=display when factor context exists and probe value is finite', () => {
+      const flip = makeFlip({
+        flip_value: 0.3,
+        current_value: 0.7,
+        margin_sensitivity: makeMarginInput(0),
+      });
+      // Range 0..100 GBP — denormalises 0 to 0.
+      const context = makeContext('f1', 0, 100);
+
+      const result = denormaliseFlipThresholds([flip], context, OPTIONS);
+
+      expect(result[0].margin_sensitivity).toBeDefined();
+      expect(result[0].margin_sensitivity!.value_scale).toBe('display');
+      expect(result[0].margin_sensitivity!.display_value_available).toBe(true);
+      expect(result[0].margin_sensitivity!.strongest_probe_value).toBe(0);
+      // Diagnostic fields pass through unchanged (probability scale).
+      expect(result[0].margin_sensitivity!.min_probe_delta).toBeCloseTo(-0.2, 10);
+      expect(result[0].margin_sensitivity!.strongest_delta_percentage_points).toBeCloseTo(20, 6);
+    });
+
+    it("leaves display_value_available=false and value_scale=normalised when there is NO factor context", () => {
+      const flip = makeFlip({ margin_sensitivity: makeMarginInput(0) });
+
+      // No context → enrichWithLabels path, margin passed through untouched.
+      const result = denormaliseFlipThresholds([flip], undefined, OPTIONS);
+
+      expect(result[0].margin_sensitivity).toBeDefined();
+      expect(result[0].margin_sensitivity!.value_scale).toBe('normalised');
+      expect(result[0].margin_sensitivity!.display_value_available).toBe(false);
+    });
+
+    it('sets display_value_available=false when strongest_probe_value is null even with factor context', () => {
+      // Strict-flip via interior binary search emits strongest_probe_value=null
+      // (no bound flip). Denormalising null yields null.
+      const flip = makeFlip({
+        margin_sensitivity: { ...makeMarginInput(null), movement: 'flipped' },
+      });
+      const context = makeContext('f1', 0, 100);
+
+      const result = denormaliseFlipThresholds([flip], context, OPTIONS);
+
+      expect(result[0].margin_sensitivity!.value_scale).toBe('display');
+      expect(result[0].margin_sensitivity!.strongest_probe_value).toBeNull();
+      expect(result[0].margin_sensitivity!.display_value_available).toBe(false);
+    });
+
+    it('omits margin_sensitivity on entries that did not carry it', () => {
+      const flip = makeFlip({ margin_sensitivity: undefined });
+      const context = makeContext('f1', 0, 100);
+
+      const result = denormaliseFlipThresholds([flip], context, OPTIONS);
+
+      expect(result[0].margin_sensitivity).toBeUndefined();
+    });
+  });
 });

--- a/tests/lib/flip-thresholds-margin-status.test.ts
+++ b/tests/lib/flip-thresholds-margin-status.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the aggregate margin-status classifier and coverage counter.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyFlipThresholdsMarginStatus,
+  computeFlipThresholdsMarginCoverage,
+} from '../../src/lib/flip-thresholds-margin-status.js';
+import type { DenormalisedFlipThreshold } from '../../src/lib/flip-threshold-denormaliser.js';
+import type { MarginSensitivity } from '../../src/analysis/margin-sensitivity.js';
+
+function ms(movement: MarginSensitivity['movement']): MarginSensitivity {
+  return {
+    movement,
+    threshold: 0.05,
+    baseline_leading_option_id: 'a',
+    baseline_runner_up_option_id: 'b',
+    baseline_margin: 0.3,
+    min_probe_margin: 0.2,
+    max_probe_margin: 0.4,
+    min_probe_delta: -0.1,
+    max_probe_delta: 0.1,
+    strongest_direction: movement === 'none' ? 'none' : 'towards_min',
+    strongest_probe_value: movement === 'none' ? null : 0,
+    value_scale: 'normalised',
+  };
+}
+
+function entry(overrides: Partial<DenormalisedFlipThreshold> = {}): DenormalisedFlipThreshold {
+  return {
+    factor_id: 'f1',
+    factor_label: 'Factor One',
+    current_value: 0.5,
+    flip_value: null,
+    direction: 'decrease',
+    flip_reason: 'no_effect_within_bounds',
+    iterations_used: 0,
+    alternative_winner_id: null,
+    alternative_winner_label: null,
+    unit: undefined,
+    margin_sensitivity: ms('none'),
+    ...overrides,
+  };
+}
+
+describe('classifyFlipThresholdsMarginStatus()', () => {
+  it("returns 'unavailable' for null / undefined / empty array", () => {
+    expect(classifyFlipThresholdsMarginStatus(null).status).toBe('unavailable');
+    expect(classifyFlipThresholdsMarginStatus(undefined).status).toBe('unavailable');
+    expect(classifyFlipThresholdsMarginStatus([]).status).toBe('unavailable');
+  });
+
+  it("returns 'unavailable' when no entry carries margin_sensitivity", () => {
+    const entries = [
+      entry({ margin_sensitivity: undefined }),
+      entry({ factor_id: 'f2', margin_sensitivity: undefined }),
+    ];
+    expect(classifyFlipThresholdsMarginStatus(entries).status).toBe('unavailable');
+  });
+
+  it("returns 'computed' when every entry-with-margin has non-none movement", () => {
+    const entries = [
+      entry({ margin_sensitivity: ms('flipped') }),
+      entry({ factor_id: 'f2', margin_sensitivity: ms('weakened') }),
+      entry({ factor_id: 'f3', margin_sensitivity: ms('strengthened') }),
+    ];
+    expect(classifyFlipThresholdsMarginStatus(entries).status).toBe('computed');
+  });
+
+  it("returns 'all_none' when every entry-with-margin has movement === 'none'", () => {
+    const entries = [
+      entry({ margin_sensitivity: ms('none') }),
+      entry({ factor_id: 'f2', margin_sensitivity: ms('none') }),
+    ];
+    expect(classifyFlipThresholdsMarginStatus(entries).status).toBe('all_none');
+  });
+
+  it("returns 'partial_movement' on a mix of none and non-none movement", () => {
+    const entries = [
+      entry({ margin_sensitivity: ms('weakened') }),
+      entry({ factor_id: 'f2', margin_sensitivity: ms('none') }),
+    ];
+    expect(classifyFlipThresholdsMarginStatus(entries).status).toBe('partial_movement');
+  });
+
+  it('ignores entries that lack margin_sensitivity (does not count them as none)', () => {
+    const entries = [
+      entry({ margin_sensitivity: ms('weakened') }),
+      entry({ factor_id: 'f2', margin_sensitivity: undefined }),
+    ];
+    // Only one classified entry, with movement → 'computed', not 'partial_movement'.
+    expect(classifyFlipThresholdsMarginStatus(entries).status).toBe('computed');
+  });
+
+  it("returns 'all_none' even when some entries lack margin_sensitivity, as long as those that have it are all 'none'", () => {
+    const entries = [
+      entry({ margin_sensitivity: ms('none') }),
+      entry({ factor_id: 'f2', margin_sensitivity: undefined }),
+    ];
+    expect(classifyFlipThresholdsMarginStatus(entries).status).toBe('all_none');
+  });
+});
+
+describe('computeFlipThresholdsMarginCoverage()', () => {
+  it('returns zeros for null / undefined', () => {
+    expect(computeFlipThresholdsMarginCoverage(null)).toEqual({ total: 0, with_margin: 0, without_margin: 0 });
+    expect(computeFlipThresholdsMarginCoverage(undefined)).toEqual({ total: 0, with_margin: 0, without_margin: 0 });
+  });
+
+  it('returns zeros for empty array', () => {
+    expect(computeFlipThresholdsMarginCoverage([])).toEqual({ total: 0, with_margin: 0, without_margin: 0 });
+  });
+
+  it('counts entries with and without margin_sensitivity', () => {
+    const entries = [
+      entry({ margin_sensitivity: ms('weakened') }),
+      entry({ factor_id: 'f2', margin_sensitivity: undefined }),
+      entry({ factor_id: 'f3', margin_sensitivity: ms('none') }),
+    ];
+    expect(computeFlipThresholdsMarginCoverage(entries)).toEqual({
+      total: 3,
+      with_margin: 2,
+      without_margin: 1,
+    });
+  });
+});

--- a/tests/util/canonical-json-margin-sensitivity.test.ts
+++ b/tests/util/canonical-json-margin-sensitivity.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Hash-stability invariant for additive margin-sensitivity diagnostic.
+ *
+ * Adding `flip_thresholds_margin_status`, `flip_thresholds_margin_coverage`,
+ * or per-entry `flip_thresholds[].margin_sensitivity` MUST NOT change a
+ * report's `sha256Stable()` hash. They are diagnostic-only and stripped
+ * inside `normaliseReport()`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sha256Stable, normaliseReport } from '../../src/util/canonical-json.js';
+
+function baseReport() {
+  return {
+    schema_version: '3.0.0',
+    meta: { seed: 42 },
+    model_card: { name: 'plot' },
+    flip_thresholds: [
+      {
+        factor_id: 'f1',
+        factor_label: 'Factor One',
+        current_value: 0.5,
+        flip_value: null,
+        direction: 'decrease' as const,
+        flip_reason: 'no_effect_within_bounds',
+        iterations_used: 0,
+        alternative_winner_id: null,
+        alternative_winner_label: null,
+      },
+    ],
+    flip_thresholds_status: 'all_no_effect' as const,
+  };
+}
+
+function reportWithMargin() {
+  const r = baseReport();
+  return {
+    ...r,
+    flip_thresholds: [
+      {
+        ...r.flip_thresholds[0],
+        margin_sensitivity: {
+          movement: 'weakened',
+          threshold: 0.05,
+          baseline_leading_option_id: 'a',
+          baseline_runner_up_option_id: 'b',
+          baseline_margin: 0.3,
+          min_probe_margin: 0.1,
+          max_probe_margin: 0.32,
+          min_probe_delta: -0.2,
+          max_probe_delta: 0.02,
+          strongest_direction: 'towards_min',
+          strongest_probe_value: 0,
+          value_scale: 'normalised',
+        },
+      },
+    ],
+    flip_thresholds_margin_status: 'computed',
+    flip_thresholds_margin_coverage: { total: 1, with_margin: 1, without_margin: 0 },
+  };
+}
+
+describe('canonical-json: margin-sensitivity hash exclusion', () => {
+  it('sha256Stable is identical with and without the additive diagnostic fields', () => {
+    const hashWithout = sha256Stable(baseReport());
+    const hashWith = sha256Stable(reportWithMargin());
+    expect(hashWith).toBe(hashWithout);
+  });
+
+  it('normaliseReport strips top-level flip_thresholds_margin_status', () => {
+    const out = normaliseReport(reportWithMargin()) as Record<string, unknown>;
+    expect(out.flip_thresholds_margin_status).toBeUndefined();
+  });
+
+  it('normaliseReport strips top-level flip_thresholds_margin_coverage', () => {
+    const out = normaliseReport(reportWithMargin()) as Record<string, unknown>;
+    expect(out.flip_thresholds_margin_coverage).toBeUndefined();
+  });
+
+  it('normaliseReport strips per-entry margin_sensitivity', () => {
+    const out = normaliseReport(reportWithMargin()) as Record<string, unknown>;
+    const arr = out.flip_thresholds as Array<Record<string, unknown>>;
+    expect(arr).toHaveLength(1);
+    expect(arr[0].margin_sensitivity).toBeUndefined();
+  });
+
+  it('normaliseReport preserves non-margin entry fields', () => {
+    const out = normaliseReport(reportWithMargin()) as Record<string, unknown>;
+    const arr = out.flip_thresholds as Array<Record<string, unknown>>;
+    expect(arr[0].factor_id).toBe('f1');
+    expect(arr[0].flip_reason).toBe('no_effect_within_bounds');
+  });
+});

--- a/tests/util/canonical-json-margin-sensitivity.test.ts
+++ b/tests/util/canonical-json-margin-sensitivity.test.ts
@@ -52,6 +52,11 @@ function reportWithMargin() {
           strongest_direction: 'towards_min',
           strongest_probe_value: 0,
           value_scale: 'normalised',
+          // Display-ready fields — also must be excluded from response_hash.
+          strongest_delta: -0.2,
+          strongest_delta_abs: 0.2,
+          strongest_delta_percentage_points: 20,
+          display_value_available: false,
         },
       },
     ],


### PR DESCRIPTION
## Summary

Adds an additive **lead-margin movement** diagnostic to flip-threshold output, so the *"what could change the result"* surface stays useful in dominance regimes where the leading option does not strictly flip. Computed from the three Step-0 probe results the flip-search already fetches — **zero additional ISL calls, no hidden latency**.

Strict winner flips keep top emphasis. Non-flipping but material lead-margin movement is now surfaced as `'weakened'` or `'strengthened'`. Genuinely flat factors stay `'none'`. PR #167's `flip_thresholds_status` semantics and existing `response_hash` values are preserved.

## Phase 0 findings (validated before coding)

- **Hook point:** [src/analysis/flip-thresholds.ts](src/analysis/flip-thresholds.ts) — immediately after the three Step-0 probes resolve. Strict-flip flag = `(W_min !== W0 || W_max !== W0)`.
- **Probe data:** every probe already exposes per-option `win_probability`. Margin = baseline-leader's prob minus the strongest alternative's prob, computable from in-scope probe results. **No additional ISL probes required.**
- **Backwards compatibility:**
  - `flip_thresholds_status` enum is OpenAPI-locked. Did **NOT** mutate; added a separate `flip_thresholds_margin_status` field instead.
  - Per-entry `flip_thresholds[]` shape is not declared in OpenAPI → nested `margin_sensitivity` is contract-safe.
  - No in-repo DGAI coupling exists (no fixtures, no types, no comments) — safest to ship a separate field.
  - `response_hash`: per OpenAPI policy for diagnostic fields, the new fields are stripped in `normaliseReport()`. Hash of existing responses is byte-identical (proven by [tests/util/canonical-json-margin-sensitivity.test.ts](tests/util/canonical-json-margin-sensitivity.test.ts)).
- **Pre-existing finding (NOT fixed here):** OpenAPI claims `flip_thresholds_status` is "Excluded from `response_hash`" but [src/util/canonical-json.ts](src/util/canonical-json.ts) does not actually strip it today. Out of scope; flagged for a future cleanup PR.

## Response-shape diff

**New top-level fields** (both declared in [contracts/openapi.yaml](contracts/openapi.yaml)):

\`\`\`yaml
flip_thresholds_margin_status: 'computed' | 'partial_movement' | 'all_none' | 'unavailable'
flip_thresholds_margin_coverage:
  total: integer
  with_margin: integer
  without_margin: integer
\`\`\`

**New per-entry field** on `flip_thresholds[]` (undeclared in OpenAPI because the per-entry shape itself is undeclared):

\`\`\`ts
margin_sensitivity?: {
  movement: 'none' | 'weakened' | 'strengthened' | 'flipped'
  threshold: number                              // provisional 0.05 (5pp)
  baseline_leading_option_id: string | null
  baseline_runner_up_option_id: string | null
  baseline_margin: number | null
  min_probe_margin: number | null
  max_probe_margin: number | null
  min_probe_delta: number | null
  max_probe_delta: number | null
  strongest_direction: 'towards_min' | 'towards_max' | 'both' | 'none'
  strongest_probe_value: number | null
  value_scale: 'normalised' | 'display'          // 'display' iff actually denormalised
}
\`\`\`

All three diagnostics are stripped in `normaliseReport()` → `response_hash` of existing responses unchanged.

## Algorithm + threshold

`computeMarginSensitivity({ baseline, min, max, strictFlipDetected })` in [src/analysis/margin-sensitivity.ts](src/analysis/margin-sensitivity.ts):

1. Baseline leader / runner-up from baseline probe (deterministic tie-break: lexicographic on `option_id`).
2. For each bound, compute the baseline-leader's margin over the strongest non-leader at that bound. Negative ⇒ bound-level flip.
3. If `strictFlipDetected` OR either bound margin is negative ⇒ `'flipped'`.
4. Otherwise: if max-absolute(min_delta, max_delta) ≥ `MARGIN_MOVEMENT_THRESHOLD` ⇒ `'weakened'` (negative) or `'strengthened'` (positive) by sign of the larger-|delta| side. Else `'none'`.
5. `strongest_direction`: `'both'` if both sides material with opposite signs; else the side that's material; else `'none'`.
6. Number safety: every numeric field is finite or `null`. Never `NaN` / `Infinity`.

`MARGIN_MOVEMENT_THRESHOLD = 0.05` (5 percentage points). **Documented as provisional, not calibrated** — centralised so a future calibration is one-line.

## Before / after fixture

The new behaviour is proven by integration tests in [tests/analysis/flip-thresholds.test.ts:631-739](tests/analysis/flip-thresholds.test.ts):

| factor case | flip_value | flip_reason | iterations_used | margin_sensitivity.movement | margin_delta | strongest_direction |
| --- | ---: | --- | ---: | --- | ---: | --- |
| Dominance regime — 20pp lead-margin compression at min, no winner flip | `null` | `no_effect_within_bounds` | `0` | `'weakened'` (NEW) | `-0.20` | `'towards_min'` |
| Strict monotonic flip at 0.35 | `~0.35` | `found` | `>0` | `'flipped'` | n/a | n/a |
| Genuinely flat factor | `null` | `no_effect_within_bounds` | `0` | `'none'` | n/a | `'none'` |
| Probe-phase exception | `null` | `error` | `0` | *omitted* | n/a | n/a |
| Non-finite baseline | `null` | `error` | `0` | *omitted* | n/a | n/a |

The first row is the headline change: previously this factor surfaced as a pure no-effect; now it correctly flags a 20pp lead-margin compression at the min bound while keeping all existing fields intact.

## Tests

- New: [tests/analysis/margin-sensitivity.test.ts](tests/analysis/margin-sensitivity.test.ts) — 13 pure-helper tests (strict flip, weakened/strengthened, no movement, threshold boundary, both directions, runner-up tie, numeric safety, NaN/Infinity, value_scale default).
- New: [tests/lib/flip-thresholds-margin-status.test.ts](tests/lib/flip-thresholds-margin-status.test.ts) — 10 classifier + coverage tests (all four statuses, entries without margin excluded from classification, coverage counters).
- New: [tests/util/canonical-json-margin-sensitivity.test.ts](tests/util/canonical-json-margin-sensitivity.test.ts) — 5 hash-stability tests (sha256Stable identical with/without new fields, normaliseReport strips each new field).
- Extended: [tests/analysis/flip-thresholds.test.ts](tests/analysis/flip-thresholds.test.ts) — 5 new integration cases on `resolveFlipValues()` (probe-completed branches carry margin, probe-failed branches do not).

**Pre-push validation** (`scripts/pre-push-validate.sh`):
```
PASS [1/7] Branch guard (current: feat/plot-margin-sensitivity)
PASS [2/7] TypeScript compilation (tsc --noEmit)
PASS [3/7] Full test suite — Tests 4794 passed | 25 skipped (4830)
PASS [4/7] No stale .js files tracked in src/
PASS [5/7] No file: dependency references
PASS [6/7] OpenAPI spec validation (spectral lint)
```

## Performance

- **ISL probes added: 0.** The three probes (`baseline`, `0`, `1`) already run today at [src/analysis/flip-thresholds.ts:199](src/analysis/flip-thresholds.ts).
- Binary search behaviour: unchanged.
- No new network calls, no new file or memory allocations of any meaningful size.
- Payload growth: ~12 small numeric/string fields per flip-threshold entry plus two top-level fields. Negligible.

## Compatibility findings

- **`flip_thresholds_status` semantics unchanged** (PR #167). Reviewed and intentional — see Phase 0 above.
- **DGAI:** no in-repo coupling exists. DGAI follow-up will consume the new fields; nothing in this PR can misrender.
- **`response_hash`:** byte-identical for existing inputs (proven by hash-stability test).
- **Heuristic-fallback entries** (entries that never reached `searchFlipForFactor`) correctly omit `margin_sensitivity`. The new `flip_thresholds_margin_coverage` object surfaces this honestly.
- **Type-only imports** for `MarginSensitivity` in `m1-review-types.ts` and `flip-threshold-denormaliser.ts` — no runtime cycle (tsc clean).

## DGAI follow-up consumption plan (no DGAI code in this PR)

This PLoT PR exposes `margin_sensitivity` and `flip_thresholds_margin_status` / `flip_thresholds_margin_coverage` for **future DGAI and debug consumption only**. The existing decision-review narration continues to consume classic flip thresholds where `flip_value !== null`; it will NOT yet narrate non-flipping margin movement. No prompts, no PMS, no CEE changes.

Future DGAI work should:

- Read `flip_thresholds_margin_status` alongside `flip_thresholds_status`.
- Per entry, switch on `margin_sensitivity.movement`:
  - `'flipped'` — highest emphasis. Continue current strict-flip UI.
  - `'weakened'` — secondary emphasis. Suggested British-English copy (sentence case): *"At this value, the leading option's margin falls by about X percentage points."*
  - `'strengthened'` — informational. Suggested: *"At this value, the leading option's margin increases by about X percentage points."*
  - `'none'` — same treatment as today's `no_effect_within_bounds`.
- `X` = `max(|min_probe_delta|, |max_probe_delta|) * 100`, rounded per house style.
- Use `strongest_probe_value` (already denormalised to display units) for the *"at this value"* copy.
- **Design system:** no new colour tokens, no new typography primitives; re-use existing warning / informational styles. Sentence case throughout. Avoid "winner" language — keep PLoT's existing *"leading option"* phrasing.
- The current all-no-effect collapse can be phased out only when product confirms the surfaced copy reads well in user testing.

## Remaining risks & out-of-scope

- **`MARGIN_MOVEMENT_THRESHOLD = 0.05` is provisional.** Not calibrated. Named, documented, and centralised so calibration is a one-line change.
- **OpenAPI doc-vs-code drift for `flip_thresholds_status`** (claims hash-exclusion that `normaliseReport()` does not enforce). NOT touched here — would alter existing hashes. Flagged for a follow-up.
- **Separate cleanup workstream needed:** the developer's primary working directory at `/Users/paulslee/Documents/GitHub/plot-lite-service` appears corrupted (missing tree objects, broken HEAD, 333 deleted files). This PR was developed in an isolated fresh clone to avoid risk. The primary repo should be backed up and recreated as part of a separate cleanup workstream — explicitly out of scope here.
- **Do not merge or deploy.** This is a review-only PR against `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)