### PR TITLE
fix(flip-thresholds): exclude overridden-by-all factors from probing; add probes_used telemetry

### DIFF
--- a/openapi/openapi-plot-lite-v1.yaml
+++ b/openapi/openapi-plot-lite-v1.yaml
@@ -1115,14 +1115,16 @@ components:
           description: Reason for the flip_value result (e.g., "flip_found", "no_flip_in_range").
         iterations_used:
           type: integer
-          description: Number of ISL inference iterations used to locate the threshold.
+          description: >
+            Number of binary-search (bisection) iterations used to locate the
+            threshold. Grid-fallback probes are counted in probes_used, not here.
         probes_used:
           type: integer
           description: >
-            Total ISL probe evaluations executed for this entry (the 3 Step-0
-            probes plus any bisection/grid midpoints). 0 when no probes ran.
-            Distinct from iterations_used: probes_used=3 with iterations_used=0
-            means the three probes ran but bisection did not.
+            Total ISL probe evaluations COMPLETED for this entry (the 3 Step-0
+            probes plus any bisection/grid midpoints; completions, not attempts).
+            0 when no probes ran. Distinct from iterations_used: probes_used=3
+            with iterations_used=0 means the three probes ran but bisection did not.
       required: [factor_id, factor_label, current_value, flip_value, direction, alternative_winner_id, alternative_winner_label, flip_reason]
     ConditionalProbability:
       type: object

--- a/openapi/openapi-plot-lite-v1.yaml
+++ b/openapi/openapi-plot-lite-v1.yaml
@@ -1116,6 +1116,13 @@ components:
         iterations_used:
           type: integer
           description: Number of ISL inference iterations used to locate the threshold.
