### PR TITLE
fix(flip-thresholds): flip probe mutates observed_state.value (ISL comparison centre)

### DIFF
--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -31,11 +31,13 @@ export interface FlipInferenceResult {
 }
 
 /**
- * Callback that runs ISL inference with a single factor's mean overridden.
+ * Callback that runs ISL inference with a single factor's value overridden.
  * The caller constructs this closure to encapsulate ISL client + request details.
  *
  * @param factorId - Factor node ID to override
- * @param overrideMean - New mean value for the factor in parameter_uncertainties
+ * @param overrideMean - Normalised [0,1] probe value applied to the factor's graph
+ *   `observed_state.value` (the field ISL's comparison reads as the sampling mean);
+ *   the factor's `parameter_uncertainties[].mean` is kept aligned to the same value.
  * @returns ISL inference result with option win_probabilities
  */
 export type ISLInferenceFn = (

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -531,9 +531,11 @@ function roundTo4(value: number): number {
 /**
  * Create an ISL inference function from the ISL service and original request.
  *
- * Constructs a closure that:
- * 1. Clones the original ISL request
- * 2. Overrides the target factor's mean in parameter_uncertainties
+ * Constructs a closure that, per probe:
+ * 1. Clones the request graph and sets the target factor's observed_state.value
+ *    to the probe value — the field ISL's comparison reads as the sampling mean
+ * 2. Keeps the target factor's parameter_uncertainties.mean aligned to the same
+ *    value (contract honesty; the comparison shadows this field)
  * 3. Calls ISL via the service's callAnalysisEndpoint
  * 4. Returns the option comparison results
  *
@@ -579,9 +581,36 @@ export function createISLInferenceFn(
       ];
     }
 
+    // Clone the graph for THIS probe and set the target factor's
+    // observed_state.value to the probe value. ISL's comparison samples each factor
+    // from Normal(observed_state.value, parameter_uncertainties.std): the comparison
+    // MEAN is read from the graph node's observed_state.value, while the request's
+    // parameter_uncertainties.mean is shadowed (not consumed) by the comparison path.
+    // So observed_state.value is the field that actually moves the winner; the aligned
+    // parameter_uncertainties.mean override above is kept only for contract honesty /
+    // possible future consumers.
+    //
+    // overrideMean is already in the normalised [0,1] scale of observed_state.value,
+    // so the normalised scale is preserved (we never write raw human values here).
+    // raw_value/cap/unit/baseline (display + denormalisation metadata) and std
+    // (uncertainty width) are left untouched. The clone is probe-local: the original
+    // request graph is never mutated, and concurrent Step-0 probes (baseline/0/1)
+    // cannot leak values into one another.
+    const probeNodes = (originalRequest.graph?.nodes ?? []).map((node) => {
+      if (node?.id !== factorId) return node; // other nodes kept by reference, never mutated
+      return {
+        ...node,
+        observed_state: {
+          ...(node.observed_state ?? {}),
+          value: overrideMean,
+        },
+      };
+    });
+    const probeGraph = { ...originalRequest.graph, nodes: probeNodes };
+
     const modifiedRequest = {
       request_id: `${requestId}__flip_${factorId}`,
-      graph: originalRequest.graph,
+      graph: probeGraph,
       options: originalRequest.options,
       goal_node_id: originalRequest.goal_node_id,
       n_samples: originalRequest.n_samples,

--- a/src/coaching/flip-thresholds.ts
+++ b/src/coaching/flip-thresholds.ts
@@ -207,8 +207,9 @@ export function computeFlipThresholdData(
  * Return the set of factor (node) IDs that EVERY compared option intervenes on.
  *
  * A factor overridden by every option is inert for assumption-threshold probing:
- * the flip probe varies `parameter_uncertainties[].mean`, but each option applies a
- * do()-intervention that fixes the factor, severing it from its prior. Probing such
+ * the flip probe varies the factor's graph `observed_state.value` (keeping
+ * `parameter_uncertainties[].mean` aligned), but each option applies a do()-
+ * intervention that fixes the factor, severing it from its prior. Probing such
  * a factor can never change any option's outcome, so it always yields
  * `no_effect_within_bounds` and wastes probe budget. Feed the result to
  * {@link computeFlipThresholdData} as `overriddenFactorIds` to exclude them.

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -783,6 +783,180 @@ describe('createISLInferenceFn()', () => {
     // Original should be unchanged
     expect(originalPU[0].mean).toBe(0.7);
   });
+
+  // ===========================================================================
+  // Branch A fix: the probe must mutate the graph node observed_state.value (the
+  // field ISL's comparison reads as the sampling mean), not only PU mean.
+  // ===========================================================================
+
+  function makeGraphRequest() {
+    return {
+      graph: {
+        nodes: [
+          { id: 'factor-x', kind: 'factor', label: 'X', observed_state: { value: 0.7, std: 0.1, raw_value: 70, cap: 100, unit: 'pct', baseline: 0.6 } },
+          { id: 'factor-y', kind: 'factor', label: 'Y', observed_state: { value: 0.3, std: 0.1 } },
+          { id: 'goal', kind: 'goal', label: 'Goal' },
+        ],
+        edges: [],
+      },
+      options: [
+        { id: 'opt-a', interventions: { 'factor-y': 0.5 } },
+        { id: 'opt-b', interventions: { 'factor-y': 0.2 } },
+      ],
+      goal_node_id: 'goal',
+      parameter_uncertainties: [
+        { node_id: 'factor-x', distribution: 'normal', mean: 0.7, std: 0.1 },
+        { node_id: 'factor-y', distribution: 'normal', mean: 0.3, std: 0.1 },
+      ],
+    };
+  }
+
+  it('sets the target graph node observed_state.value to the probe value (and aligns PU mean)', async () => {
+    let captured: any = null;
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured = body;
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const fn = createISLInferenceFn(mockCallAnalysis, makeGraphRequest(), 'req-1');
+
+    await fn('factor-x', 0.25);
+
+    const targetNode = (captured.graph.nodes as any[]).find((n) => n.id === 'factor-x');
+    expect(targetNode.observed_state.value).toBe(0.25);              // graph value = probe value
+    const puX = (captured.parameter_uncertainties as any[]).find((p) => p.node_id === 'factor-x');
+    expect(puX.mean).toBe(0.25);                                     // PU mean aligned
+    // Display/denormalisation metadata + uncertainty width preserved
+    expect(targetNode.observed_state.std).toBe(0.1);
+    expect(targetNode.observed_state.raw_value).toBe(70);
+    expect(targetNode.observed_state.cap).toBe(100);
+    expect(targetNode.observed_state.unit).toBe('pct');
+    expect(targetNode.observed_state.baseline).toBe(0.6);
+  });
+
+  it('leaves non-target graph nodes and options unchanged', async () => {
+    let captured: any = null;
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured = body;
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const req = makeGraphRequest();
+    const fn = createISLInferenceFn(mockCallAnalysis, req, 'req-1');
+
+    await fn('factor-x', 0.9);
+
+    const otherNode = (captured.graph.nodes as any[]).find((n) => n.id === 'factor-y');
+    expect(otherNode.observed_state.value).toBe(0.3);               // untouched
+    expect(captured.options).toEqual(req.options);                  // options unchanged
+  });
+
+  it('does not mutate the original request graph (probe-local clone)', async () => {
+    const mockCallAnalysis = async () => ({ data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } });
+    const req = makeGraphRequest();
+    const fn = createISLInferenceFn(mockCallAnalysis, req, 'req-1');
+
+    await fn('factor-x', 0.0);
+
+    const origTarget = (req.graph.nodes as any[]).find((n) => n.id === 'factor-x');
+    expect(origTarget.observed_state.value).toBe(0.7);             // original unchanged
+  });
+
+  it('concurrent probes each carry their own observed_state.value (no leakage)', async () => {
+    const captured: any[] = [];
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured.push(body);
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const fn = createISLInferenceFn(mockCallAnalysis, makeGraphRequest(), 'req-1');
+
+    // Run baseline/min/max concurrently, as resolveFlipValues' Step-0 does.
+    await Promise.all([fn('factor-x', 0.7), fn('factor-x', 0), fn('factor-x', 1)]);
+
+    const values = captured
+      .map((b) => (b.graph.nodes as any[]).find((n) => n.id === 'factor-x').observed_state.value)
+      .sort((a: number, b: number) => a - b);
+    expect(values).toEqual([0, 0.7, 1]);                           // each probe its own value
+  });
+});
+
+// =============================================================================
+// Contract-faithful comparison — proves the probe now moves the field ISL reads
+// =============================================================================
+
+describe('resolveFlipValues() with a contract-faithful comparison (observed_state.value-driven)', () => {
+  /**
+   * Mock ISL comparison that derives the winner SOLELY from the target factor's
+   * graph observed_state.value — the field ISL's comparison reads as the sampling
+   * mean — and IGNORES parameter_uncertainties.mean entirely. This mirrors the
+   * staging finding that comparison samples Normal(observed_state.value, PU.std).
+   *
+   * Under the previous PU-mean-only probe (which left observed_state.value
+   * unchanged), this comparison returns the same winner at every probe → no_effect.
+   * With the fix (probe mutates observed_state.value), low/high probes produce
+   * different winners → a real flip is detected.
+   */
+  function contractFaithfulMock(factorId: string, flipThreshold: number) {
+    return async (_ep: string, body: any) => {
+      const node = (body.graph.nodes as any[]).find((n) => n.id === factorId);
+      const v = node?.observed_state?.value ?? 0; // comparison reads the GRAPH value, not PU mean
+      const aWins = v >= flipThreshold;
+      return {
+        data: {
+          results: [
+            { option_id: 'opt-a', win_probability: aWins ? 0.7 : 0.3 },
+            { option_id: 'opt-b', win_probability: aWins ? 0.3 : 0.7 },
+          ],
+        },
+      };
+    };
+  }
+
+  function graphReq(targetValue: number) {
+    return {
+      graph: {
+        nodes: [
+          { id: 'delivery_gap', kind: 'factor', observed_state: { value: targetValue, std: 0.1, cap: 10, raw_value: targetValue * 10, unit: 'story_points' } },
+          { id: 'goal', kind: 'goal' },
+        ],
+        edges: [],
+      },
+      options: [
+        { id: 'opt-a', interventions: { 'delivery_gap': 0.1 } },
+        { id: 'opt-b', interventions: { 'delivery_gap': 0.9 } },
+      ],
+      goal_node_id: 'goal',
+      parameter_uncertainties: [{ node_id: 'delivery_gap', distribution: 'normal', mean: targetValue, std: 0.1 }],
+    };
+  }
+
+  it('detects a flip the comparison reads from observed_state.value (PU mean ignored)', async () => {
+    const fn = createISLInferenceFn(contractFaithfulMock('delivery_gap', 0.5), graphReq(0.7), 'req-1');
+    const candidate = makeCandidate({ factor_id: 'delivery_gap', current_value: 0.7, direction: 'decrease' });
+
+    const { results } = await resolveFlipValues([candidate], fn, 'opt-a');
+
+    // With the fix, low/high probes set different observed_state.value → winner moves.
+    expect(results[0].flip_reason).toBe('found');
+    expect(results[0].flip_value).not.toBeNull();
+    expect(results[0].flip_value!).toBeCloseTo(0.5, 1);
+    expect(results[0].alternative_winner_id).toBe('opt-b');
+    expect(results[0].margin_sensitivity?.movement).toBe('flipped');
+    // 3 Step-0 probes + bisection midpoints (probes_used > 3, iterations_used > 0).
+    expect(results[0].probes_used!).toBeGreaterThan(3);
+    expect(results[0].iterations_used!).toBeGreaterThan(0);
+  });
+
+  it('confirms the comparison ignores parameter_uncertainties.mean and tracks observed_state.value', async () => {
+    const mock = contractFaithfulMock('delivery_gap', 0.5);
+    const winner = (r: any) => [...r.data.results].sort((a, b) => b.win_probability - a.win_probability)[0].option_id;
+
+    // Same observed_state.value (0.7), different PU mean → winner UNCHANGED (old probe field).
+    const sameValueLowPU = graphReq(0.7); sameValueLowPU.parameter_uncertainties[0].mean = 0;
+    const sameValueHighPU = graphReq(0.7); sameValueHighPU.parameter_uncertainties[0].mean = 1;
+    expect(winner(await mock('x', sameValueLowPU))).toBe(winner(await mock('x', sameValueHighPU)));
+
+    // Different observed_state.value → winner CHANGES (the field the fix mutates).
+    expect(winner(await mock('x', graphReq(0.1)))).not.toBe(winner(await mock('x', graphReq(0.9))));
+  });
 });
 
 // =============================================================================

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -876,6 +876,27 @@ describe('createISLInferenceFn()', () => {
       .sort((a: number, b: number) => a - b);
     expect(values).toEqual([0, 0.7, 1]);                           // each probe its own value
   });
