### PR TITLE
fix(plot): preserve signed driver direction in decision_brief.top_drivers

### DIFF
--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -239,12 +239,30 @@ function buildTopDrivers(input: BriefAssemblyInput): BriefDriver[] {
     })
     .slice(0, MAX_TOP_DRIVERS);
 
-  // Direction derived from sign of elasticity (spec: sign(elasticity))
-  return withElasticity.map(f => ({
-    factor_label: f.factor_label?.trim() || f.factor_id,
-    sensitivity: Math.abs(f.elasticity!),
-    direction: (f.elasticity! < 0 ? 'negative' : 'positive') as 'positive' | 'negative',
-  }));
+  // Direction prefers the upstream signed `direction` field (the canonical
+  // source aligned with factor_sensitivity[*].direction and
+  // m1_coaching.key_drivers[*].direction). Falling back to sign(elasticity)
+  // would mislabel negative drivers as positive because production paths
+  // (graph: normalised_influence; ISL: null) emit `elasticity` as unsigned
+  // magnitude. Output type `BriefDriver.direction` is the narrow union
+  // 'positive' | 'negative', so 'mixed' / 'unknown' / missing must fall back
+  // to elasticity-sign and ultimately default to 'positive' when magnitude.
+  return withElasticity.map(f => {
+    const upstream = (f as { direction?: string }).direction;
+    let direction: 'positive' | 'negative';
+    if (upstream === 'positive') {
+      direction = 'positive';
+    } else if (upstream === 'negative') {
+      direction = 'negative';
+    } else {
+      direction = f.elasticity! < 0 ? 'negative' : 'positive';
+    }
+    return {
+      factor_label: f.factor_label?.trim() || f.factor_id,
+      sensitivity: Math.abs(f.elasticity!),
+      direction,
+    };
+  });
 }
 
 function buildKeyAssumptions(input: BriefAssemblyInput): string[] {

--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -239,20 +239,20 @@ function buildTopDrivers(input: BriefAssemblyInput): BriefDriver[] {
     })
     .slice(0, MAX_TOP_DRIVERS);
 
