### PR TITLE
fix(flip-thresholds): null flip_value on binary-search timeout (timeout-honesty)

### DIFF
--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -337,15 +337,23 @@ async function searchFlipForFactor(
 
     for (let i = 0; i < config.maxIterations; i++) {
       if (Date.now() >= factorDeadline) {
-        const flipValue = roundTo4(midpoint(searchLow, searchHigh));
+        // The bracket midpoint is a partial-search artefact: where the bisection
+        // happened to stop when the wall-clock deadline hit, NOT a converged
+        // threshold. It must never be surfaced as a usable `flip_value`. We keep
+        // it (and the far winner) in `diag` only — diagnostics are log-only and
+        // never reach the public response — and emit a null-threshold result so
+        // downstream consumers classify this as unresolved. `margin_sensitivity`
+        // is retained: it reflects the completed Step-0 probes (a real finding
+        // that the winner changes within bounds), independent of the timeout.
+        const partialMidpoint = roundTo4(midpoint(searchLow, searchHigh));
         diag.iterations_used = iterations;
         diag.probes_used = probes;
         diag.precision_achieved = Math.abs(searchHigh - searchLow);
         diag.flip_reason = 'timeout';
-        diag.flip_value = flipValue;
+        diag.flip_value = partialMidpoint;
         diag.alternative_winner_id = farWinner;
         return {
-          result: { ...candidate, flip_value: flipValue, flip_reason: 'timeout', iterations_used: iterations, probes_used: probes, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
+          result: { ...candidate, flip_value: null, flip_reason: 'timeout', iterations_used: iterations, probes_used: probes, alternative_winner_id: null, margin_sensitivity: marginSensitivity },
           diagnostics: diag,
         };
       }

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -345,7 +345,7 @@ describe('resolveFlipValues()', () => {
       const slowMock = createSlowLowerBoundFlipMock(100);
       const candidate = makeCandidate({ current_value: 0.9, direction: 'decrease' });
 
-      const { results } = await resolveFlipValues([candidate], slowMock, 'opt-a', {
+      const { results, diagnostics } = await resolveFlipValues([candidate], slowMock, 'opt-a', {
         perFactorTimeoutMs: 20,
         overallTimeoutMs: 20,
       });
@@ -368,6 +368,21 @@ describe('resolveFlipValues()', () => {
       // timeout branch, not the pre-probe branch (which carries no margin_sensitivity).
       expect(r.margin_sensitivity).toBeDefined();
       expect(r.margin_sensitivity?.movement).toBe('flipped');
+
+      // Diagnostic-only preservation: the partial-search midpoint and far winner
+      // MUST survive in diagnostics (log-only) even though they are suppressed from
+      // the public result above. Bracket is [0, baseline=0.9] (only the min bound
+      // flips), so the midpoint at timeout is 0.45 and the far winner is 'opt-b'.
+      // Asserting both halves locks the full contract: preserved for debugging,
+      // never surfaced as a usable threshold.
+      const d = diagnostics[0];
+      expect(d.flip_reason).toBe('timeout');
+      expect(d.flip_value).not.toBeNull();
+      expect(d.flip_value).toBeCloseTo(0.45, 4);
+      expect(d.alternative_winner_id).toBe('opt-b');
+      // The whole point: diagnostics keep the midpoint, the public result nulls it.
+      expect(r.flip_value).toBeNull();
+      expect(d.flip_value).not.toBe(r.flip_value);
     });
   });
 

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -315,28 +315,59 @@ describe('resolveFlipValues()', () => {
   });
 
   describe('Timeout Handling', () => {
-    it('returns timeout when per-factor timeout exceeded', async () => {
-      // Create a slow mock
-      const slowMock: ISLInferenceFn = async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
+    /**
+     * Mock that flips the winner ONLY at the lower bound (mean === 0) and sleeps
+     * on every probe. The Step-0 probes (baseline, min, max) run in parallel and
+     * each sleep `delayMs`, so by the time they resolve the per-factor deadline
+     * has already elapsed — driving a genuine wall-clock timeout into the
+     * binary-search loop's deadline check. The winner change at the lower bound
+     * forces a bracket to be set (strict flip), so the ONLY reachable outcome is
+     * the binary-search timeout branch — eliminating the old test's
+     * timeout/no_effect/found ambiguity.
+     */
+    function createSlowLowerBoundFlipMock(delayMs: number): ISLInferenceFn {
+      return async (_factorId: string, overrideMean: number): Promise<FlipInferenceResult> => {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        const flipped = overrideMean <= 0; // only the min bound (mean=0) flips
         return {
           options: [
-            { option_id: 'opt-a', win_probability: 0.6 },
-            { option_id: 'opt-b', win_probability: 0.4 },
+            { option_id: 'opt-a', win_probability: flipped ? 0.35 : 0.65 },
+            { option_id: 'opt-b', win_probability: flipped ? 0.65 : 0.35 },
           ],
         };
       };
+    }
 
+    it('does NOT surface the partial-search midpoint as flip_value on a genuine timeout', async () => {
+      // Real-deadline timeout: deadline (20ms) << Step-0 probe time (~100ms), so the
+      // loop's `Date.now() >= factorDeadline` check fires before any binary iteration.
+      // This is a genuine wall-clock timeout (not an injected flip_reason flag).
+      const slowMock = createSlowLowerBoundFlipMock(100);
       const candidate = makeCandidate({ current_value: 0.9, direction: 'decrease' });
 
       const { results } = await resolveFlipValues([candidate], slowMock, 'opt-a', {
-        perFactorTimeoutMs: 100, // Very short timeout
-        overallTimeoutMs: 200,
+        perFactorTimeoutMs: 20,
+        overallTimeoutMs: 20,
       });
 
       expect(results).toHaveLength(1);
-      // Should either timeout or complete (if the 3 probing calls were fast enough)
-      expect(['timeout', 'no_effect_within_bounds', 'found']).toContain(results[0].flip_reason);
+      const r = results[0];
+
+      // Authoritative honesty gate: timeout exposes no usable numeric threshold.
+      expect(r.flip_reason).toBe('timeout');
+      expect(r.flip_value).toBeNull();
+      expect(r.alternative_winner_id).toBeNull();
+
+      // iterations_used preserved (the timeout fired at the top of the loop).
+      expect(typeof r.iterations_used).toBe('number');
+      expect(r.iterations_used).toBeGreaterThanOrEqual(0);
+
+      // margin_sensitivity is retained — it reflects the COMPLETED Step-0 probes,
+      // and movement stays truthful ('flipped', since the lower bound's winner
+      // differs from baseline). Its presence also proves this is the binary-search
+      // timeout branch, not the pre-probe branch (which carries no margin_sensitivity).
+      expect(r.margin_sensitivity).toBeDefined();
+      expect(r.margin_sensitivity?.movement).toBe('flipped');
     });
   });
 

--- a/tests/lib/flip-threshold-status.test.ts
+++ b/tests/lib/flip-threshold-status.test.ts
@@ -189,5 +189,17 @@ describe('classifyFlipThresholdsStatus()', () => {
         status_reason: 'something_new_in_a_future_isl_version',
       });
     });
+
+    it('classifies the post-fix timeout producer shape { flip_value: null, flip_reason: "timeout" } as unresolved, never computed', () => {
+      // Mirrors exactly what the binary-search timeout branch now emits after the
+      // timeout-honesty fix: a null threshold with reason 'timeout'. This MUST be
+      // unresolved (not computed) so no downstream surface treats the absent
+      // threshold as actionable. Before the fix this entry carried a non-null
+      // bracket-midpoint flip_value and was misclassified as 'computed'.
+      const entries = [makeEntry({ flip_value: null, flip_reason: 'timeout' })];
+      const result = classifyFlipThresholdsStatus(entries);
+      expect(result).toEqual({ status: 'unresolved', status_reason: 'timeout' });
+      expect(result.status).not.toBe('computed');
+    });
   });
 });


### PR DESCRIPTION
## Summary

When the flip-threshold **binary search times out mid-search**, the public result previously exposed the current **bracket midpoint** as `flip_value` (with `flip_reason: "timeout"`). That midpoint is a wall-clock-dependent **partial-search artefact**, not a converged threshold — yet it looked like a usable precise value and was misclassified as `flip_thresholds_status: "computed"` downstream.

This makes the binary-search timeout branch **honest**, matching the sibling pre-probe and grid-fallback timeout paths (which already emit `flip_value: null`).

## The only production change

`src/analysis/flip-thresholds.ts` — the **binary-search timeout branch only**. Public timeout `result` shape:

| field | before | after |
|---|---|---|
| `flip_value` | `<bracket midpoint>` | **`null`** |
| `flip_reason` | `"timeout"` | `"timeout"` (preserved) |
| `alternative_winner_id` | `farWinner` | **`null`** |
| `margin_sensitivity` | present | **present (preserved)** |
| `iterations_used` / `probes_used` | present | present (preserved) |

The partial midpoint + far winner are retained in `diag` only (**log-only** — `run.ts` logs `diagnostics`; only `.results` enters the response). `margin_sensitivity.movement` (e.g. `"flipped"`) is preserved because it reflects the **completed Step-0 probes** — a real finding that the winner changes within bounds, independent of the timeout. Its `strongest_probe_value` is a bound (`0`/`1`/`null`), never the midpoint.

**Authoritative honesty gate:** `flip_reason`/`flip_value`. No downstream surface may present a usable threshold from `movement: "flipped"` alone.

## No schema / contract change

The entry shape already allows `flip_value: number | null` and `flip_reason: "timeout"`. This brings the code **into line with** the already-documented `flip_thresholds_status: "unresolved"` contract (previously code reported `"computed"` for timeouts — a contract mismatch this fixes).

## Tests

- `tests/analysis/flip-thresholds.test.ts` — replaced the flaky timeout test with a **deterministic genuine-timeout regression**: a real wall-clock deadline (20ms ≪ ~100ms Step-0 probe sleep) drives the binary-search loop's `Date.now() >= factorDeadline` check — **not** a mocked `flip_reason`. Asserts `flip_value: null`, `alternative_winner_id: null`, and preserved `margin_sensitivity.movement: "flipped"` (the latter also proves it is the binary-search branch, not the pre-probe branch which carries no `margin_sensitivity`).
- `tests/lib/flip-threshold-status.test.ts` — locks that the post-fix shape `{ flip_value: null, flip_reason: "timeout" }` classifies as `unresolved`, **never** `computed`.

Pre-push gate (full suite + tsc + spectral): **4936 passed, 25 skipped, 0 failures**.

## Review focus

1. **Independently confirm no in-repo consumer** treats timeout `movement: "flipped"`, `margin_sensitivity`, or the preserved diagnostic fields as sufficient to render a usable threshold **without** checking `flip_reason` / non-null `flip_value`. (Consumers to check: `flip-threshold-status.ts`, `flip-thresholds-margin-status.ts`, `flip-threshold-denormaliser.ts`, `routes/v2/run.ts`, `cee/decision-review-orchestrator.ts`.)
2. **Confirm DGAI/UI `TippingPointsList` / UI-SEM-037 remains a separate follow-up** (downstream repo), **not** part of this PR. It should gate numeric-threshold rendering on `flip_reason` / non-null `flip_value`, not `movement` alone — lower risk after this fix since timeout now sends `null`, not a midpoint.

## Scope / non-goals

Exactly 3 files. No schema/OpenAPI, ISL, CEE, DGAI/UI, prompts/PMS, response-hash, default `n_samples`, seed-forwarding, `insufficient_precision`, contract-hygiene, or generated/`dist`/`node_modules` changes.

## Out of scope (logged separately)

- `insufficient_precision` honesty review — it **completes** the search at loose precision (a defensible approximate threshold, unlike a timeout artefact); deliberately unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)