+
+  it('handles a target factor absent from the graph (no crash; graph unchanged; PU inserted)', async () => {
+    // Defensive only: production selection prevents this (current_value comes from the
+    // graph, so a flip candidate is always a graph node).
+    let captured: any = null;
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured = body;
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const req = makeGraphRequest();
+    const fn = createISLInferenceFn(mockCallAnalysis, req, 'req-1');
+
+    await fn('factor-missing', 0.42);
+
+    // No spurious node added; existing graph nodes/values intact.
+    expect((captured.graph.nodes as any[]).map((n) => n.id)).toEqual(['factor-x', 'factor-y', 'goal']);
+    expect((captured.graph.nodes as any[]).find((n) => n.id === 'factor-x').observed_state.value).toBe(0.7);
+    // PU still gets the factor inserted (existing fallback behaviour for non-graph factors).
+    const puMissing = (captured.parameter_uncertainties as any[]).find((p) => p.node_id === 'factor-missing');
+    expect(puMissing.mean).toBe(0.42);
+  });
 });
 
 // =============================================================================
@@ -915,16 +936,24 @@ describe('resolveFlipValues() with a contract-faithful comparison (observed_stat
       graph: {
         nodes: [
           { id: 'delivery_gap', kind: 'factor', observed_state: { value: targetValue, std: 0.1, cap: 10, raw_value: targetValue * 10, unit: 'story_points' } },
+          { id: 'cost', kind: 'factor', observed_state: { value: 0.5, std: 0.1, cap: 50000, raw_value: 25000, unit: 'GBP' } },
           { id: 'goal', kind: 'goal' },
         ],
         edges: [],
       },
+      // delivery_gap is intervened on by ONLY opt-a (partially overridden), so the
+      // PR #183 selection guard would NOT exclude it — i.e. a factor that legitimately
+      // reaches probing in production. (The contract-faithful mock ignores options; this
+      // is for fixture realism / coherence with the real selection flow.)
       options: [
         { id: 'opt-a', interventions: { 'delivery_gap': 0.1 } },
-        { id: 'opt-b', interventions: { 'delivery_gap': 0.9 } },
+        { id: 'opt-b', interventions: { 'cost': 0.3 } },
       ],
       goal_node_id: 'goal',
-      parameter_uncertainties: [{ node_id: 'delivery_gap', distribution: 'normal', mean: targetValue, std: 0.1 }],
+      parameter_uncertainties: [
+        { node_id: 'delivery_gap', distribution: 'normal', mean: targetValue, std: 0.1 },
+        { node_id: 'cost', distribution: 'normal', mean: 0.5, std: 0.1 },
+      ],
     };
   }
 


