### PR TITLE
fix(flip-thresholds): forward resolved analysis seed to flip-threshold probes (intentional CRN)

### DIFF
--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -538,11 +538,27 @@ function roundTo4(value: number): number {
  *    to the probe value — the field ISL's comparison reads as the sampling mean
  * 2. Keeps the target factor's parameter_uncertainties.mean aligned to the same
  *    value (contract honesty; the comparison shadows this field)
- * 3. Calls ISL via the service's callAnalysisEndpoint
- * 4. Returns the option comparison results
+ * 3. Forwards the resolved analysis seed (the same seed sent to the main ISL
+ *    robustness call) on every probe request
+ * 4. Calls ISL via the service's callAnalysisEndpoint
+ * 5. Returns the option comparison results
+ *
+ * Seed forwarding + intentional common random numbers: every probe in a single
+ * flip search receives `originalRequest.seed` — the resolved seed PLoT sends to
+ * the main analysis call (the explicit request seed, or the seed PLoT derived
+ * from the canonical request/graph when omitted). Holding the seed constant
+ * across probe points means ISL's PCG64 sampler draws the *same* edge
+ * configurations and factor-noise z-values at every probe; only the probed
+ * factor's sampling mean shifts. That preserves the deterministic
+ * common-random-numbers smoothness the bisection relies on, while aligning the
+ * probe world with the displayed base analysis (same seed → probe baseline
+ * margin matches the main-call margin within representation/rounding limits).
+ * We deliberately do NOT vary the seed per probe and do NOT fall back to ISL's
+ * graph-hash seed (which ignores the request seed).
  *
  * @param callAnalysis - Function that calls ISL analysis endpoint
- * @param originalRequest - The original ISL robustness request
+ * @param originalRequest - The original ISL robustness request (carries the
+ *   resolved seed forwarded to the main analysis call)
  * @param requestId - Request ID for tracing (suffixed with flip search context)
  * @returns ISLInferenceFn callback
  */
@@ -554,6 +570,10 @@ export function createISLInferenceFn(
     goal_node_id: string;
     n_samples?: number;
     parameter_uncertainties?: Array<{ node_id: string; distribution: string; mean: number; std: number }>;
+    // Resolved seed sent to the main ISL analysis call (explicit request seed,
+    // or PLoT-derived seed when omitted). Forwarded verbatim on every probe so
+    // common random numbers stay intentional and aligned with the base analysis.
+    seed?: string | number;
   },
   requestId: string
 ): ISLInferenceFn {
@@ -618,6 +638,13 @@ export function createISLInferenceFn(
       n_samples: originalRequest.n_samples,
       analysis_types: ['comparison'] as const,
       parameter_uncertainties: paramUncertainties,
+      // Forward the resolved analysis seed on every probe (intentional CRN —
+      // same seed across all probe points; never per-probe, never the
+      // graph-hash fallback). Omit the key entirely when no seed is present so
+      // ISL's existing graph-hash default still applies for seedless callers.
+      ...(originalRequest.seed !== undefined && originalRequest.seed !== null
+        ? { seed: originalRequest.seed }
+        : {}),
     };
 
     const result = await callAnalysis(

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -897,6 +897,91 @@ describe('createISLInferenceFn()', () => {
     const puMissing = (captured.parameter_uncertainties as any[]).find((p) => p.node_id === 'factor-missing');
     expect(puMissing.mean).toBe(0.42);
   });
+
+  // ===========================================================================
+  // Seed forwarding + intentional common random numbers (CRN)
+  //
+  // The probe request must carry the SAME resolved seed PLoT forwards to the
+  // main ISL analysis call (originalRequest.seed). run.ts sets that field to
+  // plotSeedUsed = resolveSeed(providedSeed, graph): the explicit request seed,
+  // or the PLoT-derived seed when omitted. Holding it constant across every
+  // probe keeps CRN deterministic and aligns the probe world with the base
+  // analysis. See createISLInferenceFn doc-comment.
+  // ===========================================================================
+
+  it('forwards the resolved analysis seed on the probe request', async () => {
+    let captured: any = null;
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured = body;
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const req = { ...makeGraphRequest(), seed: '4242' };
+    const fn = createISLInferenceFn(mockCallAnalysis, req, 'req-1');
+
+    await fn('factor-x', 0.25);
+
+    expect(captured.seed).toBe('4242');
+  });
+
+  it('forwards a PLoT-derived (omitted-then-resolved) numeric seed verbatim', async () => {
+    // When the request omits seed, run.ts resolves a derived seed from the
+    // canonical request/graph (resolveSeed → deriveSeedFromHash) BEFORE building
+    // islRequest, so originalRequest.seed is already the resolved derived value.
+    // The probe must forward that derived seed unchanged — never re-derive,
+    // never fall back to ISL's own graph-hash default.
+    let captured: any = null;
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured = body;
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const derivedSeed = 464372930; // shape of a resolveSeed()-derived value
+    const req = { ...makeGraphRequest(), seed: derivedSeed };
+    const fn = createISLInferenceFn(mockCallAnalysis, req, 'req-1');
+
+    await fn('factor-x', 0.5);
+
+    expect(captured.seed).toBe(derivedSeed);
+  });
+
+  it('uses ONE constant seed across all probe points (intentional CRN, never per-probe)', async () => {
+    const seenSeeds: unknown[] = [];
+    const mockCallAnalysis = async (_ep: string, body: any) => {
+      seenSeeds.push(body.seed);
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const req = { ...makeGraphRequest(), seed: '777' };
+    const fn = createISLInferenceFn(mockCallAnalysis, req, 'req-1');
+
+    // The three Step-0 probe points (baseline / min / max).
+    await Promise.all([fn('factor-x', 0.7), fn('factor-x', 0), fn('factor-x', 1)]);
+
+    expect(seenSeeds).toHaveLength(3);
+    expect(seenSeeds).toEqual(['777', '777', '777']); // same seed at every probe
+  });
+
+  it('omits seed entirely when originalRequest has no seed (preserves seedless-caller default)', async () => {
+    let captured: any = null;
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured = body;
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    // makeGraphRequest() carries no seed.
+    const fn = createISLInferenceFn(mockCallAnalysis, makeGraphRequest(), 'req-1');
+
+    await fn('factor-x', 0.3);
+
+    expect('seed' in captured).toBe(false); // key omitted → ISL graph-hash default applies
+  });
+
+  it('does not mutate the original request when forwarding the seed', async () => {
+    const mockCallAnalysis = async () => ({ data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } });
+    const req = { ...makeGraphRequest(), seed: '4242' };
+    const fn = createISLInferenceFn(mockCallAnalysis, req, 'req-1');
+
+    await fn('factor-x', 0.1);
+
+    expect(req.seed).toBe('4242'); // unchanged
+  });
 });
 
 // =============================================================================