+        probes_used:
+          type: integer
+          description: >
+            Total ISL probe evaluations executed for this entry (the 3 Step-0
+            probes plus any bisection/grid midpoints). 0 when no probes ran.
+            Distinct from iterations_used: probes_used=3 with iterations_used=0
+            means the three probes ran but bisection did not.
       required: [factor_id, factor_label, current_value, flip_value, direction, alternative_winner_id, alternative_winner_label, flip_reason]
     ConditionalProbability:
       type: object

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -82,10 +82,13 @@ export interface FlipDiagnostics {
   winner_at_max: string;
   bracket_low: number;
   bracket_high: number;
+  /** Binary-search (bisection) iterations only. Grid-fallback probes are NOT
+   *  counted here — they count toward `probes_used`. */
   iterations_used: number;
   /**
-   * Total probe evaluations executed for this factor: the 3 Step-0 probes
-   * (baseline + both bounds) plus any bisection/grid midpoint probes. 0 when
+   * Total probe evaluations COMPLETED for this factor: the 3 Step-0 probes
+   * (baseline + both bounds) plus any bisection/grid midpoint probes. Counts
+   * completions, not attempts — a probe that rejected is not counted. 0 when
    * the probe phase never ran (pre-probe timeout, non-finite baseline). Lets
    * `iterations_used: 0` be disambiguated: 3 means probes ran but bisection
    * did not; 0 means no probes ran at all.
@@ -217,12 +220,22 @@ async function searchFlipForFactor(
       };
     }
 
+    // Probe baseline + both bounds. Each call increments `probes` as it COMPLETES
+    // (via the wrapper), so a partial Step-0 failure still reports the number of
+    // probes that actually completed: Promise.all rejects on the first error, but
+    // siblings that already resolved have already counted. A flat `probes += 3`
+    // after the await would instead report 0 on any rejection — dishonest when one
+    // or two of the three probes had in fact completed.
+    const runProbe = (mean: number): Promise<FlipInferenceResult> =>
+      inferenceFn(candidate.factor_id, mean).then((r) => {
+        probes++;
+        return r;
+      });
     const [baselineResult, minResult, maxResult] = await Promise.all([
-      inferenceFn(candidate.factor_id, baseline),
-      inferenceFn(candidate.factor_id, 0),
-      inferenceFn(candidate.factor_id, 1),
+      runProbe(baseline),
+      runProbe(0),
+      runProbe(1),
     ]);
-    probes += 3; // Step-0 probes completed: baseline, lower bound, upper bound
 
     const W0 = getArgmaxOption(baselineResult);
     const W_min = getArgmaxOption(minResult);
@@ -396,7 +409,10 @@ async function gridFallback(
   diag: FlipDiagnostics,
   marginSensitivity: MarginSensitivity
 ): Promise<{ result: FlipThresholdInputData; diagnostics: FlipDiagnostics }> {
-  let iterations = iterationsSoFar;
+  // iterations_used stays bisection-only: grid probes count toward probes_used,
+  // never toward iterations_used. `iterations` is fixed to the bisection-iteration
+  // count at the moment we fell back to the grid scan.
+  const iterations = iterationsSoFar;
   let probes = probesSoFar;
   const step = (high - low) / (config.maxGridPoints - 1);
 
@@ -415,8 +431,7 @@ async function gridFallback(
 
     try {
       const result = await inferenceFn(candidate.factor_id, probeValue);
-      iterations++;
-      probes++; // grid probe completed
+      probes++; // grid probe completed (counts toward probes_used, not iterations_used)
 
       const winner = getArgmaxOption(result);
       if (winner !== originalWinnerId) {
@@ -432,8 +447,8 @@ async function gridFallback(
         };
       }
     } catch {
-      // Skip failed points in grid scan (probe did not complete — not counted)
-      iterations++;
+      // Skip failed points in grid scan. A failed probe did not complete, so it
+      // counts toward neither probes_used nor iterations_used.
     }
   }
 

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -83,6 +83,14 @@ export interface FlipDiagnostics {
   bracket_low: number;
   bracket_high: number;
   iterations_used: number;
+  /**
+   * Total probe evaluations executed for this factor: the 3 Step-0 probes
+   * (baseline + both bounds) plus any bisection/grid midpoint probes. 0 when
+   * the probe phase never ran (pre-probe timeout, non-finite baseline). Lets
+   * `iterations_used: 0` be disambiguated: 3 means probes ran but bisection
+   * did not; 0 means no probes ran at all.
+   */
+  probes_used: number;
   precision_target: number;
   precision_achieved: number;
   flip_reason: string;
@@ -177,6 +185,7 @@ async function searchFlipForFactor(
     bracket_low: 0,
     bracket_high: 0,
     iterations_used: 0,
+    probes_used: 0,
     precision_target: config.precisionTarget,
     precision_achieved: Infinity,
     flip_reason: '',
@@ -184,11 +193,16 @@ async function searchFlipForFactor(
     alternative_winner_id: null,
   };
 
+  // Probe-evaluation counter. Incremented as each ISL inference completes:
+  // +3 after the Step-0 probes, +1 per bisection/grid midpoint. Declared
+  // outside the try so the catch path can report the count that did complete.
+  let probes = 0;
+
   // Guard: skip binary search if current_value is not a finite number
   if (!Number.isFinite(baseline)) {
     diag.flip_reason = 'error';
     return {
-      result: { ...candidate, flip_value: null, flip_reason: 'error', iterations_used: 0, alternative_winner_id: null },
+      result: { ...candidate, flip_value: null, flip_reason: 'error', iterations_used: 0, probes_used: 0, alternative_winner_id: null },
       diagnostics: diag,
     };
   }
@@ -198,7 +212,7 @@ async function searchFlipForFactor(
     if (Date.now() >= factorDeadline) {
       diag.flip_reason = 'timeout';
       return {
-        result: { ...candidate, flip_value: null, flip_reason: 'timeout', iterations_used: 0, alternative_winner_id: null },
+        result: { ...candidate, flip_value: null, flip_reason: 'timeout', iterations_used: 0, probes_used: 0, alternative_winner_id: null },
         diagnostics: diag,
       };
     }
@@ -208,6 +222,7 @@ async function searchFlipForFactor(
       inferenceFn(candidate.factor_id, 0),
       inferenceFn(candidate.factor_id, 1),
     ]);
+    probes += 3; // Step-0 probes completed: baseline, lower bound, upper bound
 
     const W0 = getArgmaxOption(baselineResult);
     const W_min = getArgmaxOption(minResult);
@@ -233,8 +248,9 @@ async function searchFlipForFactor(
     if (W_min === W0 && W_max === W0) {
       diag.flip_reason = 'no_effect_within_bounds';
       diag.iterations_used = 0;
+      diag.probes_used = probes;
       return {
-        result: { ...candidate, flip_value: null, flip_reason: 'no_effect_within_bounds', iterations_used: 0, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
+        result: { ...candidate, flip_value: null, flip_reason: 'no_effect_within_bounds', iterations_used: 0, probes_used: probes, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
         diagnostics: diag,
       };
     }
@@ -290,12 +306,13 @@ async function searchFlipForFactor(
       if (Date.now() >= factorDeadline) {
         const flipValue = roundTo4(midpoint(searchLow, searchHigh));
         diag.iterations_used = iterations;
+        diag.probes_used = probes;
         diag.precision_achieved = Math.abs(searchHigh - searchLow);
         diag.flip_reason = 'timeout';
         diag.flip_value = flipValue;
         diag.alternative_winner_id = farWinner;
         return {
-          result: { ...candidate, flip_value: flipValue, flip_reason: 'timeout', iterations_used: iterations, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
+          result: { ...candidate, flip_value: flipValue, flip_reason: 'timeout', iterations_used: iterations, probes_used: probes, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
           diagnostics: diag,
         };
       }
@@ -307,6 +324,7 @@ async function searchFlipForFactor(
       const mid = midpoint(searchLow, searchHigh);
       const midResult = await inferenceFn(candidate.factor_id, mid);
       iterations++;
+      probes++; // bisection midpoint probe completed
 
       const midWinner = getArgmaxOption(midResult);
 
@@ -319,7 +337,7 @@ async function searchFlipForFactor(
       } else {
         // Non-monotonic: a third option became the winner. Fall back to grid scan.
         return await gridFallback(
-          candidate, inferenceFn, originalWinnerId, 0, 1, config, factorDeadline, iterations, diag, marginSensitivity
+          candidate, inferenceFn, originalWinnerId, 0, 1, config, factorDeadline, iterations, probes, diag, marginSensitivity
         );
       }
     }
@@ -329,6 +347,7 @@ async function searchFlipForFactor(
     const flipValue = roundTo4(midpoint(searchLow, searchHigh));
 
     diag.iterations_used = iterations;
+    diag.probes_used = probes;
     diag.precision_achieved = precisionAchieved;
     diag.flip_value = flipValue;
     diag.alternative_winner_id = farWinner;
@@ -336,20 +355,21 @@ async function searchFlipForFactor(
     if (precisionAchieved > config.precisionTarget) {
       diag.flip_reason = 'insufficient_precision';
       return {
-        result: { ...candidate, flip_value: flipValue, flip_reason: 'insufficient_precision', iterations_used: iterations, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
+        result: { ...candidate, flip_value: flipValue, flip_reason: 'insufficient_precision', iterations_used: iterations, probes_used: probes, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
         diagnostics: diag,
       };
     }
 
     diag.flip_reason = 'found';
     return {
-      result: { ...candidate, flip_value: flipValue, flip_reason: 'found', iterations_used: iterations, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
+      result: { ...candidate, flip_value: flipValue, flip_reason: 'found', iterations_used: iterations, probes_used: probes, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
       diagnostics: diag,
     };
   } catch (err) {
     diag.flip_reason = 'error';
+    diag.probes_used = probes;
     return {
-      result: { ...candidate, flip_value: null, flip_reason: 'error', iterations_used: 0, alternative_winner_id: null },
+      result: { ...candidate, flip_value: null, flip_reason: 'error', iterations_used: 0, probes_used: probes, alternative_winner_id: null },
       diagnostics: diag,
     };
   }
@@ -372,18 +392,21 @@ async function gridFallback(
   config: FlipSearchConfig,
   deadline: number,
   iterationsSoFar: number,
+  probesSoFar: number,
   diag: FlipDiagnostics,
   marginSensitivity: MarginSensitivity
 ): Promise<{ result: FlipThresholdInputData; diagnostics: FlipDiagnostics }> {
   let iterations = iterationsSoFar;
+  let probes = probesSoFar;
   const step = (high - low) / (config.maxGridPoints - 1);
 
   for (let i = 0; i < config.maxGridPoints; i++) {
     if (Date.now() >= deadline) {
       diag.iterations_used = iterations;
+      diag.probes_used = probes;
       diag.flip_reason = 'timeout';
       return {
-        result: { ...candidate, flip_value: null, flip_reason: 'timeout', iterations_used: iterations, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
+        result: { ...candidate, flip_value: null, flip_reason: 'timeout', iterations_used: iterations, probes_used: probes, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
         diagnostics: diag,
       };
     }
@@ -393,30 +416,33 @@ async function gridFallback(
     try {
       const result = await inferenceFn(candidate.factor_id, probeValue);
       iterations++;
+      probes++; // grid probe completed
 
       const winner = getArgmaxOption(result);
       if (winner !== originalWinnerId) {
         const flipValue = roundTo4(probeValue);
         diag.iterations_used = iterations;
+        diag.probes_used = probes;
         diag.flip_reason = 'non_monotonic_grid';
         diag.flip_value = flipValue;
         diag.alternative_winner_id = winner;
         return {
-          result: { ...candidate, flip_value: flipValue, flip_reason: 'non_monotonic_grid', iterations_used: iterations, alternative_winner_id: winner, margin_sensitivity: marginSensitivity },
+          result: { ...candidate, flip_value: flipValue, flip_reason: 'non_monotonic_grid', iterations_used: iterations, probes_used: probes, alternative_winner_id: winner, margin_sensitivity: marginSensitivity },
           diagnostics: diag,
         };
       }
     } catch {
-      // Skip failed points in grid scan
+      // Skip failed points in grid scan (probe did not complete — not counted)
       iterations++;
     }
   }
 
   // No flip found in grid
   diag.iterations_used = iterations;
+  diag.probes_used = probes;
   diag.flip_reason = 'no_effect_within_bounds';
   return {
-    result: { ...candidate, flip_value: null, flip_reason: 'no_effect_within_bounds', iterations_used: iterations, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
+    result: { ...candidate, flip_value: null, flip_reason: 'no_effect_within_bounds', iterations_used: iterations, probes_used: probes, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
     diagnostics: diag,
   };
 }

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -220,22 +220,40 @@ async function searchFlipForFactor(
       };
     }
 
-    // Probe baseline + both bounds. Each call increments `probes` as it COMPLETES
-    // (via the wrapper), so a partial Step-0 failure still reports the number of
-    // probes that actually completed: Promise.all rejects on the first error, but
-    // siblings that already resolved have already counted. A flat `probes += 3`
-    // after the await would instead report 0 on any rejection — dishonest when one
-    // or two of the three probes had in fact completed.
-    const runProbe = (mean: number): Promise<FlipInferenceResult> =>
-      inferenceFn(candidate.factor_id, mean).then((r) => {
-        probes++;
-        return r;
-      });
-    const [baselineResult, minResult, maxResult] = await Promise.all([
-      runProbe(baseline),
-      runProbe(0),
-      runProbe(1),
+    // Step-0: probe baseline + both bounds. Use allSettled (NOT Promise.all) so the
+    // completed-probe count is ORDER-INDEPENDENT. Promise.all rejects on the first
+    // failure and returns immediately, leaving the sibling probes in flight — they
+    // complete *after* the result is emitted, so a reject-first ordering would
+    // report probes_used: 0 even though two probes do complete. allSettled waits for
+    // all three to settle, so probes_used is exactly the number that fulfilled and
+    // no probe completes after emission.
+    //
+    // We deliberately do NOT race a per-probe timeout here: abandoning a probe would
+    // let it complete in the background after emission, reintroducing the same
+    // dishonesty. Boundedness relies on ISL's own HTTP-layer timeout (each probe
+    // settles fulfilled or rejected); true in-flight bounding would require request
+    // cancellation (AbortController), which is out of scope for this telemetry fix.
+    const settled = await Promise.allSettled([
+      inferenceFn(candidate.factor_id, baseline),
+      inferenceFn(candidate.factor_id, 0),
+      inferenceFn(candidate.factor_id, 1),
     ]);
+    probes += settled.filter((s) => s.status === 'fulfilled').length;
+
+    // Any Step-0 probe failing → error, with the honest count of probes that did
+    // complete. (margin_sensitivity is intentionally omitted, as on the catch path.)
+    if (settled.some((s) => s.status === 'rejected')) {
+      diag.flip_reason = 'error';
+      diag.probes_used = probes;
+      return {
+        result: { ...candidate, flip_value: null, flip_reason: 'error', iterations_used: 0, probes_used: probes, alternative_winner_id: null },
+        diagnostics: diag,
+      };
+    }
+
+    const [baselineResult, minResult, maxResult] = (
+      settled as PromiseFulfilledResult<FlipInferenceResult>[]
+    ).map((s) => s.value);
 
     const W0 = getArgmaxOption(baselineResult);
     const W_min = getArgmaxOption(minResult);

--- a/src/cee/decision-review-orchestrator.ts
+++ b/src/cee/decision-review-orchestrator.ts
@@ -163,6 +163,7 @@ export async function orchestrateDecisionReview(
           flip_reason: f.flip_reason,
           flip_value: f.flip_value,
           iterations_used: f.iterations_used,
+          probes_used: f.probes_used,
         })),
       });
     } catch (err) {

--- a/src/cee/decision-review-request.ts
+++ b/src/cee/decision-review-request.ts
@@ -25,6 +25,7 @@ import type {
 } from './validation/m1-review-types.js';
 import {
   computeFlipThresholdData,
+  getFactorsOverriddenByAllOptions,
   calculateMargin,
   getWinnerAndRunnerUp,
   type FactorSensitivityInput,
@@ -127,11 +128,15 @@ export function buildDecisionReviewRequest(
   // Get winner and runner-up
   const { winner, runnerUp } = getWinnerAndRunnerUp(optionComparison);
 
-  // Compute flip threshold data
+  // Compute flip threshold data. Exclude factors overridden by EVERY option so
+  // this path (legacy decision-review assembly) gets the same assumption-threshold
+  // selection guard as the main /v2/run route — probing a fully-overridden factor
+  // would always return no_effect_within_bounds.
   const flipThresholdData = computeFlipThresholdData(
     factorSensitivity as FactorSensitivityInput[],
     optionComparison as OptionComparisonInput[],
-    graph
+    graph,
+    getFactorsOverriddenByAllOptions(options)
   );
 
   // Calculate margin

--- a/src/cee/validation/m1-review-types.ts
+++ b/src/cee/validation/m1-review-types.ts
@@ -290,14 +290,15 @@ export interface FlipThresholdInputData {
   direction: 'increase' | 'decrease';
   /** Reason for the flip_value result */
   flip_reason?: 'found' | 'no_effect_within_bounds' | 'insufficient_precision' | 'error' | 'timeout' | 'non_monotonic_grid' | 'single_option' | 'heuristic' | 'zero_elasticity_fallback';
-  /** Number of ISL inference iterations used */
+  /** Number of binary-search (bisection) iterations used. Grid-fallback probes
+   *  are counted in probes_used, not here. */
   iterations_used?: number;
   /**
-   * Total probe evaluations executed for this entry: the 3 Step-0 probes plus
-   * any bisection/grid midpoints. 0 for heuristic candidates (no probes run yet)
-   * and for entries whose probe phase never started. Distinct from
-   * iterations_used — probes_used:3 with iterations_used:0 means the three probes
-   * ran but bisection did not.
+   * Total probe evaluations COMPLETED for this entry: the 3 Step-0 probes plus
+   * any bisection/grid midpoints (completions, not attempts). 0 for heuristic
+   * candidates (no probes run yet) and for entries whose probe phase never
+   * started. Distinct from iterations_used — probes_used:3 with iterations_used:0
+   * means the three probes ran but bisection did not.
    */
   probes_used?: number;
   /** Option that becomes winner after the flip (null if no flip found) */

--- a/src/cee/validation/m1-review-types.ts
+++ b/src/cee/validation/m1-review-types.ts
@@ -292,6 +292,14 @@ export interface FlipThresholdInputData {
   flip_reason?: 'found' | 'no_effect_within_bounds' | 'insufficient_precision' | 'error' | 'timeout' | 'non_monotonic_grid' | 'single_option' | 'heuristic' | 'zero_elasticity_fallback';
   /** Number of ISL inference iterations used */
   iterations_used?: number;
+  /**
+   * Total probe evaluations executed for this entry: the 3 Step-0 probes plus
+   * any bisection/grid midpoints. 0 for heuristic candidates (no probes run yet)
+   * and for entries whose probe phase never started. Distinct from
+   * iterations_used — probes_used:3 with iterations_used:0 means the three probes
+   * ran but bisection did not.
+   */
+  probes_used?: number;
   /** Option that becomes winner after the flip (null if no flip found) */
   alternative_winner_id?: string | null;
   /** Factor unit from observed_state (e.g., "GBP", "%") */

--- a/src/coaching/flip-thresholds.ts
+++ b/src/coaching/flip-thresholds.ts
@@ -76,12 +76,20 @@ const MAX_FLIP_THRESHOLDS = 5;
  * @param factorSensitivity Factor sensitivity array from ISL
  * @param optionComparison Option comparison array from ISL
  * @param graph Normalized graph (for current_value lookup)
- * @returns Array of flip threshold input data (max 2)
+ * @param overriddenFactorIds Factor IDs overridden by EVERY compared option.
+ *   These are inert for assumption-threshold probing (the flip probe varies a
+ *   factor's prior mean, but a do()-intervention on every option severs that
+ *   factor from its prior, so probing can never move the winner). Excluded from
+ *   both the primary ranked selection and the zero-elasticity fallback so they
+ *   never consume flip-threshold probe budget. Factors intervened by only SOME
+ *   options, or by none, are preserved. Optional — omit to disable exclusion.
+ * @returns Array of flip threshold input data (max MAX_FLIP_THRESHOLDS)
  */
 export function computeFlipThresholdData(
   factorSensitivity: FactorSensitivityInput[],
   optionComparison: OptionComparisonInput[],
-  graph: EngineGraphV3
+  graph: EngineGraphV3,
+  overriddenFactorIds?: ReadonlySet<string>
 ): FlipThresholdInputData[] {
   // Edge case: Only one option (no runner_up) → no flip thresholds
   if (!optionComparison || optionComparison.length < 2) {
@@ -106,12 +114,16 @@ export function computeFlipThresholdData(
     return [];
   }
 
-  // Filter factors with meaningful elasticity
+  // Filter factors with meaningful elasticity. Also exclude factors overridden by
+  // every compared option: their prior value is severed by each option's
+  // intervention, so an assumption-threshold probe on them always returns
+  // no_effect_within_bounds (see overriddenFactorIds param docs).
   const validFactors = factorSensitivity.filter(
     (f) =>
       f.elasticity !== null &&
       f.elasticity !== undefined &&
-      Math.abs(f.elasticity) >= MIN_ELASTICITY_THRESHOLD
+      Math.abs(f.elasticity) >= MIN_ELASTICITY_THRESHOLD &&
+      !overriddenFactorIds?.has(f.factor_id)
   );
 
   // Sort by |elasticity| descending (highest sensitivity = most likely to flip)
@@ -146,15 +158,18 @@ export function computeFlipThresholdData(
       direction,
       flip_reason: 'heuristic',
       iterations_used: 0,
+      probes_used: 0, // Heuristic candidate — no probes run until resolveFlipValues
       alternative_winner_id: null,
       unit: factorNode?.observed_state?.unit,
     });
   }
 
-  // Fallback: zero-elasticity graphs (all factors filtered out by MIN_ELASTICITY_THRESHOLD)
-  // Emit top 2 factors by distance from midpoint (most room to flip)
+  // Fallback: zero-elasticity graphs (all factors filtered out by MIN_ELASTICITY_THRESHOLD).
+  // Emit top 2 factors by distance from midpoint (most room to flip). Overridden-by-all
+  // factors are excluded here too so the fallback never re-introduces inert factors.
   if (results.length === 0 && factorSensitivity.length > 0) {
     const fallbackCandidates = factorSensitivity
+      .filter((f) => !overriddenFactorIds?.has(f.factor_id))
       .map((f) => {
         const currentValue = getFactorCurrentValue(f.factor_id, graph);
         if (currentValue === null) return null;
@@ -178,6 +193,7 @@ export function computeFlipThresholdData(
         direction: candidate.currentValue < 0.5 ? 'increase' : 'decrease',
         flip_reason: 'zero_elasticity_fallback',
         iterations_used: 0,
+        probes_used: 0, // Heuristic candidate — no probes run until resolveFlipValues
         alternative_winner_id: null,
         unit: factorNode?.observed_state?.unit,
       });
@@ -185,6 +201,51 @@ export function computeFlipThresholdData(
   }
 
   return results;
+}
+
+/**
+ * Return the set of factor (node) IDs that EVERY compared option intervenes on.
+ *
+ * A factor overridden by every option is inert for assumption-threshold probing:
+ * the flip probe varies `parameter_uncertainties[].mean`, but each option applies a
+ * do()-intervention that fixes the factor, severing it from its prior. Probing such
+ * a factor can never change any option's outcome, so it always yields
+ * `no_effect_within_bounds` and wastes probe budget. Feed the result to
+ * {@link computeFlipThresholdData} as `overriddenFactorIds` to exclude them.
+ *
+ * IMPORTANT — "overridden by every option", not "intervention target":
+ *  - a factor intervened on by only SOME options is NOT included (the
+ *    non-intervening options still respond to the prior, so a flip is possible);
+ *  - a non-intervened factor is never included.
+ *
+ * @param options Compared options; intervention keys are factor node IDs.
+ * @returns Set of factor IDs overridden by every option (empty if none / no options).
+ */
+export function getFactorsOverriddenByAllOptions(
+  options: ReadonlyArray<{ interventions?: Record<string, unknown> | null }>
+): Set<string> {
+  if (!Array.isArray(options) || options.length === 0) {
+    return new Set<string>();
+  }
+
+  // Intervention-key set (factor node IDs) per option.
+  const perOptionKeys = options.map((opt) => {
+    const interventions = opt?.interventions;
+    if (!interventions || typeof interventions !== 'object') {
+      return new Set<string>();
+    }
+    return new Set<string>(Object.keys(interventions));
+  });
+
+  // Intersect across all options: a factor must appear in every option's key set.
+  const [firstKeys, ...restKeys] = perOptionKeys;
+  const overridden = new Set<string>();
+  for (const factorId of firstKeys) {
+    if (restKeys.every((keys) => keys.has(factorId))) {
+      overridden.add(factorId);
+    }
+  }
+  return overridden;
 }
 
 // =============================================================================

--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -37,11 +37,12 @@ export interface DenormalisedFlipThreshold {
   alternative_winner_label: string | null;
   /** Reason for the flip_value result */
   flip_reason: string;
-  /** Number of ISL inference iterations used */
+  /** Number of binary-search (bisection) iterations used (grid probes excluded). */
   iterations_used?: number;
   /**
-   * Total probe evaluations executed (3 Step-0 probes plus any bisection/grid
-   * midpoints). 0 when no probes ran. Disambiguates iterations_used:0.
+   * Total probe evaluations COMPLETED (3 Step-0 probes plus any bisection/grid
+   * midpoints; completions, not attempts). 0 when no probes ran. Disambiguates
+   * iterations_used:0.
    */
   probes_used?: number;
   /**

--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -40,6 +40,11 @@ export interface DenormalisedFlipThreshold {
   /** Number of ISL inference iterations used */
   iterations_used?: number;
   /**
+   * Total probe evaluations executed (3 Step-0 probes plus any bisection/grid
+   * midpoints). 0 when no probes ran. Disambiguates iterations_used:0.
+   */
+  probes_used?: number;
+  /**
    * Additive lead-margin diagnostic. Omitted on entries whose flip-search
    * Step-0 probes did not complete (pre-probe timeout, non-finite baseline,
    * exception during probe phase, heuristic-only entries).
@@ -93,6 +98,7 @@ export function denormaliseFlipThresholds(
       alternative_winner_label: resolveLabel(flip.alternative_winner_id, options),
       flip_reason: flip.flip_reason ?? 'heuristic',
       iterations_used: flip.iterations_used,
+      probes_used: flip.probes_used,
       ...(flip.margin_sensitivity
         ? { margin_sensitivity: denormaliseMarginSensitivity(flip.margin_sensitivity, factorContext.range) }
         : {}),
@@ -123,6 +129,7 @@ function enrichWithLabels(
     alternative_winner_label: resolveLabel(flip.alternative_winner_id, options),
     flip_reason: flip.flip_reason ?? 'heuristic',
     iterations_used: flip.iterations_used,
+    probes_used: flip.probes_used,
     // No factor context for denormalisation. Pass margin_sensitivity through
     // untouched: `value_scale` stays `'normalised'` for honesty.
     ...(flip.margin_sensitivity ? { margin_sensitivity: flip.margin_sensitivity } : {}),

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -106,7 +106,7 @@ import {
   REQUEST_BUDGET_MS,
 } from '../../config/timeouts.js';
 import { createISLInferenceFn, resolveFlipValues } from '../../analysis/flip-thresholds.js';
-import { computeFlipThresholdData } from '../../coaching/flip-thresholds.js';
+import { computeFlipThresholdData, getFactorsOverriddenByAllOptions } from '../../coaching/flip-thresholds.js';
 import { denormaliseFlipThresholds, type DenormalisedFlipThreshold } from '../../lib/flip-threshold-denormaliser.js';
 import { classifyFlipThresholdsStatus } from '../../lib/flip-threshold-status.js';
 import {
@@ -4374,7 +4374,23 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
 
         if (islSuccess && factorSensitivity && optionComparisonData && optionComparisonData.length >= 2) {
           try {
-            // Step 1: Compute heuristic candidates (top 5 by |elasticity|)
+            // Selection guard: exclude factors overridden by EVERY compared option.
+            // The flip probe varies a factor's prior mean (parameter_uncertainties),
+            // but a do()-intervention on every option severs that factor from its
+            // prior, so probing it can only ever return no_effect_within_bounds.
+            // Factors intervened by only some options, or by none, stay eligible.
+            const overriddenByAllOptions = getFactorsOverriddenByAllOptions(normalizedOptions);
+            if (overriddenByAllOptions.size > 0) {
+              req.log.info({
+                event: 'flip_thresholds_overridden_excluded',
+                request_id: requestId,
+                excluded_count: overriddenByAllOptions.size,
+                excluded_factor_ids: [...overriddenByAllOptions].slice(0, 10),
+              });
+            }
+
+            // Step 1: Compute heuristic candidates (top 5 by |elasticity|),
+            // skipping the overridden-by-all factors above.
             const flipCandidates = computeFlipThresholdData(
               factorSensitivity.map((f: any) => ({
                 factor_id: f.factor_id,
@@ -4388,7 +4404,8 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                 win_probability: o.win_probability ?? 0,
                 expected_outcome: o.expected_outcome,
               })),
-              filteredGraph
+              filteredGraph,
+              overriddenByAllOptions
             );
 
             if (flipCandidates.length > 0) {

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -552,11 +552,10 @@ describe('resolveFlipValues() — probes_used telemetry', () => {
     expect(diagnostics[0].iterations_used).toBe(0);
   });
 
-  it('counts only COMPLETED Step-0 probes on partial failure (not 0)', async () => {
-    // baseline (0.5) and lower bound (0) resolve immediately; the upper bound (1)
-    // rejects after a tick, so the other two definitely complete first. Under a
-    // flat `probes += 3` after Promise.all this would wrongly report 0.
-    const partialFailMock: ISLInferenceFn = async (_id, mean) => {
+  it('counts COMPLETED Step-0 probes on partial failure (failure settles LAST)', async () => {
+    // baseline (0.5) and lower bound (0) fulfil immediately; the upper bound (1)
+    // rejects after a tick (settles last).
+    const failLastMock: ISLInferenceFn = async (_id, mean) => {
       if (mean >= 1) {
         await new Promise((r) => setTimeout(r, 5));
         throw new Error('upper-bound probe failed');
@@ -570,11 +569,35 @@ describe('resolveFlipValues() — probes_used telemetry', () => {
     };
     const candidate = makeCandidate({ current_value: 0.5 });
 
-    const { results } = await resolveFlipValues([candidate], partialFailMock, 'opt-a');
+    const { results } = await resolveFlipValues([candidate], failLastMock, 'opt-a');
 
     expect(results[0].flip_reason).toBe('error');
-    // 2 of 3 Step-0 probes completed before the upper-bound rejection.
-    expect(results[0].probes_used).toBe(2);
+    expect(results[0].probes_used).toBe(2); // baseline + lower bound fulfilled
+  });
+
+  it('counts COMPLETED Step-0 probes order-independently (failure rejects FIRST)', async () => {
+    // The upper-bound probe rejects IMMEDIATELY (first to settle); baseline and lower
+    // bound fulfil afterwards. With Promise.all this returns probes_used: 0 (catch
+    // reads the count before the siblings resolve, and they complete after emission).
+    // allSettled waits for all three to settle, so the honest count is 2 regardless.
+    const failFirstMock: ISLInferenceFn = async (_id, mean) => {
+      if (mean >= 1) {
+        throw new Error('upper-bound probe failed immediately');
+      }
+      await new Promise((r) => setTimeout(r, 5));
+      return {
+        options: [
+          { option_id: 'opt-a', win_probability: 0.6 },
+          { option_id: 'opt-b', win_probability: 0.4 },
+        ],
+      };
+    };
+    const candidate = makeCandidate({ current_value: 0.5 });
+
+    const { results } = await resolveFlipValues([candidate], failFirstMock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('error');
+    expect(results[0].probes_used).toBe(2); // both siblings completed; NOT 0
   });
 
   it('keeps iterations_used bisection-only on the grid-fallback path (grid probes only in probes_used)', async () => {

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -472,6 +472,87 @@ describe('resolveFlipValues()', () => {
   });
 });
 
+// =============================================================================
+// probes_used telemetry — distinguishes "no probes ran" from
+// "probes ran but no bisection ran" (iterations_used: 0 is otherwise ambiguous).
+// =============================================================================
+
+describe('resolveFlipValues() — probes_used telemetry', () => {
+  it('no-bisection three-probe path reports probes_used: 3 with iterations_used: 0', async () => {
+    const mock = createNeverFlipMock('opt-a');
+    const candidate = makeCandidate({ current_value: 0.7, direction: 'decrease' });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('no_effect_within_bounds');
+    expect(results[0].iterations_used).toBe(0);
+    expect(results[0].probes_used).toBe(3); // baseline + min bound + max bound, no bisection
+  });
+
+  it('iterations_used: 0 no longer implies no probes ran (probes_used disambiguates)', async () => {
+    const mock = createNeverFlipMock('opt-a');
+    const candidate = makeCandidate({ current_value: 0.5 });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].iterations_used).toBe(0);
+    expect(results[0].probes_used).toBe(3);
+    expect(results[0].probes_used).toBeGreaterThan(0);
+  });
+
+  it('bisection path counts initial probes plus midpoint probes (3 + iterations_used)', async () => {
+    const mock = createMonotonicMock(0.35, 'opt-a', 'opt-b', 'decrease');
+    const candidate = makeCandidate({ current_value: 0.7, direction: 'decrease' });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('found');
+    expect(results[0].iterations_used).toBeGreaterThan(0);
+    expect(results[0].probes_used).toBe(3 + results[0].iterations_used!);
+  });
+
+  it('does not fabricate probes_used when the probe phase never runs (non-finite baseline)', async () => {
+    const mock = createNeverFlipMock('opt-a');
+    const candidate = makeCandidate({ current_value: NaN });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('error');
+    expect(results[0].probes_used).toBe(0); // honest: no probes executed
+  });
+
+  it('reports probes_used: 0 when the probe phase throws before any probe completes', async () => {
+    const mock = createErrorMock();
+    const candidate = makeCandidate({ current_value: 0.5 });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('error');
+    expect(results[0].probes_used).toBe(0);
+  });
+
+  it('leaves existing free/non-overridden factor behaviour unchanged (flip found, probes_used > 3)', async () => {
+    const mock = createMonotonicMock(0.85, 'opt-a', 'opt-b', 'increase');
+    const candidate = makeCandidate({ current_value: 0.6, direction: 'increase' });
+
+    const { results } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('found');
+    expect(results[0].flip_value!).toBeCloseTo(0.85, 1);
+    expect(results[0].probes_used).toBeGreaterThan(3); // 3 Step-0 probes + bisection midpoints
+  });
+
+  it('diagnostics carry probes_used alongside iterations_used', async () => {
+    const mock = createNeverFlipMock('opt-a');
+    const candidate = makeCandidate({ current_value: 0.5 });
+
+    const { diagnostics } = await resolveFlipValues([candidate], mock, 'opt-a');
+
+    expect(diagnostics[0].probes_used).toBe(3);
+    expect(diagnostics[0].iterations_used).toBe(0);
+  });
+});
+
 describe('createISLInferenceFn()', () => {
   it('overrides the target factor mean in parameter_uncertainties', async () => {
     let capturedBody: any = null;

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -551,6 +551,59 @@ describe('resolveFlipValues() — probes_used telemetry', () => {
     expect(diagnostics[0].probes_used).toBe(3);
     expect(diagnostics[0].iterations_used).toBe(0);
   });
+
+  it('counts only COMPLETED Step-0 probes on partial failure (not 0)', async () => {
+    // baseline (0.5) and lower bound (0) resolve immediately; the upper bound (1)
+    // rejects after a tick, so the other two definitely complete first. Under a
+    // flat `probes += 3` after Promise.all this would wrongly report 0.
+    const partialFailMock: ISLInferenceFn = async (_id, mean) => {
+      if (mean >= 1) {
+        await new Promise((r) => setTimeout(r, 5));
+        throw new Error('upper-bound probe failed');
+      }
+      return {
+        options: [
+          { option_id: 'opt-a', win_probability: 0.6 },
+          { option_id: 'opt-b', win_probability: 0.4 },
+        ],
+      };
+    };
+    const candidate = makeCandidate({ current_value: 0.5 });
+
+    const { results } = await resolveFlipValues([candidate], partialFailMock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('error');
+    // 2 of 3 Step-0 probes completed before the upper-bound rejection.
+    expect(results[0].probes_used).toBe(2);
+  });
+
+  it('keeps iterations_used bisection-only on the grid-fallback path (grid probes only in probes_used)', async () => {
+    // Step-0: baseline(0.5)=a, min(0)=b (differs → search toward_min), max(1)=a.
+    // First bisection midpoint (0.25) returns a THIRD option → grid fallback after
+    // exactly 1 bisection iteration. Grid probe at 0 returns b → flip found.
+    const gridMock: ISLInferenceFn = async (_id, mean) => {
+      let leader: string;
+      if (mean === 0) leader = 'opt-b';
+      else if (mean === 0.5 || mean === 1) leader = 'opt-a';
+      else leader = 'opt-c'; // interior midpoint → non-monotonic
+      return {
+        options: [
+          { option_id: 'opt-a', win_probability: leader === 'opt-a' ? 0.6 : 0.2 },
+          { option_id: 'opt-b', win_probability: leader === 'opt-b' ? 0.6 : 0.2 },
+          { option_id: 'opt-c', win_probability: leader === 'opt-c' ? 0.6 : 0.2 },
+        ],
+      };
+    };
+    const candidate = makeCandidate({ current_value: 0.5, direction: 'decrease' });
+
+    const { results } = await resolveFlipValues([candidate], gridMock, 'opt-a');
+
+    expect(results[0].flip_reason).toBe('non_monotonic_grid');
+    // 1 bisection midpoint before fallback; grid probes do NOT inflate iterations_used.
+    expect(results[0].iterations_used).toBe(1);
+    // 3 Step-0 + 1 bisection + 1 grid probe = 5 completed evaluations.
+    expect(results[0].probes_used).toBe(5);
+  });
 });
 
 describe('createISLInferenceFn()', () => {

--- a/tests/contract/cee-decision-review-contract.test.ts
+++ b/tests/contract/cee-decision-review-contract.test.ts
@@ -592,4 +592,43 @@ describe('CEE Decision Review Contract', () => {
       expect(result.success).toBe(true);
     });
   });
+
+  // ===========================================================================
+  // Flip-threshold selection guard on the legacy assembly path. The contract
+  // schema only validates shape/presence, so this exercises the by-all-options
+  // exclusion behaviour directly.
+  // ===========================================================================
+  describe('flip-threshold overridden-by-all exclusion', () => {
+    // The shared testGraph omits observed_state.value, which would skip every factor
+    // during flip-threshold selection. Give the factors values so they are genuinely
+    // eligible, then assert the guard removes only the fully-overridden one.
+    const graphWithValues: EngineGraphV3 = {
+      nodes: [
+        { id: 'goal', kind: 'goal', label: 'Maximize Revenue' },
+        { id: 'factor_a', kind: 'factor', label: 'Market Size', observed_state: { value: 0.5, belief: 0.8 } },
+        { id: 'factor_b', kind: 'factor', label: 'Competition', observed_state: { value: 0.5, belief: 0.7 } },
+      ],
+      edges: testGraph.edges,
+    };
+
+    it('excludes a factor overridden by EVERY option, preserves one overridden by only SOME', () => {
+      // testOptions: opt_a → {factor_a}; opt_b → {factor_a, factor_b}.
+      //   factor_a is overridden by every option → excluded from assumption-threshold probing.
+      //   factor_b is overridden by only opt_b → preserved.
+      // testIslResult.factor_sensitivity carries both factor_a (0.45) and factor_b (0.25)
+      // with no intervention_override zero_reason, so the by-all guard (not the ISL
+      // zero_reason filter) is what removes factor_a.
+      const request = buildDecisionReviewRequest(
+        'Flip-threshold exclusion unit test',
+        graphWithValues,
+        testOptions,
+        testIslResult,
+        testM1Coaching,
+      );
+
+      const flipFactorIds = request.flip_threshold_data.map((f) => f.factor_id);
+      expect(flipFactorIds).toContain('factor_b');     // partially intervened → eligible
+      expect(flipFactorIds).not.toContain('factor_a'); // overridden by all → excluded
+    });
+  });
 });

--- a/tests/golden/decision-review/flip-thresholds.test.ts
+++ b/tests/golden/decision-review/flip-thresholds.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeFlipThresholdData } from '../../../src/coaching/flip-thresholds.js';
+import {
+  computeFlipThresholdData,
+  getFactorsOverriddenByAllOptions,
+} from '../../../src/coaching/flip-thresholds.js';
 import type { EngineGraphV3 } from '../../../src/types/engine-v3.js';
 
 // =============================================================================
@@ -319,5 +322,129 @@ describe('computeFlipThresholdData()', () => {
       // f-low (0.2 < 0.5) should suggest increase
       expect(lowFactor?.direction).toBe('increase');
     });
+  });
+});
+
+// =============================================================================
+// Overridden-by-all-options exclusion (assumption-threshold selection guard)
+// =============================================================================
+
+describe('getFactorsOverriddenByAllOptions()', () => {
+  it('returns only factors intervened on by EVERY option (intersection)', () => {
+    const options = [
+      { id: 'opt-a', label: 'A', interventions: { 'factor-x': { value: 0.8 }, 'factor-y': { value: 0.3 } } },
+      { id: 'opt-b', label: 'B', interventions: { 'factor-x': { value: 0.2 }, 'factor-z': { value: 0.5 } } },
+    ];
+    const overridden = getFactorsOverriddenByAllOptions(options);
+    expect([...overridden]).toEqual(['factor-x']);
+  });
+
+  it('does NOT include a factor intervened on by only SOME options', () => {
+    const options = [
+      { id: 'opt-a', label: 'A', interventions: { 'factor-x': { value: 0.8 }, 'factor-partial': { value: 0.4 } } },
+      { id: 'opt-b', label: 'B', interventions: { 'factor-x': { value: 0.2 } } },
+    ];
+    const overridden = getFactorsOverriddenByAllOptions(options);
+    expect(overridden.has('factor-partial')).toBe(false);
+    expect(overridden.has('factor-x')).toBe(true);
+  });
+
+  it('does NOT include non-intervened factors', () => {
+    const options = [
+      { id: 'opt-a', label: 'A', interventions: { 'factor-x': { value: 0.8 } } },
+      { id: 'opt-b', label: 'B', interventions: { 'factor-x': { value: 0.2 } } },
+    ];
+    const overridden = getFactorsOverriddenByAllOptions(options);
+    // factor-external is never intervened — must not appear
+    expect(overridden.has('factor-external')).toBe(false);
+  });
+
+  it('returns empty set when an option intervenes on nothing', () => {
+    const options = [
+      { id: 'opt-a', label: 'A', interventions: { 'factor-x': { value: 0.8 } } },
+      { id: 'opt-b', label: 'B', interventions: {} },
+    ];
+    expect(getFactorsOverriddenByAllOptions(options).size).toBe(0);
+  });
+
+  it('returns empty set for empty / missing options', () => {
+    expect(getFactorsOverriddenByAllOptions([]).size).toBe(0);
+    expect(getFactorsOverriddenByAllOptions([{ id: 'a', label: 'A' } as any]).size).toBe(0);
+  });
+});
+
+describe('computeFlipThresholdData() — overridden-by-all exclusion', () => {
+  it('excludes fully overridden factors before flip-threshold probing', () => {
+    // factor-high (0.5) is the top candidate but is overridden by every option.
+    const overridden = new Set(['factor-high']);
+    const result = computeFlipThresholdData(
+      TEST_FACTOR_SENSITIVITY,
+      TEST_OPTION_COMPARISON,
+      TEST_GRAPH,
+      overridden
+    );
+    const ids = result.map((r) => r.factor_id);
+    expect(ids).not.toContain('factor-high');
+    // Non-overridden sensitive factors are still selected (and become probe candidates).
+    expect(ids).toContain('factor-neg');
+    expect(ids).toContain('factor-medium');
+  });
+
+  it('keeps factors intervened by only some options eligible (not in the overridden set)', () => {
+    // A "partial" factor is NOT in the overridden-by-all set, so it stays eligible.
+    const overridden = new Set(['factor-high']); // only the fully-overridden one
+    const result = computeFlipThresholdData(
+      TEST_FACTOR_SENSITIVITY,
+      TEST_OPTION_COMPARISON,
+      TEST_GRAPH,
+      overridden
+    );
+    // factor-medium stands in for a partially/never-intervened sensitive factor.
+    expect(result.map((r) => r.factor_id)).toContain('factor-medium');
+  });
+
+  it('keeps non-intervened sensitive factors eligible', () => {
+    // Empty overridden set → nothing excluded; behaves like the no-arg call.
+    const withGuard = computeFlipThresholdData(TEST_FACTOR_SENSITIVITY, TEST_OPTION_COMPARISON, TEST_GRAPH, new Set());
+    const withoutGuard = computeFlipThresholdData(TEST_FACTOR_SENSITIVITY, TEST_OPTION_COMPARISON, TEST_GRAPH);
+    expect(withGuard.map((r) => r.factor_id)).toEqual(withoutGuard.map((r) => r.factor_id));
+  });
+
+  it('emits no entries (no fabricated flip values) when all candidates are overridden', () => {
+    const overridden = new Set(['factor-high', 'factor-medium', 'factor-low', 'factor-neg']);
+    const result = computeFlipThresholdData(
+      TEST_FACTOR_SENSITIVITY,
+      TEST_OPTION_COMPARISON,
+      TEST_GRAPH,
+      overridden
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not re-introduce overridden factors via the zero-elasticity fallback', () => {
+    const zeroElasticity = [
+      { factor_id: 'f1', factor_label: 'F1', elasticity: 0.0, confidence: 0.8 },
+      { factor_id: 'f2', factor_label: 'F2', elasticity: 0.0, confidence: 0.7 },
+    ];
+    const graph: EngineGraphV3 = {
+      nodes: [
+        { id: 'f1', label: 'F1', kind: 'factor', observed_state: { value: 0.9, belief: 0.8 } },
+        { id: 'f2', label: 'F2', kind: 'factor', observed_state: { value: 0.1, belief: 0.7 } },
+      ],
+      edges: [],
+    };
+    // f1 would normally be the top fallback pick (furthest from 0.5), but it is overridden.
+    const result = computeFlipThresholdData(zeroElasticity, TEST_OPTION_COMPARISON, graph, new Set(['f1']));
+    const ids = result.map((r) => r.factor_id);
+    expect(ids).not.toContain('f1');
+    expect(ids).toContain('f2');
+  });
+
+  it('tags heuristic candidates with probes_used: 0 (no probes run pre-resolution)', () => {
+    const result = computeFlipThresholdData(TEST_FACTOR_SENSITIVITY, TEST_OPTION_COMPARISON, TEST_GRAPH);
+    expect(result.length).toBeGreaterThan(0);
+    for (const entry of result) {
+      expect(entry.probes_used).toBe(0);
+    }
   });
 });


### PR DESCRIPTION
## Summary

PLoT was emitting universal `flip_value: null` / `margin_sensitivity.movement: none` for flip thresholds on staging. A prior read-only investigation showed this is **not a regression**: the flip probe varies a factor's prior assumption (`parameter_uncertainties[].mean`) while leaving option interventions unchanged, so for a factor that **every** compared option intervenes on (a `do()`-intervention), the probe is causally inert and `no_effect_within_bounds` is the mathematically-correct result. The real defect was in **selection** — graph-based factor influence is blind to interventions, so PLoT spent assumption-threshold probes on fully-overridden factors.

This PR fixes selection and adds honest probe telemetry.

## Primary selection fix
- **Factors overridden by _every_ compared option are excluded** from assumption-threshold probing. New `getFactorsOverriddenByAllOptions()` intersects intervention keys across all options; `computeFlipThresholdData()` excludes that set from both the ranked selection and the zero-elasticity fallback.
- **Partially overridden factors remain eligible** — a factor intervened on by only _some_ options is preserved (the non-intervening options still respond to its prior, so a flip is possible). This is deliberately **not** the same as "intervention target".
- **Non-overridden / background factors can enter the candidate pool** — external/uncertainty factors are the intended assumption-threshold targets.
- Applied on both the live `/v2/run` path and the legacy `buildDecisionReviewRequest()` assembly path.

## Telemetry
- **`probes_used`** (new, additive) counts **completed probe evaluations** per entry — the 3 Step-0 probes plus any bisection/grid midpoints. Uses `Promise.allSettled` so the count is order-independent and no probe completes after emission. Disambiguates `iterations_used: 0` (`probes_used: 3` = probes ran but bisection did not; `0` = no probes ran).
- **`iterations_used` remains bisection-only** — grid-fallback probes count toward `probes_used`, never `iterations_used`.

## Honest empty state
- When **all** candidate factors are overridden, no entries are emitted and **`flip_thresholds: []`** is returned (same shape as the existing no-candidates path). No fabricated flip values.

## Out of scope
- **Intervention-threshold design** ("at what intervention _level_ does an option stop winning?") is explicitly **out of scope** — it needs a structurally different probe (sweeping option intervention values, not the shared prior mean).

## Follow-ups (not in this PR)
1. **Residual cases:** the 9 not-fully-overridden cases that still show `max_probe_delta = 0` need fresh **post-fix staging investigation** — partially-intervened / background factors with no margin movement, to be re-examined once this fix is live.
2. **True probe cancellation (P3):** `AbortController` plumbed through the ISL client to bound in-flight Step-0 probes without abandoning them (the current fix relies on ISL's HTTP-layer timeout). Track separately as **P3**.

## Tests
- **Selection:** fully-overridden excluded; partially-overridden preserved; background eligible; all-overridden -> `[]`; fallback excludes overridden; helper intersection; direct `buildDecisionReviewRequest` exclusion test.
- **Telemetry:** 3-probe -> `probes_used: 3` / `iterations_used: 0`; bisection -> `3 + midpoints`; grid path -> `iterations_used` bisection-only; partial Step-0 failure in **both** orderings (incl. reject-first) -> order-independent completed count; free factor unchanged.

## Validation
- Pre-push suite green: **4909 passed / 25 skipped / 0 failures**; `tsc --noEmit` clean; OpenAPI spectral lint pass; no stale `.js`.
- One earlier full-suite run flagged a **flaky, pre-existing** `tests/metrics.shape.test.ts` failure (`/metrics` 404 vs 200), unrelated to this change — it passes in isolation and passed on a clean re-run. Not addressed here (unrelated debt).

## Scope confirmation
No changes to: PR #238, PR #188, UI/copy, intervention-threshold design, EVPI, provenance, path decomposition, CI debt, packages, prompt/PMS, CEE service, ISL, DGAI/UI, or other unrelated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)