### PR TITLE
ci(smoke): drop dead engine-test harness step from tests-smoke/engine-safety

### DIFF
--- a/.github/workflows/engine-safety.yml
+++ b/.github/workflows/engine-safety.yml
@@ -16,11 +16,3 @@ jobs:
       - name: Install (if needed)
         run: |
           if [ -f package.json ]; then npm ci || true; fi
-      - name: Run engine tests
-        run: node tools/run-tests.cjs
-      - name: Upload tests report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: tests-report
-          path: reports/tests.json

--- a/.github/workflows/tests-smoke.yml
+++ b/.github/workflows/tests-smoke.yml
@@ -23,12 +23,3 @@ jobs:
       - name: Install (if needed)
         run: |
           if [ -f package.json ]; then npm ci || true; fi
-      - name: Run engine tests
-        run: node tools/run-tests.cjs
-      - name: Upload tests report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: tests-report
-          path: reports/tests.json
-          if-no-files-found: warn


### PR DESCRIPTION
## What
Remove the broken `Run engine tests` step (and its now-orphaned `tests.json` upload) from `tests-smoke.yml` and `engine-safety.yml`. `tools/run-tests.cjs` is **kept** in the tree.

## Why — this is a temporary removal of a dead legacy harness path
`tools/run-tests.cjs` dynamically imports `src/engine/core.js` to get `runPlot`, then scans `test/engine`:
- **`src/engine/core.js` does not exist** — no `core.ts` source has ever existed and `runPlot` is defined nowhere, so **the old harness is not repairable in this lane** (there is no module to import or build).
- it also scans `test/engine` (singular) while the cases live in `tests/engine` (plural), and those `.cjs` cases additionally need compiled `src/engine/*.js` plus a `runPlot` that doesn't exist.

So the step has **always failed** in CI. That failure makes `tests-smoke` red, which `tools/ci/pr-verify.cjs` reports as a failed required run, turning the `main`-required `verify` check red.

**This change is intended only to stop `tests-smoke` / `engine-safety` failing on dead plumbing.**

## Follow-up
A future PR should add a **real, current smoke/safety check** if engine smoke coverage is wanted — the old `.cjs` harness exercised nothing in CI. That would need a build step, the npm-ci auth token, and a real engine entry point.

## Scope (strictly minimal)
- Workflow YAML only — `tests-smoke.yml` and `engine-safety.yml`.
- `tools/run-tests.cjs` intentionally **kept** (still referenced non-fatally by `pr-verify.cjs` and by the `test:engine` npm script) — nothing dangles.
- No `package.json`, `pr-verify.cjs`, source, tests, or product changes. Workflows not deleted.

## Validation
- Pre-push gate **PASSED**: `tsc --noEmit`; full suite (**4887 passed / 25 skipped / 0 failed**); no stale `.js`; no `file:` deps; spectral OpenAPI.
- Diff = exactly the two workflow files (**17 deletions, 0 additions**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