@@ -1162,5 +1247,125 @@ describe('resolveFlipValues() margin_sensitivity integration', () => {
       expect(results[0].flip_reason).toBe('no_effect_within_bounds');
       expect(results[0].margin_sensitivity?.baseline_leading_option_id).toBe('a');
     });
+  });
+});
+
+// =============================================================================
+// Seed-driven flip determinism (end-to-end through the real createISLInferenceFn)
+//
+// These exercise the FULL probe path: resolveFlipValues → real
+// createISLInferenceFn → ISL request body (with the forwarded seed) → a
+// seed-sensitive ISL stub. They prove the forwarded seed actually changes what
+// the search converges to, and that the same seed is deterministic.
+// =============================================================================
+
+describe('resolveFlipValues() — seed forwarding drives flip determinism', () => {
+  /**
+   * Seed-sensitive ISL comparison stub: the flip point depends on body.seed.
+   * Winner is opt-a when the probed observed_state.value is at/above a
+   * seed-derived threshold in (0, baseline). Mirrors ISL's real behaviour
+   * (the seed shifts the sampled flip point) without a Monte Carlo sampler.
+   * Also records every seed it observed, for CRN/consistency assertions.
+   */
+  function seedThreshold(seed: unknown): number {
+    const n = Number(seed);
+    const s = Number.isFinite(n) ? Math.abs(Math.trunc(n)) : 0;
+    return 0.3 + (s % 5) * 0.05; // 0.30, 0.35, 0.40, 0.45, 0.50 — all inside (0, 0.7)
+  }
+
+  function makeSeedSensitiveCallAnalysis(factorId: string) {
+    const seenSeeds: unknown[] = [];
+    const callAnalysis = async (_ep: string, body: any) => {
+      seenSeeds.push(body.seed);
+      const node = (body.graph.nodes as any[]).find((n) => n.id === factorId);
+      const v = node?.observed_state?.value ?? 0;
+      const aWins = v >= seedThreshold(body.seed); // decrease search: high value → opt-a
+      return {
+        data: {
+          results: [
+            { option_id: 'opt-a', win_probability: aWins ? 0.7 : 0.3 },
+            { option_id: 'opt-b', win_probability: aWins ? 0.3 : 0.7 },
+          ],
+        },
+      };
+    };
+    return { callAnalysis, seenSeeds };
+  }
+
+  function seedFlipRequest(seed: number) {
+    return {
+      graph: {
+        nodes: [
+          { id: 'delivery_gap', kind: 'factor', observed_state: { value: 0.7, std: 0.1, cap: 10, raw_value: 7, unit: 'story_points' } },
+          { id: 'goal', kind: 'goal' },
+        ],
+        edges: [],
+      },
+      options: [
+        { id: 'opt-a', interventions: {} },
+        { id: 'opt-b', interventions: {} },
+      ],
+      goal_node_id: 'goal',
+      n_samples: 1000,
+      parameter_uncertainties: [
+        { node_id: 'delivery_gap', distribution: 'normal', mean: 0.7, std: 0.1 },
+      ],
+      seed,
+    };
+  }
+
+  const candidate = () => makeCandidate({ factor_id: 'delivery_gap', current_value: 0.7, direction: 'decrease' });
+
+  it('same seed → identical flip result (deterministic)', async () => {
+    const run = async () => {
+      const { callAnalysis } = makeSeedSensitiveCallAnalysis('delivery_gap');
+      const fn = createISLInferenceFn(callAnalysis, seedFlipRequest(10), 'req-seed');
+      const { results } = await resolveFlipValues([candidate()], fn, 'opt-a');
+      return results[0];
+    };
+
+    const a = await run();
+    const b = await run();
+
+    expect(a.flip_reason).toBe('found');
+    expect(a.flip_value).not.toBeNull();
+    expect(b.flip_value).toBe(a.flip_value); // byte-identical across repeats
+    // seed 10 → threshold 0.30
+    expect(a.flip_value!).toBeCloseTo(0.3, 1);
+  });
+
+  it('different seeds → different flip result (the forwarded seed is consumed)', async () => {
+    const runWithSeed = async (seed: number) => {
+      const { callAnalysis } = makeSeedSensitiveCallAnalysis('delivery_gap');
+      const fn = createISLInferenceFn(callAnalysis, seedFlipRequest(seed), 'req-seed');
+      const { results } = await resolveFlipValues([candidate()], fn, 'opt-a');
+      return results[0];
+    };
+
+    const low = await runWithSeed(10); // threshold 0.30
+    const high = await runWithSeed(14); // threshold 0.50
+
+    expect(low.flip_reason).toBe('found');
+    expect(high.flip_reason).toBe('found');
+    expect(low.flip_value!).toBeCloseTo(0.3, 1);
+    expect(high.flip_value!).toBeCloseTo(0.5, 1);
+    expect(high.flip_value).not.toBe(low.flip_value); // seed changed the threshold
+  });
+
+  it('every probe in one search carries the same forwarded seed (CRN), and different searches carry different seeds', async () => {
+    const a = makeSeedSensitiveCallAnalysis('delivery_gap');
+    const fnA = createISLInferenceFn(a.callAnalysis, seedFlipRequest(10), 'req-a');
+    await resolveFlipValues([candidate()], fnA, 'opt-a');
+
+    const b = makeSeedSensitiveCallAnalysis('delivery_gap');
+    const fnB = createISLInferenceFn(b.callAnalysis, seedFlipRequest(14), 'req-b');
+    await resolveFlipValues([candidate()], fnB, 'opt-a');
+
+    // Within a single search: every probe used the one resolved seed (CRN).
+    expect(a.seenSeeds.length).toBeGreaterThan(3); // Step-0 (3) + bisection midpoints
+    expect(new Set(a.seenSeeds)).toEqual(new Set([10]));
+    expect(new Set(b.seenSeeds)).toEqual(new Set([14]));
+    // Across searches: the probe requests carried different seeds.
+    expect(new Set(a.seenSeeds)).not.toEqual(new Set(b.seenSeeds));
   });
 });

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -988,6 +988,12 @@ describe('createISLInferenceFn()', () => {
   // explicit !== undefined && !== null, so falsy-but-valid seeds (0, '') are
   // forwarded; a future "simplify to a truthy check" would silently drop them
   // and break determinism for seed 0 — these cases lock that in.
+  //
+  // NB: '' is asserted as a PRESENT seed (forwarded), which documents this
+  // layer's verbatim behaviour only. Whether an empty string is a *valid*
+  // product-level seed (vs invalid/seedless) is a route/schema concern decided
+  // by the /v2/run contract + resolveSeed(), not here — changing it would be a
+  // separate route/schema change.
   it.each([
     { label: 'numeric string', seed: '4242', expected: '4242' },
     { label: 'number', seed: 4242, expected: 4242 },

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -982,6 +982,47 @@ describe('createISLInferenceFn()', () => {
 
     expect(req.seed).toBe('4242'); // unchanged
   });
+
+  // Boundary values: the probe forwards the resolved seed VERBATIM (no
+  // normalisation — resolveSeed does that upstream). The conditional uses
+  // explicit !== undefined && !== null, so falsy-but-valid seeds (0, '') are
+  // forwarded; a future "simplify to a truthy check" would silently drop them
+  // and break determinism for seed 0 — these cases lock that in.
+  it.each([
+    { label: 'numeric string', seed: '4242', expected: '4242' },
+    { label: 'number', seed: 4242, expected: 4242 },
+    { label: 'zero (falsy but valid)', seed: 0, expected: 0 },
+    { label: 'empty string (falsy but present)', seed: '', expected: '' },
+    { label: 'non-numeric string', seed: 'derived-seed', expected: 'derived-seed' },
+  ])('forwards a $label seed verbatim', async ({ seed, expected }) => {
+    let captured: any = null;
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured = body;
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const fn = createISLInferenceFn(mockCallAnalysis, { ...makeGraphRequest(), seed }, 'req-1');
+
+    await fn('factor-x', 0.4);
+
+    expect('seed' in captured).toBe(true);
+    expect(captured.seed).toBe(expected);
+  });
+
+  it.each([
+    { label: 'explicit null', seed: null },
+    { label: 'explicit undefined', seed: undefined },
+  ])('omits the seed key for $label (preserves ISL graph-hash default)', async ({ seed }) => {
+    let captured: any = null;
+    const mockCallAnalysis = async (_ep: string, body: unknown) => {
+      captured = body;
+      return { data: { results: [{ option_id: 'opt-a', win_probability: 1.0 }] } };
+    };
+    const fn = createISLInferenceFn(mockCallAnalysis, { ...makeGraphRequest(), seed } as any, 'req-1');
+
+    await fn('factor-x', 0.4);
+
+    expect('seed' in captured).toBe(false);
+  });
 });
 
 // =============================================================================

--- a/tests/v2-run.flip-probe-seed.contract.test.ts
+++ b/tests/v2-run.flip-probe-seed.contract.test.ts
@@ -210,4 +210,29 @@ describe('V2 Run · flip-threshold probes carry the resolved seed', () => {
     expect(seedsRun2).toEqual(new Set(['999']));
     expect(seedsRun1).not.toEqual(seedsRun2);
   });
+
+  it('numeric seed 0 → route normalises to "0" and every probe carries it (falsy seed survives end-to-end)', async () => {
+    // The unit test proves createISLInferenceFn forwards 0; this proves the full
+    // route path: resolveSeed(0) → "0" (the public path String()-normalises the
+    // number), and that normalised seed reaches every flip probe. Guards the
+    // classic falsy-zero trap across the whole /v2/run → probe chain.
+    capturedBodies.length = 0;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: 0 }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.meta.seed_used).toBe('0'); // numeric 0 normalised to "0", not dropped
+    expect(body.meta.seed_source).toBe('client_generated');
+
+    const probes = flipProbeBodies();
+    expect(probes.length).toBeGreaterThan(0);
+    for (const p of probes) {
+      expect(String(p.seed)).toBe('0'); // probe carries the normalised resolved seed
+    }
+  });
 });