### PR DESCRIPTION
## Summary

The `__flip` assumption-threshold probe was varying a field ISL's comparison does not read, so it never detected flips that full analysis detects (the remaining Branch A blocker). This PR makes each probe mutate the **graph node's `observed_state.value`** — the field ISL uses as the factor centre — so probing now moves the winner. Builds on PR #183 (selection fix), live on staging (`cb44455`).

## Core fix
- Each `__flip` probe now sends a **probe-local cloned graph** whose target factor node has `observed_state.value = <probe value>` — the field ISL's comparison uses as the factor centre.
- `parameter_uncertainties[].mean` is kept **aligned** to the same value for contract honesty, but is **not relied on** for the behavioural fix.
- Change is confined to `createISLInferenceFn` (`src/analysis/flip-thresholds.ts`). The clone is probe-local: the original request graph is never mutated and concurrent Step-0 probes (baseline/0/1) cannot leak into one another.

## ISL source verification (confirms the black-box finding)
- ISL's `ParameterUncertainty` has **no `mean` field**; extra fields are ignored.
- `observed_state.value` is the factor **centre**; `parameter_uncertainties.std` is the **spread**.
- `observed_state.baseline` is **not read** on the V2 path.
- So overriding `parameter_uncertainties.mean` was inert by construction; mutating `observed_state.value` is the correct lever.