-  // Direction prefers the upstream signed `direction` field (the canonical
-  // source aligned with factor_sensitivity[*].direction and
-  // m1_coaching.key_drivers[*].direction). Falling back to sign(elasticity)
-  // would mislabel negative drivers as positive because production paths
-  // (graph: normalised_influence; ISL: null) emit `elasticity` as unsigned
-  // magnitude. Output type `BriefDriver.direction` is the narrow union
-  // 'positive' | 'negative', so 'mixed' / 'unknown' / missing must fall back
-  // to elasticity-sign and ultimately default to 'positive' when magnitude.
+  // Direction prefers the upstream signed `direction` field — the canonical
+  // source already used by factor_sensitivity[*].direction and
+  // m1_coaching.key_drivers[*].direction. Deriving from sign(elasticity)
+  // mislabels negative drivers as positive in production because no real
+  // path emits a signed elasticity: the graph path sets
+  // `elasticity = normalised_influence` (always >= 0) and the ISL path
+  // sets it to null. Output `BriefDriver.direction` is the narrow union
+  // 'positive' | 'negative', so 'mixed' / 'unknown' / missing fall back to
+  // sign(elasticity) — which yields 'positive' for unsigned magnitudes.
   return withElasticity.map(f => {
-    const upstream = (f as { direction?: string }).direction;
     let direction: 'positive' | 'negative';
-    if (upstream === 'positive') {
+    if (f.direction === 'positive') {
       direction = 'positive';
-    } else if (upstream === 'negative') {
+    } else if (f.direction === 'negative') {
       direction = 'negative';
     } else {
       direction = f.elasticity! < 0 ? 'negative' : 'positive';

--- a/tests/coaching/post-analysis-scenario-replay.test.ts
+++ b/tests/coaching/post-analysis-scenario-replay.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateExecutiveSummary } from '../../src/coaching/executive-summary.js';
 import { generateNextActions } from '../../src/coaching/next-actions.js';
+import { assembleBrief, type BriefAssemblyInput } from '../../src/assembly/decision-brief.js';
 import type { CoachingInputs, EngineGraphV3, EvidenceGap } from '../../src/coaching/types.js';
 import type { KeyDriver } from '../../src/coaching/key-drivers.js';
 
@@ -161,5 +162,177 @@ describe('Scenario B — Tech Lead (strong lead, low-confidence drivers / eviden
     expectNoBannedPhrasing(summary.summary);
     expect(summary.summary).toContain('strong current lead');
     expect(summary.action_implication).toContain('reasonable to move forward');
+  });
+});
+
+// ===========================================================================
+// Scenario C — Staging-derived near-tie (PR #174 tone gate + driver direction)
+//
+// Mirrors the latest staging debug bundle for build b8b05a5:
+//   - Hire One Tech Lead ≈ 48.475% vs Hire Two Developers ≈ 48.425% (near-tie).
+//   - robustness.level = very_low, isRobust = false, recommendationStability ≈ 0.48475.
+//   - Multiple fragile edges; evidence gaps include Annual Salary Cost and
+//     Team Technical Maturity.
+//   - factor_sensitivity for Annual Salary Cost has direction = negative.
+//
+// Locks in two things simultaneously:
+//   1. PR #174 tone gate: executive_summary, decision_brief.headline and
+//      next_actions use cautious near-tie wording; banned phrases stay out.
+//   2. Driver-direction projection bug fix: decision_brief.top_drivers
+//      preserves direction = negative for Annual Salary Cost even though the
+//      production-shape `elasticity` arrives as an unsigned magnitude (mirrors
+//      computeFactorSensitivityFromGraph's normalised_influence output).
+// ===========================================================================
+describe('Scenario C — Staging-derived near-tie (PR #174 + driver direction projection)', () => {
+  const tieGraph = (): EngineGraphV3 => ({
+    nodes: [
+      { id: 'goal', kind: 'goal', label: 'Engineering capacity' },
+      { id: 'f_salary', kind: 'factor', label: 'Annual Salary Cost' },
+      { id: 'f_maturity', kind: 'factor', label: 'Team Technical Maturity' },
+    ],
+    edges: [
+      { from: 'f_salary', to: 'goal', strength: { mean: -0.6, std: 0.2 } },
+      { from: 'f_maturity', to: 'goal', strength: { mean: 0.55, std: 0.2 } },
+    ],
+  });
+
+  const nearTieInputs: CoachingInputs = {
+    graph: tieGraph(),
+    options: [
+      { id: 'opt_one_lead', label: 'Hire One Tech Lead', winProbability: 0.48475, outcomeMean: 100, outcomeP10: 70, outcomeP90: 130 },
+      { id: 'opt_two_devs', label: 'Hire Two Developers', winProbability: 0.48425, outcomeMean: 99, outcomeP10: 69, outcomeP90: 129 },
+    ],
+    factorSensitivity: [
+      // Production shape: elasticity is the unsigned magnitude (graph path emits
+      // normalised_influence, ISL path emits null). The signed signal lives on
+      // the `direction` field — that's the source decision_brief.top_drivers
+      // must honour.
+      { node_id: 'f_salary', label: 'Annual Salary Cost', importance_rank: 1, elasticity: 0.78, influence_score: 0.78, confidence: 0.35, direction: 'negative', zero_reason: undefined },
+      { node_id: 'f_maturity', label: 'Team Technical Maturity', importance_rank: 2, elasticity: 0.6, influence_score: 0.6, confidence: 0.4, direction: 'positive', zero_reason: undefined },
+    ],
+    fragileEdges: [
+      {
+        edgeId: 'f_salary→goal', fromId: 'f_salary', toId: 'goal', fromLabel: 'Annual Salary Cost',
+        toLabel: 'Engineering capacity', displayLabel: 'Annual Salary Cost → Engineering capacity', switchProb: 0.34,
+        altWinnerId: 'opt_two_devs', altWinnerLabel: 'Hire Two Developers',
+      },
+      {
+        edgeId: 'f_maturity→goal', fromId: 'f_maturity', toId: 'goal', fromLabel: 'Team Technical Maturity',
+        toLabel: 'Engineering capacity', displayLabel: 'Team Technical Maturity → Engineering capacity', switchProb: 0.28,
+        altWinnerId: 'opt_two_devs', altWinnerLabel: 'Hire Two Developers',
+      },
+    ],
+    robustness: { level: 'very_low', recommendationStability: 0.48475, isRobust: false },
+  };
+
+  const nearTieKeyDrivers: KeyDriver[] = [
+    { factor_id: 'f_salary', factor_label: 'Annual Salary Cost', influence_score: 0.78, normalised_impact: 1, impact_display: 'Very High', direction: 'negative', rank: 1 },
+    { factor_id: 'f_maturity', factor_label: 'Team Technical Maturity', influence_score: 0.6, normalised_impact: 0.77, impact_display: 'High', direction: 'positive', rank: 2 },
+  ];
+
+  const nearTieGaps: EvidenceGap[] = [
+    evidenceGap('f_salary', 'Annual Salary Cost', 0.62, 0.35),
+    evidenceGap('f_maturity', 'Team Technical Maturity', 0.55, 0.4),
+  ];
+
+  it('m1_coaching.key_drivers preserves direction = negative for Annual Salary Cost (input contract)', () => {
+    const salary = nearTieKeyDrivers.find((d) => d.factor_id === 'f_salary');
+    expect(salary?.direction).toBe('negative');
+  });
+
+  it('factor_sensitivity preserves direction = negative for Annual Salary Cost (input contract)', () => {
+    const salary = nearTieInputs.factorSensitivity.find((f) => f.node_id === 'f_salary');
+    expect(salary?.direction).toBe('negative');
+  });
+
+  it('executive summary uses cautious near-tie wording; no banned phrases', () => {
+    const summary = generateExecutiveSummary(nearTieInputs, 'close_call', 'close_call', nearTieKeyDrivers, nearTieGaps);
+    expectNoBannedPhrasing(summary.summary);
+    expect(summary.summary).toContain('Hire One Tech Lead edges ahead');
+    expect(summary.summary).toContain('recommendation stability');
+    expect(summary.action_implication.toLowerCase()).not.toMatch(/^proceed with/);
+    expect(summary.summary.toLowerCase()).not.toContain('robust and ready');
+  });
+
+  it('next_actions surface validation / tie-breaker guidance and no bare imperative', () => {
+    const summary = generateExecutiveSummary(nearTieInputs, 'close_call', 'close_call', nearTieKeyDrivers, nearTieGaps);
+    const actions = generateNextActions(nearTieInputs, 'close_call', [], nearTieGaps);
+    const all = collectAllUserFacingText(summary, actions);
+    expectNoBannedPhrasing(all);
+    // Tie-breaker or evidence-gathering guidance must appear somewhere in the
+    // combined surface (action_implication or a next_action rationale).
+    expect(all.toLowerCase()).toMatch(/tie-?breaker|gather additional evidence|gather evidence/);
+    // No priority should emit the bare "Proceed with implementation" imperative
+    // under close_call readiness.
+    for (const a of actions) {
+      expect(a.action).not.toBe('Proceed with implementation.');
+      expect(a.action.toLowerCase()).not.toMatch(/^proceed with implementation/);
+    }
+  });
+
+  it('decision_brief.top_drivers preserves direction = negative for Annual Salary Cost', () => {
+    // Build BriefAssemblyInput in production shape: elasticity is unsigned
+    // magnitude, direction carries the signed signal.
+    const briefInput: BriefAssemblyInput = {
+      analysis_status: 'computed',
+      critiques: [],
+      option_comparison: [
+        { option_id: 'opt_one_lead', option_label: 'Hire One Tech Lead', id: 'opt_one_lead', label: 'Hire One Tech Lead', win_probability: 0.48475 },
+        { option_id: 'opt_two_devs', option_label: 'Hire Two Developers', id: 'opt_two_devs', label: 'Hire Two Developers', win_probability: 0.48425 },
+      ] as any,
+      factor_sensitivity: [
+        { factor_id: 'f_salary', factor_label: 'Annual Salary Cost', elasticity: 0.78, direction: 'negative', sensitivity_score: 0.78 },
+        { factor_id: 'f_maturity', factor_label: 'Team Technical Maturity', elasticity: 0.6, direction: 'positive', sensitivity_score: 0.6 },
+      ] as any,
+      robustness: { level: 'very_low', fragile_edges: [], robust_edges: [] } as any,
+      meta: { seed_used: '1' },
+    } as any;
+
+    const brief = assembleBrief(briefInput);
+    expect(brief).not.toBeNull();
+
+    const salary = brief!.top_drivers.find((d) => d.factor_label === 'Annual Salary Cost');
+    expect(salary).toBeDefined();
+    expect(salary!.direction).toBe('negative');
+    expect(salary!.sensitivity).toBeCloseTo(0.78, 5);
+
+    const maturity = brief!.top_drivers.find((d) => d.factor_label === 'Team Technical Maturity');
+    expect(maturity!.direction).toBe('positive');
+    expect(maturity!.sensitivity).toBeCloseTo(0.6, 5);
+  });
+
+  it('decision_brief.headline uses cautious near-tie wording (no banned phrasing)', () => {
+    const summary = generateExecutiveSummary(nearTieInputs, 'close_call', 'close_call', nearTieKeyDrivers, nearTieGaps);
+
+    const briefInput: BriefAssemblyInput = {
+      analysis_status: 'computed',
+      critiques: [],
+      option_comparison: [
+        { option_id: 'opt_one_lead', option_label: 'Hire One Tech Lead', id: 'opt_one_lead', label: 'Hire One Tech Lead', win_probability: 0.48475 },
+        { option_id: 'opt_two_devs', option_label: 'Hire Two Developers', id: 'opt_two_devs', label: 'Hire Two Developers', win_probability: 0.48425 },
+      ] as any,
+      factor_sensitivity: [
+        { factor_id: 'f_salary', factor_label: 'Annual Salary Cost', elasticity: 0.78, direction: 'negative', sensitivity_score: 0.78 },
+      ] as any,
+      robustness: { level: 'very_low', fragile_edges: [], robust_edges: [] } as any,
+      m1_coaching: {
+        executive_summary: {
+          summary: summary.summary,
+          decision_statement: summary.decision_statement,
+          key_qualifier: summary.key_qualifier,
+          action_implication: summary.action_implication,
+        },
+      } as any,
+      meta: { seed_used: '1' },
+    } as any;
+
+    const brief = assembleBrief(briefInput);
+    expect(brief).not.toBeNull();
+    expectNoBannedPhrasing(brief!.headline);
+    expect(brief!.headline.toLowerCase()).not.toContain('robust and ready');
+    expect(brief!.headline.toLowerCase()).not.toContain('ready to proceed');
+    // Headline must include cautious near-tie wording sourced from the
+    // PR #174-gated executive_summary.
+    expect(brief!.headline).toContain('edges ahead');
   });
 });

