### PR TITLE
feat(plot): margin-sensitivity review follow-ups (tie-break, OpenAPI, route test)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -6016,7 +6016,8 @@ components:
 
             Entries lacking `margin_sensitivity` are excluded from the
             classification — see `flip_thresholds_margin_coverage` for
-            honest counts.
+            honest counts. The per-entry `margin_sensitivity` object's
+            shape is declared at `#/components/schemas/MarginSensitivity`.
         flip_thresholds_margin_coverage:
           type: object
           description: |
@@ -6412,3 +6413,138 @@ components:
         trace_id:
           type: string
           description: 'Optional client-provided trace identifier echoed from X-Trace-Id when TRACE_ID_PASSTHROUGH=1'
+
+    # =========================================================================
+    # MarginSensitivity — additive per-entry lead-margin diagnostic surfaced
+    # on each `flip_thresholds[]` entry. Declared here as a standalone schema
+    # so DGAI generated clients can $ref a concrete type; the surrounding
+    # per-entry `flip_thresholds[]` shape itself remains undeclared (consistent
+    # with the rest of `flip_thresholds[]` today). Excluded from response_hash.
+    # =========================================================================
+    MarginSensitivity:
+      type: object
+      description: |
+        Additive lead-margin diagnostic computed from the Step-0 flip-search
+        probes (baseline / lower-bound / upper-bound). Surfaces whether the
+        tested factor range materially weakens, strengthens, or flips the
+        baseline-leading option's win-probability margin over the strongest
+        alternative.
+
+        Display-ready fields (`strongest_delta`, `strongest_delta_abs`,
+        `strongest_delta_percentage_points`, `display_value_available`) let
+        DGAI render copy directly without re-deriving from the raw deltas.
+
+        Notes:
+          - `strongest_probe_value` is the tested bound (or `null` when the
+            strict flip was found inside the interval by binary search). It
+            is NOT the exact flip threshold — that remains `flip_value` on
+            the surrounding flip_thresholds entry.
+          - `display_value_available` is `true` only when
+            `strongest_probe_value` is finite AND has been denormalised to
+            display units (`value_scale === 'display'`). DGAI must not
+            render `strongest_probe_value` unless this is `true`.
+          - `min_probe_delta` and `max_probe_delta` are raw diagnostics, not
+            the field DGAI should display.
+          - Excluded from `response_hash`.
+      required:
+        - movement
+        - threshold
+        - baseline_leading_option_id
+        - baseline_runner_up_option_id
+        - baseline_margin
+        - min_probe_margin
+        - max_probe_margin
+        - min_probe_delta
+        - max_probe_delta
+        - strongest_direction
+        - strongest_probe_value
+        - value_scale
+        - strongest_delta
+        - strongest_delta_abs
+        - strongest_delta_percentage_points
+        - display_value_available
+      properties:
+        movement:
+          type: string
+          enum: [none, weakened, strengthened, flipped]
+          description: |
+            'flipped'      = strict flip (winner identity changes, or a bound
+                             probe shows the baseline leader is no longer the
+                             strongest);
+            'weakened'     = lead margin compresses by >= `threshold` at one
+                             or both bounds (no strict flip);
+            'strengthened' = lead margin grows by >= `threshold` at one or
+                             both bounds (no strict flip);
+            'none'         = no material movement and no flip.
+        threshold:
+          type: number
+          description: |
+            Provisional minimum signed lead-margin movement (in probability
+            decimals) required to classify a probe as material. Default 0.05
+            = 5 percentage points. Documented as provisional, not calibrated.
+        baseline_leading_option_id:
+          type: string
+          nullable: true
+          description: Option_id of the baseline-leading option, or null when fewer than 2 valid options were available at baseline.
+        baseline_runner_up_option_id:
+          type: string
+          nullable: true
+          description: Option_id of the baseline runner-up (deterministic tie-break - lexicographic option_id ascending).
+        baseline_margin:
+          type: number
+          nullable: true
+          description: 'Baseline leader''s win_probability minus runner-up''s win_probability. Decimals in [0, 1].'
+        min_probe_margin:
+          type: number
+          nullable: true
+          description: Lead margin at the lower factor bound, for the baseline leader. Negative when the baseline leader is no longer the strongest at this probe (a bound-level flip).
+        max_probe_margin:
+          type: number
+          nullable: true
+          description: Lead margin at the upper factor bound, for the baseline leader.
+        min_probe_delta:
+          type: number
+          nullable: true
+          description: 'min_probe_margin - baseline_margin. Negative = lead margin weakened toward the lower bound.'
+        max_probe_delta:
+          type: number
+          nullable: true
+          description: 'max_probe_margin - baseline_margin. Negative = lead margin weakened toward the upper bound.'
+        strongest_direction:
+          type: string
+          enum: [towards_min, towards_max, both, none]
+          description: |
+            Direction of the strongest material movement.
+            'both' when both bounds exceed threshold with opposite signs.
+            'none' when no material movement, or for strict-flip-via-interior-binary-search (where neither bound flipped on its own).
+        strongest_probe_value:
+          type: number
+          nullable: true
+          description: |
+            Tested bound corresponding to `strongest_direction` (in normalised [0, 1] until denormalised). NOT the exact flip threshold - see `flip_value` on the surrounding entry. Null when `strongest_direction === 'none'` or no finite probe value applies.
+        value_scale:
+          type: string
+          enum: [normalised, display]
+          description: |
+            'normalised' when `strongest_probe_value` is in [0, 1] (helper output, or no factor context available for denormalisation).
+            'display' when `strongest_probe_value` has been converted to the factor's display units.
+        strongest_delta:
+          type: number
+          nullable: true
+          description: |
+            Signed decimal of the selected delta. Negative = baseline leader's margin weakened; positive = strengthened. Null when movement === 'none' or no finite delta is available.
+        strongest_delta_abs:
+          type: number
+          nullable: true
+          minimum: 0
+          description: '|strongest_delta|. Null when strongest_delta is null.'
+        strongest_delta_percentage_points:
+          type: number
+          nullable: true
+          minimum: 0
+          description: |
+            `strongest_delta_abs * 100`. The display-ready percentage-point value DGAI should render. Not aggressively rounded - house style applies the final rounding. Null when strongest_delta_abs is null.
+        display_value_available:
+          type: boolean
+          description: |
+            True ONLY when `strongest_probe_value` is finite AND `value_scale === 'display'`. DGAI must not render `strongest_probe_value` unless true.

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -427,12 +427,23 @@ async function gridFallback(
 
 /**
  * Get the option_id with the highest win_probability (argmax).
+ *
+ * Deterministic tie-break: when two options share the highest win_probability,
+ * the lexicographically-smaller `option_id` wins. This matches the tie-break
+ * used by `topTwo()` in `./margin-sensitivity.ts` so that strict-flip
+ * detection (`W0 !== W_min || W0 !== W_max`) cannot disagree with the
+ * margin-sensitivity diagnostic on exact ties. Without this, ISL option-
+ * array order could produce a spurious `movement: 'flipped'` classification
+ * for a non-flip.
  */
 function getArgmaxOption(result: FlipInferenceResult): string {
   let maxProb = -Infinity;
   let maxId = '';
   for (const opt of result.options) {
-    if (opt.win_probability > maxProb) {
+    if (
+      opt.win_probability > maxProb ||
+      (opt.win_probability === maxProb && maxId !== '' && opt.option_id < maxId)
+    ) {
       maxProb = opt.win_probability;
       maxId = opt.option_id;
     }

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -735,4 +735,72 @@ describe('resolveFlipValues() margin_sensitivity integration', () => {
     expect(results[0].flip_reason).toBe('error');
     expect(results[0].margin_sensitivity).toBeUndefined();
   });
+
+  // =========================================================================
+  // Argmax tie-handling — must match topTwo()'s lexicographic tie-break so a
+  // baseline/bound exact tie cannot produce a spurious 'flipped' movement
+  // purely from ISL option-array order.
+  // =========================================================================
+
+  describe('exact tie handling in getArgmaxOption (via no-flip-on-tie)', () => {
+    /**
+     * Mock that returns the same two equal-probability options at every probe,
+     * but rotates the *order* of options[] in the returned array. Under a
+     * naive first-wins argmax, baseline 'a-first' vs min 'b-first' would
+     * register a spurious winner change (W0='a', W_min='b') and trigger
+     * strict-flip detection. With deterministic lex tie-break, both probes
+     * return 'a' (lexicographically smaller) and no flip is detected.
+     */
+    function createTieRotatingMock(): ISLInferenceFn {
+      let n = 0;
+      return async (): Promise<FlipInferenceResult> => {
+        const flip = n++ % 2 === 0;
+        return {
+          options: flip
+            ? [
+                { option_id: 'a', win_probability: 0.5 },
+                { option_id: 'b', win_probability: 0.5 },
+              ]
+            : [
+                { option_id: 'b', win_probability: 0.5 },
+                { option_id: 'a', win_probability: 0.5 },
+              ],
+        };
+      };
+    }
+
+    it('treats exact ties consistently regardless of ISL options[] order (no spurious flip)', async () => {
+      const mock = createTieRotatingMock();
+      const candidate = makeCandidate({ current_value: 0.5 });
+
+      const { results } = await resolveFlipValues([candidate], mock, 'a');
+
+      // With tie-broken argmax, W0 === W_min === W_max === 'a' → no_effect.
+      expect(results[0].flip_reason).toBe('no_effect_within_bounds');
+      expect(results[0].flip_value).toBeNull();
+      expect(results[0].iterations_used).toBe(0);
+      expect(results[0].alternative_winner_id).toBeNull();
+      // Margin-sensitivity should report 'none' — both leader and runner-up
+      // are tied, margins are zero, no movement.
+      expect(results[0].margin_sensitivity?.movement).toBe('none');
+      expect(results[0].margin_sensitivity?.baseline_leading_option_id).toBe('a');
+      expect(results[0].margin_sensitivity?.baseline_runner_up_option_id).toBe('b');
+    });
+
+    it('picks lexicographically-smaller option_id on exact win_probability ties', async () => {
+      // Single-probe sanity check: order does not change the result.
+      const mockBFirst: ISLInferenceFn = async () => ({
+        options: [
+          { option_id: 'b', win_probability: 0.6 },
+          { option_id: 'a', win_probability: 0.6 },
+        ],
+      });
+      const candidate = makeCandidate({ current_value: 0.5 });
+      const { results } = await resolveFlipValues([candidate], mockBFirst, 'a');
+      // Baseline leader from topTwo and strict-flip W0 should both pick 'a'
+      // (deterministic lex order), not 'b' (first-in-array under naive argmax).
+      expect(results[0].flip_reason).toBe('no_effect_within_bounds');
+      expect(results[0].margin_sensitivity?.baseline_leading_option_id).toBe('a');
+    });
+  });
 });

--- a/tests/v2-run.margin-sensitivity.contract.test.ts
+++ b/tests/v2-run.margin-sensitivity.contract.test.ts
@@ -1,0 +1,197 @@
+/**
+ * /v2/run route-level contract for the additive margin-sensitivity surface.
+ *
+ * The helper-, classifier-, denormaliser-, and hash-stability tests cover the
+ * pieces. This file exercises the full assembly path: a real POST through
+ * `/v2/run`, asserting that the new top-level fields (`flip_thresholds_margin_status`,
+ * `flip_thresholds_margin_coverage`) and the per-entry `margin_sensitivity`
+ * object are emitted with the documented shape. Catches future route-wiring
+ * regressions that the granular tests cannot.
+ *
+ * @see PR #171 (margin-sensitivity diagnostic) and the follow-up review.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { spawnServer, requestJSON, type ServerHandle } from './utils.js';
+
+describe('V2 Run · margin-sensitivity contract', () => {
+  let server: ServerHandle | null = null;
+
+  const ENV = {
+    TEST_ROUTES: '1',
+    AUTH_ENABLED: '0',
+    RATE_LIMIT_ENABLED: '0',
+  };
+
+  afterEach(async () => {
+    await server?.kill();
+    server = null;
+  });
+
+  it('emits the new margin diagnostic fields with documented shape on a flip-threshold-bearing graph', async () => {
+    vi.resetModules();
+    server = await spawnServer({ env: ENV });
+
+    // A multi-factor graph with two options that intervene on the same factor.
+    // The other factors become flip-threshold candidates (after intervention
+    // exclusion from PR #166), each of which exercises the Step-0 probe path
+    // and therefore the margin-sensitivity hook.
+    const res = await requestJSON(`${server.baseUrl}/v2/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        graph: {
+          nodes: [
+            {
+              id: 'marketing-spend',
+              kind: 'factor',
+              label: 'Marketing Spend',
+              observed_state: { value: 60, baseline: 60, unit: 'GBP-k' },
+              state_space: { range: { min: 0, max: 120 } },
+            },
+            {
+              id: 'conversion-rate',
+              kind: 'factor',
+              label: 'Conversion Rate',
+              observed_state: { value: 0.04, baseline: 0.04, unit: '%' },
+              state_space: { range: { min: 0.01, max: 0.1 } },
+            },
+            {
+              id: 'brand-awareness',
+              kind: 'factor',
+              label: 'Brand Awareness',
+              observed_state: { value: 0.5, baseline: 0.5 },
+              state_space: { range: { min: 0, max: 1 } },
+            },
+            { id: 'revenue', kind: 'goal', label: 'Revenue' },
+          ],
+          edges: [
+            { from: 'marketing-spend', to: 'brand-awareness', exists_probability: 0.9, strength: { mean: 0.55, std: 0.1 } },
+            { from: 'conversion-rate', to: 'revenue', exists_probability: 0.95, strength: { mean: 0.8, std: 0.08 } },
+            { from: 'brand-awareness', to: 'revenue', exists_probability: 0.85, strength: { mean: 0.6, std: 0.12 } },
+          ],
+        },
+        options: [
+          {
+            id: 'opt-aggressive',
+            label: 'Aggressive Spend',
+            interventions: { 'marketing-spend': { value: 110, source: 'user_specified' } },
+          },
+          {
+            id: 'opt-conservative',
+            label: 'Conservative Spend',
+            interventions: { 'marketing-spend': { value: 30, source: 'user_specified' } },
+          },
+        ],
+        goal_node_id: 'revenue',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.data as Record<string, unknown>;
+
+    // Existing strict-flip status surface (PR #167) must still be present.
+    expect(body).toHaveProperty('flip_thresholds_status');
+    expect(['computed', 'all_no_effect', 'partial_no_effect', 'unresolved', 'unavailable'])
+      .toContain(body.flip_thresholds_status);
+
+    // ===== New top-level margin diagnostic =====
+    expect(body).toHaveProperty('flip_thresholds_margin_status');
+    expect(['computed', 'partial_movement', 'all_none', 'unavailable'])
+      .toContain(body.flip_thresholds_margin_status);
+
+    expect(body).toHaveProperty('flip_thresholds_margin_coverage');
+    const cov = body.flip_thresholds_margin_coverage as { total: number; with_margin: number; without_margin: number };
+    expect(cov).toMatchObject({
+      total: expect.any(Number),
+      with_margin: expect.any(Number),
+      without_margin: expect.any(Number),
+    });
+    // Coverage internal consistency:
+    expect(cov.total).toBeGreaterThanOrEqual(0);
+    expect(cov.with_margin).toBeGreaterThanOrEqual(0);
+    expect(cov.without_margin).toBeGreaterThanOrEqual(0);
+    expect(cov.with_margin + cov.without_margin).toBe(cov.total);
+
+    // ===== Per-entry margin_sensitivity (when flip_thresholds[] is populated) =====
+    const ft = body.flip_thresholds as Array<Record<string, unknown>> | undefined;
+    if (ft && ft.length > 0) {
+      // Coverage must match the actual array length.
+      expect(cov.total).toBe(ft.length);
+
+      // Every entry that completed Step-0 probes should carry margin_sensitivity.
+      // (Entries that did NOT carry it are counted in cov.without_margin.)
+      const withMargin = ft.filter((e) => e.margin_sensitivity !== undefined);
+      expect(withMargin.length).toBe(cov.with_margin);
+
+      // Every margin_sensitivity object must have the full documented shape.
+      for (const e of withMargin) {
+        const ms = e.margin_sensitivity as Record<string, unknown>;
+        // Movement + classification fields.
+        expect(['none', 'weakened', 'strengthened', 'flipped']).toContain(ms.movement);
+        expect(typeof ms.threshold).toBe('number');
+        expect(['towards_min', 'towards_max', 'both', 'none']).toContain(ms.strongest_direction);
+        expect(['normalised', 'display']).toContain(ms.value_scale);
+
+        // Numeric fields are finite-or-null.
+        const numericKeys = [
+          'baseline_margin',
+          'min_probe_margin',
+          'max_probe_margin',
+          'min_probe_delta',
+          'max_probe_delta',
+          'strongest_probe_value',
+          'strongest_delta',
+          'strongest_delta_abs',
+          'strongest_delta_percentage_points',
+        ] as const;
+        for (const k of numericKeys) {
+          const v = ms[k];
+          if (v !== null && v !== undefined) {
+            expect(Number.isFinite(v)).toBe(true);
+          }
+        }
+
+        // Display-ready field invariants.
+        expect(typeof ms.display_value_available).toBe('boolean');
+
+        if (ms.movement === 'none') {
+          // No movement → strongest_delta family must all be null.
+          expect(ms.strongest_delta).toBeNull();
+          expect(ms.strongest_delta_abs).toBeNull();
+          expect(ms.strongest_delta_percentage_points).toBeNull();
+        } else if (ms.strongest_delta !== null && ms.strongest_delta !== undefined) {
+          // When populated, abs and pp must be coherent with strongest_delta.
+          const sd = ms.strongest_delta as number;
+          const sda = ms.strongest_delta_abs as number;
+          const sdpp = ms.strongest_delta_percentage_points as number;
+          expect(sda).toBeCloseTo(Math.abs(sd), 10);
+          expect(sdpp).toBeCloseTo(sda * 100, 6);
+        }
+
+        // display_value_available implies value_scale === 'display' AND strongest_probe_value is finite.
+        if (ms.display_value_available === true) {
+          expect(ms.value_scale).toBe('display');
+          expect(Number.isFinite(ms.strongest_probe_value)).toBe(true);
+        }
+
+        // Existing strict-flip fields preserved on the surrounding entry.
+        expect(e).toHaveProperty('flip_value');
+        expect(e).toHaveProperty('flip_reason');
+        expect(e).toHaveProperty('iterations_used');
+      }
+    } else {
+      // No flip_thresholds[] → status must be 'unavailable' for both classifiers.
+      expect(body.flip_thresholds_margin_status).toBe('unavailable');
+      expect(cov.total).toBe(0);
+    }
+
+    // The diagnostic fields are excluded from response_hash. Hash must still
+    // be present and well-formed (existing hash invariant).
+    if ('response_hash' in body) {
+      const h = body.response_hash;
+      expect(typeof h).toBe('string');
+      expect(h as string).toMatch(/^[a-f0-9]{16}$/);
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #171 after the post-merge margin-sensitivity review. Addresses the actionable PLoT-side findings while keeping out-of-scope ISL and hash-drift items deferred.

## Addressed

1. **P1.1 — Tie-break determinism**
   - Aligns `getArgmaxOption` tie handling with the existing `topTwo` behaviour.
   - Exact win-probability ties now resolve by `option_id`, removing a latent false-positive `flipped` classification risk caused by array-order differences.

2. **P1.2 — OpenAPI `MarginSensitivity` schema**
   - Adds a standalone `MarginSensitivity` schema fragment to `contracts/openapi.yaml`.
   - Documents the per-entry margin diagnostic surface for downstream consumers, especially DGAI, without changing the existing `flip_thresholds[]` envelope shape.

3. **P2.5 — Route-level `/v2/run` contract test**
   - Adds an end-to-end route-level contract test that verifies full response assembly of the new margin-sensitivity surface.
   - Strengthens coverage beyond helper/classifier/integration tests and catches future route-wiring regressions.

## Deferred intentionally

- **P1.3 — Staging ISL unable to produce `weakened` / `strengthened` live cases**
  - Deferred because this appears to be ISL-side staging inference behaviour, not a PLoT contract or implementation issue.

- **P2.4 — Existing `flip_thresholds_status` response-hash doc/code drift**
  - Deferred because fixing it would change existing response hashes and should be handled as a separate, explicit hash-contract cleanup workstream.

## Scope

PLoT only.

No DGAI, CEE, ISL, prompt, package, lockfile, migration, or workflow changes.

## Validation

Local pre-push validation passed before push:

```text
PASS [1/7] Branch guard
PASS [2/7] TypeScript compilation (tsc --noEmit)
PASS [3/7] Full test suite — 4,811 passed | 25 skipped
PASS [4/7] No stale .js files tracked in src/
PASS [5/7] No file: dependency references
PASS [6/7] OpenAPI spec validation (spectral lint)
```

## Notes

This PR is intended to make the already-merged margin-sensitivity surface safer and easier for DGAI to consume. It should be reviewed and merged to staging after CI/contract checks complete.

Do not deploy to production from this PR.