### PR TITLE
feat(plot/coaching): D2-tone gate for post-analysis wording honesty

### DIFF
--- a/src/coaching/executive-summary.ts
+++ b/src/coaching/executive-summary.ts
@@ -4,11 +4,16 @@
  * One-paragraph summary (2-3 sentences) of decision quality and recommendation.
  * CRITICAL: Never use "confidence" for composite scores (only for probabilities).
  * Use "readiness", "stability", "robustness" instead.
+ *
+ * Wording is gated by the D2-tone classifier so confident phrasing only appears
+ * when robustness / fragility / evidence signals all support it.
  */
 
 import type { CoachingInputs, Readiness, HeadlineType } from './types.js';
 import type { KeyDriver } from './key-drivers.js';
 import type { EvidenceGap } from './types.js';
+import { deriveReadinessTone, type ReadinessTone, type ReadinessToneResult } from './readiness-tone.js';
+import { getThresholds } from './thresholds.js';
 
 export interface ExecutiveSummary {
   summary: string;
@@ -17,16 +22,6 @@ export interface ExecutiveSummary {
   action_implication: string;
 }
 
-/**
- * Generate executive summary from coaching components.
- *
- * @param inputs Normalised coaching inputs
- * @param readiness Overall readiness
- * @param headlineType Headline type from B1
- * @param keyDrivers Top drivers from D1
- * @param evidenceGaps Evidence gaps from B2
- * @returns ExecutiveSummary with structured text
- */
 export function generateExecutiveSummary(
   inputs: CoachingInputs,
   readiness: Readiness,
@@ -36,23 +31,27 @@ export function generateExecutiveSummary(
 ): ExecutiveSummary {
   const winner = inputs.options[0];
   const runnerUp = inputs.options[1];
+  const thresholds = getThresholds();
+  const toneResult = deriveReadinessTone(
+    inputs,
+    readiness,
+    headlineType,
+    keyDrivers,
+    evidenceGaps,
+    thresholds,
+  );
 
-  // Decision statement
-  const decisionStatement = generateDecisionStatement(winner, runnerUp, headlineType);
-
-  // Key qualifier (based on readiness and headline type)
+  const decisionStatement = generateDecisionStatement(winner, runnerUp, headlineType, toneResult.tone);
   const keyQualifier = generateKeyQualifier(
     readiness,
     headlineType,
     inputs,
     keyDrivers,
-    evidenceGaps
+    evidenceGaps,
+    toneResult.tone,
   );
+  const actionImplication = generateActionImplication(readiness, evidenceGaps, inputs, toneResult.tone);
 
-  // Action implication
-  const actionImplication = generateActionImplication(readiness, evidenceGaps, inputs);
-
-  // Combine into summary
   const summary = `${decisionStatement} ${keyQualifier} ${actionImplication}`;
 
   return {
@@ -63,13 +62,11 @@ export function generateExecutiveSummary(
   };
 }
 
-/**
- * Generate decision statement (who wins and by how much).
- */
 function generateDecisionStatement(
   winner: { label: string; winProbability: number } | undefined,
   runnerUp: { label: string; winProbability: number } | undefined,
-  headlineType: HeadlineType
+  headlineType: HeadlineType,
+  tone: ReadinessTone,
 ): string {
   if (!winner) {
     return 'Decision analysis incomplete.';
@@ -80,9 +77,18 @@ function generateDecisionStatement(
 
   switch (headlineType) {
     case 'clear_winner':
-      return `${winner.label} is the clear leading option with a ${marginPoints}-point advantage.`;
+      if (tone === 'confident') {
+        return `${winner.label} has a strong current lead with a ${marginPoints}-point advantage.`;
+      }
+      if (tone === 'caution') {
+        return `${winner.label} currently leads by ${marginPoints} points, but the model is not yet strong enough for an unqualified decision.`;
+      }
+      return `${winner.label} currently leads by ${marginPoints} points on the current model.`;
     case 'moderate_winner':
-      return `${winner.label} leads by ${marginPoints} points.`;
+      if (tone === 'caution') {
+        return `${winner.label} currently leads by ${marginPoints} points, but the model is not yet strong enough for an unqualified decision.`;
+      }
+      return `${winner.label} currently leads by ${marginPoints} points on the current model.`;
     case 'close_call':
       return `${winner.label} edges ahead by ${marginPoints} points.`;
     case 'high_uncertainty':
@@ -90,20 +96,17 @@ function generateDecisionStatement(
     case 'needs_evidence':
       return 'The decision is unclear based on current evidence.';
     default:
-      return `${winner.label} is the top option.`;
+      return `${winner.label} is the top option on the current model.`;
   }
 }
 
-/**
- * Generate key qualifier (what affects reliability).
- * CRITICAL: Use "stability", "robustness", "readiness" - NEVER "confidence" for composite scores.
- */
 function generateKeyQualifier(
   readiness: Readiness,
-  headlineType: HeadlineType,
+  _headlineType: HeadlineType,
   inputs: CoachingInputs,
   keyDrivers: KeyDriver[],
-  evidenceGaps: EvidenceGap[]
+  evidenceGaps: EvidenceGap[],
+  tone: ReadinessTone,
 ): string {
   const stability = inputs.robustness.recommendationStability;
   const topDriver = keyDrivers[0];
@@ -111,14 +114,20 @@ function generateKeyQualifier(
 
   switch (readiness) {
     case 'ready':
-      if (stability !== undefined && stability >= 0.75) {
-        return `The recommendation has high stability (${Math.round(stability * 100)}%) and is ready to proceed.`;
+      if (tone === 'confident') {
+        if (stability !== undefined) {
+          return `The current model favours this option on the strongest combination of signals (${Math.round(stability * 100)}% recommendation stability).`;
+        }
+        return 'The current model favours this option on the strongest combination of signals.';
       }
-      return 'The recommendation is robust and ready to proceed.';
+      if (tone === 'caution') {
+        return 'Treat this as a provisional lead until the fragile assumptions are checked.';
+      }
+      return 'This option leads on the current model, with important caveats.';
 
     case 'close_call':
       if (stability !== undefined) {
-        return `However, the ${Math.round(stability * 100)}% stability score indicates the decision could shift with new information.`;
+        return `However, the ${Math.round(stability * 100)}% recommendation stability indicates the decision could shift with new information.`;
       }
       return 'However, the outcome is within model uncertainty.';
 
@@ -139,17 +148,21 @@ function generateKeyQualifier(
   }
 }
 
-/**
- * Generate action implication (what to do next).
- */
 function generateActionImplication(
   readiness: Readiness,
   evidenceGaps: EvidenceGap[],
-  inputs: CoachingInputs
+  _inputs: CoachingInputs,
+  tone: ReadinessTone,
 ): string {
   switch (readiness) {
     case 'ready':
-      return 'Proceed with implementation.';
+      if (tone === 'confident') {
+        return 'It is reasonable to move forward while validating the key assumptions.';
+      }
+      if (tone === 'caution') {
+        return 'Validate the fragile assumptions before treating this as a decision.';
+      }
+      return 'Before acting, validate the assumptions most likely to change the result.';
 
     case 'close_call':
       return 'Define tie-breaker criteria or gather additional evidence.';
@@ -167,4 +180,14 @@ function generateActionImplication(
     default:
       return 'Review assumptions before proceeding.';
   }
+}
+
+export function deriveExecutiveSummaryTone(
+  inputs: CoachingInputs,
+  readiness: Readiness,
+  headlineType: HeadlineType,
+  keyDrivers: KeyDriver[],
+  evidenceGaps: EvidenceGap[],
+): ReadinessToneResult {
+  return deriveReadinessTone(inputs, readiness, headlineType, keyDrivers, evidenceGaps, getThresholds());
 }

--- a/src/coaching/next-actions.ts
+++ b/src/coaching/next-actions.ts
@@ -2,9 +2,9 @@
  * B4: Next Actions
  *
  * Generates prioritized action list (max 3) with required rationales.
- * Priority 5 wording is gated by the D2-tone classifier so the imperative
- * "Proceed with {option}" only appears when robustness / fragility / evidence
- * signals support a confident tone.
+ * Priority 5 wording is gated by the D2-tone classifier: confident tone emits
+ * a forward-leaning action; tempered/caution swap in validation-first actions
+ * so we never issue an imperative the evidence does not support.
  */
 
 import type { CoachingInputs, Critique, NextAction, Readiness, HeadlineType, EvidenceGap } from './types.js';

--- a/src/coaching/next-actions.ts
+++ b/src/coaching/next-actions.ts
@@ -2,10 +2,15 @@
  * B4: Next Actions
  *
  * Generates prioritized action list (max 3) with required rationales.
+ * Priority 5 wording is gated by the D2-tone classifier so the imperative
+ * "Proceed with {option}" only appears when robustness / fragility / evidence
+ * signals support a confident tone.
  */
 
 import type { CoachingInputs, Critique, NextAction, Readiness, HeadlineType, EvidenceGap } from './types.js';
 import { getThresholds } from './thresholds.js';
+import { computeKeyDrivers } from './key-drivers.js';
+import { deriveReadinessTone, type ReadinessToneReason } from './readiness-tone.js';
 
 export function generateNextActions(
   inputs: CoachingInputs,
@@ -15,7 +20,7 @@ export function generateNextActions(
 ): NextAction[] {
   const thresholds = getThresholds();
 
-  // Compute readiness
+  // Compute readiness (unchanged semantics — downstream consumers depend on it).
   const readiness = computeReadiness(headlineType, critiques, evidenceGaps, thresholds);
 
   // Build context for action interpolation
@@ -41,7 +46,6 @@ export function generateNextActions(
       action: 'Reconsider framing — add alternatives or Status Quo baseline',
       rationale: `With only ${context.optionCount} options and no baseline, comparisons may be misleading`,
       related_critique: 'NARROW_FRAMING',
-      // No specific target - framing issue affects entire decision
     });
   }
 
@@ -75,30 +79,67 @@ export function generateNextActions(
 
   // Priority 4: Close call
   if (headlineType === 'close_call' && actions.length < 3) {
-    const winnerLabel = context.winner?.label ?? 'winning option';
+    const leadingLabel = context.winner?.label ?? 'the leading option';
     const delta = context.winner ? Math.round((context.winner.winProbability - (inputs.options[1]?.winProbability ?? 0)) * 100) : 0;
     actions.push({
       priority: 4,
       action: 'Define tie-breaker criteria — margin is too close to call',
-      rationale: `Winner leads by only ${delta} points; within model uncertainty`,
+      rationale: `${leadingLabel} leads by only ${delta} points; within model uncertainty`,
       target_type: 'option',
       target_id: context.winner?.id,
-      target_label: winnerLabel,
+      target_label: leadingLabel,
     });
   }
 
-  // Priority 5: Ready to proceed
+  // Priority 5: Ready — tone-gated wording.
+  // Confident tone allows a forward-leaning action; tempered/caution swap in
+  // a validation-first action so we don't issue an imperative the evidence
+  // doesn't support.
   if (readiness === 'ready' && actions.length < 3) {
-    const winnerLabel = context.winner?.label ?? 'top option';
+    const leadingLabel = context.winner?.label ?? 'the leading option';
     const delta = context.winner ? Math.round((context.winner.winProbability - (inputs.options[1]?.winProbability ?? 0)) * 100) : 0;
-    const stabilityDisplay = context.stability ? Math.round(context.stability * 100) : 0;
+    const stabilityDisplay = context.stability !== undefined ? Math.round(context.stability * 100) : 0;
+    const keyDrivers = computeKeyDrivers(inputs);
+    const { tone, reasons } = deriveReadinessTone(
+      inputs,
+      readiness,
+      headlineType,
+      keyDrivers,
+      evidenceGaps,
+      thresholds,
+    );
+    const reasonSummary = summariseTopReason(reasons);
+
+    let action: string;
+    let rationale: string;
+    if (tone === 'confident') {
+      action = `Move forward with ${leadingLabel} while validating the key assumptions`;
+      rationale = context.stability !== undefined
+        ? `${leadingLabel} has a strong current lead by ${delta} points with ${stabilityDisplay}% recommendation stability`
+        : `${leadingLabel} has a strong current lead by ${delta} points`;
+    } else if (tone === 'caution') {
+      action = `Validate the fragile assumptions before treating ${leadingLabel} as a decision`;
+      rationale = reasonSummary
+        ? `${leadingLabel} currently leads by ${delta} points, but ${reasonSummary}`
+        : `${leadingLabel} currently leads by ${delta} points, but the model is not yet strong enough for an unqualified decision`;
+    } else {
+      action = `Validate the key assumptions before acting on ${leadingLabel}`;
+      rationale = context.stability !== undefined
+        ? (reasonSummary
+            ? `${leadingLabel} currently leads by ${delta} points with ${stabilityDisplay}% recommendation stability, but ${reasonSummary}`
+            : `${leadingLabel} currently leads by ${delta} points with ${stabilityDisplay}% recommendation stability`)
+        : (reasonSummary
+            ? `${leadingLabel} currently leads by ${delta} points, but ${reasonSummary}`
+            : `${leadingLabel} currently leads by ${delta} points`);
+    }
+
     actions.push({
       priority: 7,
-      action: `Proceed with ${winnerLabel}`,
-      rationale: `Decision is robust: ${delta}-point margin with ${stabilityDisplay}% stability`,
+      action,
+      rationale,
       target_type: 'option',
       target_id: context.winner?.id,
-      target_label: winnerLabel,
+      target_label: leadingLabel,
     });
   }
 
@@ -108,11 +149,10 @@ export function generateNextActions(
       priority: 99,
       action: 'Review model assumptions',
       rationale: 'Unable to generate specific guidance',
-      // No specific target - general fallback
     });
   }
 
-  return actions.slice(0, 3); // Max 3
+  return actions.slice(0, 3);
 }
 
 export function computeReadiness(
@@ -142,4 +182,37 @@ export function computeReadiness(
   }
 
   return 'needs_evidence';
+}
+
+const REASON_PHRASES: Record<ReadinessToneReason, string> = {
+  NOT_ROBUST: 'the recommendation is not yet robust',
+  LOW_ROBUSTNESS: 'robustness is below the confident threshold',
+  LOW_STABILITY: 'stability is below the confident threshold',
+  MATERIAL_FRAGILE_EDGE: 'a fragile edge could flip the result',
+  EVIDENCE_GAPS: 'multiple evidence gaps remain',
+  LOW_DRIVER_CONFIDENCE: 'the top driver has low confidence',
+  NEAR_TIE: 'the margin is near a tie',
+  INSUFFICIENT_SIGNALS: 'key signals are not yet available',
+};
+
+// Reasons are surfaced in display priority order so the rationale leads with
+// the most decision-relevant signal failure.
+const REASON_DISPLAY_ORDER: ReadinessToneReason[] = [
+  'NOT_ROBUST',
+  'MATERIAL_FRAGILE_EDGE',
+  'EVIDENCE_GAPS',
+  'LOW_ROBUSTNESS',
+  'LOW_STABILITY',
+  'LOW_DRIVER_CONFIDENCE',
+  'NEAR_TIE',
+  'INSUFFICIENT_SIGNALS',
+];
+
+function summariseTopReason(reasons: ReadinessToneReason[]): string | null {
+  if (reasons.length === 0) return null;
+  const reasonSet = new Set(reasons);
+  for (const r of REASON_DISPLAY_ORDER) {
+    if (reasonSet.has(r)) return REASON_PHRASES[r];
+  }
+  return null;
 }

--- a/src/coaching/next-actions.ts
+++ b/src/coaching/next-actions.ts
@@ -108,7 +108,7 @@ export function generateNextActions(
       evidenceGaps,
       thresholds,
     );
-    const reasonSummary = summariseTopReason(reasons);
+    const reasonSummary = summariseTopReason(reasons, { evidenceGapCount: evidenceGaps.length });
 
     let action: string;
     let rationale: string;
@@ -184,12 +184,11 @@ export function computeReadiness(
   return 'needs_evidence';
 }
 
-const REASON_PHRASES: Record<ReadinessToneReason, string> = {
+const REASON_PHRASES: Record<Exclude<ReadinessToneReason, 'EVIDENCE_GAPS'>, string> = {
   NOT_ROBUST: 'the recommendation is not yet robust',
   LOW_ROBUSTNESS: 'robustness is below the confident threshold',
   LOW_STABILITY: 'stability is below the confident threshold',
   MATERIAL_FRAGILE_EDGE: 'a fragile edge could flip the result',
-  EVIDENCE_GAPS: 'multiple evidence gaps remain',
   LOW_DRIVER_CONFIDENCE: 'the top driver has low confidence',
   NEAR_TIE: 'the margin is near a tie',
   INSUFFICIENT_SIGNALS: 'key signals are not yet available',
@@ -208,11 +207,24 @@ const REASON_DISPLAY_ORDER: ReadinessToneReason[] = [
   'INSUFFICIENT_SIGNALS',
 ];
 
-function summariseTopReason(reasons: ReadinessToneReason[]): string | null {
+interface ReasonContext {
+  evidenceGapCount: number;
+}
+
+function summariseTopReason(reasons: ReadinessToneReason[], ctx: ReasonContext): string | null {
   if (reasons.length === 0) return null;
   const reasonSet = new Set(reasons);
   for (const r of REASON_DISPLAY_ORDER) {
-    if (reasonSet.has(r)) return REASON_PHRASES[r];
+    if (!reasonSet.has(r)) continue;
+    if (r === 'EVIDENCE_GAPS') {
+      // EVIDENCE_GAPS fires for either ≥2 gaps OR a single gap above the
+      // high-VoI threshold. Match the wording to which one applies so the
+      // user-facing rationale doesn't falsely claim "multiple" for a single gap.
+      return ctx.evidenceGapCount <= 1
+        ? 'a decision-relevant evidence gap remains'
+        : 'multiple evidence gaps remain';
+    }
+    return REASON_PHRASES[r];
   }
   return null;
 }

--- a/src/coaching/readiness-tone.ts
+++ b/src/coaching/readiness-tone.ts
@@ -70,7 +70,13 @@ export function deriveReadinessTone(
     reasons.push('MATERIAL_FRAGILE_EDGE');
   }
 
-  if (evidenceGaps.length >= thresholds.readiness_high_evidence_gap_count) {
+  // Evidence gaps temper the tone if the count is at-or-above the readiness
+  // threshold OR if even a single gap has VoI above the existing high-VoI
+  // threshold (one decision-relevant gap is enough to disqualify confident tone).
+  const topVoi = evidenceGaps.reduce((max, g) => (g.voi_score > max ? g.voi_score : max), 0);
+  const hasGapCountIssue = evidenceGaps.length >= thresholds.readiness_high_evidence_gap_count;
+  const hasHighVoiGap = evidenceGaps.length >= 1 && topVoi > thresholds.readiness_high_voi_threshold;
+  if (hasGapCountIssue || hasHighVoiGap) {
     reasons.push('EVIDENCE_GAPS');
   }
 

--- a/src/coaching/readiness-tone.ts
+++ b/src/coaching/readiness-tone.ts
@@ -1,0 +1,130 @@
+/**
+ * D2-tone: Readiness-tone classifier
+ *
+ * Pure, deterministic classifier that derives a coaching-copy tone from the
+ * scientific signals already present in CoachingInputs. Used by D2 executive
+ * summary and B4 next-actions to gate over-confident wording when the
+ * underlying robustness / fragility / evidence signals do not warrant it.
+ *
+ * Does NOT alter Readiness semantics — downstream consumers (CEE prompt, DGAI
+ * view-model) keep seeing the same Readiness enum.
+ */
+
+import type { CoachingInputs, EvidenceGap, HeadlineType, Readiness } from './types.js';
+import type { KeyDriver } from './key-drivers.js';
+import type { CoachingThresholds } from './thresholds.js';
+
+export type ReadinessTone = 'confident' | 'tempered' | 'caution';
+
+export type ReadinessToneReason =
+  | 'NOT_ROBUST'
+  | 'LOW_ROBUSTNESS'
+  | 'LOW_STABILITY'
+  | 'MATERIAL_FRAGILE_EDGE'
+  | 'EVIDENCE_GAPS'
+  | 'LOW_DRIVER_CONFIDENCE'
+  | 'NEAR_TIE'
+  | 'INSUFFICIENT_SIGNALS';
+
+export interface ReadinessToneResult {
+  tone: ReadinessTone;
+  reasons: ReadinessToneReason[];
+}
+
+const HARD_REASONS: ReadonlySet<ReadinessToneReason> = new Set<ReadinessToneReason>([
+  'NOT_ROBUST',
+  'LOW_ROBUSTNESS',
+  'LOW_STABILITY',
+  'MATERIAL_FRAGILE_EDGE',
+  'EVIDENCE_GAPS',
+  'LOW_DRIVER_CONFIDENCE',
+  'NEAR_TIE',
+]);
+
+export function deriveReadinessTone(
+  inputs: CoachingInputs,
+  _readiness: Readiness,
+  _headlineType: HeadlineType,
+  keyDrivers: KeyDriver[],
+  evidenceGaps: EvidenceGap[],
+  thresholds: CoachingThresholds,
+): ReadinessToneResult {
+  const reasons: ReadinessToneReason[] = [];
+  const { robustness, fragileEdges, factorSensitivity, options } = inputs;
+
+  if (robustness.isRobust === false) {
+    reasons.push('NOT_ROBUST');
+  }
+
+  if (robustness.level === 'low' || robustness.level === 'very_low' || robustness.level === 'moderate') {
+    reasons.push('LOW_ROBUSTNESS');
+  }
+
+  const stability = robustness.recommendationStability;
+  if (stability !== undefined && stability < thresholds.tone_confident_stability_min) {
+    reasons.push('LOW_STABILITY');
+  }
+
+  const topFragile = pickTopFragile(fragileEdges);
+  if (topFragile !== undefined && topFragile.switchProb > thresholds.action_fragile_edge_threshold) {
+    reasons.push('MATERIAL_FRAGILE_EDGE');
+  }
+
+  if (evidenceGaps.length >= thresholds.readiness_high_evidence_gap_count) {
+    reasons.push('EVIDENCE_GAPS');
+  }
+
+  const topDriver = keyDrivers[0];
+  let topDriverConfidence: number | undefined;
+  if (topDriver !== undefined) {
+    const factor = factorSensitivity.find((f) => f.node_id === topDriver.factor_id);
+    topDriverConfidence = factor?.confidence;
+    if (topDriverConfidence !== undefined && topDriverConfidence <= thresholds.tone_low_driver_confidence_max) {
+      reasons.push('LOW_DRIVER_CONFIDENCE');
+    }
+  }
+
+  if (options.length >= 2 && options[0] !== undefined && options[1] !== undefined) {
+    const margin = options[0].winProbability - options[1].winProbability;
+    if (margin < thresholds.headline_close_call_delta) {
+      reasons.push('NEAR_TIE');
+    }
+  }
+
+  // Missing-data policy: absence of an optional signal does not by itself force
+  // tempering, but combined with any other weakness signal we add a
+  // conservative INSUFFICIENT_SIGNALS marker so callers can surface it.
+  const hasMissingSignal =
+    robustness.level === undefined
+    || stability === undefined
+    || (topDriver !== undefined && topDriverConfidence === undefined);
+  if (hasMissingSignal && reasons.length > 0) {
+    reasons.push('INSUFFICIENT_SIGNALS');
+  }
+
+  const hardCount = reasons.filter((r) => HARD_REASONS.has(r)).length;
+  let tone: ReadinessTone;
+  if (reasons.length === 0) {
+    tone = 'confident';
+  } else if (hardCount >= 2) {
+    tone = 'caution';
+  } else {
+    tone = 'tempered';
+  }
+
+  return { tone, reasons };
+}
+
+function pickTopFragile(
+  fragileEdges: CoachingInputs['fragileEdges'],
+): CoachingInputs['fragileEdges'][number] | undefined {
+  if (fragileEdges.length === 0) return undefined;
+  let top = fragileEdges[0];
+  for (let i = 1; i < fragileEdges.length; i++) {
+    const candidate = fragileEdges[i];
+    if (candidate !== undefined && top !== undefined && candidate.switchProb > top.switchProb) {
+      top = candidate;
+    }
+  }
+  return top;
+}

--- a/src/coaching/thresholds.ts
+++ b/src/coaching/thresholds.ts
@@ -41,6 +41,10 @@ export interface CoachingThresholds {
   // C4: Joint Probability Gate (Task 1)
   readiness_joint_prob_floor: number;
   readiness_joint_prob_close_call: number;
+
+  // D2-tone: Readiness-tone classifier (post-analysis wording honesty)
+  tone_confident_stability_min: number;
+  tone_low_driver_confidence_max: number;
 }
 
 /**
@@ -83,6 +87,12 @@ export const DEFAULT_THRESHOLDS: CoachingThresholds = {
   // C4: Joint Probability Gate
   readiness_joint_prob_floor: 0.05,
   readiness_joint_prob_close_call: 0.30,
+
+  // D2-tone: Readiness-tone classifier
+  // confident requires recommendationStability >= this value
+  tone_confident_stability_min: 0.75,
+  // top-driver confidence at-or-below this counts as "low / negligible"
+  tone_low_driver_confidence_max: 0.5,
 };
 
 /**
@@ -219,6 +229,16 @@ export function getThresholds(): CoachingThresholds {
     readiness_joint_prob_close_call: parseEnvFloat(
       'READINESS_JOINT_PROB_CLOSE_CALL',
       DEFAULT_THRESHOLDS.readiness_joint_prob_close_call
+    ),
+
+    // D2-tone: Readiness-tone classifier
+    tone_confident_stability_min: parseEnvFloat(
+      'M1_THRESHOLD_TONE_CONFIDENT_STABILITY_MIN',
+      DEFAULT_THRESHOLDS.tone_confident_stability_min
+    ),
+    tone_low_driver_confidence_max: parseEnvFloat(
+      'M1_THRESHOLD_TONE_LOW_DRIVER_CONFIDENCE_MAX',
+      DEFAULT_THRESHOLDS.tone_low_driver_confidence_max
     ),
   };
 }

--- a/tests/coaching/executive-summary.test.ts
+++ b/tests/coaching/executive-summary.test.ts
@@ -1,0 +1,149 @@
+/**
+ * D2 Executive Summary — tone-gated wording tests.
+ *
+ * Confirms that overconfident phrasing only appears when every tone gate is
+ * clean, and that the banned vocabulary never appears at any tone.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateExecutiveSummary } from '../../src/coaching/executive-summary.js';
+import type { CoachingInputs, EngineGraphV3, EvidenceGap } from '../../src/coaching/types.js';
+import type { KeyDriver } from '../../src/coaching/key-drivers.js';
+
+const minimalGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Goal' },
+    { id: 'f1', kind: 'factor', label: 'Cost' },
+  ],
+  edges: [{ from: 'f1', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+});
+
+const cleanInputs = (overrides: Partial<CoachingInputs> = {}): CoachingInputs => ({
+  graph: minimalGraph(),
+  options: [
+    { id: 'opt1', label: 'Option A', winProbability: 0.7, outcomeMean: 100, outcomeP10: 90, outcomeP90: 110 },
+    { id: 'opt2', label: 'Option B', winProbability: 0.3, outcomeMean: 80, outcomeP10: 70, outcomeP90: 90 },
+  ],
+  factorSensitivity: [
+    {
+      node_id: 'f1', label: 'Cost', importance_rank: 1, elasticity: 0.5, influence_score: 0.5,
+      confidence: 0.9, direction: 'positive', zero_reason: undefined,
+    },
+  ],
+  fragileEdges: [],
+  robustness: { level: 'high', recommendationStability: 0.9, isRobust: true },
+  ...overrides,
+});
+
+const cleanKeyDrivers = (): KeyDriver[] => [
+  { factor_id: 'f1', factor_label: 'Cost', influence_score: 0.5, normalised_impact: 1, impact_display: 'Very High', direction: 'positive', rank: 1 },
+];
+
+const gap = (factor_id: string, factor_label: string, voi: number): EvidenceGap => ({
+  factor_id, factor_label, voi_score: voi, confidence: 0.4, confidence_display: '40%',
+  confidence_defaulted: false, influence: 0.8, influence_display: '80%', suggestion: '', notes: [],
+});
+
+const BANNED_PHRASES = [
+  'ready to proceed',
+  'Proceed with implementation',
+  'robust and ready',
+  'clear leading option',
+];
+
+const BANNED_WORDS_REGEX = /\bwinner\b/i;
+
+function expectNoBannedPhrasing(text: string) {
+  for (const phrase of BANNED_PHRASES) {
+    expect(text.toLowerCase()).not.toContain(phrase.toLowerCase());
+  }
+  expect(text).not.toMatch(BANNED_WORDS_REGEX);
+}
+
+describe('D2 Executive Summary — tone gate', () => {
+  it('low robustness: does not emit any banned phrasing', () => {
+    const inputs = cleanInputs({
+      robustness: { level: 'low', recommendationStability: 0.4, isRobust: false },
+    });
+    const summary = generateExecutiveSummary(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), []);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.summary.toLowerCase()).not.toContain('robust');
+  });
+
+  it('fragile edge above the switch-probability ceiling: output is tempered', () => {
+    const inputs = cleanInputs({
+      fragileEdges: [{
+        edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+        displayLabel: 'Cost → Goal', switchProb: 0.35, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+      }],
+    });
+    const summary = generateExecutiveSummary(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), []);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.summary).toContain('currently leads');
+    expect(summary.action_implication).toContain('validate the assumptions');
+  });
+
+  it('two evidence gaps: output is tempered', () => {
+    const inputs = cleanInputs();
+    const gaps = [gap('f1', 'Cost', 0.5), gap('f2', 'Other', 0.3)];
+    const summary = generateExecutiveSummary(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), gaps);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.summary).toContain('currently leads');
+  });
+
+  it('low top-driver confidence: output is tempered', () => {
+    const inputs = cleanInputs({
+      factorSensitivity: [{
+        node_id: 'f1', label: 'Cost', importance_rank: 1, elasticity: 0.5, influence_score: 0.5,
+        confidence: 0.3, direction: 'positive', zero_reason: undefined,
+      }],
+    });
+    const summary = generateExecutiveSummary(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), []);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.summary).toContain('currently leads');
+  });
+
+  it('clean strong case: confident copy allowed, but no banned imperative', () => {
+    const inputs = cleanInputs();
+    const summary = generateExecutiveSummary(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), []);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.summary).toContain('strong current lead');
+    expect(summary.action_implication).toContain('reasonable to move forward');
+  });
+
+  it('caution: multiple severe gates fail — caution copy is used', () => {
+    const inputs = cleanInputs({
+      robustness: { level: 'low', recommendationStability: 0.5, isRobust: false },
+      fragileEdges: [{
+        edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+        displayLabel: 'Cost → Goal', switchProb: 0.4, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+      }],
+    });
+    const summary = generateExecutiveSummary(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), []);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.key_qualifier).toContain('provisional lead');
+    expect(summary.action_implication).toContain('Validate the fragile assumptions');
+  });
+
+  it('copy compliance: every tone variant uses sentence case and contains no raw factor IDs', () => {
+    const scenarios = [
+      { name: 'tempered', inputs: cleanInputs({ robustness: { level: 'moderate', recommendationStability: 0.9, isRobust: true } }) },
+      { name: 'confident', inputs: cleanInputs() },
+      { name: 'caution', inputs: cleanInputs({
+        robustness: { level: 'low', recommendationStability: 0.5, isRobust: false },
+        fragileEdges: [{
+          edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+          displayLabel: 'Cost → Goal', switchProb: 0.4, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+        }],
+      }) },
+    ];
+    for (const s of scenarios) {
+      const summary = generateExecutiveSummary(s.inputs, 'ready', 'clear_winner', cleanKeyDrivers(), []);
+      expectNoBannedPhrasing(summary.summary);
+      expect(summary.summary).not.toMatch(/\bopt1\b/);
+      expect(summary.summary).not.toMatch(/\bopt2\b/);
+      // No raw factor node IDs.
+      expect(summary.summary).not.toMatch(/\bf1\b/);
+    }
+  });
+});

--- a/tests/coaching/m1-coaching.test.ts
+++ b/tests/coaching/m1-coaching.test.ts
@@ -993,7 +993,7 @@ describe('NextAction Targeting Fields', () => {
     expect(tieBreaker?.target_label).toBe('Option A');
   });
 
-  it('populates target_type and target_id for "Proceed with" actions', () => {
+  it('populates target_type and target_id for the ready-branch action', () => {
     const inputs: CoachingInputs = {
       graph: createMinimalGraph(),
       options: [
@@ -1007,10 +1007,12 @@ describe('NextAction Targeting Fields', () => {
 
     const actions = generateNextActions(inputs, 'clear_winner', [], []);
 
-    const proceedAction = actions.find((a) => a.action.includes('Proceed with'));
-    expect(proceedAction?.target_type).toBe('option');
-    expect(proceedAction?.target_id).toBe('opt1');
-    expect(proceedAction?.target_label).toBe('Option A');
+    // Priority 7 is the ready-branch action; wording is tone-gated and may use
+    // "Move forward with", "Validate the key assumptions before acting on", etc.
+    const readyAction = actions.find((a) => a.priority === 7);
+    expect(readyAction?.target_type).toBe('option');
+    expect(readyAction?.target_id).toBe('opt1');
+    expect(readyAction?.target_label).toBe('Option A');
   });
 
   it('omits targeting fields for narrow framing actions (no specific target)', () => {

--- a/tests/coaching/next-actions-tone.test.ts
+++ b/tests/coaching/next-actions-tone.test.ts
@@ -1,0 +1,119 @@
+/**
+ * B4 Next Actions — Priority 5 tone-gated wording tests.
+ *
+ * Confirms the bare imperative "Proceed with {label}" never appears when the
+ * tone is not confident, and that the rationale surfaces a reason summary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateNextActions } from '../../src/coaching/next-actions.js';
+import type { CoachingInputs, EngineGraphV3 } from '../../src/coaching/types.js';
+
+const minimalGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Goal' },
+    { id: 'f1', kind: 'factor', label: 'Cost' },
+  ],
+  edges: [{ from: 'f1', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+});
+
+const cleanInputs = (overrides: Partial<CoachingInputs> = {}): CoachingInputs => ({
+  graph: minimalGraph(),
+  options: [
+    { id: 'opt1', label: 'Option A', winProbability: 0.7, outcomeMean: 100, outcomeP10: 90, outcomeP90: 110 },
+    { id: 'opt2', label: 'Option B', winProbability: 0.3, outcomeMean: 80, outcomeP10: 70, outcomeP90: 90 },
+  ],
+  factorSensitivity: [
+    {
+      node_id: 'f1', label: 'Cost', importance_rank: 1, elasticity: 0.5, influence_score: 0.5,
+      confidence: 0.9, direction: 'positive', zero_reason: undefined,
+    },
+  ],
+  fragileEdges: [],
+  robustness: { level: 'high', recommendationStability: 0.9, isRobust: true },
+  ...overrides,
+});
+
+describe('B4 Next Actions — Priority 5 tone gate', () => {
+  it('confident tone: emits a forward-leaning action with a confident rationale', () => {
+    const actions = generateNextActions(cleanInputs(), 'clear_winner', [], []);
+    const priority5 = actions.find((a) => a.priority === 7);
+    expect(priority5).toBeDefined();
+    expect(priority5!.action).toContain('Move forward with Option A');
+    expect(priority5!.rationale).toContain('strong current lead');
+    expect(priority5!.rationale).not.toContain('robust');
+    expect(priority5!.action.toLowerCase()).not.toContain('proceed with');
+  });
+
+  it('tempered tone (fragile edge above ceiling): action is validation-first', () => {
+    const inputs = cleanInputs({
+      fragileEdges: [{
+        edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+        displayLabel: 'Cost → Goal', switchProb: 0.35, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+      }],
+    });
+    const actions = generateNextActions(inputs, 'clear_winner', [], []);
+    // Priority 3 fragile-edge action fires first; Priority 5 may still be present.
+    const priority5 = actions.find((a) => a.priority === 7);
+    if (priority5) {
+      expect(priority5.action).toContain('Validate the key assumptions');
+      expect(priority5.action.toLowerCase()).not.toContain('proceed with');
+      expect(priority5.rationale).toContain('currently leads');
+      expect(priority5.rationale.toLowerCase()).not.toContain('decision is robust');
+    }
+  });
+
+  it('caution tone: action and rationale use caution phrasing', () => {
+    const inputs = cleanInputs({
+      robustness: { level: 'low', recommendationStability: 0.5, isRobust: false },
+      fragileEdges: [{
+        edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+        displayLabel: 'Cost → Goal', switchProb: 0.4, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+      }],
+    });
+    const actions = generateNextActions(inputs, 'clear_winner', [], []);
+    const priority5 = actions.find((a) => a.priority === 7);
+    if (priority5) {
+      expect(priority5.action).toContain('Validate the fragile assumptions');
+      expect(priority5.action.toLowerCase()).not.toContain('proceed with');
+    }
+  });
+
+  it('never emits the bare imperative "Proceed with {label}" in tempered or caution tone', () => {
+    const scenarios = [
+      // tempered: moderate robustness
+      cleanInputs({ robustness: { level: 'moderate', recommendationStability: 0.9, isRobust: true } }),
+      // tempered: low stability
+      cleanInputs({ robustness: { level: 'high', recommendationStability: 0.6, isRobust: true } }),
+      // caution: not robust + fragile edge
+      cleanInputs({
+        robustness: { level: 'low', recommendationStability: 0.5, isRobust: false },
+        fragileEdges: [{
+          edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+          displayLabel: 'Cost → Goal', switchProb: 0.4, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+        }],
+      }),
+    ];
+    for (const inputs of scenarios) {
+      const actions = generateNextActions(inputs, 'clear_winner', [], []);
+      const priority5 = actions.find((a) => a.priority === 7);
+      if (priority5) {
+        expect(priority5.action).not.toMatch(/^Proceed with/);
+        expect(priority5.rationale.toLowerCase()).not.toContain('decision is robust');
+      }
+    }
+  });
+
+  it('Priority 4 (close call) does not use the word "winner"', () => {
+    const inputs = cleanInputs({
+      options: [
+        { id: 'opt1', label: 'Option A', winProbability: 0.52, outcomeMean: 100, outcomeP10: 90, outcomeP90: 110 },
+        { id: 'opt2', label: 'Option B', winProbability: 0.48, outcomeMean: 98, outcomeP10: 88, outcomeP90: 108 },
+      ],
+    });
+    const actions = generateNextActions(inputs, 'close_call', [], []);
+    const priority4 = actions.find((a) => a.priority === 4);
+    expect(priority4).toBeDefined();
+    expect(priority4!.rationale).not.toMatch(/\bwinner\b/i);
+  });
+});

--- a/tests/coaching/next-actions-tone.test.ts
+++ b/tests/coaching/next-actions-tone.test.ts
@@ -104,6 +104,43 @@ describe('B4 Next Actions — Priority 5 tone gate', () => {
     }
   });
 
+  it('single high-VoI evidence gap: action is validation-first and rationale uses singular wording', () => {
+    const inputs = cleanInputs();
+    const gaps = [
+      {
+        factor_id: 'f1', factor_label: 'Cost', voi_score: 0.6, confidence: 0.4,
+        confidence_display: '40%', confidence_defaulted: false, influence: 1,
+        influence_display: '100%', suggestion: '', notes: [],
+      },
+    ];
+    const actions = generateNextActions(inputs, 'clear_winner', [], gaps);
+    const priority5 = actions.find((a) => a.priority === 7);
+    expect(priority5).toBeDefined();
+    // Validation-first action, never the bare imperative.
+    expect(priority5!.action).toMatch(/Validate the key assumptions before acting on/);
+    expect(priority5!.action).not.toMatch(/^Proceed with/);
+    expect(priority5!.action).not.toMatch(/^Move forward/);
+    // Singular wording — must not falsely claim "multiple evidence gaps".
+    expect(priority5!.rationale.toLowerCase()).not.toContain('multiple evidence gaps');
+    expect(priority5!.rationale).toContain('a decision-relevant evidence gap remains');
+  });
+
+  it('two-plus low-VoI evidence gaps: rationale uses plural wording', () => {
+    // Two gaps with VoI below the high-VoI threshold (0.40) keep
+    // computeReadiness at 'ready' so Priority 5 fires; the tone classifier
+    // still flags EVIDENCE_GAPS via count, so the rationale must use plural.
+    const inputs = cleanInputs();
+    const gaps = [
+      { factor_id: 'f1', factor_label: 'Cost', voi_score: 0.3, confidence: 0.4, confidence_display: '40%', confidence_defaulted: false, influence: 1, influence_display: '100%', suggestion: '', notes: [] },
+      { factor_id: 'f2', factor_label: 'Other', voi_score: 0.2, confidence: 0.5, confidence_display: '50%', confidence_defaulted: false, influence: 0.5, influence_display: '50%', suggestion: '', notes: [] },
+    ];
+    const actions = generateNextActions(inputs, 'clear_winner', [], gaps);
+    const priority5 = actions.find((a) => a.priority === 7);
+    expect(priority5).toBeDefined();
+    expect(priority5!.rationale).toContain('multiple evidence gaps remain');
+    expect(priority5!.rationale).not.toContain('a decision-relevant evidence gap remains');
+  });
+
   it('Priority 4 (close call) does not use the word "winner"', () => {
     const inputs = cleanInputs({
       options: [

--- a/tests/coaching/post-analysis-scenario-replay.test.ts
+++ b/tests/coaching/post-analysis-scenario-replay.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Post-analysis wording honesty — scenario replay tests.
+ *
+ * Two end-to-end fixtures matching the workstream brief:
+ *   - Marketing: moderate lead, low robustness, fragile edges + evidence gaps.
+ *   - Tech Lead: strong lead but with a low-confidence top driver / evidence
+ *     gap. Confident copy may appear if every gate is clean, but the bare
+ *     imperative "Proceed with implementation" never does.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateExecutiveSummary } from '../../src/coaching/executive-summary.js';
+import { generateNextActions } from '../../src/coaching/next-actions.js';
+import type { CoachingInputs, EngineGraphV3, EvidenceGap } from '../../src/coaching/types.js';
+import type { KeyDriver } from '../../src/coaching/key-drivers.js';
+
+const minimalGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'f_brand', kind: 'factor', label: 'Brand awareness' },
+    { id: 'f_cost', kind: 'factor', label: 'Campaign cost' },
+  ],
+  edges: [
+    { from: 'f_brand', to: 'goal', strength: { mean: 0.7, std: 0.2 } },
+    { from: 'f_cost', to: 'goal', strength: { mean: -0.5, std: 0.15 } },
+  ],
+});
+
+const evidenceGap = (factor_id: string, factor_label: string, voi: number, confidence = 0.4): EvidenceGap => ({
+  factor_id,
+  factor_label,
+  voi_score: voi,
+  confidence,
+  confidence_display: `${Math.round(confidence * 100)}%`,
+  confidence_defaulted: false,
+  influence: 0.8,
+  influence_display: '80%',
+  suggestion: '',
+  notes: [],
+});
+
+function collectAllUserFacingText(execSummary: ReturnType<typeof generateExecutiveSummary>, actions: ReturnType<typeof generateNextActions>): string {
+  return [
+    execSummary.summary,
+    execSummary.decision_statement,
+    execSummary.key_qualifier,
+    execSummary.action_implication,
+    ...actions.flatMap((a) => [a.action, a.rationale]),
+  ].join(' | ');
+}
+
+const BANNED_PHRASES = [
+  'ready to proceed',
+  'Proceed with implementation',
+  'robust and ready',
+  'clear leading option',
+];
+
+function expectNoBannedPhrasing(text: string) {
+  for (const phrase of BANNED_PHRASES) {
+    expect(text.toLowerCase()).not.toContain(phrase.toLowerCase());
+  }
+  expect(text).not.toMatch(/\bwinner\b/i);
+}
+
+describe('Scenario A — Marketing (moderate lead, low robustness, fragile edges + evidence gaps)', () => {
+  const marketingInputs: CoachingInputs = {
+    graph: minimalGraph(),
+    options: [
+      { id: 'opt_paid', label: 'Paid Acquisition', winProbability: 0.62, outcomeMean: 110, outcomeP10: 80, outcomeP90: 140 },
+      { id: 'opt_organic', label: 'Organic Growth', winProbability: 0.38, outcomeMean: 90, outcomeP10: 60, outcomeP90: 120 },
+    ],
+    factorSensitivity: [
+      { node_id: 'f_brand', label: 'Brand awareness', importance_rank: 1, elasticity: 0.6, influence_score: 0.6, confidence: 0.35, direction: 'positive', zero_reason: undefined },
+      { node_id: 'f_cost', label: 'Campaign cost', importance_rank: 2, elasticity: -0.4, influence_score: 0.4, confidence: 0.4, direction: 'negative', zero_reason: undefined },
+    ],
+    fragileEdges: [
+      {
+        edgeId: 'f_brand→goal', fromId: 'f_brand', toId: 'goal', fromLabel: 'Brand awareness',
+        toLabel: 'Revenue', displayLabel: 'Brand awareness → Revenue', switchProb: 0.32,
+        altWinnerId: 'opt_organic', altWinnerLabel: 'Organic Growth',
+      },
+    ],
+    robustness: { level: 'low', recommendationStability: 0.55, isRobust: false },
+  };
+
+  const keyDrivers: KeyDriver[] = [
+    { factor_id: 'f_brand', factor_label: 'Brand awareness', influence_score: 0.6, normalised_impact: 1, impact_display: 'Very High', direction: 'positive', rank: 1 },
+    { factor_id: 'f_cost', factor_label: 'Campaign cost', influence_score: 0.4, normalised_impact: 0.67, impact_display: 'High', direction: 'negative', rank: 2 },
+  ];
+
+  const gaps = [
+    evidenceGap('f_brand', 'Brand awareness', 0.65, 0.35),
+    evidenceGap('f_cost', 'Campaign cost', 0.5, 0.4),
+  ];
+
+  it('executive summary contains no banned phrasing and tempers the lead', () => {
+    const summary = generateExecutiveSummary(marketingInputs, 'ready', 'moderate_winner', keyDrivers, gaps);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.summary.toLowerCase()).not.toContain('robust');
+    expect(summary.summary).toContain('currently leads');
+  });
+
+  it('next actions: no Priority 5 bare imperative; rationale surfaces the active concern', () => {
+    const actions = generateNextActions(marketingInputs, 'moderate_winner', [], gaps);
+    const all = collectAllUserFacingText(generateExecutiveSummary(marketingInputs, 'ready', 'moderate_winner', keyDrivers, gaps), actions);
+    expectNoBannedPhrasing(all);
+    const priority5 = actions.find((a) => a.priority === 7);
+    if (priority5) {
+      expect(priority5.action.toLowerCase()).not.toMatch(/^proceed with/);
+      expect(priority5.rationale.toLowerCase()).not.toContain('decision is robust');
+    }
+  });
+});
+
+describe('Scenario B — Tech Lead (strong lead, low-confidence drivers / evidence gaps)', () => {
+  const techLeadInputs: CoachingInputs = {
+    graph: minimalGraph(),
+    options: [
+      { id: 'opt_a', label: 'Tech Lead Path', winProbability: 0.85, outcomeMean: 130, outcomeP10: 110, outcomeP90: 150 },
+      { id: 'opt_b', label: 'IC Path', winProbability: 0.15, outcomeMean: 90, outcomeP10: 70, outcomeP90: 110 },
+    ],
+    factorSensitivity: [
+      // Strong lead, but the top driver has low confidence — confident tone must NOT fire.
+      { node_id: 'f_brand', label: 'Career fit', importance_rank: 1, elasticity: 0.6, influence_score: 0.6, confidence: 0.4, direction: 'positive', zero_reason: undefined },
+    ],
+    fragileEdges: [],
+    robustness: { level: 'high', recommendationStability: 0.88, isRobust: true },
+  };
+
+  const keyDrivers: KeyDriver[] = [
+    { factor_id: 'f_brand', factor_label: 'Career fit', influence_score: 0.6, normalised_impact: 1, impact_display: 'Very High', direction: 'positive', rank: 1 },
+  ];
+
+  const gaps = [evidenceGap('f_brand', 'Career fit', 0.5, 0.4)];
+
+  it('strong-lead summary may use "strong current lead" wording but never the bare imperative', () => {
+    const summary = generateExecutiveSummary(techLeadInputs, 'ready', 'clear_winner', keyDrivers, gaps);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.action_implication).not.toBe('Proceed with implementation.');
+  });
+
+  it('with low-confidence top driver, copy is tempered (not confident)', () => {
+    const summary = generateExecutiveSummary(techLeadInputs, 'ready', 'clear_winner', keyDrivers, gaps);
+    // Low driver confidence + evidence gap of 1 (below threshold) ⇒ at least one hard reason fires
+    // ⇒ tempered.
+    expect(summary.summary).toContain('currently leads');
+  });
+
+  it('all-clean Tech Lead variant: confident copy permitted', () => {
+    const inputs: CoachingInputs = {
+      ...techLeadInputs,
+      factorSensitivity: [{
+        node_id: 'f_brand', label: 'Career fit', importance_rank: 1, elasticity: 0.6, influence_score: 0.6,
+        confidence: 0.9, direction: 'positive', zero_reason: undefined,
+      }],
+    };
+    const summary = generateExecutiveSummary(inputs, 'ready', 'clear_winner', keyDrivers, []);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.summary).toContain('strong current lead');
+    expect(summary.action_implication).toContain('reasonable to move forward');
+  });
+});

--- a/tests/coaching/post-analysis-scenario-replay.test.ts
+++ b/tests/coaching/post-analysis-scenario-replay.test.ts
@@ -140,11 +140,13 @@ describe('Scenario B — Tech Lead (strong lead, low-confidence drivers / eviden
     expect(summary.action_implication).not.toBe('Proceed with implementation.');
   });
 
-  it('with low-confidence top driver, copy is tempered (not confident)', () => {
+  it('with low-confidence top driver and a high-VoI gap, copy is not confident', () => {
     const summary = generateExecutiveSummary(techLeadInputs, 'ready', 'clear_winner', keyDrivers, gaps);
-    // Low driver confidence + evidence gap of 1 (below threshold) ⇒ at least one hard reason fires
-    // ⇒ tempered.
+    // LOW_DRIVER_CONFIDENCE + EVIDENCE_GAPS (single gap, VoI 0.5 > 0.4 threshold)
+    // ⇒ two hard reasons ⇒ caution. Both tempered and caution decision_statements
+    // contain "currently leads", so we assert on that shared substring.
     expect(summary.summary).toContain('currently leads');
+    expect(summary.summary).not.toContain('strong current lead');
   });
 
   it('all-clean Tech Lead variant: confident copy permitted', () => {

--- a/tests/coaching/readiness-tone.test.ts
+++ b/tests/coaching/readiness-tone.test.ts
@@ -106,11 +106,31 @@ describe('deriveReadinessTone', () => {
   it('flags EVIDENCE_GAPS when evidence-gap count meets the readiness threshold', () => {
     const inputs = cleanInputs();
     const evidenceGaps = [
-      { factor_id: 'f1', factor_label: 'Cost', voi_score: 0.5, confidence: 0.4, confidence_display: '40%', confidence_defaulted: false, influence: 1, influence_display: '100%', suggestion: '', notes: [] },
-      { factor_id: 'f2', factor_label: 'Other', voi_score: 0.3, confidence: 0.5, confidence_display: '50%', confidence_defaulted: false, influence: 0.5, influence_display: '50%', suggestion: '', notes: [] },
+      { factor_id: 'f1', factor_label: 'Cost', voi_score: 0.3, confidence: 0.4, confidence_display: '40%', confidence_defaulted: false, influence: 1, influence_display: '100%', suggestion: '', notes: [] },
+      { factor_id: 'f2', factor_label: 'Other', voi_score: 0.2, confidence: 0.5, confidence_display: '50%', confidence_defaulted: false, influence: 0.5, influence_display: '50%', suggestion: '', notes: [] },
     ];
     const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), evidenceGaps, getThresholds());
     expect(result.reasons).toContain('EVIDENCE_GAPS');
+  });
+
+  it('flags EVIDENCE_GAPS when a single gap exceeds the high-VoI threshold', () => {
+    const inputs = cleanInputs();
+    const evidenceGaps = [
+      { factor_id: 'f1', factor_label: 'Cost', voi_score: 0.6, confidence: 0.4, confidence_display: '40%', confidence_defaulted: false, influence: 1, influence_display: '100%', suggestion: '', notes: [] },
+    ];
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), evidenceGaps, getThresholds());
+    expect(result.reasons).toContain('EVIDENCE_GAPS');
+    expect(result.tone).toBe('tempered');
+  });
+
+  it('does not flag EVIDENCE_GAPS for a single low-VoI gap', () => {
+    const inputs = cleanInputs();
+    const evidenceGaps = [
+      { factor_id: 'f1', factor_label: 'Cost', voi_score: 0.3, confidence: 0.6, confidence_display: '60%', confidence_defaulted: false, influence: 0.5, influence_display: '50%', suggestion: '', notes: [] },
+    ];
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), evidenceGaps, getThresholds());
+    expect(result.reasons).not.toContain('EVIDENCE_GAPS');
+    expect(result.tone).toBe('confident');
   });
 
   it('flags LOW_DRIVER_CONFIDENCE when the top driver has confidence at or below the ceiling', () => {

--- a/tests/coaching/readiness-tone.test.ts
+++ b/tests/coaching/readiness-tone.test.ts
@@ -1,0 +1,195 @@
+/**
+ * D2-tone: Readiness-tone classifier unit tests.
+ *
+ * Each tone gate is exercised in isolation, multi-severe-gate caution is
+ * verified, and the missing-data policy is checked.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveReadinessTone, type ReadinessToneReason } from '../../src/coaching/readiness-tone.js';
+import type { CoachingInputs, EngineGraphV3 } from '../../src/coaching/types.js';
+import { getThresholds, DEFAULT_THRESHOLDS } from '../../src/coaching/thresholds.js';
+import type { KeyDriver } from '../../src/coaching/key-drivers.js';
+
+const minimalGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Goal' },
+    { id: 'f1', kind: 'factor', label: 'Cost' },
+  ],
+  edges: [{ from: 'f1', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+});
+
+const cleanInputs = (overrides: Partial<CoachingInputs> = {}): CoachingInputs => ({
+  graph: minimalGraph(),
+  options: [
+    { id: 'opt1', label: 'Option A', winProbability: 0.7, outcomeMean: 100, outcomeP10: 90, outcomeP90: 110 },
+    { id: 'opt2', label: 'Option B', winProbability: 0.3, outcomeMean: 80, outcomeP10: 70, outcomeP90: 90 },
+  ],
+  factorSensitivity: [
+    {
+      node_id: 'f1',
+      label: 'Cost',
+      importance_rank: 1,
+      elasticity: 0.5,
+      influence_score: 0.5,
+      confidence: 0.9,
+      direction: 'positive',
+      zero_reason: undefined,
+    },
+  ],
+  fragileEdges: [],
+  robustness: { level: 'high', recommendationStability: 0.9, isRobust: true },
+  ...overrides,
+});
+
+const cleanKeyDrivers = (): KeyDriver[] => [
+  { factor_id: 'f1', factor_label: 'Cost', influence_score: 0.5, normalised_impact: 1, impact_display: 'Very High', direction: 'positive', rank: 1 },
+];
+
+describe('deriveReadinessTone', () => {
+  it('returns confident with no reasons when every gate is clean', () => {
+    const inputs = cleanInputs();
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.tone).toBe('confident');
+    expect(result.reasons).toEqual([]);
+  });
+
+  it('flags NOT_ROBUST when robustness.isRobust is false', () => {
+    const inputs = cleanInputs({ robustness: { level: 'high', recommendationStability: 0.9, isRobust: false } });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).toContain('NOT_ROBUST');
+    expect(result.tone).not.toBe('confident');
+  });
+
+  it('flags LOW_ROBUSTNESS when robustness.level is moderate', () => {
+    const inputs = cleanInputs({ robustness: { level: 'moderate', recommendationStability: 0.9, isRobust: true } });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).toContain('LOW_ROBUSTNESS');
+    expect(result.tone).toBe('tempered');
+  });
+
+  it('flags LOW_ROBUSTNESS when robustness.level is low', () => {
+    const inputs = cleanInputs({ robustness: { level: 'low', recommendationStability: 0.9, isRobust: true } });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).toContain('LOW_ROBUSTNESS');
+  });
+
+  it('flags LOW_STABILITY when stability is below the confident threshold', () => {
+    const inputs = cleanInputs({ robustness: { level: 'high', recommendationStability: 0.6, isRobust: true } });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).toContain('LOW_STABILITY');
+  });
+
+  it('flags MATERIAL_FRAGILE_EDGE when a fragile edge exceeds the switch-probability ceiling', () => {
+    const inputs = cleanInputs({
+      fragileEdges: [{
+        edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+        displayLabel: 'Cost → Goal', switchProb: 0.35, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+      }],
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).toContain('MATERIAL_FRAGILE_EDGE');
+  });
+
+  it('does NOT flag fragile edges at-or-below the threshold', () => {
+    const inputs = cleanInputs({
+      fragileEdges: [{
+        edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+        displayLabel: 'Cost → Goal', switchProb: DEFAULT_THRESHOLDS.action_fragile_edge_threshold,
+        altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+      }],
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).not.toContain('MATERIAL_FRAGILE_EDGE');
+  });
+
+  it('flags EVIDENCE_GAPS when evidence-gap count meets the readiness threshold', () => {
+    const inputs = cleanInputs();
+    const evidenceGaps = [
+      { factor_id: 'f1', factor_label: 'Cost', voi_score: 0.5, confidence: 0.4, confidence_display: '40%', confidence_defaulted: false, influence: 1, influence_display: '100%', suggestion: '', notes: [] },
+      { factor_id: 'f2', factor_label: 'Other', voi_score: 0.3, confidence: 0.5, confidence_display: '50%', confidence_defaulted: false, influence: 0.5, influence_display: '50%', suggestion: '', notes: [] },
+    ];
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), evidenceGaps, getThresholds());
+    expect(result.reasons).toContain('EVIDENCE_GAPS');
+  });
+
+  it('flags LOW_DRIVER_CONFIDENCE when the top driver has confidence at or below the ceiling', () => {
+    const inputs = cleanInputs({
+      factorSensitivity: [{
+        node_id: 'f1', label: 'Cost', importance_rank: 1, elasticity: 0.5, influence_score: 0.5,
+        confidence: 0.3, direction: 'positive', zero_reason: undefined,
+      }],
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).toContain('LOW_DRIVER_CONFIDENCE');
+  });
+
+  it('flags NEAR_TIE when leading margin is below the close-call delta', () => {
+    const inputs = cleanInputs({
+      options: [
+        { id: 'opt1', label: 'Option A', winProbability: 0.52, outcomeMean: 100, outcomeP10: 90, outcomeP90: 110 },
+        { id: 'opt2', label: 'Option B', winProbability: 0.48, outcomeMean: 98, outcomeP10: 88, outcomeP90: 108 },
+      ],
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).toContain('NEAR_TIE');
+  });
+
+  it('escalates to caution when two or more hard reasons fire', () => {
+    const inputs = cleanInputs({
+      robustness: { level: 'low', recommendationStability: 0.6, isRobust: false },
+      fragileEdges: [{
+        edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+        displayLabel: 'Cost → Goal', switchProb: 0.4, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+      }],
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.tone).toBe('caution');
+    const expectedHard: ReadinessToneReason[] = ['NOT_ROBUST', 'LOW_ROBUSTNESS', 'LOW_STABILITY', 'MATERIAL_FRAGILE_EDGE'];
+    for (const r of expectedHard) {
+      expect(result.reasons).toContain(r);
+    }
+  });
+
+  it('returns tempered (not caution) when exactly one hard reason fires', () => {
+    const inputs = cleanInputs({
+      fragileEdges: [{
+        edgeId: 'e1', fromId: 'f1', toId: 'goal', fromLabel: 'Cost', toLabel: 'Goal',
+        displayLabel: 'Cost → Goal', switchProb: 0.35, altWinnerId: 'opt2', altWinnerLabel: 'Option B',
+      }],
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.tone).toBe('tempered');
+    expect(result.reasons).toEqual(['MATERIAL_FRAGILE_EDGE']);
+  });
+
+  it('does not block confident when an optional signal is missing and everything else is clean', () => {
+    const inputs = cleanInputs({
+      robustness: { level: undefined, recommendationStability: 0.9, isRobust: true },
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.tone).toBe('confident');
+    expect(result.reasons).toEqual([]);
+  });
+
+  it('adds INSUFFICIENT_SIGNALS when an optional signal is missing AND another weakness exists', () => {
+    const inputs = cleanInputs({
+      robustness: { level: undefined, recommendationStability: 0.6, isRobust: true },
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).toContain('LOW_STABILITY');
+    expect(result.reasons).toContain('INSUFFICIENT_SIGNALS');
+    expect(result.tone).toBe('tempered');
+  });
+
+  it('does not flag LOW_DRIVER_CONFIDENCE when driver confidence is unavailable', () => {
+    const inputs = cleanInputs({
+      factorSensitivity: [{
+        node_id: 'f1', label: 'Cost', importance_rank: 1, elasticity: 0.5, influence_score: 0.5,
+        confidence: undefined, direction: 'positive', zero_reason: undefined,
+      }],
+    });
+    const result = deriveReadinessTone(inputs, 'ready', 'clear_winner', cleanKeyDrivers(), [], getThresholds());
+    expect(result.reasons).not.toContain('LOW_DRIVER_CONFIDENCE');
+  });
+});

--- a/tests/decision-brief-driver-direction.test.ts
+++ b/tests/decision-brief-driver-direction.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Driver-direction regression fixture.
+ *
+ * Locks in the current correct behaviour of assembleBrief's top_drivers:
+ * negative-elasticity cost / time / risk factors must surface with
+ * direction = 'negative' and sensitivity = abs(elasticity). The investigation
+ * found no bug here; this test exists to catch regressions if a future change
+ * flattens factor sign into absolute impact.
+ *
+ * Per the post-analysis-wording-honesty workstream, no production change to
+ * src/assembly/decision-brief.ts is required unless this test fails.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assembleBrief, type BriefAssemblyInput } from '../src/assembly/decision-brief.js';
+
+const MINIMAL_OPTIONS = [
+  { option_id: 'opt_a', option_label: 'Option A', id: 'opt_a', label: 'Option A', win_probability: 0.6 },
+  { option_id: 'opt_b', option_label: 'Option B', id: 'opt_b', label: 'Option B', win_probability: 0.4 },
+] as any[];
+
+const baseInput: BriefAssemblyInput = {
+  analysis_status: 'computed',
+  critiques: [],
+  option_comparison: MINIMAL_OPTIONS,
+  robustness: { level: 'moderate', fragile_edges: [], robust_edges: [] } as any,
+  meta: { seed_used: '1' },
+} as any;
+
+describe('assembleBrief — driver direction regression', () => {
+  it('cost factor (negative elasticity) surfaces as direction: negative with absolute sensitivity', () => {
+    const result = assembleBrief({
+      ...baseInput,
+      factor_sensitivity: [
+        { factor_id: 'cost', factor_label: 'Campaign cost', elasticity: -0.85, direction: 'negative' },
+        { factor_id: 'brand', factor_label: 'Brand awareness', elasticity: 0.5, direction: 'positive' },
+      ] as any[],
+    } as any);
+
+    const costDriver = result?.top_drivers.find((d) => d.factor_label === 'Campaign cost');
+    expect(costDriver).toBeDefined();
+    expect(costDriver!.direction).toBe('negative');
+    expect(costDriver!.sensitivity).toBeCloseTo(0.85, 5);
+  });
+
+  it('time-burden factor (negative elasticity) surfaces as direction: negative', () => {
+    const result = assembleBrief({
+      ...baseInput,
+      factor_sensitivity: [
+        { factor_id: 'time_to_ship', factor_label: 'Time to ship', elasticity: -0.7, direction: 'negative' },
+      ] as any[],
+    } as any);
+
+    const timeDriver = result?.top_drivers.find((d) => d.factor_label === 'Time to ship');
+    expect(timeDriver).toBeDefined();
+    expect(timeDriver!.direction).toBe('negative');
+    expect(timeDriver!.sensitivity).toBeCloseTo(0.7, 5);
+  });
+
+  it('risk factor (negative elasticity) surfaces as direction: negative', () => {
+    const result = assembleBrief({
+      ...baseInput,
+      factor_sensitivity: [
+        { factor_id: 'execution_risk', factor_label: 'Execution risk', elasticity: -0.6, direction: 'negative' },
+      ] as any[],
+    } as any);
+
+    const riskDriver = result?.top_drivers.find((d) => d.factor_label === 'Execution risk');
+    expect(riskDriver).toBeDefined();
+    expect(riskDriver!.direction).toBe('negative');
+    expect(riskDriver!.sensitivity).toBeCloseTo(0.6, 5);
+  });
+
+  it('mixed positive and negative drivers retain their respective directions', () => {
+    const result = assembleBrief({
+      ...baseInput,
+      factor_sensitivity: [
+        { factor_id: 'brand', factor_label: 'Brand awareness', elasticity: 0.8, direction: 'positive' },
+        { factor_id: 'cost', factor_label: 'Campaign cost', elasticity: -0.85, direction: 'negative' },
+        { factor_id: 'time_to_ship', factor_label: 'Time to ship', elasticity: -0.4, direction: 'negative' },
+      ] as any[],
+    } as any);
+
+    expect(result?.top_drivers.find((d) => d.factor_label === 'Brand awareness')?.direction).toBe('positive');
+    expect(result?.top_drivers.find((d) => d.factor_label === 'Campaign cost')?.direction).toBe('negative');
+    expect(result?.top_drivers.find((d) => d.factor_label === 'Time to ship')?.direction).toBe('negative');
+
+    for (const d of result!.top_drivers) {
+      expect(d.sensitivity).toBeGreaterThanOrEqual(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Deterministic PLoT-only fix for the post-analysis wording honesty workstream. Introduces a small readiness-tone classifier that gates over-confident wording in `executive-summary.ts` and `next-actions.ts` Priority 5. Confident phrasing only appears when robustness, fragile-edge, evidence-gap, driver-confidence, stability, and margin gates are all clean; otherwise the copy is tempered or caution.

Banned at every tone: "Proceed with implementation", "ready to proceed", "robust and ready", "clear leading option", and the word "winner".

`computeReadiness` semantics are unchanged, so CEE and DGAI consumers see no behavioural drift.

## Scope

- PLoT only. No CEE, DGAI, prompt, schema, or lockfile changes.
- Branched off `origin/staging` in an isolated worktree.
- Driver-direction added as a regression test only — investigation found no current bug; no production change to `decision-brief.ts`.

## Changes

| File | Why |
|---|---|
| `src/coaching/readiness-tone.ts` *(new)* | Pure `deriveReadinessTone` returning `{ tone, reasons }`. Reason codes: `NOT_ROBUST`, `LOW_ROBUSTNESS`, `LOW_STABILITY`, `MATERIAL_FRAGILE_EDGE`, `EVIDENCE_GAPS`, `LOW_DRIVER_CONFIDENCE`, `NEAR_TIE`, `INSUFFICIENT_SIGNALS`. |
| `src/coaching/thresholds.ts` | Adds `tone_confident_stability_min` (0.75) and `tone_low_driver_confidence_max` (0.5). Reuses existing `action_fragile_edge_threshold`, `readiness_high_evidence_gap_count`, `headline_close_call_delta`. |
| `src/coaching/executive-summary.ts` | Derives tone once and threads it into `generateDecisionStatement`, `generateKeyQualifier`, `generateActionImplication`. Tone-keyed copy variants. |
| `src/coaching/next-actions.ts` | Priority 5 tone-gated wording. `computeReadiness` unchanged. Priority 4 rationale no longer uses "winner". |
| `tests/coaching/readiness-tone.test.ts` *(new)* | 15 unit tests — per-gate reason codes, caution escalation, missing-data policy. |
| `tests/coaching/executive-summary.test.ts` *(new)* | 7 fixtures — low robustness, fragile edge, evidence gaps, low driver confidence, clean strong, caution, copy compliance. |
| `tests/coaching/next-actions-tone.test.ts` *(new)* | 5 Priority 5 tone tests + Priority 4 "winner" guard. |
| `tests/coaching/post-analysis-scenario-replay.test.ts` *(new)* | Scenario A (marketing) + Scenario B (Tech Lead) end-to-end fixtures matching the workstream brief. |
| `tests/decision-brief-driver-direction.test.ts` *(new)* | Cost / time / risk factor regression — negative elasticity stays `direction: 'negative'`, `sensitivity = abs(elasticity)`. |
| `tests/coaching/m1-coaching.test.ts` | Updates one existing assertion that looked up the Priority 5 action by the now-changed "Proceed with" label string. Now finds it by `priority === 7`. |

## Tone selection (summary)

| Hard reasons fired | Tone |
|---|---|
| 0 | confident |
| 1 | tempered |
| 2+ | caution |

`INSUFFICIENT_SIGNALS` is soft — added when an optional signal is missing AND any other weakness exists.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/coaching/ tests/decision-brief.test.ts tests/decision-brief-driver-direction.test.ts` — 172 / 172 pass
- [x] Pre-push validation (Husky) accepted the push
- [ ] Manual replay — marketing scenario: no "robust", "ready to proceed", "Proceed with implementation", "winner" anywhere
- [ ] Manual replay — Tech Lead scenario: confident only if every gate is clean; bare imperative never appears
- [ ] Reviewer approval before merge to `staging`

## Out of scope (explicit)

- CEE egress guard / decision_review prompt v11 → v12 — separate workstream, prompt is PMS-owned.
- DGAI view-model tightening — coordinate with the existing `DecisionGuideAI-display-honesty` worktree.
- Methodology, schema, package, or lockfile changes.
- Production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)