## Value representation (unchanged contract)
- `observed_state.value` remains the **normalised model value** (probe value is normalised [0,1]; scale preserved — no raw values written).
- `raw_value`, `cap`, `unit`, `std`, and `baseline` are **preserved** (display/denormalisation metadata + uncertainty width).
- **Options/interventions are unchanged** → this remains **assumption-threshold** probing, not intervention-threshold design.

## PR #183 behaviour intact
Fully-overridden factors still excluded; partially-overridden eligible; `probes_used` counts completed probes; `iterations_used` bisection-only; `flip_thresholds: []` honest empty state.

## Tests
- Request construction: low/high probes differ in target `observed_state.value`; PU mean aligned; non-target nodes & options unchanged.
- Immutability / no leakage: original graph untouched; concurrent probes isolated.
- Contract-faithful comparison stub that reads `observed_state.value` and ignores PU mean → flip found (non-null `flip_value`, `movement: flipped`) — **would report `no_effect` under the old PU-mean-only probe**.
- Defensive target-factor-absent path.

## Branch A status
**Remains pending.** The pending-scenario flag stays until staging acceptance proves non-zero `max_probe_delta` and a usable (non-null) `flip_value` for a non-/partially-overridden factor, plus no regression in fully-overridden exclusion.

## Housekeeping note (NOT addressed here)
Pre-existing: `resolveFlipValues`' comment says "max 2 concurrency" but the code runs all candidates concurrently (~5 candidates × 3 Step-0 probes ≈ 15 initial ISL calls). Not introduced by this PR; logged for future housekeeping only.

## CI context (known, unrelated debt)
- `audit` / `fast-uri` advisories may be red (CI-debt PR2; non-required).
- `gates (windows-latest)` colon-path (`tools/sdk-smoke:python.mjs`) may be red (CI-debt PR4).
- A known full-suite test-isolation flake (metrics / SCM-Lite factor-values) may require a retry; the `main`-required gates (`test`/`verify`/`guard`) are the signal.

## Scope
Only the flip-probe request-construction path + two doc comments + tests (3 files). No ISL/CEE/DGAI/UI, prompts/PMS, intervention-threshold design, EVPI, provenance, path decomposition, CI debt, packages, PR #238/#188, Branch A replay, or pending-flag changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)