### PR TITLE
ci: authenticate npm ci to GitHub Packages for @talchain/schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,6 +20,8 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint (ESLint)
         run: npx eslint src tests --ext .ts --max-warnings 29
       - name: Validate contracts

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -7,6 +7,7 @@ on:
     - cron: '0 6 * * 1'
 permissions:
   contents: read
+  packages: read
 jobs:
   audit:
     runs-on: ubuntu-latest
@@ -16,5 +17,7 @@ jobs:
         with: { node-version: 20 }
       - name: Install deps
         run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=high

--- a/.github/workflows/engine-gates.yml
+++ b/.github/workflows/engine-gates.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   gates:
     runs-on: ${{ matrix.os }}
@@ -51,6 +55,8 @@ jobs:
       - name: Install dependencies
         if: steps.changes.outputs.non_maintenance == 'true'
         run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure jq (Linux only)
         if: runner.os == 'Linux' && steps.changes.outputs.non_maintenance == 'true'

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  packages: read
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -14,6 +15,8 @@ jobs:
         with: { node-version: 20 }
       - name: Install deps
         run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint (ESLint)
         run: npx eslint src tests --ext .ts --max-warnings 29
       - name: Run pr-verify (Node)


### PR DESCRIPTION
## Summary

Fixes the repo-wide CI `npm ci` **`E401 Unauthorized`** when installing the private `@talchain/schemas@0.2.1` from GitHub Packages (currently red on all PRs).

**Root cause:** the repo `.npmrc` authenticates the `@talchain` scope via `${GITHUB_TOKEN}`, but the CI jobs running `npm ci` neither exposed that variable to the step nor granted `packages: read` — so the token resolved empty → `401`.

## Change (workflow YAML only — +18 lines, additive)

For each job that runs a hard `npm ci`, add `permissions: packages: read` and a step-level `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`:

| File | Job |
|---|---|
| `.github/workflows/ci.yml` | `test` |
| `.github/workflows/engine-gates.yml` | `gates` |
| `.github/workflows/dependency-audit.yml` | `audit` |
| `.github/workflows/pr-verify.yml` | `verify` |

Existing permissions preserved (`contents: read` everywhere; `pull-requests: write` in `pr-verify`). No `.npmrc`, package, application-code, or test changes. Uses the existing `.npmrc` `${GITHUB_TOKEN}` pattern (no migration to `setup-node` `registry-url`).

## ⚠️ Admin prerequisite (likely required)

For the default `secrets.GITHUB_TOKEN` to actually **read** the package (it's published from a different repo), `@talchain/schemas` must grant read access to this repo: **Package → Manage Actions access → add `Talchain/plot-lite-service` (Read)**, or rely on org-wide internal access if configured. If that can't be granted, swap the env to a `read:packages` **PAT** stored as a repo/org Actions secret. Without this, the wiring is correct but the token still won't resolve.

## Validation

- Local pre-push gate: `tsc` ✓, full suite **4880 passed / 25 skipped** ✓, stale-`.js` ✓, deps ✓, OpenAPI spectral lint ✓.
- **This PR's CI is the live test.** Jobs that run `npm ci` on every PR — `ci.yml/test`, `dependency-audit/audit`, `pr-verify/verify` — exercise the fix directly. `engine-gates/gates` has a **maintenance-only short-circuit** (`.github/workflows/**` counts as "maintenance"), so it **skips `npm ci`** on this workflow-only PR (exits 0); its fix still applies to future non-maintenance PRs.

## Out of scope

- The separate `safety`/`smoke` failure (`tools/run-tests.cjs` → non-existent `src/engine/core.js`) is **not** addressed here — tracked independently.
- PR #178 (Track S provenance) untouched; `confidence_source` OpenAPI cleanup still queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