--- a/tests/decision-brief-driver-direction.test.ts
+++ b/tests/decision-brief-driver-direction.test.ts
@@ -89,4 +89,84 @@ describe('assembleBrief — driver direction regression', () => {
       expect(d.sensitivity).toBeGreaterThanOrEqual(0);
     }
   });
+
+  // -------------------------------------------------------------------------
+  // Production-shape regressions
+  //
+  // Real factor_sensitivity inputs reaching assembleBrief never carry a signed
+  // `elasticity`. The graph path sets `elasticity = normalised_influence`
+  // (always >= 0); the ISL path sets `elasticity = null`. The signed signal
+  // lives on the `direction` field instead. These cases lock in that
+  // buildTopDrivers honours that upstream signal.
+  // -------------------------------------------------------------------------
+
+  it('production shape: direction=negative with positive (magnitude) elasticity preserves negative', () => {
+    // Mirrors the staging-bundle bug: Annual Salary Cost arrives from the
+    // graph path with normalised_influence ≈ 0.85 (positive magnitude) and
+    // direction = 'negative'. decision_brief.top_drivers must report negative.
+    const result = assembleBrief({
+      ...baseInput,
+      factor_sensitivity: [
+        { factor_id: 'annual_salary_cost', factor_label: 'Annual Salary Cost', elasticity: 0.85, direction: 'negative' },
+        { factor_id: 'team_maturity', factor_label: 'Team Technical Maturity', elasticity: 0.6, direction: 'positive' },
+      ] as any[],
+    } as any);
+
+    const cost = result?.top_drivers.find((d) => d.factor_label === 'Annual Salary Cost');
+    expect(cost).toBeDefined();
+    expect(cost!.direction).toBe('negative');
+    expect(cost!.sensitivity).toBeCloseTo(0.85, 5);
+
+    const maturity = result?.top_drivers.find((d) => d.factor_label === 'Team Technical Maturity');
+    expect(maturity!.direction).toBe('positive');
+    expect(maturity!.sensitivity).toBeCloseTo(0.6, 5);
+  });
+
+  it('direction-vs-sign disagreement: upstream direction wins over elasticity sign', () => {
+    // Documents the contract: when upstream sets direction explicitly,
+    // buildTopDrivers respects it regardless of elasticity sign.
+    const result = assembleBrief({
+      ...baseInput,
+      factor_sensitivity: [
+        { factor_id: 'brand', factor_label: 'Brand awareness', elasticity: -0.7, direction: 'positive' },
+        { factor_id: 'cost', factor_label: 'Campaign cost', elasticity: 0.5, direction: 'negative' },
+      ] as any[],
+    } as any);
+
+    expect(result?.top_drivers.find((d) => d.factor_label === 'Brand awareness')?.direction).toBe('positive');
+    expect(result?.top_drivers.find((d) => d.factor_label === 'Campaign cost')?.direction).toBe('negative');
+  });
+
+  it('mixed direction with positive elasticity falls back to positive (documented limitation)', () => {
+    // BriefDriver.direction is the narrow union 'positive' | 'negative'.
+    // Upstream 'mixed' / 'unknown' / missing must collapse to one of those.
+    // The fallback is sign(elasticity); unsigned magnitudes therefore land on
+    // 'positive'. This is the unavoidable narrowing the workstream brief
+    // allows — known signed signals (above) take precedence over it.
+    const result = assembleBrief({
+      ...baseInput,
+      factor_sensitivity: [
+        { factor_id: 'mixed_factor', factor_label: 'Mixed-direction factor', elasticity: 0.6, direction: 'mixed' },
+        { factor_id: 'unknown_factor', factor_label: 'Unknown-direction factor', elasticity: 0.5, direction: 'unknown' },
+        { factor_id: 'missing_factor', factor_label: 'No-direction factor', elasticity: 0.4 },
+      ] as any[],
+    } as any);
+
+    expect(result?.top_drivers.find((d) => d.factor_label === 'Mixed-direction factor')?.direction).toBe('positive');
+    expect(result?.top_drivers.find((d) => d.factor_label === 'Unknown-direction factor')?.direction).toBe('positive');
+    expect(result?.top_drivers.find((d) => d.factor_label === 'No-direction factor')?.direction).toBe('positive');
+  });
+
+  it('mixed/unknown direction with negative elasticity falls back to negative', () => {
+    const result = assembleBrief({
+      ...baseInput,
+      factor_sensitivity: [
+        { factor_id: 'mixed_neg', factor_label: 'Mixed negative magnitude', elasticity: -0.5, direction: 'mixed' },
+        { factor_id: 'missing_neg', factor_label: 'No direction negative magnitude', elasticity: -0.3 },
+      ] as any[],
+    } as any);
+
+    expect(result?.top_drivers.find((d) => d.factor_label === 'Mixed negative magnitude')?.direction).toBe('negative');
+    expect(result?.top_drivers.find((d) => d.factor_label === 'No direction negative magnitude')?.direction).toBe('negative');
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes a PLoT scientific-presentation bug observed on staging build `b8b05a5`: `decision_brief.top_drivers` flattened negative-direction drivers (e.g. Annual Salary Cost) to `positive`, while the upstream `factor_sensitivity[*].direction` and `m1_coaching.key_drivers[*].direction` for the same factor correctly showed `negative`.
- Root cause: `buildTopDrivers` in `src/assembly/decision-brief.ts` derived direction from `sign(elasticity)`. That works for hand-crafted fixtures but no production path emits a signed elasticity — the graph path sets `elasticity = normalised_influence` (always ≥ 0), the ISL path sets `elasticity = null` (ISL has no such field). The signed signal lives on the upstream `direction` field that the sibling surfaces already read.
- Fix: prefer upstream `f.direction` when it is `'positive'` or `'negative'`; fall back to `sign(elasticity)` only for `'mixed'` / `'unknown'` / missing direction (the narrow `BriefDriver.direction` output union cannot represent mixed). `sensitivity` remains `Math.abs(elasticity)`.

Scope is strictly PLoT-assembly. No CEE, DGAI, ISL, prompt, schema, package, lockfile, CI/auth or deployment changes.

## Tests

- Extends `tests/decision-brief-driver-direction.test.ts` with production-shape regressions:
  - `direction: 'negative'` + positive (magnitude) `elasticity` → preserved as `'negative'` (the staging-bundle reproducer).
  - Direction-vs-sign disagreement → upstream `direction` wins.
  - `'mixed'` / `'unknown'` / missing direction → falls back to `sign(elasticity)` (documented limitation).
- Adds a staging-derived near-tie scenario (Scenario C) to `tests/coaching/post-analysis-scenario-replay.test.ts` pinning both the PR #174 D2-tone gate AND the projection fix:
  - Hire One Tech Lead ≈ 48.475% vs Hire Two Developers ≈ 48.425%; robustness `very_low`, `recommendationStability` 0.48475, multiple fragile edges, evidence gaps on Annual Salary Cost + Team Technical Maturity.
  - Asserts: cautious near-tie wording in `executive_summary` and `decision_brief.headline`; tie-breaker / evidence-gathering guidance in `next_actions`; no banned phrases; `direction: 'negative'` preserved on Annual Salary Cost across `factor_sensitivity`, `m1_coaching.key_drivers`, and `decision_brief.top_drivers`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/decision-brief-driver-direction.test.ts tests/coaching/post-analysis-scenario-replay.test.ts` (19/19 pass, including 8 new + 6 staging-scenario tests)
- [x] `npx vitest run tests/coaching/ tests/decision-brief*.test.ts tests/near-tie.test.ts tests/robustness-analysis.test.ts` (212/212 pass)
- [x] Pre-push gate `scripts/pre-push-validate.sh` (4861 tests pass; typecheck, OpenAPI lint, stale-.js, file: refs all clean)
- [ ] CI green on staging PR

## Deployment

Targets `staging` only. Do not merge to `main` from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)