--- a/tests/v2-run.flip-probe-seed.contract.test.ts
+++ b/tests/v2-run.flip-probe-seed.contract.test.ts
@@ -1,0 +1,213 @@
+/**
+ * /v2/run route-level contract: flip-threshold probes carry the resolved seed.
+ *
+ * The unit tests in tests/analysis/flip-thresholds.test.ts prove
+ * createISLInferenceFn forwards originalRequest.seed. This file exercises the
+ * FULL assembly path through a real POST to `/v2/run`, asserting that the
+ * resolved seed PLoT forwards to the MAIN ISL analysis call is the SAME seed
+ * attached to every flip-threshold probe request — including the case where the
+ * request omits seed and PLoT derives one from the canonical request/graph.
+ *
+ * ISL is mocked in-process; the mock captures every analyze/v2 body so the test
+ * can read the seed off the `__flip` probe requests and compare it against the
+ * response's resolved seed_used.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// ISL Mock — captures every analyze/v2 request body (main + flip probes)
+// ---------------------------------------------------------------------------
+
+const capturedBodies: any[] = [];
+
+function optionComparison(options: any[]) {
+  return options.map((opt: any, idx: number) => ({
+    option_id: opt.id,
+    win_probability: 0.6 - idx * 0.2, // distinct winner (opt1 > opt2)
+    outcome: { mean: 0.65 + idx * 0.12, std: 0.08, p10: 0.45, p50: 0.65, p90: 0.85, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+    rank: idx + 1,
+  }));
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock validation', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      options: optionComparison(options),
+      edges: [
+        { from: 'factor-a', to: 'goal', sensitivity: 0.5, confidence: 0.8, direction: 'positive' },
+        { from: 'factor-b', to: 'goal', sensitivity: -0.3, confidence: 0.7, direction: 'negative' },
+      ],
+      edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [
+        { node_id: 'factor-a', sensitivity: 0.5, confidence: 0.8, direction: 'positive' },
+        { node_id: 'factor-b', sensitivity: -0.3, confidence: 0.7, direction: 'negative' },
+      ],
+      value_of_information: [],
+      factors_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      factor_sensitivity_status: 'available' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.82,
+      fragile_edges: [], robust_edges: [],
+      latency_ms: 42, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.82, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    capturedBodies.push(body);
+    const options = body.options || [];
+    return {
+      data: {
+        options: optionComparison(options),
+        edges: [
+          { from: 'factor-a', to: 'goal', sensitivity: 0.5, confidence: 0.8, direction: 'positive' },
+          { from: 'factor-b', to: 'goal', sensitivity: -0.3, confidence: 0.7, direction: 'negative' },
+        ],
+        factors: [
+          { node_id: 'factor-a', sensitivity: 0.5, confidence: 0.8, direction: 'positive' },
+          { node_id: 'factor-b', sensitivity: -0.3, confidence: 0.7, direction: 'negative' },
+        ],
+        value_of_information: [],
+        overall_robustness: 'robust', robustness_score: 0.82,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — two factors, each intervened by a DIFFERENT option, so neither is
+// overridden-by-all (PR #183) and both remain flip-threshold candidates → the
+// probe path runs and produces __flip analyze/v2 requests.
+// ---------------------------------------------------------------------------
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+    { id: 'factor-b', kind: 'factor', label: 'Customer Churn', observed_state: { value: 0.5 } },
+  ],
+  edges: [
+    { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'factor-b', to: 'goal', strength: { mean: -0.3, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 0.8 } },
+  { id: 'opt2', label: 'Reduce Churn', interventions: { 'factor-b': 0.3 } },
+];
+
+/** Probe requests carry request_id `<rid>__flip_<factorId>`. */
+function flipProbeBodies() {
+  return capturedBodies.filter((b) => typeof b?.request_id === 'string' && b.request_id.includes('__flip'));
+}
+
+describe('V2 Run · flip-threshold probes carry the resolved seed', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  it('explicit request seed → every flip probe body carries that same seed (= main-call seed_used)', async () => {
+    capturedBodies.length = 0;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '4242' }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    const seedUsed = body.meta.seed_used;
+    expect(seedUsed).toBe('4242');
+
+    const probes = flipProbeBodies();
+    expect(probes.length).toBeGreaterThan(0); // flip path actually ran
+    for (const p of probes) {
+      // ISL request seed is forwarded verbatim; compare as strings to be
+      // representation-agnostic (string vs number).
+      expect(String(p.seed)).toBe(String(seedUsed));
+    }
+  });
+
+  it('omitted request seed → probes carry the PLoT-derived resolved seed (same as main-call seed_used)', async () => {
+    capturedBodies.length = 0;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal' }), // no seed
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    const seedUsed = body.meta.seed_used;
+    // PLoT derived a non-empty seed from the canonical request/graph.
+    expect(seedUsed).toBeDefined();
+    expect(String(seedUsed).length).toBeGreaterThan(0);
+    expect(body.meta.seed_source).toBe('server_generated');
+
+    const probes = flipProbeBodies();
+    expect(probes.length).toBeGreaterThan(0);
+    for (const p of probes) {
+      expect(p.seed).toBeDefined(); // NOT falling back to ISL's graph-hash default
+      expect(String(p.seed)).toBe(String(seedUsed)); // derived seed === probe seed === main-call seed
+    }
+  });
+
+  it('different seeds → flip probe requests carry different seeds (seed is consumed, not inert)', async () => {
+    capturedBodies.length = 0;
+    await app.inject({
+      method: 'POST', url: '/v2/run', headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '111' }),
+    });
+    const seedsRun1 = new Set(flipProbeBodies().map((p) => String(p.seed)));
+
+    capturedBodies.length = 0;
+    await app.inject({
+      method: 'POST', url: '/v2/run', headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '999' }),
+    });
+    const seedsRun2 = new Set(flipProbeBodies().map((p) => String(p.seed)));
+
+    expect(seedsRun1).toEqual(new Set(['111'])); // CRN: one seed across all probes in a run
+    expect(seedsRun2).toEqual(new Set(['999']));
+    expect(seedsRun1).not.toEqual(seedsRun2);
+  });
+});


