### PR TITLE
feat(plot): pass through ISL Track S factor value provenance

### DIFF
--- a/contracts/schemas/plot-response.schema.json
+++ b/contracts/schemas/plot-response.schema.json
@@ -284,6 +284,18 @@
           },
           "zero_reason": {
             "type": "string"
+          },
+          "value_source": {
+            "type": "string",
+            "description": "Track S: provenance of this factor's input value (ISL FactorSensitivityV2 passthrough). Distinct from `source` (producing engine). Absent on older ISL responses."
+          },
+          "value_extraction_type": {
+            "type": "string",
+            "description": "Track S: how the factor value was extracted/derived (ISL passthrough). Absent on older ISL responses."
+          },
+          "value_defaulted": {
+            "type": "boolean",
+            "description": "Track S: true when ISL substituted a default for the factor value. Absent means not reported / older ISL response; never coerced to false."
           }
         }
       }

--- a/openapi/openapi-plot-lite-v1.yaml
+++ b/openapi/openapi-plot-lite-v1.yaml
@@ -1147,4 +1147,18 @@ components:
           description: >
             Range derivation tier for this factor's intervention range.
             Values: explicit_cap, explicit, extracted, inferred_spread, inferred_baseline, inferred_value, default.
+        value_source:
+          type: string
+          description: >
+            Track S: provenance of this factor's input value (additive passthrough
+            from ISL FactorSensitivityV2). Distinct from `source`, which records the
+            producing engine. Absent on older ISL responses.
+        value_extraction_type:
+          type: string
+          description: 'Track S: how the factor value was extracted/derived (ISL passthrough). Absent on older ISL responses.'
+        value_defaulted:
+          type: boolean
+          description: >
+            Track S: true when ISL substituted a default for the factor value.
+            Absent means "not reported / older ISL response" and is never coerced to false.
       required: [factor_id]

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -208,6 +208,15 @@ export interface ISLFactorSensitivityItem {
   stability_method?: string;
   /** ISL-computed confidence from bootstrap stability (0-1) */
   confidence?: number;
+
+  // Track S: factor value provenance (additive fields on ISL FactorSensitivityV2).
+  // Optional — absent on older ISL responses. PLoT preserves these verbatim.
+  /** Provenance of the factor's input value (where the value came from). */
+  value_source?: string;
+  /** How the factor value was extracted/derived. */
+  value_extraction_type?: string;
+  /** True when ISL substituted a default for the factor value. Absent ≠ false. */
+  value_defaulted?: boolean;
 }
 
 /**

--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -920,6 +920,14 @@ export function mergeIslConfidenceIntoGraphFactors(
       ...(islMatch.elasticity_std !== undefined && { elasticity_std: islMatch.elasticity_std }),
       ...(islMatch.rank_flip_rate !== undefined && { rank_flip_rate: islMatch.rank_flip_rate }),
       ...(islMatch.stability_method !== undefined && { stability_method: islMatch.stability_method }),
+      // Track S: carry ISL factor value provenance onto the merged graph factor.
+      // The graph factor (`gf`) never carries these — they originate from ISL —
+      // so without this the common graph+ISL merge path would drop them.
+      // Preserve-only-when-present: absent value_defaulted stays absent (the
+      // ISL-only append branch below preserves them via the `...islFCleaned` spread).
+      ...(islMatch.value_source !== undefined && { value_source: islMatch.value_source }),
+      ...(islMatch.value_extraction_type !== undefined && { value_extraction_type: islMatch.value_extraction_type }),
+      ...(islMatch.value_defaulted !== undefined && { value_defaulted: islMatch.value_defaulted }),
     };
   });
 

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -639,6 +639,14 @@ function mapIslFactorEntry(f: any, normContext?: NormalisationContext): FactorSe
   if (f.rank_flip_rate !== undefined) entry.rank_flip_rate = f.rank_flip_rate;
   if (f.stability_method !== undefined) entry.stability_method = f.stability_method;
 
+  // Track S: ISL factor value provenance — carry through when ISL provides them.
+  // Preserve-only-when-present: absent value_defaulted MUST NOT be coerced to
+  // false (absent can mean "older ISL response" or "not reported", which is
+  // distinct from an explicit false). Mirrors the 3C stability carry above.
+  if (f.value_source !== undefined) entry.value_source = f.value_source;
+  if (f.value_extraction_type !== undefined) entry.value_extraction_type = f.value_extraction_type;
+  if (f.value_defaulted !== undefined) entry.value_defaulted = f.value_defaulted;
+
   // Flag when normalisation was active but ranges unavailable for denorm
   if (sensitivityNormalised) entry._normalised = true;
 

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1771,6 +1771,23 @@ export interface FactorSensitivityResultV3 {
   /** Method used by ISL to compute stability metrics */
   stability_method?: string;
 
