### PR TITLE
feat(plot): forward Track S factor value provenance to ISL request

### DIFF
--- a/src/integrations/isl/translator-v3.ts
+++ b/src/integrations/isl/translator-v3.ts
@@ -44,6 +44,9 @@ export interface ISLNodeV3 {
     cap?: number;
     factor_type?: string;
     uncertainty_drivers?: string[];
+    /** Track S: value provenance forwarded to ISL (echoed back as value_source / value_extraction_type). camelCase matches CEE/ISL — do not rename. */
+    source?: string;
+    extractionType?: string;
   };
   intercept?: number;
   epsilon_std?: number;

--- a/src/normalisation/graph-normaliser.ts
+++ b/src/normalisation/graph-normaliser.ts
@@ -258,9 +258,10 @@ export function normaliseNode(
   }
 
   if (node.observed_state?.value !== undefined) {
-    // Explicit allowlist: core fields + V3 expansion metadata
+    // Explicit allowlist: core fields + V3 expansion metadata + Track S provenance
     // This preserves V3 fields (raw_value, cap, factor_type, uncertainty_drivers)
-    // without passing through arbitrary upstream garbage.
+    // and value provenance (source, extractionType) without passing through
+    // arbitrary upstream garbage.
     const os = node.observed_state;
     observedState = {
       value: node.observed_state.value, // use narrowed path (TS knows !== undefined)
@@ -271,6 +272,13 @@ export function normaliseNode(
       cap: os.cap,
       factor_type: os.factor_type,
       uncertainty_drivers: os.uncertainty_drivers,
+      // Track S: forward value provenance to the ISL request (request-side
+      // forwarding). Copied verbatim so request-side casing matches CEE emit /
+      // ISL receive — do not rename to extraction_type / value_source, which are
+      // ISL's response-side echo names. JSON.stringify drops these when undefined,
+      // so absent provenance is preserved-when-present, not invented.
+      source: os.source,
+      extractionType: os.extractionType,
       // For constraint nodes, preserve metadata (contains operator) so the
       // constraint compiler can extract it via observed_state.metadata.operator.
       ...((os as any).metadata !== undefined && { metadata: (os as any).metadata }),

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -80,6 +80,10 @@ export interface UpstreamNode {
     factor_type?: string;
     /** V3 expansion: sources of uncertainty */
     uncertainty_drivers?: string[];
+    /** Track S: value provenance — where the value came from (e.g. 'brief_extraction', 'cee_inference'). */
+    source?: string;
+    /** Track S: value provenance — how the value was extracted (e.g. 'explicit', 'inferred'). camelCase matches CEE/ISL — do not rename. */
+    extractionType?: string;
   };
   /** State space bounds for the factor (used for uncertainty calculation) */
   state_space?: {
@@ -191,6 +195,10 @@ export interface EngineNodeV3 {
     factor_type?: string;
     /** V3 expansion: sources of uncertainty */
     uncertainty_drivers?: string[];
+    /** Track S: value provenance — where the value came from (e.g. 'brief_extraction', 'cee_inference'). */
+    source?: string;
+    /** Track S: value provenance — how the value was extracted (e.g. 'explicit', 'inferred'). camelCase matches CEE/ISL — do not rename. */
+    extractionType?: string;
   };
   /** State space bounds for the factor (used for uncertainty calculation) */
   state_space?: {

--- a/tests/track-s-provenance-request-forwarding.test.ts
+++ b/tests/track-s-provenance-request-forwarding.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Track S — Request-side value provenance forwarding
+ *
+ * Companion to `track-s-provenance-passthrough.test.ts`, which covers the ISL
+ * *response* echo (value_source / value_extraction_type). This file covers the
+ * *request* path: factor value provenance emitted by CEE on each factor node's
+ * `observed_state` — `source` and `extractionType` — must survive PLoT
+ * normalisation and reach the ISL robustness request unchanged.
+ *
+ * Drop point fixed: `src/normalisation/graph-normaliser.ts` rebuilt
+ * `observed_state` from an explicit allow-list that omitted `source` and
+ * `extractionType`. The translator (`toISLNode`) is a pure passthrough, so
+ * preserving the two fields in the normaliser is sufficient for them to reach
+ * the ISL request.
+ *
+ * Casing contract: the request-side names are `source` (lowercase) and
+ * `extractionType` (camelCase) on BOTH the CEE emit and the ISL receive side —
+ * NOT the response-side echo names `value_source` / `value_extraction_type`.
+ *
+ * Preserve-only-when-present: provenance is copied verbatim and is `undefined`
+ * when absent; `JSON.stringify` drops undefined keys, so the wire request omits
+ * provenance entirely when the incoming node had none (no invented fields).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normaliseNode } from '../src/normalisation/graph-normaliser.js';
+import { normaliseGraphWithRepairs } from '../src/normalisation/normalise-and-repair.js';
+import { toISLRobustnessRequest } from '../src/integrations/isl/translator-v3.js';
+import type {
+  UpstreamNode,
+  UpstreamGraph,
+  EngineGraphV3,
+  EngineNodeV3,
+  OptionV3,
+} from '../src/types/engine-v3.js';
+
+// A factor node as CEE emits it: full observed_state including both provenance
+// fields and the V3 expansion fields.
+const RICH_FACTOR: UpstreamNode = {
+  id: 'fac_cost',
+  kind: 'factor',
+  label: 'Hiring Cost',
+  observed_state: {
+    value: 120000,
+    unit: 'GBP',
+    raw_value: 120000,
+    cap: 500000,
+    factor_type: 'cost',
+    uncertainty_drivers: ['market rate volatility'],
+    source: 'brief_extraction',
+    extractionType: 'explicit',
+  },
+};
+
+const OPTIONS: OptionV3[] = [
+  { id: 'opt_a', label: 'Option A', interventions: { fac_cost: { value: 100000, source: 'user_specified' } } },
+  { id: 'opt_b', label: 'Option B', interventions: { fac_cost: { value: 140000, source: 'user_specified' } } },
+];
+
+// =============================================================================
+// Normaliser — must preserve provenance through observed_state reconstruction
+// =============================================================================
+
+describe('graph-normaliser preserves Track S value provenance', () => {
+  it('keeps source and extractionType on the normalised observed_state', () => {
+    const node = normaliseNode(RICH_FACTOR);
+    expect(node.observed_state?.source).toBe('brief_extraction');
+    expect(node.observed_state?.extractionType).toBe('explicit');
+  });
+
+  it('regression: existing observed_state fields still survive normalisation', () => {
+    const node = normaliseNode(RICH_FACTOR);
+    expect(node.observed_state?.value).toBe(120000);
+    expect(node.observed_state?.unit).toBe('GBP');
+    expect(node.observed_state?.raw_value).toBe(120000);
+    expect(node.observed_state?.cap).toBe(500000);
+    expect(node.observed_state?.factor_type).toBe('cost');
+    expect(node.observed_state?.uncertainty_drivers).toEqual(['market rate volatility']);
+  });
+
+  it('preserve-only-when-present: does not invent provenance when absent', () => {
+    const bare = normaliseNode({
+      id: 'fac_velocity',
+      kind: 'factor',
+      label: 'Team Velocity',
+      observed_state: { value: 0.7 },
+    });
+    expect(bare.observed_state?.value).toBe(0.7);
+    expect(bare.observed_state?.source).toBeUndefined();
+    expect(bare.observed_state?.extractionType).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Translator — must forward provenance into the ISL robustness request
+// =============================================================================
+
+describe('toISLRobustnessRequest forwards Track S value provenance', () => {
+  function buildGraph(factor: EngineNodeV3): EngineGraphV3 {
+    const goal: EngineNodeV3 = { id: 'goal', kind: 'goal', label: 'Profit' } as EngineNodeV3;
+    return {
+      nodes: [goal, factor],
+      edges: [{ from: 'fac_cost', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+    } as EngineGraphV3;
+  }
+
+  it('ISL request observed_state contains source and extractionType', () => {
+    const graph = buildGraph(normaliseNode(RICH_FACTOR));
+    const islReq = toISLRobustnessRequest(graph, OPTIONS, 'goal', 'req-translator', 1000);
+
+    const islFactor = islReq.graph.nodes.find((n) => n.id === 'fac_cost');
+    expect(islFactor?.observed_state?.source).toBe('brief_extraction');
+    expect(islFactor?.observed_state?.extractionType).toBe('explicit');
+  });
+
+  it('survives JSON serialisation (the actual HTTP wire body to ISL)', () => {
+    const graph = buildGraph(normaliseNode(RICH_FACTOR));
+    const islReq = toISLRobustnessRequest(graph, OPTIONS, 'goal', 'req-wire', 1000);
+
+    const wire = JSON.parse(JSON.stringify(islReq));
+    const wireFactor = wire.graph.nodes.find((n: { id: string }) => n.id === 'fac_cost');
+    expect(wireFactor.observed_state.source).toBe('brief_extraction');
+    expect(wireFactor.observed_state.extractionType).toBe('explicit');
+  });
+});
+
+// =============================================================================
+// End-to-end production path — normaliseGraphWithRepairs → toISLRobustnessRequest
+// (exactly the chain run.ts executes for /v2/run)
+// =============================================================================
+
+describe('Track S provenance survives the full /v2/run request path', () => {
+  it('CEE-shaped graph → normalise → ISL request carries provenance + existing fields', () => {
+    const upstream: UpstreamGraph = {
+      nodes: [
+        { id: 'goal', kind: 'goal', label: 'Profit' },
+        RICH_FACTOR,
+      ],
+      edges: [{ from: 'fac_cost', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+    };
+
+    const { graph } = normaliseGraphWithRepairs(upstream);
+    const islReq = toISLRobustnessRequest(graph, OPTIONS, 'goal', 'req-e2e', 1000);
+
+    const wire = JSON.parse(JSON.stringify(islReq));
+    const wireFactor = wire.graph.nodes.find((n: { id: string }) => n.id === 'fac_cost');
+
+    // Provenance forwarded
+    expect(wireFactor.observed_state.source).toBe('brief_extraction');
+    expect(wireFactor.observed_state.extractionType).toBe('explicit');
+
+    // Regression: the fields that already reached ISL must still reach it
+    expect(wireFactor.observed_state.value).toBe(120000);
+    expect(wireFactor.observed_state.unit).toBe('GBP');
+    expect(wireFactor.observed_state.raw_value).toBe(120000);
+    expect(wireFactor.observed_state.cap).toBe(500000);
+    expect(wireFactor.observed_state.factor_type).toBe('cost');
+    expect(wireFactor.observed_state.uncertainty_drivers).toEqual(['market rate volatility']);
+  });
+
+  it('preserve-only-when-present: wire request omits provenance keys when absent', () => {
+    const upstream: UpstreamGraph = {
+      nodes: [
+        { id: 'goal', kind: 'goal', label: 'Profit' },
+        { id: 'fac_velocity', kind: 'factor', label: 'Team Velocity', observed_state: { value: 0.7 } },
+      ],
+      edges: [{ from: 'fac_velocity', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+    };
+
+    const { graph } = normaliseGraphWithRepairs(upstream);
+    const islReq = toISLRobustnessRequest(
+      graph,
+      [
+        { id: 'opt_a', label: 'Option A', interventions: { fac_velocity: { value: 0.8, source: 'user_specified' } } },
+        { id: 'opt_b', label: 'Option B', interventions: { fac_velocity: { value: 0.9, source: 'user_specified' } } },
+      ],
+      'goal',
+      'req-absent',
+      1000,
+    );
+
+    const wire = JSON.parse(JSON.stringify(islReq));
+    const wireFactor = wire.graph.nodes.find((n: { id: string }) => n.id === 'fac_velocity');
+    expect(wireFactor.observed_state).toBeDefined();
+    expect(wireFactor.observed_state.value).toBe(0.7);
+    expect(wireFactor.observed_state).not.toHaveProperty('source');
+    expect(wireFactor.observed_state).not.toHaveProperty('extractionType');
+  });
+});


### PR DESCRIPTION
## Summary

Request-side fix for **Track S** factor value provenance. PLoT's graph-normaliser rebuilt each factor node's `observed_state` from an explicit allow-list that omitted `source` and `extractionType`, so provenance emitted by CEE never reached the ISL robustness request. This adds the two fields to the allow-list (and widens the three PLoT-internal `observed_state` types) so provenance survives normalisation and is forwarded to ISL.

Complements #178 (response-side passthrough): once PLoT forwards provenance on the **request**, ISL echoes it back as `value_source` / `value_extraction_type`.

## Root cause

`src/normalisation/graph-normaliser.ts` reconstructs `observed_state` field-by-field. The allow-list copied `value, baseline, unit, std, raw_value, cap, factor_type, uncertainty_drivers` but not `source` / `extractionType`. The translator (`toISLNode`) is a pure passthrough, so the normaliser was the single drop point on the live `/v2/run` path (`normaliseGraphWithRepairs` → `filteredGraph` → `toISLRobustnessRequest`).

## Changes

- `src/normalisation/graph-normaliser.ts` — add `source` and `extractionType` to the `observed_state` allow-list (copied verbatim).
- `src/types/engine-v3.ts` — widen `UpstreamNode.observed_state` and `EngineNodeV3.observed_state`.
- `src/integrations/isl/translator-v3.ts` — widen `ISLNodeV3.observed_state` (wire contract; `toISLNode` logic unchanged).
- `tests/track-s-provenance-request-forwarding.test.ts` — new (7 tests).

## Casing

Request-side names are `source` (lowercase) and `extractionType` (camelCase) on both CEE emit and ISL receive — **not** renamed to the response-side echo names `value_source` / `value_extraction_type`. ISL's pydantic model carries a "camelCase matches CEE output — do not rename" note.

## Preserve-only-when-present

Provenance is copied verbatim and is `undefined` when absent; `JSON.stringify` drops undefined keys, so the wire request omits provenance when the incoming node had none (no invented fields). Determinism is unaffected — the request canonicaliser hashes only `observed_state.value`/`std`, never these fields.

## Tests

New suite proves: normaliser preservation; `toISLRobustnessRequest` request shape; JSON wire-body preservation; absent-stays-absent; existing-field regression (`value, unit, raw_value, cap, factor_type, uncertainty_drivers`). Locally: `npm run typecheck` PASS; targeted suites (normaliser, translator, golden contract, determinism, idempotency, provenance) green.

## Scope

PLoT request-side provenance forwarding only. **Not touched:** CEE, ISL, DGAI/UI, prompts/PMS, OpenAPI/generated schemas, EVPI, path-decomposition, `confidence_source`, CI/workflows, package files, #188, the stale `src/routes/v2/run 2.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
