### PR TITLE
docs(plot): clarify robustness vs readiness vs VOI semantics; pin tensions

### DIFF
--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -104,8 +104,9 @@ export type BriefAssemblyInput = Pick<RunResponseV3, 'analysis_status' | 'critiq
 // =============================================================================
 
 /**
- * Pure projection of ISL `robustness.level` into the `BriefDriver`-adjacent
- * narrow union surfaced on `DecisionBriefV1.robustness`.
+ * Pure projection of ISL `robustness.level` onto the
+ * `DecisionBriefV1.robustness` field (narrow union
+ * `'robust' | 'moderate' | 'fragile'`).
  *
  * **This is NOT a synthesis.** It does not consult fragile edges, evidence
  * gaps, low driver confidence, or `recommendation_stability`. Those signals

--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -103,6 +103,24 @@ export type BriefAssemblyInput = Pick<RunResponseV3, 'analysis_status' | 'critiq
 // Robustness Level Mapping
 // =============================================================================
 
+/**
+ * Pure projection of ISL `robustness.level` into the `BriefDriver`-adjacent
+ * narrow union surfaced on `DecisionBriefV1.robustness`.
+ *
+ * **This is NOT a synthesis.** It does not consult fragile edges, evidence
+ * gaps, low driver confidence, or `recommendation_stability`. Those signals
+ * are surfaced separately:
+ *   - fragile edges → `what_would_change` and (via PR #174 tone gate) the
+ *     `headline` wording;
+ *   - evidence gaps → `key_assumptions` and (via tone gate) `headline`;
+ *   - low driver confidence and near-tie status → tone gate `headline`.
+ *
+ * The semantic mapping is "graph perturbation stability under ISL's
+ * robustness analysis" — `high → 'robust'`, `moderate → 'moderate'`,
+ * `low | very_low → 'fragile'`. See `src/types/decision-brief.ts` jsdoc
+ * for the consumer-facing contract and the readiness-widening follow-up
+ * for the longer-term action-readiness surface.
+ */
 function mapRobustnessLevel(level: string | undefined): 'robust' | 'moderate' | 'fragile' {
   switch (level) {
     case 'high': return 'robust';

--- a/src/coaching/types.ts
+++ b/src/coaching/types.ts
@@ -98,7 +98,26 @@ export interface StoryHeadlines {
 export interface EvidenceGap {
   factor_id: string;
   factor_label: string;
-  voi_score: number;             // Normalised VoI (0-1)
+  /**
+   * Coaching-internal prioritisation score for evidence-gap selection.
+   *
+   * Formula (see `src/coaching/evidence-gaps.ts`):
+   *   `voi_score = normalisedImpact × (1 - confidence)`
+   * where `normalisedImpact = |influence_score| / max(|influence_score|)`.
+   *
+   * **Distinct from `factor_sensitivity[*].value_of_information`.** The
+   * coaching score never consults fragile edges, so it can be non-zero
+   * even when the same factor's `factor_sensitivity[*].value_of_information`
+   * is 0 (e.g. when the factor has no adjacent fragile edge in the graph
+   * fallback path). The two surfaces measure related but different
+   * quantities — see `tests/voi-surface-divergence.test.ts` for the
+   * regression pin and `src/types/engine-v3.ts:FactorSensitivityResultV3.value_of_information`
+   * jsdoc for the public-surface formula.
+   *
+   * Used only for coaching prioritisation (gap selection + ordering),
+   * NOT comparable across surfaces. Range: 0-1.
+   */
+  voi_score: number;
   confidence: number;            // 0-1 (raw)
   confidence_display: string;    // "50%" (formatted)
   confidence_defaulted: boolean; // True if confidence was missing
@@ -111,8 +130,14 @@ export interface EvidenceGap {
   raw_value?: number;            // Original unscaled value for UI display
   unit?: string;                 // Factor unit (e.g. "USD", "users")
   cap?: number;                  // Normalisation scale cap
-  // EVPI heuristic (when win probabilities available)
-  evpi_percentage_points?: number;  // VOI × win probability spread × 100
+  /**
+   * EVPI heuristic (when win probabilities available).
+   * Formula: `voi_score × win_probability_spread × 100`.
+   * Inherits the coaching-internal nature of `voi_score` — NOT comparable
+   * to `factor_sensitivity[*].evpi_percentage_points`, which is derived
+   * from the public-surface VOI (see the latter's jsdoc).
+   */
+  evpi_percentage_points?: number;
   evpi_method?: 'heuristic' | 'counterfactual';
 }
 

--- a/src/types/decision-brief.ts
+++ b/src/types/decision-brief.ts
@@ -39,7 +39,27 @@ export interface DecisionBriefV1 {
   /** What would need to change to flip the recommendation (max 10) */
   what_would_change: string[];
 
-  /** Overall robustness assessment */
+  /**
+   * Graph perturbation stability — a direct projection of ISL
+   * `robustness.level` via `mapRobustnessLevel` in `src/assembly/decision-brief.ts`.
+   *
+   * **This field is NOT an action-readiness assessment.** It does not
+   * consult fragile edges, evidence gaps, low driver confidence, or
+   * `recommendation_stability`. A brief can carry `robustness: 'robust'`
+   * while simultaneously containing material fragile edges and high-VoI
+   * evidence gaps — in that case the underlying decision surface is
+   * structurally stable to small perturbations, but the wider scientific
+   * picture is more cautious.
+   *
+   * Consumers wanting action-readiness signals should also check:
+   *   - `warnings` (PARTIAL_ANALYSIS, model critiques);
+   *   - `key_assumptions` (high-VoI evidence gaps);
+   *   - `what_would_change` (fragile edges and top drivers);
+   *   - `headline` (which is tone-gated by PR #174 `deriveReadinessTone` in
+   *     `src/coaching/readiness-tone.ts` against the broader signal set —
+   *     fragile edges, robustness level, recommendation stability, evidence
+   *     gaps, low driver confidence, near-tie status).
+   */
   robustness: 'robust' | 'moderate' | 'fragile';
 
   /** Merged warnings from critiques and model critiques (max 10) */

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1652,7 +1652,32 @@ export interface FactorSensitivityResultV3 {
   importance_rank?: number;
   /** Human-readable interpretation from ISL */
   interpretation?: string;
-  /** Value of information from ISL */
+  /**
+   * Value of information for this factor on the public response surface.
+   *
+   * Provenance is path-dependent:
+   *   - **ISL path:** sourced from ISL's Monte Carlo VOI estimator and
+   *     sanitised non-negative via `sanitiseIslVoi`
+   *     (`src/lib/evpi-emission.ts`) per the Howard 1966 EVPI contract.
+   *   - **Graph fallback path:** computed by `computeValueOfInformation` in
+   *     `src/lib/factor-influence.ts` as
+   *     `|sensitivity| × (1 - confidence) × decision_fragility`, where
+   *     `decision_fragility` is the max `marginal_switch_probability`
+   *     across adjacent fragile edges.
+   *
+   * **May legitimately be 0** when:
+   *   - the factor has no adjacent fragile edge in the graph-fallback path
+   *     (decision_fragility = 0 → product = 0); or
+   *   - ISL emitted a non-positive VOI value (sampling artefact) which the
+   *     non-negativity sanitiser collapsed.
+   *
+   * This is a **different quantity** from
+   * `m1_coaching.evidence_gaps[*].voi_score`, which is a coaching-internal
+   * impact × uncertainty score that does not consult fragile edges. The
+   * two surfaces can legitimately disagree on the same factor — see
+   * `tests/voi-surface-divergence.test.ts` for a regression pin and
+   * `src/coaching/types.ts:EvidenceGap.voi_score` for the coaching formula.
+   */
   value_of_information?: number;
   /**
    * Estimated EVPI in percentage points of win probability.

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1681,10 +1681,19 @@ export interface FactorSensitivityResultV3 {
   value_of_information?: number;
   /**
    * Estimated EVPI in percentage points of win probability.
-   * Heuristic approximation: VOI × win probability spread × 100.
+   * Heuristic approximation: `value_of_information × win_probability_spread × 100`.
    * Not true counterfactual EVPI. To be replaced when ISL supports
    * per-factor counterfactual EVPI.
    * Present only when both VOI and win probabilities are available.
+   *
+   * **Derived from this field's own `value_of_information`** — inherits its
+   * public-surface provenance (ISL Monte Carlo or graph fallback with
+   * fragile-edge dependency). **NOT comparable to
+   * `m1_coaching.evidence_gaps[*].evpi_percentage_points`**, which is
+   * derived from the coaching-internal `voi_score`. The two EVPI fields
+   * legitimately diverge wherever the underlying VOI fields do — see
+   * `tests/voi-surface-divergence.test.ts` for the regression pin and
+   * `src/coaching/types.ts:EvidenceGap` for the coaching formula.
    */
   evpi_percentage_points?: number;
   /** Method used to compute evpi_percentage_points */

--- a/tests/coaching/robustness-readiness-coherence.test.ts
+++ b/tests/coaching/robustness-readiness-coherence.test.ts
@@ -176,7 +176,12 @@ describe('Robustness / readiness coherence — known semantic tension', () => {
     // This is the scientific-presentation debt documented in the workstream
     // plan and addressed by the Priority 1 follow-up (schema-versioned
     // readiness widening with DGAI/UI coordination).
-
+    //
+    // The brief fixture below carries the same fragile edge present in
+    // `coherenceInputs.fragileEdges` so the "same inputs" narrative is
+    // literal, not just directional. The outcome is unchanged either way —
+    // `mapRobustnessLevel` only reads `level` — but the fixture parity
+    // makes the documentary value of the pin honest.
     const briefInput: BriefAssemblyInput = {
       analysis_status: 'computed',
       critiques: [],
@@ -184,7 +189,19 @@ describe('Robustness / readiness coherence — known semantic tension', () => {
         { option_id: 'opt_a', option_label: 'Option A', id: 'opt_a', label: 'Option A', win_probability: 0.7 },
         { option_id: 'opt_b', option_label: 'Option B', id: 'opt_b', label: 'Option B', win_probability: 0.3 },
       ] as any,
-      robustness: { level: 'high', fragile_edges: [], robust_edges: [] } as any,
+      robustness: {
+        level: 'high',
+        fragile_edges: [
+          {
+            from_id: 'f_cost',
+            to_id: 'goal',
+            from_label: 'Campaign cost',
+            to_label: 'Revenue',
+            switch_probability: 0.34,
+          },
+        ],
+        robust_edges: [],
+      } as any,
       meta: { seed_used: '1' },
     } as any;
     const brief = assembleBrief(briefInput);

--- a/tests/coaching/robustness-readiness-coherence.test.ts
+++ b/tests/coaching/robustness-readiness-coherence.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Robustness / readiness coherence regression pin.
+ *
+ * Documents the *current* semantic tension between three PLoT output surfaces:
+ *
+ *   - `decision_brief.robustness` (`src/assembly/decision-brief.ts:mapRobustnessLevel`)
+ *     is a pure projection of ISL `robustness.level` — graph perturbation
+ *     stability only.
+ *
+ *   - `m1_coaching.readiness` (`src/coaching/next-actions.ts:computeReadiness`)
+ *     consumes only `headlineType` + `NARROW_FRAMING` critiques + evidence-gap
+ *     count and top VoI. It does NOT consume fragile edges, robustness.level,
+ *     low driver confidence, or recommendation_stability directly.
+ *
+ *   - `deriveReadinessTone` (PR #174, `src/coaching/readiness-tone.ts`)
+ *     consumes the broader signal set — fragile edges, robustness level,
+ *     stability, driver confidence, near-tie status, evidence gaps — and
+ *     gates the executive-summary prose accordingly.
+ *
+ * Consequence: a brief can carry `robustness: 'robust'` AND `readiness: 'ready'`
+ * AND yet produce `caution`-toned executive-summary copy. This is "PR #174's
+ * tone gate compensating for narrow readiness semantics, not fixing them" —
+ * the headline finding of the scientific-consistency follow-up workstream.
+ *
+ * This test pins that current behaviour. **Any future change must update it
+ * intentionally.** The Priority 1 follow-up (schema-versioned readiness
+ * widening) would, when it lands, replace this test with one asserting that
+ * `readiness` itself reflects the broader signal set (with DGAI/UI
+ * coordination on the enum-to-confidence-tier mapping).
+ *
+ * See workstream plan and the PR description for the full framing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assembleBrief, type BriefAssemblyInput } from '../../src/assembly/decision-brief.js';
+import { computeReadiness } from '../../src/coaching/next-actions.js';
+import { generateExecutiveSummary } from '../../src/coaching/executive-summary.js';
+import { deriveReadinessTone } from '../../src/coaching/readiness-tone.js';
+import { getThresholds } from '../../src/coaching/thresholds.js';
+import type { CoachingInputs, EngineGraphV3, EvidenceGap } from '../../src/coaching/types.js';
+import type { KeyDriver } from '../../src/coaching/key-drivers.js';
+
+const minimalGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'f_brand', kind: 'factor', label: 'Brand awareness' },
+    { id: 'f_cost', kind: 'factor', label: 'Campaign cost' },
+  ],
+  edges: [
+    { from: 'f_brand', to: 'goal', strength: { mean: 0.7, std: 0.1 } },
+    { from: 'f_cost', to: 'goal', strength: { mean: -0.5, std: 0.1 } },
+  ],
+});
+
+const evidenceGap = (factor_id: string, factor_label: string, voi: number, confidence = 0.6): EvidenceGap => ({
+  factor_id,
+  factor_label,
+  voi_score: voi,
+  confidence,
+  confidence_display: `${Math.round(confidence * 100)}%`,
+  confidence_defaulted: false,
+  influence: 0.7,
+  influence_display: '70%',
+  suggestion: '',
+  notes: [],
+});
+
+describe('Robustness / readiness coherence — known semantic tension', () => {
+  // Carefully constructed inputs:
+  //   - Clear-winner margin (70% vs 30%) → headlineType = 'clear_winner'.
+  //   - robustness.level = 'high', isRobust = true, stability = 0.85
+  //     → no NOT_ROBUST, LOW_ROBUSTNESS, or LOW_STABILITY reasons.
+  //   - Driver confidence = 0.80 → no LOW_DRIVER_CONFIDENCE.
+  //   - Win-prob delta 0.40 → no NEAR_TIE.
+  //   - 1 fragile edge with switchProb = 0.34 (> 0.20 threshold)
+  //     → triggers MATERIAL_FRAGILE_EDGE (hard reason).
+  //   - 1 evidence gap with voi_score = 0.60 (> 0.40 threshold)
+  //     → triggers EVIDENCE_GAPS (hard reason).
+  //   - 2 hard reasons → tone = 'caution'.
+  // Readiness computation (narrow): only 1 evidence gap (< 2-count threshold),
+  // headlineType 'clear_winner', no NARROW_FRAMING critique → 'ready'.
+  // Robustness projection: level 'high' → 'robust'.
+  const coherenceInputs: CoachingInputs = {
+    graph: minimalGraph(),
+    options: [
+      { id: 'opt_a', label: 'Option A', winProbability: 0.7, outcomeMean: 110, outcomeP10: 95, outcomeP90: 125 },
+      { id: 'opt_b', label: 'Option B', winProbability: 0.3, outcomeMean: 90, outcomeP10: 75, outcomeP90: 105 },
+    ],
+    factorSensitivity: [
+      { node_id: 'f_brand', label: 'Brand awareness', importance_rank: 1, elasticity: 0.7, influence_score: 0.7, confidence: 0.80, direction: 'positive', zero_reason: undefined },
+      { node_id: 'f_cost', label: 'Campaign cost', importance_rank: 2, elasticity: 0.4, influence_score: 0.4, confidence: 0.70, direction: 'negative', zero_reason: undefined },
+    ],
+    fragileEdges: [
+      {
+        edgeId: 'f_cost→goal', fromId: 'f_cost', toId: 'goal', fromLabel: 'Campaign cost',
+        toLabel: 'Revenue', displayLabel: 'Campaign cost → Revenue', switchProb: 0.34,
+        altWinnerId: 'opt_b', altWinnerLabel: 'Option B',
+      },
+    ],
+    robustness: { level: 'high', recommendationStability: 0.85, isRobust: true },
+  };
+
+  const coherenceKeyDrivers: KeyDriver[] = [
+    { factor_id: 'f_brand', factor_label: 'Brand awareness', influence_score: 0.7, normalised_impact: 1, impact_display: 'Very High', direction: 'positive', rank: 1 },
+    { factor_id: 'f_cost', factor_label: 'Campaign cost', influence_score: 0.4, normalised_impact: 0.57, impact_display: 'High', direction: 'negative', rank: 2 },
+  ];
+
+  const coherenceGaps: EvidenceGap[] = [
+    evidenceGap('f_brand', 'Brand awareness', 0.60, 0.80),
+  ];
+
+  it("decision_brief.robustness projects level='high' to 'robust' (status quo)", () => {
+    const briefInput: BriefAssemblyInput = {
+      analysis_status: 'computed',
+      critiques: [],
+      option_comparison: [
+        { option_id: 'opt_a', option_label: 'Option A', id: 'opt_a', label: 'Option A', win_probability: 0.7 },
+        { option_id: 'opt_b', option_label: 'Option B', id: 'opt_b', label: 'Option B', win_probability: 0.3 },
+      ] as any,
+      robustness: { level: 'high', fragile_edges: [], robust_edges: [] } as any,
+      meta: { seed_used: '1' },
+    } as any;
+
+    const brief = assembleBrief(briefInput);
+    expect(brief).not.toBeNull();
+    expect(brief!.robustness).toBe('robust');
+  });
+
+  it("m1_coaching.readiness narrow semantics: stays 'ready' despite fragile edges and high-VoI gap", () => {
+    const readiness = computeReadiness('clear_winner', [], coherenceGaps, getThresholds());
+    expect(readiness).toBe('ready');
+  });
+
+  it("deriveReadinessTone (PR #174) returns 'caution' on the same inputs", () => {
+    const tone = deriveReadinessTone(
+      coherenceInputs,
+      'ready',
+      'clear_winner',
+      coherenceKeyDrivers,
+      coherenceGaps,
+      getThresholds(),
+    );
+
+    expect(tone.tone).toBe('caution');
+    expect(tone.reasons).toContain('MATERIAL_FRAGILE_EDGE');
+    expect(tone.reasons).toContain('EVIDENCE_GAPS');
+    // Robustness signals should NOT fire (level='high', isRobust=true, stability>=0.75)
+    expect(tone.reasons).not.toContain('NOT_ROBUST');
+    expect(tone.reasons).not.toContain('LOW_ROBUSTNESS');
+    expect(tone.reasons).not.toContain('LOW_STABILITY');
+    // Driver confidence and near-tie should not fire either.
+    expect(tone.reasons).not.toContain('LOW_DRIVER_CONFIDENCE');
+    expect(tone.reasons).not.toContain('NEAR_TIE');
+  });
+
+  it('executive_summary uses cautious wording despite readiness=ready and robustness=robust', () => {
+    const summary = generateExecutiveSummary(coherenceInputs, 'ready', 'clear_winner', coherenceKeyDrivers, coherenceGaps);
+
+    // The PR #174 tone gate must engage: confident "strong current lead"
+    // and "reasonable to move forward" copy must NOT appear when tone='caution'.
+    expect(summary.summary).not.toContain('strong current lead');
+    expect(summary.action_implication).not.toContain('reasonable to move forward');
+
+    // PR #174 banned phrases must remain absent.
+    expect(summary.summary.toLowerCase()).not.toContain('ready to proceed');
+    expect(summary.summary.toLowerCase()).not.toContain('proceed with implementation');
+    expect(summary.summary.toLowerCase()).not.toContain('robust and ready');
+
+    // For clear_winner + caution tone, decision statement uses cautious copy.
+    // See executive-summary.ts:83-85.
+    expect(summary.decision_statement).toMatch(/not yet strong enough|currently leads/);
+  });
+
+  it('the three surfaces disagree by design — robustness=robust + readiness=ready + tone=caution', () => {
+    // The headline pin: same inputs, three surfaces, three different "answers".
+    // This is the scientific-presentation debt documented in the workstream
+    // plan and addressed by the Priority 1 follow-up (schema-versioned
+    // readiness widening with DGAI/UI coordination).
+
+    const briefInput: BriefAssemblyInput = {
+      analysis_status: 'computed',
+      critiques: [],
+      option_comparison: [
+        { option_id: 'opt_a', option_label: 'Option A', id: 'opt_a', label: 'Option A', win_probability: 0.7 },
+        { option_id: 'opt_b', option_label: 'Option B', id: 'opt_b', label: 'Option B', win_probability: 0.3 },
+      ] as any,
+      robustness: { level: 'high', fragile_edges: [], robust_edges: [] } as any,
+      meta: { seed_used: '1' },
+    } as any;
+    const brief = assembleBrief(briefInput);
+    const readiness = computeReadiness('clear_winner', [], coherenceGaps, getThresholds());
+    const tone = deriveReadinessTone(coherenceInputs, 'ready', 'clear_winner', coherenceKeyDrivers, coherenceGaps, getThresholds());
+
+    expect(brief!.robustness).toBe('robust');       // Graph perturbation stability only.
+    expect(readiness).toBe('ready');                // Narrow semantics: framing + gap count.
+    expect(tone.tone).toBe('caution');              // Broad signal set — the honest answer.
+  });
+});

--- a/tests/voi-surface-divergence.test.ts
+++ b/tests/voi-surface-divergence.test.ts
@@ -1,0 +1,108 @@
+/**
+ * VOI surface-divergence regression pin.
+ *
+ * `factor_sensitivity[*].value_of_information` (public surface) and
+ * `m1_coaching.evidence_gaps[*].voi_score` (coaching-internal) use
+ * different formulas and can legitimately diverge on the same factor.
+ *
+ * Public-surface VOI (graph fallback in `src/lib/factor-influence.ts`):
+ *     |sensitivity| × (1 - confidence) × decision_fragility
+ *   where `decision_fragility` requires an adjacent fragile edge. Returns
+ *   0 when the factor has no fragile-edge neighbour.
+ *
+ * Coaching VOI (`src/coaching/evidence-gaps.ts`):
+ *     normalisedImpact × (1 - confidence)
+ *   Never consults fragile edges. Almost always non-zero when impact > 0
+ *   and confidence < 1.
+ *
+ * This test pins the divergence on a graph with no fragile edges, where
+ * the two surfaces MUST disagree by design. No PR behaviour change is
+ * involved — see the workstream plan for the documentation jsdoc that
+ * makes this contract visible to consumers.
+ *
+ * See follow-up: VOI/EVPI naming/provenance clarification (Priority 2)
+ * for the longer-term schema-versioned rename
+ * (`EvidenceGap.voi_score` → `EvidenceGap.impact_score` or similar).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeValueOfInformation } from '../src/lib/factor-influence.js';
+import { computeEvidenceGaps } from '../src/coaching/evidence-gaps.js';
+import type { CoachingInputs, EngineGraphV3 } from '../src/coaching/types.js';
+
+const noFragileGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'f_brand', kind: 'factor', label: 'Brand awareness' },
+    { id: 'f_cost', kind: 'factor', label: 'Campaign cost' },
+  ],
+  edges: [
+    { from: 'f_brand', to: 'goal', strength: { mean: 0.7, std: 0.1 } },
+    { from: 'f_cost', to: 'goal', strength: { mean: -0.5, std: 0.1 } },
+  ],
+});
+
+const noFragileInputs: CoachingInputs = {
+  graph: noFragileGraph(),
+  options: [
+    { id: 'opt_a', label: 'Option A', winProbability: 0.7, outcomeMean: 110, outcomeP10: 90, outcomeP90: 130 },
+    { id: 'opt_b', label: 'Option B', winProbability: 0.3, outcomeMean: 90, outcomeP10: 70, outcomeP90: 110 },
+  ],
+  factorSensitivity: [
+    // Both factors: high impact, low confidence — coaching VOI will be high.
+    // No fragile edges below — graph-path VOI will be 0.
+    { node_id: 'f_brand', label: 'Brand awareness', importance_rank: 1, elasticity: 0.7, influence_score: 0.7, confidence: 0.3, direction: 'positive', zero_reason: undefined },
+    { node_id: 'f_cost', label: 'Campaign cost', importance_rank: 2, elasticity: 0.5, influence_score: 0.5, confidence: 0.4, direction: 'negative', zero_reason: undefined },
+  ],
+  fragileEdges: [],
+  robustness: { level: 'high', recommendationStability: 0.85, isRobust: true },
+};
+
+describe('VOI surface divergence — graph fallback vs coaching formula', () => {
+  it('graph-fallback VOI is 0 when factor has no adjacent fragile edge', () => {
+    // The public-surface VOI for both factors is 0 because decision_fragility = 0
+    // (no fragile edges to be adjacent to). This is the production path that
+    // emits factor_sensitivity[*].value_of_information when ISL is absent.
+    const brandVoi = computeValueOfInformation('f_brand', 0.7, 0.3, []);
+    const costVoi = computeValueOfInformation('f_cost', 0.5, 0.4, []);
+
+    expect(brandVoi).toBe(0);
+    expect(costVoi).toBe(0);
+  });
+
+  it('coaching evidence-gaps VOI is positive for the same factors with no fragile edges', () => {
+    // The coaching-internal voi_score uses impact × (1 - confidence) and does
+    // NOT consult fragile edges, so both factors surface as evidence gaps
+    // with positive voi_score.
+    const gaps = computeEvidenceGaps(noFragileInputs);
+
+    expect(gaps.length).toBeGreaterThanOrEqual(1);
+    for (const gap of gaps) {
+      expect(gap.voi_score).toBeGreaterThan(0);
+    }
+  });
+
+  it('the two surfaces diverge by design — same factors, different VOI values', () => {
+    // The headline pin: same factor (f_brand / f_cost), same confidence and
+    // impact, but factor_sensitivity VOI = 0 while evidence_gaps voi_score > 0.
+    // This is correct: the two surfaces measure related but different
+    // quantities. The factor_sensitivity surface answers "what would perfect
+    // info about this factor be worth, given how fragile the decision is to
+    // it?" (zero when the factor is not in the decision-fragility set). The
+    // evidence_gaps surface answers "which uncertainties matter most for the
+    // decision, ranked by impact × uncertainty?" (independent of fragility).
+    const graphBrandVoi = computeValueOfInformation('f_brand', 0.7, 0.3, []);
+    const gaps = computeEvidenceGaps(noFragileInputs);
+    const coachingBrandGap = gaps.find((g) => g.factor_id === 'f_brand');
+
+    expect(graphBrandVoi).toBe(0);
+    expect(coachingBrandGap).toBeDefined();
+    expect(coachingBrandGap!.voi_score).toBeGreaterThan(0);
+
+    // Documented contract: the two are NOT directly comparable. Any future
+    // PR that makes them numerically equal must update the surface jsdocs
+    // (src/types/engine-v3.ts FactorSensitivityResultV3.value_of_information
+    // and src/coaching/types.ts EvidenceGap.voi_score) to drop the
+    // distinction.
+  });
+});


### PR DESCRIPTION
## Summary

Phase-0 follow-up after PR #175. **Documents and pins three known scientific-presentation tensions in PLoT output without changing any computation.** No behaviour changes, no schema changes, no CEE/DGAI/ISL/prompt changes.

### Framing

- **No currently observed production computation bug** requiring a local PLoT behaviour fix.
- **But real scientific-presentation debt exists** — most notably that PR #174's tone gate is *compensating* for narrow \`m1_coaching.readiness\` semantics rather than *fixing* them, and the enum still flows into DGAI/UI through \`deriveConfidenceTier\` independently of the tone-gated prose.
- **This PR documents and pins current behaviour** so future fixes are deliberate, not incidental.

The investigation evidence anchor is the code trace itself, not any single staging bundle. The traces show what the production code can and cannot emit, regardless of which scenario is loaded.

## Three documented tensions

### 1. \`decision_brief.robustness\` is graph perturbation stability, not action readiness

- \`mapRobustnessLevel\` (\`src/assembly/decision-brief.ts:106\`) is a literal projection of ISL \`robustness.level\`. It does NOT consult fragile edges, evidence gaps, or driver confidence.
- A brief can carry \`robustness: 'robust'\` while simultaneously containing material fragile edges and high-VoI evidence gaps. That is correct for the stability-only meaning, but easy to misread.
- **Doc updates**: jsdoc on \`DecisionBriefV1.robustness\` (\`src/types/decision-brief.ts:42\`) and the \`mapRobustnessLevel\` function point consumers at the action-readiness signal set (warnings, key_assumptions, what_would_change, tone-gated headline).

### 2. \`m1_coaching.readiness\` is narrow — PR #174 tone gate compensates in prose only

- \`computeReadiness\` (\`src/coaching/next-actions.ts:158\`) consumes only \`headlineType\` + \`NARROW_FRAMING\` critiques + evidence-gap count + top VoI.
- \`deriveReadinessTone\` (PR #174) consumes the broader signal set — fragile edges, robustness level, stability, driver confidence, near-tie status, evidence gaps — and produces \`tone: 'caution'\` even when readiness is \`'ready'\`.
- **The enum value still propagates to DGAI/UI** via \`src/trust/confidence-tier.ts\` (\`deriveConfidenceTier\` → \`'strong' | 'fair' | 'needs_work'\`), so the broader caution signal is invisible to non-LLM consumers.
- **New pin test**: \`tests/coaching/robustness-readiness-coherence.test.ts\` asserts that \`robustness='robust'\` + \`readiness='ready'\` + \`tone='caution'\` all coexist on the same inputs. Any future behaviour change must update this test intentionally.

### 3. VOI / EVPI naming hides a by-design divergence

- \`factor_sensitivity[*].value_of_information\` is ISL-emitted (Monte Carlo, non-negativity-sanitised) or graph-fallback \`|sensitivity| × (1 - confidence) × decision_fragility\` (\`src/lib/factor-influence.ts:598\`). **Returns 0 when the factor has no adjacent fragile edge.**
- \`m1_coaching.evidence_gaps[*].voi_score\` is the coaching formula \`normalisedImpact × (1 - confidence)\` (\`src/coaching/evidence-gaps.ts:34\`). **Never consults fragile edges.**
- Both fields are named "VOI" but compute different quantities. They can legitimately disagree on the same factor.
- **Doc updates**: jsdoc on both fields makes the distinction explicit. **New pin test**: \`tests/voi-surface-divergence.test.ts\` shows factor VOI = 0 and coaching voi_score > 0 on the same factors with no fragile edges.

## Files changed

**Production docs (jsdoc / comments only — no behaviour changes):**
- \`src/types/decision-brief.ts\` — \`DecisionBriefV1.robustness\` jsdoc
- \`src/assembly/decision-brief.ts\` — \`mapRobustnessLevel\` comment block
- \`src/types/engine-v3.ts\` — \`FactorSensitivityResultV3.value_of_information\` jsdoc
- \`src/coaching/types.ts\` — \`EvidenceGap.voi_score\` + \`evpi_percentage_points\` jsdoc

**New tests (regression pins):**
- \`tests/voi-surface-divergence.test.ts\` (3 tests)
- \`tests/coaching/robustness-readiness-coherence.test.ts\` (5 tests)

## Follow-up backlog (priority-ordered)

To be tracked as separate tasks after merge:

1. **Schema-versioned readiness widening** *(highest priority)*. Make \`m1_coaching.readiness\` consume fragile edges, low driver confidence, \`recommendation_stability\`, and \`robustness.level\` directly. **Requires DGAI/UI coordination** because \`deriveConfidenceTier\` maps the enum into UI tiers.
2. **VOI/EVPI naming/provenance clarification** in a versioned schema change. Rename \`EvidenceGap.voi_score\` → \`EvidenceGap.impact_score\` (or similar) to disambiguate.
3. **\`decision_brief.robustness\` demotion or rename** when fragile edges are present. Observable behaviour change; needs flagged rollout.
4. **Tone-gate result surfacing** as an explicit \`m1_coaching.readiness_tone\` field or \`BriefWarning[]\` entries.
5. *(separate track)* **\`BriefDriver.direction\` widening** to include \`'mixed' | 'unknown'\` (existing PR #175 follow-up).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Focused: 8 new tests across \`tests/voi-surface-divergence.test.ts\` (3) + \`tests/coaching/robustness-readiness-coherence.test.ts\` (5) pass
- [x] Related regression suites (\`tests/decision-brief*.test.ts\`, \`tests/coaching/\`, \`tests/evpi-emission.test.ts\`, \`tests/near-tie.test.ts\`, \`tests/robustness-analysis.test.ts\`) — 251 tests, all green
- [x] PR #174 tone-gate tests and PR #175 direction-preservation tests unchanged and green
- [x] Pre-push full gate (\`scripts/pre-push-validate.sh\`): 4869 tests, typecheck, OpenAPI lint, stale-.js, file: refs — all clean
- [ ] CI green on staging PR (pre-existing GitHub Packages E401 will likely re-appear; same as PR #175)

## Deployment

Targets \`staging\` only. **Do not merge.** Do not deploy production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)