+  // Track S: ISL factor value provenance (additive passthrough from ISL
+  // FactorSensitivityV2). Distinct from `source` above: `source` records which
+  // engine produced the row (graph vs ISL); these record where the factor's
+  // *input value* came from. Carried verbatim from ISL when present; absent on
+  // older ISL responses.
+  /** Provenance of the factor's input value (where the value came from). */
+  value_source?: string;
+  /** How the factor value was extracted/derived. */
+  value_extraction_type?: string;
+  /**
+   * True when ISL substituted a default for the factor value.
+   * Absent ≠ false: absent means "older ISL response or not reported" and is
+   * never coerced to false — see mapIslFactorEntry and
+   * mergeIslConfidenceIntoGraphFactors.
+   */
+  value_defaulted?: boolean;
+
   /**
    * Progressive disclosure: raw components of the unified confidence formula.
    * Allows UI to expose what drives the confidence score.

--- a/tests/passthrough-enrichment.test.ts
+++ b/tests/passthrough-enrichment.test.ts
@@ -286,3 +286,126 @@ describe('new fields excluded from response_hash', () => {
     expect(partial.conditional_winners).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Track S: factor value provenance passthrough
+// (value_source / value_extraction_type / value_defaulted)
+// ---------------------------------------------------------------------------
+
+describe('Track S provenance passthrough — mergeIslConfidenceIntoGraphFactors', () => {
+  const GRAPH: EngineGraphV3 = {
+    nodes: [
+      { id: 'root', kind: 'factor', label: 'Root' },
+      { id: 'fac_a', kind: 'factor', label: 'Factor A' },
+      { id: 'goal', kind: 'goal', label: 'Goal' },
+    ],
+    edges: [
+      { from: 'root', to: 'fac_a', exists_probability: 0.9, strength: { mean: 0.5, std: 0.1 } },
+      { from: 'fac_a', to: 'goal', exists_probability: 0.99, strength: { mean: 0.8, std: 0.01 } },
+    ],
+  };
+
+  it('graph+ISL match carries value_source / value_extraction_type / value_defaulted onto the merged graph factor', () => {
+    const graphFactors = computeFactorSensitivityFromGraph(GRAPH, 'goal')!;
+    const islFactors: FactorSensitivityResultV3[] = [{
+      factor_id: 'fac_a',
+      factor_label: 'Factor A',
+      sensitivity_score: 0.6,
+      source: 'isl',
+      attribution_stability: 'high',
+      value_source: 'user_input',
+      value_extraction_type: 'explicit',
+      value_defaulted: true,
+    }];
+
+    const merged = mergeIslConfidenceIntoGraphFactors(graphFactors, islFactors, GRAPH.edges);
+    const facA = merged.find(f => f.factor_id === 'fac_a')!;
+
+    expect(facA.value_source).toBe('user_input');
+    expect(facA.value_extraction_type).toBe('explicit');
+    expect(facA.value_defaulted).toBe(true);
+    // Confidence is still PLoT-recomputed (provenance carry must not disturb it).
+    expect(facA.confidence_source).toBe('plot_unified_from_isl_bootstrap');
+  });
+
+  it('absent value_defaulted stays absent (never coerced to false) on the merge path', () => {
+    const graphFactors = computeFactorSensitivityFromGraph(GRAPH, 'goal')!;
+    const islFactors: FactorSensitivityResultV3[] = [{
+      factor_id: 'fac_a',
+      factor_label: 'Factor A',
+      sensitivity_score: 0.6,
+      source: 'isl',
+      attribution_stability: 'high',
+      value_source: 'calibrated_estimate',
+      // value_defaulted intentionally absent (e.g. older ISL response)
+    }];
+
+    const merged = mergeIslConfidenceIntoGraphFactors(graphFactors, islFactors, GRAPH.edges);
+    const facA = merged.find(f => f.factor_id === 'fac_a')!;
+
+    expect(facA.value_source).toBe('calibrated_estimate');
+    expect(facA.value_defaulted).toBeUndefined();
+    expect(facA).not.toHaveProperty('value_defaulted'); // absent ≠ false
+  });
+
+  it('ISL-only factor (not in graph) preserves provenance via the spread branch; explicit false is kept', () => {
+    const graphFactors = computeFactorSensitivityFromGraph(GRAPH, 'goal')!;
+    // 'orphan' is NOT a graph node → exercises the ISL-only append branch
+    const islFactors: FactorSensitivityResultV3[] = [{
+      factor_id: 'orphan',
+      factor_label: 'Orphan Factor',
+      sensitivity_score: 0.4,
+      source: 'isl',
+      value_source: 'historical_default',
+      value_extraction_type: 'inferred',
+      value_defaulted: false,
+    }];
+
+    const merged = mergeIslConfidenceIntoGraphFactors(graphFactors, islFactors, GRAPH.edges);
+    const orphan = merged.find(f => f.factor_id === 'orphan')!;
+
+    expect(orphan).toBeDefined();
+    expect(orphan.value_source).toBe('historical_default');
+    expect(orphan.value_extraction_type).toBe('inferred');
+    expect(orphan.value_defaulted).toBe(false); // explicit false preserved (distinct from absent)
+  });
+});
+
+describe('Track S provenance type contract', () => {
+  it('FactorSensitivityResultV3 accepts value_source / value_extraction_type / value_defaulted', () => {
+    const entry: FactorSensitivityResultV3 = {
+      factor_id: 'price',
+      factor_label: 'Price',
+      source: 'isl',
+      value_source: 'user_input',
+      value_extraction_type: 'explicit',
+      value_defaulted: true,
+    };
+    expect(entry.value_source).toBe('user_input');
+    expect(entry.value_extraction_type).toBe('explicit');
+    expect(entry.value_defaulted).toBe(true);
+  });
+
+  it('the three provenance fields are optional on FactorSensitivityResultV3', () => {
+    const entry: FactorSensitivityResultV3 = {
+      factor_id: 'price',
+      factor_label: 'Price',
+      source: 'isl',
+    };
+    expect(entry.value_source).toBeUndefined();
+    expect(entry.value_extraction_type).toBeUndefined();
+    expect(entry.value_defaulted).toBeUndefined();
+  });
+
+  it('ISLFactorSensitivityItem accepts the three provenance fields', () => {
+    const item: import('../src/integrations/isl/types/isl-types.js').ISLFactorSensitivityItem = {
+      node_id: 'fac_a',
+      sensitivity_score: 0.5,
+      value_source: 'user_input',
+      value_extraction_type: 'explicit',
+      value_defaulted: false,
+    };
+    expect(item.value_source).toBe('user_input');
+    expect(item.value_defaulted).toBe(false);
+  });
+});

--- a/tests/track-s-provenance-passthrough.test.ts
+++ b/tests/track-s-provenance-passthrough.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Track S — factor value provenance passthrough (end-to-end).
+ *
+ * Proves that ISL's additive FactorSensitivityV2 provenance fields
+ * (value_source / value_extraction_type / value_defaulted) survive the full
+ * /v2/run pipeline:
+ *
+ *   ISL response  →  mapIslFactorEntry (run.ts)  →
+ *   mergeIslConfidenceIntoGraphFactors graph+ISL branch (factor-influence.ts)  →
+ *   /v2/run response.factor_sensitivity
+ *
+ * `factor-a` exists in BOTH the request graph and the mocked ISL response, so
+ * this exercises the graph+ISL merge branch — the common production path that
+ * previously dropped these fields (mapIslFactorEntry used an explicit object
+ * literal; the merge graph-branch copied only a named allow-list of ISL fields).
+ *
+ * This file uses a SINGLE vi.mock of the ISL service so the mocked
+ * factor_sensitivity actually reaches the route (the broader
+ * boundary-isl-to-ui.contract.test.ts registers two vi.mocks for the same
+ * module, the second of which wins and returns an empty factor_sensitivity).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ISL factor_sensitivity entry carrying the Track S provenance trio plus a
+// bootstrap stability field (so the merge's v3 confidence branch fires cleanly).
+const ISL_FACTOR_A = {
+  node_id: 'factor-a',
+  label: 'Marketing Spend',
+  sensitivity_score: 0.5,
+  direction: 'positive' as const,
+  confidence: 0.8,
+  attribution_stability: 'high' as const,
+  value_source: 'user_input',
+  value_extraction_type: 'explicit',
+  value_defaulted: true,
+};
+
+const ISL_DATA = {
+  options: [
+    { option_id: 'opt1', outcome: { mean: 0.8, std: 0.1, p10: 0.6, p50: 0.8, p90: 0.95, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 1, win_probability: 0.7, probability_of_goal: 0.65 },
+    { option_id: 'opt2', outcome: { mean: 0.7, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 2, win_probability: 0.3, probability_of_goal: 0.55 },
+  ],
+  sensitivity: [
+    { edge_from: 'factor-a', edge_to: 'goal', sensitivity_type: 'magnitude', elasticity: 0.6, importance_rank: 1, interpretation: 'High impact' },
+  ],
+  factor_sensitivity: [ISL_FACTOR_A],
+  robustness: {
+    score: 0.82,
+    label: 'robust',
+    fragile_edges: [],
+    robust_edges: ['factor-a::goal'],
+  },
+};
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness() {
+    return { ...ISL_DATA, source: 'isl' as const, latency_ms: 42 };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.82, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, _body: any): Promise<{ data: T | null; error: string | null }> {
+    return { data: ISL_DATA as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 0.8 } },
+  { id: 'opt2', label: 'Reduce Spend', interventions: { 'factor-a': 0.3 } },
+];
+
+describe('Track S provenance passthrough — /v2/run end-to-end', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  async function run() {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: 'track-s-test' }),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  it('value_source / value_extraction_type / value_defaulted survive ISL → mapIslFactorEntry → merge → response', async () => {
+    const body = await run();
+    expect(Array.isArray(body.factor_sensitivity)).toBe(true);
+    const factor = body.factor_sensitivity.find((f: any) => f.factor_id === 'factor-a');
+    expect(factor).toBeDefined();
+    // factor-a is graph-derived (`source: 'graph'`), so it merges via the
+    // graph-match branch with a graph factor as the base. Pinning this proves
+    // the provenance survived the *common* graph+ISL merge path — the decisive
+    // historical drop point — rather than only the ISL-only append branch.
+    expect(factor.source).toBe('graph');
+    expect(factor.value_source).toBe('user_input');
+    expect(factor.value_extraction_type).toBe('explicit');
+    expect(factor.value_defaulted).toBe(true);
+    // Confidence is still PLoT-recomputed (provenance carry must not disturb the
+    // confidence honesty contract — A1-PRIMARY).
+    expect(factor.confidence_source).toMatch(/^plot_unified_/);
+  });
+});


### PR DESCRIPTION
## Summary

Track S PR1 — passes ISL factor **value provenance** through to the `/v2/run` response (supports downstream confidence-panel retirement).

ISL `FactorSensitivityV2` emits three additive, optional fields per factor:
- `value_source` — where the factor's input value came from
- `value_extraction_type` — how the value was extracted/derived
- `value_defaulted` — whether ISL substituted a default (boolean)

These are default-on under `response_version=2` (which PLoT already sends) — **not** gated behind `include_path_decomposition`.

## What was dropping them

The HTTP client preserves raw ISL JSON, but two PLoT mapping layers discarded the fields:
1. `mapIslFactorEntry` (`src/routes/v2/run.ts`) — explicit object literal, no spread.
2. `mergeIslConfidenceIntoGraphFactors` graph-match branch (`src/lib/factor-influence.ts`) — named allow-list copy; this is the **common** `graph+isl_merge` path, so it had to be patched too.

The ISL-only merge branch already preserved them via the `...islFCleaned` spread.

## Fix (additive, preserve-only-when-present)

Carry the three fields at both drop points using the existing `if (x !== undefined)` pattern. Absent `value_defaulted` stays absent — never coerced to `false` (absent = older ISL response / not reported; explicit `false` is preserved). Confidence recomputation and the A1-PRIMARY confidence-honesty contract are unchanged.

Type, OpenAPI, and JSON-schema docs updated additively.

## Files (8, +339, additive only)

| File | Change |
|---|---|
| `src/integrations/isl/types/isl-types.ts` | ISL type += 3 optional fields |
| `src/types/engine-v3.ts` | `FactorSensitivityResultV3` += 3 optional fields (doc distinguishes from engine-level `source`) |
| `src/routes/v2/run.ts` | `mapIslFactorEntry` carry |
| `src/lib/factor-influence.ts` | merge graph-match branch carry |
| `openapi/openapi-plot-lite-v1.yaml` | document 3 fields |
| `contracts/schemas/plot-response.schema.json` | document 3 fields |
| `tests/passthrough-enrichment.test.ts` | unit tests (graph-match carry, absent-stays-absent, ISL-only spread, type contracts) |
| `tests/track-s-provenance-passthrough.test.ts` | **new** e2e test — asserts fields survive the graph+ISL merge path to the response |

## Tests

Pre-push validation passed: `tsc --noEmit`, full suite (**4887 passed / 25 skipped**), stale-`.js` guard, dependency audit, OpenAPI spectral lint.

## Scope / out-of-scope (confirmed)

- ✅ PLoT-only; provenance passthrough only.
- ❌ No `path_decomposition` request or surfacing (deferred to PR2, default-off pending product wording).
- ❌ No CEE, DGAI, UI, ISL, prompt, PMS, CI, workflow, performance-test, or uncertainty-quality changes.
- ❌ Pre-existing `confidence_source` OpenAPI enum drift (`[isl, graph, fallback_degenerate]` vs runtime `plot_unified_*`) is **not** included here — tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