### PR DESCRIPTION
## Summary
Flip-threshold probe requests were built without a `seed`, so ISL fell back to a graph-hash-derived seed that ignores the request seed. Because that fallback hash excludes the probed value, all probe points shared draws by accident — common random numbers, but in a **different Monte Carlo world** than the displayed base analysis (probe baseline margin diverged from the main-call margin). This forwards the **same resolved seed** PLoT already sends to the main ISL robustness call onto every flip-threshold probe.

## Change (single area)
`src/analysis/flip-thresholds.ts` · `createISLInferenceFn`:
- add `seed?: string | number` to the `originalRequest` type;
- include `seed` in the per-probe `modifiedRequest`, **omitting the key entirely when no seed is present** so seedless callers keep ISL's graph-hash default.

The `/v2/run` call site already passes `islRequest`, whose seed is `plotSeedUsed = resolveSeed(providedSeed, graph)` (the explicit request seed, or the PLoT-derived seed when omitted) — so **no route change**. The coaching flip-threshold path only selects candidates and builds no ISL requests, so it is untouched. **There is no second flip-probe ISL request path.**

## Behaviour
- Probe world aligns with base analysis: same seed → probe baseline margin matches the main-call margin within representation/rounding limits.
- Intentional CRN preserved: **one constant seed across all probe points** within a single search (never per-probe, never the graph-hash fallback).

## Acceptance signal (durable)
The durable acceptance signal is **probe baseline margin matching the main-call margin under the resolved seed** — not any specific flip value. Verified locally against staging ISL with the `delivery_gap` artefact (seed 4242): probe baseline margin moved **0.309 → 0.346** to match the main-call margin; `max_probe_delta` moved −1.052 → −1.129 (the probe MC world genuinely changed).

**`delivery_gap.flip_value = 6.055` is not a fixed contract.** It happened to remain `6.055` at `n=1000` only because the crossing landed at the same bisection midpoint within ~0.1-story-point resolution — but it is now produced under the **aligned** seed. **Future acceptance should re-capture the current artefact value rather than hard-code the old number.**

## Out of scope (unchanged)
Response hashing, timeout behaviour, default `n_samples`, ISL, CEE, DGAI/UI, prompts/PMS, schemas/contracts. No Branch A replay.

## Tests
- `tests/analysis/flip-thresholds.test.ts`: probe forwards the resolved seed; forwards a PLoT-derived (omitted-then-resolved) seed; one constant seed across all probe points (CRN); omits seed when absent (graph-hash default preserved); no mutation of the original request; same seed → identical flip result; different seeds → different result / different probe seeds.
- `tests/v2-run.flip-probe-seed.contract.test.ts` (new): full `/v2/run` path — explicit and omitted-then-derived seeds both reach every `__flip` probe and equal `meta.seed_used`; different seeds → different probe seeds.

## Reviewer checklist (Codex focus)
- [ ] No hidden second flip-probe ISL request path (only `createISLInferenceFn` builds probe requests; coaching path selects candidates only).
- [ ] Probes receive the **resolved** seed (`plotSeedUsed`), not merely the raw optional request seed.
- [ ] Omitted-seed path forwards the **derived** resolved seed (covered by the contract test's omitted-then-derived case).
- [ ] Seedless callers with truly no seed preserve ISL's graph-hash default (key omitted).
- [ ] Probe points share one seed within a single search (intentional CRN).
- [ ] Response hash, timeout behaviour, default `n_samples`, ISL, CEE, DGAI/UI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
