### PR TITLE
feat(track-s): raise standard MC sample depth 1000->4000 (env rollback) [PR-E]

### DIFF
--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -17,7 +17,7 @@
 
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
 import { computeMarginSensitivity, type MarginSensitivity } from './margin-sensitivity.js';
-import { parseBoundedIntEnv, MIN_N_SAMPLES, MAX_N_SAMPLES } from '../config/env-int.js';
+import { resolveBoundedIntEnvOrWarn, MIN_N_SAMPLES, MAX_N_SAMPLES } from '../config/env-int.js';
 
 // =============================================================================
 // Types
@@ -95,7 +95,7 @@ export const DEFAULT_FLIP_PROBE_N_SAMPLES = 1000;
  *     run deeper than the base, and crucially do NOT scale up when the base does.
  */
 export function resolveFlipProbeNSamples(baseNSamples?: number): number {
-  const envOverride = parseBoundedIntEnv(process.env.FLIP_PROBE_N_SAMPLES, MIN_N_SAMPLES, MAX_N_SAMPLES);
+  const envOverride = resolveBoundedIntEnvOrWarn('FLIP_PROBE_N_SAMPLES', MIN_N_SAMPLES, MAX_N_SAMPLES);
   if (envOverride !== null) return envOverride;
   const base = typeof baseNSamples === 'number' && Number.isFinite(baseNSamples) && baseNSamples > 0
     ? baseNSamples

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -17,6 +17,7 @@
 
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
 import { computeMarginSensitivity, type MarginSensitivity } from './margin-sensitivity.js';
+import { parseBoundedIntEnv, MIN_N_SAMPLES, MAX_N_SAMPLES } from '../config/env-int.js';
 
 // =============================================================================
 // Types
@@ -88,16 +89,14 @@ export const DEFAULT_FLIP_PROBE_N_SAMPLES = 1000;
  * Resolve the sample depth to use for flip probes, independent of base depth.
  *
  * Precedence:
- *  1. `FLIP_PROBE_N_SAMPLES` env (absolute ops override — may exceed base);
+ *  1. `FLIP_PROBE_N_SAMPLES` env — strictly parsed, in-bounds (100..10000) ops
+ *     override (may exceed base); malformed/out-of-bounds values are ignored;
  *  2. otherwise `min(DEFAULT_FLIP_PROBE_N_SAMPLES, baseNSamples)` — probes never
  *     run deeper than the base, and crucially do NOT scale up when the base does.
  */
 export function resolveFlipProbeNSamples(baseNSamples?: number): number {
-  const raw = process.env.FLIP_PROBE_N_SAMPLES;
-  if (raw !== undefined && raw.trim() !== '') {
-    const parsed = parseInt(raw, 10);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  }
+  const envOverride = parseBoundedIntEnv(process.env.FLIP_PROBE_N_SAMPLES, MIN_N_SAMPLES, MAX_N_SAMPLES);
+  if (envOverride !== null) return envOverride;
   const base = typeof baseNSamples === 'number' && Number.isFinite(baseNSamples) && baseNSamples > 0
     ? baseNSamples
     : DEFAULT_FLIP_PROBE_N_SAMPLES;

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -73,6 +73,38 @@ function getDefaultConfig(): FlipSearchConfig {
 }
 
 /**
+ * Track S — Flip-probe sample depth (decoupled from base analysis depth).
+ *
+ * Each flip probe is a full ISL `comparison` call inside a binary search under a
+ * fixed per-factor/overall time budget. If probes inherited the base analysis
+ * `n_samples`, raising the base depth would slow every probe and push the search
+ * into timeout (observed: flip-threshold timeouts rose from ~1/12 runs at 1000
+ * samples to ~3/12 at 4000). Decoupling lets the base analysis use a higher depth
+ * for display-stable probabilities while flip probes stay fast.
+ */
+export const DEFAULT_FLIP_PROBE_N_SAMPLES = 1000;
+
+/**
+ * Resolve the sample depth to use for flip probes, independent of base depth.
+ *
+ * Precedence:
+ *  1. `FLIP_PROBE_N_SAMPLES` env (absolute ops override — may exceed base);
+ *  2. otherwise `min(DEFAULT_FLIP_PROBE_N_SAMPLES, baseNSamples)` — probes never
+ *     run deeper than the base, and crucially do NOT scale up when the base does.
+ */
+export function resolveFlipProbeNSamples(baseNSamples?: number): number {
+  const raw = process.env.FLIP_PROBE_N_SAMPLES;
+  if (raw !== undefined && raw.trim() !== '') {
+    const parsed = parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  const base = typeof baseNSamples === 'number' && Number.isFinite(baseNSamples) && baseNSamples > 0
+    ? baseNSamples
+    : DEFAULT_FLIP_PROBE_N_SAMPLES;
+  return Math.min(DEFAULT_FLIP_PROBE_N_SAMPLES, base);
+}
+
+/**
  * Per-factor diagnostics emitted alongside flip_thresholds_resolved log event.
  */
 export interface FlipDiagnostics {
@@ -583,7 +615,10 @@ export function createISLInferenceFn(
     // common random numbers stay intentional and aligned with the base analysis.
     seed?: string | number;
   },
-  requestId: string
+  requestId: string,
+  // Track S: sample depth for flip probes, decoupled from base analysis depth.
+  // When omitted, probes fall back to the base request's n_samples (legacy behaviour).
+  flipProbeNSamples?: number
 ): ISLInferenceFn {
   return async (factorId: string, overrideMean: number): Promise<FlipInferenceResult> => {
     // Clone parameter_uncertainties with the target factor's mean overridden
@@ -643,7 +678,9 @@ export function createISLInferenceFn(
       graph: probeGraph,
       options: originalRequest.options,
       goal_node_id: originalRequest.goal_node_id,
-      n_samples: originalRequest.n_samples,
+      // Track S: probes use their own depth (decoupled). Falls back to base depth
+      // when no probe depth is supplied, preserving legacy behaviour for old callers.
+      n_samples: flipProbeNSamples ?? originalRequest.n_samples,
       analysis_types: ['comparison'] as const,
       parameter_uncertainties: paramUncertainties,
       // Forward the resolved analysis seed on every probe (intentional CRN —

--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -65,10 +65,17 @@ function computeBriefId(graphHash: string, seed: number, configVersion: string):
   ].join('-');
 }
 
-/** Compute config_version as SHA-256 hash of computation-affecting config values. */
-function computeConfigVersion(): string {
+/**
+ * Compute config_version as SHA-256 hash of computation-affecting config values.
+ *
+ * Track S: the sample depth is now a per-request input (was hardcoded 1000), so
+ * briefs computed at different depths get different config_versions (and thus
+ * different brief_ids). Defaults to 1000 when omitted, which reproduces the
+ * pre-Track-S hash for callers that don't supply a depth.
+ */
+function computeConfigVersion(nSamples: number = 1000): string {
   const configInputs = {
-    n_samples_default: 1000,
+    n_samples_default: nSamples,
     enable_review_pass: process.env.ENABLE_REVIEW_PASS ?? 'default',
     enable_facts_assembly: process.env.ENABLE_FACTS_ASSEMBLY ?? 'default',
     brief_assembly_version: '1',
@@ -96,6 +103,8 @@ export type BriefAssemblyInput = Pick<RunResponseV3, 'analysis_status' | 'critiq
   response_hash?: string;
   meta: {
     seed_used: string;
+    /** Track S: resolved Monte Carlo sample depth (drives config_version + lineage.n_samples) */
+    n_samples?: number;
   };
 };
 
@@ -388,8 +397,12 @@ function buildWarnings(input: BriefAssemblyInput, isPartial: boolean): BriefWarn
 }
 
 function buildLineage(input: BriefAssemblyInput): BriefLineage {
+  const nSamples = input.meta.n_samples;
   return {
-    config_version: computeConfigVersion(),
+    config_version: computeConfigVersion(nSamples),
     response_hash: input.response_hash ?? '',
+    // Track S: record sample depth explicitly. Omitted when absent so pre-Track-S
+    // briefs (and fixtures without a depth) keep their existing lineage shape.
+    ...(nSamples !== undefined ? { n_samples: nSamples } : {}),
   };
 }

--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -31,6 +31,7 @@ import type {
 } from '../types/decision-brief.js';
 import { DECISION_BRIEF_VERSION } from '../types/decision-brief.js';
 import type { RunResponseV3 } from '../types/engine-v3.js';
+import { STANDARD_N_SAMPLES_DEFAULT } from '../config/sampling.js';
 
 // =============================================================================
 // Constants
@@ -70,10 +71,11 @@ function computeBriefId(graphHash: string, seed: number, configVersion: string):
  *
  * Track S: the sample depth is now a per-request input (was hardcoded 1000), so
  * briefs computed at different depths get different config_versions (and thus
- * different brief_ids). Defaults to 1000 when omitted, which reproduces the
- * pre-Track-S hash for callers that don't supply a depth.
+ * different brief_ids). Defaults to the standard depth (PR-E: 4000) when omitted.
+ * The live route always passes the resolved depth, so the default only affects
+ * direct callers/tests.
  */
-function computeConfigVersion(nSamples: number = 1000): string {
+function computeConfigVersion(nSamples: number = STANDARD_N_SAMPLES_DEFAULT): string {
   const configInputs = {
     n_samples_default: nSamples,
     enable_review_pass: process.env.ENABLE_REVIEW_PASS ?? 'default',

--- a/src/config/env-int.ts
+++ b/src/config/env-int.ts
@@ -1,0 +1,32 @@
+/**
+ * Strict, bounded integer parsing for ops-controlled sample-depth env vars (Track S).
+ *
+ * `parseInt` is too permissive for this: `parseInt('1,000')` is `1`,
+ * `parseInt('4_000')` is `4`, `parseInt('1000abc')` is `1000`. Used for a sample
+ * depth that is forwarded to ISL, those silently bypass the `/v2/run` request
+ * schema bound (`100..10000`) and run the Monte Carlo at a garbage depth.
+ *
+ * This helper accepts ONLY a plain non-negative integer string within [min, max].
+ * Anything else — empty, malformed (`1,000`, `4_000`, `1000abc`), fractional,
+ * signed, scientific (`1e3`), or out-of-bounds — returns `null` so the caller
+ * falls back to a safe default rather than to a misparsed value.
+ */
+
+/** Lower bound for a Monte Carlo sample depth (mirrors the /v2/run schema). */
+export const MIN_N_SAMPLES = 100;
+/** Upper bound for a Monte Carlo sample depth (mirrors the /v2/run schema). */
+export const MAX_N_SAMPLES = 10_000;
+
+/**
+ * Parse a strictly-formatted, in-bounds positive integer from an env value.
+ * @returns the integer, or `null` if absent/malformed/out-of-bounds.
+ */
+export function parseBoundedIntEnv(raw: string | undefined, min: number, max: number): number | null {
+  if (raw === undefined) return null;
+  const trimmed = raw.trim();
+  // Plain digits only — rejects '', '1,000', '4_000', '1000abc', '1.5', '-5', '+1', '1e3'.
+  if (!/^\d+$/.test(trimmed)) return null;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n) || n < min || n > max) return null;
+  return n;
+}

--- a/src/config/env-int.ts
+++ b/src/config/env-int.ts
@@ -30,3 +30,33 @@ export function parseBoundedIntEnv(raw: string | undefined, min: number, max: nu
   if (!Number.isInteger(n) || n < min || n > max) return null;
   return n;
 }
+
+/** Tracks env vars already warned about, so a call-time resolver does not spam. */
+const warnedEnvVars = new Set<string>();
+
+/** Test-only: reset the once-per-process warning state. */
+export function __resetEnvIntWarnings(): void {
+  warnedEnvVars.clear();
+}
+
+/**
+ * Resolve `process.env[name]` via {@link parseBoundedIntEnv}, emitting a single
+ * process-lifetime warning when the var is SET but invalid/out-of-bounds.
+ *
+ * Resolution is call-time (per request), so the once-per-process guard avoids
+ * log spam while still surfacing an operator typo — e.g. an emergency rollback
+ * `STANDARD_N_SAMPLES=1,000` would otherwise be silently ignored, leaving the
+ * service at the wrong depth exactly when someone is trying to change it.
+ *
+ * @returns the parsed integer, or `null` (caller supplies its own fallback).
+ */
+export function resolveBoundedIntEnvOrWarn(name: string, min: number, max: number): number | null {
+  const raw = process.env[name];
+  const parsed = parseBoundedIntEnv(raw, min, max);
+  if (parsed === null && raw !== undefined && raw.trim() !== '' && !warnedEnvVars.has(name)) {
+    warnedEnvVars.add(name);
+    // console.warn matches the existing src/config convention (timeouts, feature-flags).
+    console.warn(`[track-s] Ignoring invalid ${name}="${raw}"; expected an integer in [${min}, ${max}]. Using the default instead.`);
+  }
+  return parsed;
+}

--- a/src/config/env-int.ts
+++ b/src/config/env-int.ts
@@ -56,7 +56,7 @@ export function resolveBoundedIntEnvOrWarn(name: string, min: number, max: numbe
   if (parsed === null && raw !== undefined && raw.trim() !== '' && !warnedEnvVars.has(name)) {
     warnedEnvVars.add(name);
     // console.warn matches the existing src/config convention (timeouts, feature-flags).
-    console.warn(`[track-s] Ignoring invalid ${name}="${raw}"; expected an integer in [${min}, ${max}]. Using the default instead.`);
+    console.warn(`[track-s] Ignoring invalid ${name}="${raw}"; expected an integer in [${min}, ${max}]. Using the fallback instead.`);
   }
   return parsed;
 }

--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -1,0 +1,46 @@
+/**
+ * Track S — Standard Monte Carlo sample depth (base analysis).
+ *
+ * PR-E raises the standard base-analysis depth from 1,000 to 4,000. Seed-sweep
+ * evidence (live ISL, 12 seeds × 4 fixtures) showed 1,000 is unstable/fragile on
+ * harder fixtures while 4,000 is the first depth where all fixtures meet the
+ * provisional ±3pp displayed-probability stability target; 8,000 gives only
+ * diminishing returns. The seed-sweep evidence is summarised in the PR
+ * description and reproducible via tools/seed-sweep.mjs.
+ *
+ * Rollback: set the `STANDARD_N_SAMPLES` env var (e.g. `1000`) to override the
+ * default without a code change. This is the emergency knob if latency or
+ * operational issues appear after the raise.
+ *
+ * Flip-threshold probes intentionally do NOT inherit this depth — they have an
+ * independent control (see resolveFlipProbeNSamples / FLIP_PROBE_N_SAMPLES in
+ * src/analysis/flip-thresholds.ts). Raising the base must not slow flip probes.
+ */
+
+import { resolveBoundedIntEnvOrWarn, MIN_N_SAMPLES, MAX_N_SAMPLES } from './env-int.js';
+
+/**
+ * Compile-time standard base-analysis sample depth. Fixed (not env-derived) so
+ * it can anchor deterministic, environment-independent fallbacks (e.g. the
+ * canonical-hash default). The live request path uses resolveStandardNSamples().
+ */
+export const STANDARD_N_SAMPLES_DEFAULT = 4000;
+
+/**
+ * Resolve the standard base-analysis sample depth for a request whose
+ * `n_samples` was omitted.
+ *
+ * Precedence:
+ *  1. `STANDARD_N_SAMPLES` env — strictly parsed, in-bounds (100..10000)
+ *     emergency rollback / override; malformed (`1,000`, `1000abc`) or
+ *     out-of-bounds values are ignored (with a one-time warning) so they cannot
+ *     bypass the /v2/run schema bound or forward a garbage depth to ISL;
+ *  2. otherwise `STANDARD_N_SAMPLES_DEFAULT` (4,000).
+ *
+ * Read at call time so the override takes effect without a rebuild and is
+ * trivially testable. An explicit `n_samples` in the request always wins over
+ * this default (the route applies `body.n_samples ?? resolveStandardNSamples()`).
+ */
+export function resolveStandardNSamples(): number {
+  return resolveBoundedIntEnvOrWarn('STANDARD_N_SAMPLES', MIN_N_SAMPLES, MAX_N_SAMPLES) ?? STANDARD_N_SAMPLES_DEFAULT;
+}

--- a/src/facts/hash.ts
+++ b/src/facts/hash.ts
@@ -42,7 +42,13 @@ function sha256(input: string): string {
  */
 export function generateFactId(factKey: FactKey, lineage: FactLineage): string {
   const keyPayload = canonicalJson(factKey);
-  const lineagePayload = `${lineage.graph_hash}:${lineage.seed}:${lineage.config_version}:${lineage.isl_request_id}`;
+  let lineagePayload = `${lineage.graph_hash}:${lineage.seed}:${lineage.config_version}:${lineage.isl_request_id}`;
+  // Track S: depth-aware fact ids. Appended ONLY when present so pre-Track-S
+  // facts (no n_samples) keep their original ids — facts computed at different
+  // sample depths get distinct ids.
+  if (lineage.n_samples !== undefined) {
+    lineagePayload += `:${lineage.n_samples}`;
+  }
   return sha256(`${keyPayload}:${lineagePayload}`).slice(0, 16);
 }
 

--- a/src/facts/types.ts
+++ b/src/facts/types.ts
@@ -114,6 +114,13 @@ export interface FactLineage {
   seed: number;
   config_version: string;
   isl_request_id: string;
+  /**
+   * Track S: resolved Monte Carlo sample depth the facts were computed at.
+   * Additive + backward-compatible: optional, and only contributes to fact_id
+   * when present, so pre-Track-S facts (no n_samples) reproduce identical ids.
+   * Absence ⇒ a fact written before sample-depth provenance existed.
+   */
+  n_samples?: number;
   /** From CEE checkpoint, if available */
   plan_id?: string;
   plan_hash?: string;

--- a/src/normalisation/canonicalise.ts
+++ b/src/normalisation/canonicalise.ts
@@ -108,6 +108,7 @@
 
 import { createHash } from 'node:crypto';
 import type { RunRequestV3, OptionV3, EngineGraphV3, GoalConstraint, IdentifiabilityAssessment, FactorStabilityEntry } from '../types/engine-v3.js';
+import { STANDARD_N_SAMPLES_DEFAULT } from '../config/sampling.js';
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -119,10 +120,13 @@ export const HASH_VERSION = 7;
 /**
  * Fallback Monte Carlo sample depth used when canonicalising a request whose
  * `n_samples` is omitted and no resolved depth is passed by the caller.
- * MUST match `DEFAULT_N_SAMPLES` in `src/routes/v2/run.ts` so that an omitted
- * `n_samples` and an explicit default-valued one produce the same hash.
+ *
+ * Anchored to the compile-time standard default (`STANDARD_N_SAMPLES_DEFAULT`,
+ * PR-E: 4000) — NOT the env-resolved value — so canonical hashing stays
+ * deterministic and environment-independent. The live route always passes the
+ * resolved depth explicitly, so this fallback only affects direct callers/tests.
  */
-export const DEFAULT_HASH_N_SAMPLES = 1000;
+export const DEFAULT_HASH_N_SAMPLES = STANDARD_N_SAMPLES_DEFAULT;
 
 /** Number of decimal places for float normalisation */
 const DECIMAL_PRECISION = 12;

--- a/src/normalisation/canonicalise.ts
+++ b/src/normalisation/canonicalise.ts
@@ -86,6 +86,24 @@
  * The `identifiability` and `factorStability` parameters are retained in
  * `canonicaliseRequest` and `hashRequest` for API backwards compatibility
  * but are no longer included in the hash input.
+ *
+ * ## BREAKING CHANGE (v7)
+ *
+ * Hash version 7 adds the resolved Monte Carlo sample depth to the canonical form:
+ *
+ * 1. **n_samples inclusion**: The resolved `n_samples` (request value, or the
+ *    server default when omitted) now contributes to the hash. Monte Carlo error
+ *    scales with sample depth, so the same graph + same seed at a different
+ *    `n_samples` is a genuinely different computation and MUST hash differently.
+ *    - An omitted `n_samples` resolves to the server default before hashing, so
+ *      an explicit default-valued request and an omitted one share a hash.
+ *    - Impact: ALL hashes change due to version prefix bump (v6→v7).
+ *
+ * **Migration**: ALL hashes change from v6. Cache invalidation required. Old
+ * stored facts/responses keep their v6 hashes (namespaced by the `version`
+ * field); this change does not rewrite history — new runs emit v7.
+ * `n_samples` is request-derived and deterministic, consistent with the v6
+ * principle that the hash is computable from the request alone.
  */
 
 import { createHash } from 'node:crypto';
@@ -96,7 +114,15 @@ import type { RunRequestV3, OptionV3, EngineGraphV3, GoalConstraint, Identifiabi
 // -----------------------------------------------------------------------------
 
 /** Hash version to prevent collisions when canonicalisation changes */
-export const HASH_VERSION = 6;
+export const HASH_VERSION = 7;
+
+/**
+ * Fallback Monte Carlo sample depth used when canonicalising a request whose
+ * `n_samples` is omitted and no resolved depth is passed by the caller.
+ * MUST match `DEFAULT_N_SAMPLES` in `src/routes/v2/run.ts` so that an omitted
+ * `n_samples` and an explicit default-valued one produce the same hash.
+ */
+export const DEFAULT_HASH_N_SAMPLES = 1000;
 
 /** Number of decimal places for float normalisation */
 const DECIMAL_PRECISION = 12;
@@ -254,6 +280,8 @@ interface CanonicalConstraint {
 interface CanonicalRequest {
   version: number;
   seed: string;
+  /** Resolved Monte Carlo sample depth (v7) — affects MC error of all surfaced numbers */
+  n_samples: number;
   goal_node_id: string;
   detail_level: string;
   /** Goal threshold affects probability_of_goal computation */
@@ -286,6 +314,9 @@ interface CanonicalRequest {
  * @param seedUsed Seed that will be used (already normalised to string)
  * @param _identifiability Unused since v6 — retained for API backwards compatibility
  * @param _factorStability Unused since v6 — retained for API backwards compatibility
+ * @param nSamples Resolved Monte Carlo sample depth (v7). When omitted, falls back
+ *   to `req.n_samples`, then to `DEFAULT_HASH_N_SAMPLES`, so callers that have
+ *   already applied the route default should pass it explicitly.
  * @returns Canonical JSON string
  */
 export function canonicaliseRequest(
@@ -293,11 +324,20 @@ export function canonicaliseRequest(
   normalizedGraph: EngineGraphV3,
   seedUsed: string,
   _identifiability?: IdentifiabilityAssessment,
-  _factorStability?: FactorStabilityEntry[]
+  _factorStability?: FactorStabilityEntry[],
+  nSamples?: number
 ): string {
+  // v7: resolve the sample depth the same way the route does, so an omitted
+  // n_samples and an explicit default-valued one canonicalise identically.
+  const resolvedNSamples =
+    nSamples ??
+    (typeof req.n_samples === 'number' && Number.isFinite(req.n_samples)
+      ? req.n_samples
+      : DEFAULT_HASH_N_SAMPLES);
   const canonical: CanonicalRequest = {
     version: HASH_VERSION,
     seed: seedUsed,
+    n_samples: resolvedNSamples,
     goal_node_id: req.goal_node_id,
     detail_level: req.detail_level ?? 'standard',
     graph: {
@@ -364,6 +404,7 @@ export function computeResponseHash(canonicalised: string): string {
  * @param seedUsed Seed that will be used (already normalised to string)
  * @param identifiability Optional identifiability assessment
  * @param factorStability Optional ISL stability assessment per factor
+ * @param nSamples Resolved Monte Carlo sample depth (v7); see canonicaliseRequest
  * @returns 16-character hex hash
  */
 export function hashRequest(
@@ -371,8 +412,9 @@ export function hashRequest(
   normalizedGraph: EngineGraphV3,
   seedUsed: string,
   identifiability?: IdentifiabilityAssessment,
-  factorStability?: FactorStabilityEntry[]
+  factorStability?: FactorStabilityEntry[],
+  nSamples?: number
 ): string {
-  const canonical = canonicaliseRequest(req, normalizedGraph, seedUsed, identifiability, factorStability);
+  const canonical = canonicaliseRequest(req, normalizedGraph, seedUsed, identifiability, factorStability, nSamples);
   return computeResponseHash(canonical);
 }

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -105,7 +105,7 @@ import {
   THRESHOLDS_MIN_REMAINING_BUDGET_MS,
   REQUEST_BUDGET_MS,
 } from '../../config/timeouts.js';
-import { createISLInferenceFn, resolveFlipValues } from '../../analysis/flip-thresholds.js';
+import { createISLInferenceFn, resolveFlipValues, resolveFlipProbeNSamples } from '../../analysis/flip-thresholds.js';
 import { computeFlipThresholdData, getFactorsOverriddenByAllOptions } from '../../coaching/flip-thresholds.js';
 import { denormaliseFlipThresholds, type DenormalisedFlipThreshold } from '../../lib/flip-threshold-denormaliser.js';
 import { classifyFlipThresholdsStatus } from '../../lib/flip-threshold-status.js';
@@ -1056,6 +1056,8 @@ interface MetaParams {
   /** CIL Phase 1: Seed origin — type from @talchain/schemas SeedSource */
   seedSource: SeedSourceType;
   nSamples: number;
+  /** Track S: sample depth used for flip probes (decoupled from nSamples). Omitted when no flip search ran. */
+  flipProbeNSamples?: number;
   detailLevel: string;
   latencyMs: number;
   normalizationMs?: number;
@@ -1833,7 +1835,8 @@ function buildResponse(
     m1_coaching: m1Coaching,
     m1_review: m2DecisionReview?.m1_review ?? undefined,
     response_hash: responseHash,
-    meta: { seed_used: meta.seedUsed },
+    // Track S: depth-aware brief lineage (config_version + lineage.n_samples).
+    meta: { seed_used: meta.seedUsed, n_samples: meta.nSamples },
   });
 
   // Review cards: evidence priority card from factor sensitivity data.
@@ -1869,6 +1872,8 @@ function buildResponse(
       seed: Number(meta.seedUsed) || 0,
       config_version: '1',
       isl_request_id: requestId,
+      // Track S: record the sample depth facts were computed at (depth-aware lineage).
+      n_samples: meta.nSamples,
     };
 
     // Map V2 analysis data to ISLResponseInput shape
@@ -2221,6 +2226,11 @@ function buildResponse(
       //             (client_generated or server_generated)
       seed_source: meta.seedSource,
       n_samples: meta.nSamples,
+      // Track S: probe depth, surfaced only when a flip search ran and it differs
+      // from base depth (decoupled control). Excluded from response_hash (meta).
+      ...(meta.flipProbeNSamples !== undefined && meta.flipProbeNSamples !== meta.nSamples
+        ? { flip_probe_n_samples: meta.flipProbeNSamples }
+        : {}),
       detail_level: meta.detailLevel,
       latency_ms: meta.latencyMs,
       normalization_ms: meta.normalizationMs,
@@ -3426,7 +3436,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // Base hash used for early-return paths (ISL not enabled, ISL error).
         // On the success path, this is recomputed after ISL returns (v6: ISL-derived
         // fields are excluded from the hash — see canonicalise.ts BREAKING CHANGE v6).
-        let responseHash = hashRequest(body, filteredGraph, plotSeedUsed, toIdentifiabilityResponse(identifiabilityResult));
+        let responseHash = hashRequest(body, filteredGraph, plotSeedUsed, toIdentifiabilityResponse(identifiabilityResult), undefined, nSamples);
 
         // =================================================================
         // Phase 4: ISL Call
@@ -4184,7 +4194,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // Recompute response hash (v6: ISL-derived fields excluded — identifiability
         // and factor_stability are passed for API backwards compat but ignored by
         // canonicaliseRequest; see canonicalise.ts BREAKING CHANGE v6).
-        responseHash = hashRequest(body, filteredGraph, plotSeedUsed, toIdentifiabilityResponse(identifiabilityResult), factorStability);
+        responseHash = hashRequest(body, filteredGraph, plotSeedUsed, toIdentifiabilityResponse(identifiabilityResult), factorStability, nSamples);
 
         const sensitivityData: SensitivityData = { edgeSensitivity, factorSensitivity, edgeEValues, conditionalWinners };
 
@@ -4371,6 +4381,9 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // =================================================================
         let resolvedFlipData: import('../../cee/validation/m1-review-types.js').FlipThresholdInputData[] | undefined;
         let flipThresholds: DenormalisedFlipThreshold[] | undefined;
+        // Track S: depth actually used for flip probes (decoupled from base nSamples).
+        // Set when a flip search runs; surfaced in response meta for transparency.
+        let flipProbeNSamples: number | undefined;
 
         if (islSuccess && factorSensitivity && optionComparisonData && optionComparisonData.length >= 2) {
           try {
@@ -4415,10 +4428,15 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               const winnerId = topWinnerOption?.option_id ?? topWinnerOption?.id ?? '';
 
               if (winnerId) {
+                // Track S: flip probes use a depth decoupled from the base analysis
+                // (`nSamples`), so raising base depth cannot silently push probes into
+                // timeout. See resolveFlipProbeNSamples / FLIP_PROBE_N_SAMPLES.
+                flipProbeNSamples = resolveFlipProbeNSamples(nSamples);
                 const flipInferenceFn = createISLInferenceFn(
                   (endpoint, body, rid) => islService.callAnalysisEndpoint(endpoint, body, rid),
                   islRequest,
-                  requestId
+                  requestId,
+                  flipProbeNSamples
                 );
 
                 const flipResult = await resolveFlipValues(
@@ -4742,6 +4760,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             seedUsed: plotSeedUsed,
             seedSource: providedSeed !== undefined ? 'client_generated' : 'server_generated',
             nSamples,
+            flipProbeNSamples,
             detailLevel,
             latencyMs: finalTotalMs,
             normalizationMs,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -119,6 +119,7 @@ import type { SeedSourceType } from '@talchain/schemas';
 import { factorReviewV2, type CEESchemaV2Config } from '../../cee/client.js';
 import { FLAGS } from '../../config/flags.js';
 import { getAllFeatureFlags } from '../../config/feature-flags.js';
+import { resolveStandardNSamples } from '../../config/sampling.js';
 import { generateM1Coaching } from '../../coaching/m1-coaching.js';
 import { filterInterventionOverrides } from '../../coaching/sensitivity-filter.js';
 import type { M1Review } from '../../cee/validation/m1-review-types.js';
@@ -795,7 +796,8 @@ function buildISLResponseSummary(
 // -----------------------------------------------------------------------------
 
 const PREFLIGHT_VERSION_VALUE = '2025-12-26';
-const DEFAULT_N_SAMPLES = 1000;
+// Track S PR-E: standard base-analysis depth is resolved per-request via
+// resolveStandardNSamples() (default 4000, env STANDARD_N_SAMPLES override).
 const BODY_LIMIT_BYTES = 10 * 1024 * 1024; // 10MB
 
 // -----------------------------------------------------------------------------
@@ -2696,7 +2698,9 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
       // Note: plotSeedUsed is resolved AFTER graph normalization for determinism
       // When seed is omitted, we derive it from the normalized graph hash
       const providedSeed = body.seed;  // May be undefined - will resolve after normalization
-      const nSamples = body.n_samples ?? DEFAULT_N_SAMPLES;
+      // Track S PR-E: standard base-analysis depth (default 4000, env-overridable
+      // to 1000 via STANDARD_N_SAMPLES). An explicit request n_samples always wins.
+      const nSamples = body.n_samples ?? resolveStandardNSamples();
       const detailLevel = body.detail_level ?? 'standard';
 
       // Normalize goal_threshold: null is treated as absent

--- a/src/types/decision-brief.ts
+++ b/src/types/decision-brief.ts
@@ -98,6 +98,8 @@ export interface BriefLineage {
   model_id?: string;
   config_version: string;
   response_hash: string;
+  /** Track S: resolved Monte Carlo sample depth the brief was computed at (additive, optional) */
+  n_samples?: number;
 }
 
 // =============================================================================

--- a/src/util/display-precision.ts
+++ b/src/util/display-precision.ts
@@ -1,0 +1,107 @@
+/**
+ * Track S — Display precision for surfaced win-probabilities (HELPER ONLY).
+ *
+ * ⚠️  NOT WIRED INTO THE RESPONSE. This module is a pure helper plus the
+ *     recommendation derived from seed-sweep evidence. Per the Track S mandate,
+ *     user-facing precision behaviour must not change without seed-sweep
+ *     justification AND Neil/Jinghui sign-off on acceptable MC error. Wire this
+ *     in only once that decision lands.
+ *
+ * ## Evidence (seed-sweep against live ISL, 12 seeds × {1000,2000,4000,8000})
+ *
+ * Winner win-probability spread (max − min across seeds), percentage points:
+ *
+ *   depth | clear-winner | near-tie | multi-option | constrained
+ *   ------|--------------|----------|--------------|------------
+ *   1000  |     3.05     |   5.35   |     6.57     |    5.85
+ *   2000  |     1.90     |   2.70   |     3.92     |    4.08
+ *   4000  |     1.19     |   1.84   |     2.54     |    2.24
+ *   8000  |     1.19     |   1.15   |     1.70     |    1.51
+ *
+ * ISL already rounds win_probability to 0.01 (1 percentage point). The spread
+ * above is *seed-to-seed* Monte Carlo variation at that display granularity
+ * (ISL is bit-for-bit deterministic at a FIXED seed — verified separately).
+ *
+ * ## Rules encoded here
+ *
+ * 1. Display win-probabilities to whole percentage points (1pp). Anything finer
+ *    (e.g. "84.2%") implies precision the simulation does not support at any of
+ *    the tested depths.
+ * 2. The displayed value carries an MC-uncertainty band. At the recommended
+ *    4,000-sample depth the observed spread is ≤ ~3pp, so ±3pp is the default
+ *    band. Below that depth the band widens (see DISPLAY_BANDS_BY_DEPTH).
+ * 3. When the seed-to-seed spread exceeds ±5pp, OR two options are within the
+ *    band of each other, suppress precise point/winner claims and present the
+ *    comparison as "too close to call" (a genuine near-tie).
+ *
+ * These thresholds (±3pp ordinary, ±5pp fragile) are PROVISIONAL engineering
+ * values. The open decision for Neil/Jinghui: "What MC error is acceptable for
+ * displayed probabilities?" This is simulation-stability evidence, NOT calibration.
+ */
+
+/** Display granularity for win-probabilities, in percentage points. */
+export const WIN_PROBABILITY_DISPLAY_PRECISION_PP = 1;
+
+/** Spread (pp) at/under which an ordinary point display is considered honest. */
+export const ORDINARY_DISPLAY_SPREAD_PP = 3;
+
+/** Spread (pp) above which a result is "fragile" — suppress precise point claims. */
+export const FRAGILE_SPREAD_PP = 5;
+
+/**
+ * Recommended MC-uncertainty band (± pp) to show alongside a point estimate, by
+ * sample depth. Derived from the worst-case fixture spread at each depth, rounded
+ * up to whole pp. Depths between table entries snap to the next-lower tabulated
+ * depth (more conservative band).
+ */
+export const DISPLAY_BANDS_BY_DEPTH: ReadonlyArray<{ n_samples: number; band_pp: number }> = [
+  { n_samples: 1000, band_pp: 7 },
+  { n_samples: 2000, band_pp: 5 },
+  { n_samples: 4000, band_pp: 3 },
+  { n_samples: 8000, band_pp: 2 },
+];
+
+/** Round a probability (0..1) to the display granularity, returned as 0..1. */
+export function roundWinProbabilityForDisplay(p: number): number {
+  if (!Number.isFinite(p)) return p;
+  const stepsPerUnit = 100 / WIN_PROBABILITY_DISPLAY_PRECISION_PP; // 100 for 1pp
+  return Math.round(p * stepsPerUnit) / stepsPerUnit;
+}
+
+/** Format a probability (0..1) as a whole-percent string, e.g. 0.842 → "84%". */
+export function formatWinProbability(p: number): string {
+  if (!Number.isFinite(p)) return '—';
+  return `${Math.round(roundWinProbabilityForDisplay(p) * 100)}%`;
+}
+
+/** Recommended ± uncertainty band (pp) for a given resolved sample depth. */
+export function recommendedDisplayBandPp(nSamples: number): number {
+  let band = DISPLAY_BANDS_BY_DEPTH[0].band_pp;
+  for (const row of DISPLAY_BANDS_BY_DEPTH) {
+    if (nSamples >= row.n_samples) band = row.band_pp;
+  }
+  return band;
+}
+
+/**
+ * Whether a precise point/winner claim should be suppressed in favour of a
+ * "too close to call" presentation.
+ *
+ * @param observedSpreadPp seed-to-seed spread of the winner's win-probability (pp),
+ *   when known from a sweep; pass undefined if not measured.
+ * @param marginPp gap between the top two options' win-probabilities (pp).
+ * @param nSamples resolved sample depth (used for the default band when margin given).
+ */
+export function shouldSuppressPointClaim(args: {
+  observedSpreadPp?: number;
+  marginPp?: number;
+  nSamples?: number;
+}): boolean {
+  const { observedSpreadPp, marginPp, nSamples } = args;
+  if (observedSpreadPp !== undefined && observedSpreadPp > FRAGILE_SPREAD_PP) return true;
+  if (marginPp !== undefined) {
+    const band = nSamples !== undefined ? recommendedDisplayBandPp(nSamples) : ORDINARY_DISPLAY_SPREAD_PP;
+    if (marginPp <= band) return true; // options indistinguishable within the band
+  }
+  return false;
+}

--- a/tests/3c-factor-sensitivity-enrichment.test.ts
+++ b/tests/3c-factor-sensitivity-enrichment.test.ts
@@ -215,10 +215,10 @@ describe('3C: Response hash policy', () => {
       expect(hashWithIdent).toBe(hashWithout);
     });
 
-    it('hash version is 6', () => {
+    it('hash version is 7', () => {
       const req = makeRequest();
       const canonical = JSON.parse(canonicaliseRequest(req, GRAPH, '42'));
-      expect(canonical.version).toBe(6);
+      expect(canonical.version).toBe(7); // Track S: bumped 6→7 (n_samples in canonical form)
     });
   });
 });

--- a/tests/cil-canonical-hash-v3.test.ts
+++ b/tests/cil-canonical-hash-v3.test.ts
@@ -122,7 +122,7 @@ describe('CIL C2: Canonical hash with goal_constraints', () => {
     expect(hashA).toBe(hashB);
   });
 
-  it('hash version is 6 (includes version in canonical form)', () => {
+  it('hash version is 7 (includes version in canonical form)', () => {
     const req = makeRequest({
       goal_constraints: [
         { constraint_id: 'c1', node_id: 'goal', operator: '>=', value: 20000 },
@@ -132,7 +132,9 @@ describe('CIL C2: Canonical hash with goal_constraints', () => {
     const canonical = canonicaliseRequest(req, GRAPH, '42');
     const parsed = JSON.parse(canonical);
 
-    expect(parsed.version).toBe(6);
+    // Track S: HASH_VERSION bumped 6→7 (n_samples added to canonical form).
+    expect(parsed.version).toBe(7);
+    expect(parsed.n_samples).toBe(1000); // resolved default depth (v7)
     expect(parsed.goal_constraints).toBeDefined();
     expect(parsed.goal_constraints).toHaveLength(1);
     expect(parsed.goal_constraints[0].constraint_id).toBe('c1');

--- a/tests/cil-canonical-hash-v3.test.ts
+++ b/tests/cil-canonical-hash-v3.test.ts
@@ -134,7 +134,7 @@ describe('CIL C2: Canonical hash with goal_constraints', () => {
 
     // Track S: HASH_VERSION bumped 6→7 (n_samples added to canonical form).
     expect(parsed.version).toBe(7);
-    expect(parsed.n_samples).toBe(1000); // resolved default depth (v7)
+    expect(parsed.n_samples).toBe(4000); // PR-E: standard default depth raised 1000→4000
     expect(parsed.goal_constraints).toBeDefined();
     expect(parsed.goal_constraints).toHaveLength(1);
     expect(parsed.goal_constraints[0].constraint_id).toBe('c1');

--- a/tests/display-precision.test.ts
+++ b/tests/display-precision.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Track S — Display-precision helper (H4). Helper-only; not wired into responses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  roundWinProbabilityForDisplay,
+  formatWinProbability,
+  recommendedDisplayBandPp,
+  shouldSuppressPointClaim,
+  WIN_PROBABILITY_DISPLAY_PRECISION_PP,
+  FRAGILE_SPREAD_PP,
+} from '../src/util/display-precision.js';
+
+describe('display precision', () => {
+  it('rounds to whole percentage points', () => {
+    expect(WIN_PROBABILITY_DISPLAY_PRECISION_PP).toBe(1);
+    expect(roundWinProbabilityForDisplay(0.842)).toBe(0.84);
+    expect(roundWinProbabilityForDisplay(0.846)).toBe(0.85);
+    expect(formatWinProbability(0.842)).toBe('84%');
+    expect(formatWinProbability(0.5)).toBe('50%');
+  });
+
+  it('recommends a tighter band as depth increases', () => {
+    expect(recommendedDisplayBandPp(1000)).toBe(7);
+    expect(recommendedDisplayBandPp(2000)).toBe(5);
+    expect(recommendedDisplayBandPp(4000)).toBe(3);
+    expect(recommendedDisplayBandPp(8000)).toBe(2);
+    // between-table depths snap to the next-lower tabulated depth (more conservative)
+    expect(recommendedDisplayBandPp(3000)).toBe(5);
+    expect(recommendedDisplayBandPp(500)).toBe(7);
+  });
+
+  it('suppresses point claims for fragile spreads', () => {
+    expect(shouldSuppressPointClaim({ observedSpreadPp: FRAGILE_SPREAD_PP + 0.1 })).toBe(true);
+    expect(shouldSuppressPointClaim({ observedSpreadPp: 2 })).toBe(false);
+  });
+
+  it('suppresses point claims when the option margin is within the depth band', () => {
+    // near-tie at 1.2pp margin, 4000 samples (band 3pp) → too close to call
+    expect(shouldSuppressPointClaim({ marginPp: 1.2, nSamples: 4000 })).toBe(true);
+    // clear winner at 68pp margin → fine
+    expect(shouldSuppressPointClaim({ marginPp: 68, nSamples: 4000 })).toBe(false);
+  });
+});

--- a/tests/env-int.test.ts
+++ b/tests/env-int.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Track S — strict, bounded integer env parsing (parseBoundedIntEnv).
+ *
+ * Guards against the parseInt foot-guns that would let a malformed ops env value
+ * silently set a garbage Monte Carlo sample depth and bypass the /v2/run bound.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseBoundedIntEnv, MIN_N_SAMPLES, MAX_N_SAMPLES } from '../src/config/env-int.js';
+
+const within = (raw: string | undefined) => parseBoundedIntEnv(raw, MIN_N_SAMPLES, MAX_N_SAMPLES);
+
+describe('parseBoundedIntEnv', () => {
+  it('accepts a plain in-bounds integer (with surrounding whitespace)', () => {
+    expect(within('1000')).toBe(1000);
+    expect(within('4000')).toBe(4000);
+    expect(within('  2000  ')).toBe(2000);
+    expect(within('100')).toBe(MIN_N_SAMPLES);
+    expect(within('10000')).toBe(MAX_N_SAMPLES);
+  });
+
+  it('rejects malformed numeric-prefix / separator values (the parseInt foot-guns)', () => {
+    // parseInt would return 1, 4, and 1000 respectively — all unsafe.
+    expect(within('1,000')).toBeNull();
+    expect(within('4_000')).toBeNull();
+    expect(within('1000abc')).toBeNull();
+  });
+
+  it('rejects empty, non-numeric, fractional, signed, and scientific forms', () => {
+    expect(within(undefined)).toBeNull();
+    expect(within('')).toBeNull();
+    expect(within('   ')).toBeNull();
+    expect(within('oops')).toBeNull();
+    expect(within('1.5')).toBeNull();
+    expect(within('-500')).toBeNull();
+    expect(within('+1000')).toBeNull();
+    expect(within('1e3')).toBeNull();
+  });
+
+  it('rejects out-of-bounds positives (cannot bypass the 100..10000 guard)', () => {
+    expect(within('99')).toBeNull();
+    expect(within('0')).toBeNull();
+    expect(within('10001')).toBeNull();
+    expect(within('50000')).toBeNull();
+  });
+
+  it('honours custom bounds', () => {
+    expect(parseBoundedIntEnv('5', 1, 10)).toBe(5);
+    expect(parseBoundedIntEnv('11', 1, 10)).toBeNull();
+  });
+});

--- a/tests/env-int.test.ts
+++ b/tests/env-int.test.ts
@@ -5,8 +5,14 @@
  * silently set a garbage Monte Carlo sample depth and bypass the /v2/run bound.
  */
 
-import { describe, it, expect } from 'vitest';
-import { parseBoundedIntEnv, MIN_N_SAMPLES, MAX_N_SAMPLES } from '../src/config/env-int.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  parseBoundedIntEnv,
+  resolveBoundedIntEnvOrWarn,
+  __resetEnvIntWarnings,
+  MIN_N_SAMPLES,
+  MAX_N_SAMPLES,
+} from '../src/config/env-int.js';
 
 const within = (raw: string | undefined) => parseBoundedIntEnv(raw, MIN_N_SAMPLES, MAX_N_SAMPLES);
 
@@ -47,5 +53,41 @@ describe('parseBoundedIntEnv', () => {
   it('honours custom bounds', () => {
     expect(parseBoundedIntEnv('5', 1, 10)).toBe(5);
     expect(parseBoundedIntEnv('11', 1, 10)).toBeNull();
+  });
+});
+
+describe('resolveBoundedIntEnvOrWarn', () => {
+  const NAME = '__TRACK_S_TEST_DEPTH__';
+  beforeEach(() => { __resetEnvIntWarnings(); delete process.env[NAME]; });
+  afterEach(() => { delete process.env[NAME]; vi.restoreAllMocks(); });
+
+  it('returns the value for a valid env (no warning)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env[NAME] = '2000';
+    expect(resolveBoundedIntEnvOrWarn(NAME, MIN_N_SAMPLES, MAX_N_SAMPLES)).toBe(2000);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('returns null and does NOT warn when the var is absent', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(resolveBoundedIntEnvOrWarn(NAME, MIN_N_SAMPLES, MAX_N_SAMPLES)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns exactly once for a SET-but-invalid value (no per-request spam)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env[NAME] = '1,000'; // would parseInt to 1
+    expect(resolveBoundedIntEnvOrWarn(NAME, MIN_N_SAMPLES, MAX_N_SAMPLES)).toBeNull();
+    expect(resolveBoundedIntEnvOrWarn(NAME, MIN_N_SAMPLES, MAX_N_SAMPLES)).toBeNull();
+    expect(resolveBoundedIntEnvOrWarn(NAME, MIN_N_SAMPLES, MAX_N_SAMPLES)).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain(NAME);
+  });
+
+  it('warns on out-of-bounds too', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env[NAME] = '50000';
+    expect(resolveBoundedIntEnvOrWarn(NAME, MIN_N_SAMPLES, MAX_N_SAMPLES)).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/flip-probe-depth-decoupling.test.ts
+++ b/tests/flip-probe-depth-decoupling.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Track S — Flip-probe sample-depth decoupling (H3)
+ *
+ * Flip probes must NOT inherit the base analysis `n_samples`. Raising the base
+ * depth (for display-stable probabilities) must not silently push flip probes
+ * into timeout. These tests pin the contract: probe depth is its own control.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  createISLInferenceFn,
+  resolveFlipProbeNSamples,
+  DEFAULT_FLIP_PROBE_N_SAMPLES,
+} from '../src/analysis/flip-thresholds.js';
+
+const ORIGINAL = {
+  graph: {
+    nodes: [
+      { id: 'factor-a', kind: 'factor', observed_state: { value: 1.0, std: 0.3 } },
+      { id: 'goal', kind: 'goal' },
+    ],
+    edges: [{ from: 'factor-a', to: 'goal' }],
+  },
+  options: [{ id: 'opt1' }, { id: 'opt2' }],
+  goal_node_id: 'goal',
+  n_samples: 4000, // base analysis depth (raised)
+  parameter_uncertainties: [{ node_id: 'factor-a', distribution: 'normal', mean: 1.0, std: 0.3 }],
+  seed: '42',
+};
+
+/** callAnalysis stub that records the probe body's n_samples. */
+function recordingInference(flipProbeNSamples?: number) {
+  const seen: Array<number | undefined> = [];
+  const callAnalysis = async (_endpoint: string, body: any) => {
+    seen.push(body?.n_samples);
+    return { data: { results: [{ option_id: 'opt1', win_probability: 0.5 }, { option_id: 'opt2', win_probability: 0.5 }] } };
+  };
+  const fn = createISLInferenceFn(callAnalysis, ORIGINAL, 'req-1', flipProbeNSamples);
+  return { fn, seen };
+}
+
+const ENV_KEY = 'FLIP_PROBE_N_SAMPLES';
+afterEach(() => { delete process.env[ENV_KEY]; });
+
+describe('resolveFlipProbeNSamples', () => {
+  it('does NOT scale up when the base depth is raised (decoupled)', () => {
+    expect(resolveFlipProbeNSamples(1000)).toBe(1000);
+    expect(resolveFlipProbeNSamples(4000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES); // stays at 1000
+    expect(resolveFlipProbeNSamples(8000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES);
+  });
+
+  it('never runs probes deeper than the base depth', () => {
+    expect(resolveFlipProbeNSamples(500)).toBe(500);
+  });
+
+  it('honours an explicit FLIP_PROBE_N_SAMPLES env override (may exceed default)', () => {
+    process.env[ENV_KEY] = '2000';
+    expect(resolveFlipProbeNSamples(4000)).toBe(2000);
+    expect(resolveFlipProbeNSamples(1000)).toBe(2000);
+  });
+
+  it('ignores a malformed env value', () => {
+    process.env[ENV_KEY] = 'not-a-number';
+    expect(resolveFlipProbeNSamples(4000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES);
+  });
+});
+
+describe('createISLInferenceFn probe depth', () => {
+  it('sends the probe depth, not the base depth, to ISL', async () => {
+    const probeDepth = resolveFlipProbeNSamples(ORIGINAL.n_samples); // 1000, base is 4000
+    const { fn, seen } = recordingInference(probeDepth);
+    await fn('factor-a', 0.5);
+    expect(seen).toEqual([1000]);
+    expect(seen[0]).not.toBe(ORIGINAL.n_samples); // base raise did not reach the probe
+  });
+
+  it('falls back to base depth when no probe depth is supplied (legacy)', async () => {
+    const { fn, seen } = recordingInference(undefined);
+    await fn('factor-a', 0.5);
+    expect(seen).toEqual([ORIGINAL.n_samples]); // 4000
+  });
+});

--- a/tests/flip-probe-depth-decoupling.test.ts
+++ b/tests/flip-probe-depth-decoupling.test.ts
@@ -63,6 +63,14 @@ describe('resolveFlipProbeNSamples', () => {
     process.env[ENV_KEY] = 'not-a-number';
     expect(resolveFlipProbeNSamples(4000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES);
   });
+
+  it('ignores parseInt foot-guns and out-of-bounds env values (falls back, never misparses)', () => {
+    for (const bad of ['1,000', '4_000', '1000abc', '1.5', '-5', '50000', '99', '0']) {
+      process.env[ENV_KEY] = bad;
+      // Falls back to min(1000, base) — never to a misparsed value like 1 or 4.
+      expect(resolveFlipProbeNSamples(4000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES);
+    }
+  });
 });
 
 describe('createISLInferenceFn probe depth', () => {

--- a/tests/flip-probe-depth-decoupling.test.ts
+++ b/tests/flip-probe-depth-decoupling.test.ts
@@ -6,7 +6,7 @@
  * into timeout. These tests pin the contract: probe depth is its own control.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   createISLInferenceFn,
   resolveFlipProbeNSamples,
@@ -40,7 +40,10 @@ function recordingInference(flipProbeNSamples?: number) {
 }
 
 const ENV_KEY = 'FLIP_PROBE_N_SAMPLES';
-afterEach(() => { delete process.env[ENV_KEY]; });
+// Invalid-env cases below intentionally trip the once-per-process warning;
+// stub console.warn so the expected operator warning doesn't clutter test output.
+beforeEach(() => { vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+afterEach(() => { delete process.env[ENV_KEY]; vi.restoreAllMocks(); });
 
 describe('resolveFlipProbeNSamples', () => {
   it('does NOT scale up when the base depth is raised (decoupled)', () => {

--- a/tests/hash-sample-awareness.test.ts
+++ b/tests/hash-sample-awareness.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Track S — Hash sample-awareness (HASH_VERSION v7)
+ *
+ * Monte Carlo error scales with sample depth, so the same graph + same seed at a
+ * different `n_samples` is a genuinely different computation and MUST hash
+ * differently. An omitted `n_samples` resolves to the server default before
+ * hashing, so an explicit default-valued request and an omitted one share a hash.
+ *
+ * These are the machine-enforced contract guarantees for H1 — not advisory.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  canonicaliseRequest,
+  computeResponseHash,
+  hashRequest,
+  HASH_VERSION,
+  DEFAULT_HASH_N_SAMPLES,
+} from '../src/normalisation/canonicalise.js';
+import type { RunRequestV3, EngineGraphV3 } from '../src/types/engine-v3.js';
+
+const GRAPH: EngineGraphV3 = {
+  nodes: [
+    { id: 'factor-a', kind: 'factor', label: 'Factor A' },
+    { id: 'factor-b', kind: 'factor', label: 'Factor B' },
+    { id: 'goal', kind: 'goal', label: 'Goal' },
+  ],
+  edges: [
+    { from: 'factor-a', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
+    { from: 'factor-b', to: 'goal', exists_probability: 0.9, strength: { mean: 0.7, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt1', label: 'Option 1', interventions: { 'factor-a': { value: 1.5, source: 'user_specified' } } },
+  { id: 'opt2', label: 'Option 2', interventions: { 'factor-b': { value: 2.0, source: 'user_specified' } } },
+];
+
+function makeRequest(overrides: Partial<RunRequestV3> = {}): RunRequestV3 {
+  return {
+    graph: GRAPH,
+    options: OPTIONS,
+    goal_node_id: 'goal',
+    seed: '42',
+    ...overrides,
+  } as RunRequestV3;
+}
+
+// seedUsed (3rd arg) is the seed the route resolved; mirror req.seed so the
+// helper exercises seed discrimination correctly.
+const hashWith = (req: RunRequestV3, nSamples?: number) =>
+  computeResponseHash(canonicaliseRequest(req, GRAPH, String(req.seed ?? '42'), undefined, undefined, nSamples));
+
+describe('Hash sample-awareness (v7)', () => {
+  it('HASH_VERSION is 7', () => {
+    expect(HASH_VERSION).toBe(7);
+  });
+
+  it('same graph + same seed + different n_samples → different response_hash', () => {
+    const req = makeRequest();
+    const h1000 = hashWith(req, 1000);
+    const h2000 = hashWith(req, 2000);
+    const h4000 = hashWith(req, 4000);
+    expect(h1000).not.toBe(h2000);
+    expect(h2000).not.toBe(h4000);
+    expect(h1000).not.toBe(h4000);
+  });
+
+  it('omitted n_samples hashes identically to explicit default depth', () => {
+    // Resolved-default path: passing no depth and no req.n_samples must equal
+    // passing the server default explicitly.
+    const omitted = hashWith(makeRequest(), undefined);
+    const explicitDefault = hashWith(makeRequest(), DEFAULT_HASH_N_SAMPLES);
+    const reqWithDefault = hashWith(makeRequest({ n_samples: DEFAULT_HASH_N_SAMPLES }), undefined);
+    expect(omitted).toBe(explicitDefault);
+    expect(omitted).toBe(reqWithDefault);
+  });
+
+  it('explicit param overrides req.n_samples for the hash', () => {
+    // The route passes the *resolved* depth explicitly; it must win over the raw body value.
+    const req = makeRequest({ n_samples: 1000 });
+    expect(hashWith(req, 4000)).toBe(hashWith(makeRequest({ n_samples: 4000 }), 4000));
+    expect(hashWith(req, 4000)).not.toBe(hashWith(req, 1000));
+  });
+
+  it('n_samples only changes the hash — graph/seed still matter', () => {
+    const a = hashWith(makeRequest({ seed: '42' }), 2000);
+    const b = hashWith(makeRequest({ seed: '43' }), 2000);
+    expect(a).not.toBe(b); // seed still discriminates at fixed depth
+  });
+
+  it('hashRequest convenience fn forwards n_samples', () => {
+    const req = makeRequest();
+    expect(hashRequest(req, GRAPH, '42', undefined, undefined, 1000)).not.toBe(
+      hashRequest(req, GRAPH, '42', undefined, undefined, 4000)
+    );
+  });
+});

--- a/tests/sample-depth-provenance.test.ts
+++ b/tests/sample-depth-provenance.test.ts
@@ -61,9 +61,13 @@ describe('Decision-brief lineage sample-depth awareness', () => {
     expect(assembleBrief(baseInput(undefined))?.lineage.n_samples).toBeUndefined();
   });
 
-  it('omitted depth reproduces the legacy (default-1000) config_version', () => {
-    // Backward compat: a brief with no depth hashes the same as an explicit 1000.
+  it('omitted depth reproduces the standard-default config_version', () => {
+    // A brief with no depth hashes the same as one at the standard default
+    // (PR-E: 4000), and differs from a non-default depth.
     expect(assembleBrief(baseInput(undefined))?.lineage.config_version).toBe(
+      assembleBrief(baseInput(4000))?.lineage.config_version
+    );
+    expect(assembleBrief(baseInput(undefined))?.lineage.config_version).not.toBe(
       assembleBrief(baseInput(1000))?.lineage.config_version
     );
   });

--- a/tests/sample-depth-provenance.test.ts
+++ b/tests/sample-depth-provenance.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Track S — Sample-depth provenance (H2)
+ *
+ * Stored facts and decision-brief lineage must record the resolved n_samples,
+ * so facts/briefs computed at different depths are distinguishable — while
+ * pre-Track-S records (no n_samples) keep their existing identity.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateFactId } from '../src/facts/hash.js';
+import type { FactKey, FactLineage } from '../src/facts/types.js';
+import { assembleBrief, type BriefAssemblyInput } from '../src/assembly/decision-brief.js';
+
+const KEY: FactKey = { type: 'probability', option_id: 'opt1' };
+const BASE_LINEAGE: FactLineage = {
+  graph_hash: 'abc123',
+  seed: 42,
+  config_version: '1',
+  isl_request_id: 'req-1',
+};
+
+describe('Fact lineage sample-depth awareness', () => {
+  it('different n_samples → different fact_id', () => {
+    const at1000 = generateFactId(KEY, { ...BASE_LINEAGE, n_samples: 1000 });
+    const at4000 = generateFactId(KEY, { ...BASE_LINEAGE, n_samples: 4000 });
+    expect(at1000).not.toBe(at4000);
+  });
+
+  it('absent n_samples reproduces the pre-Track-S fact_id (backward compatible)', () => {
+    // The pre-Track-S pre-image was graph_hash:seed:config_version:isl_request_id.
+    // Reconstruct it independently to prove no silent id drift for old facts.
+    const legacy = generateFactId(KEY, BASE_LINEAGE); // no n_samples
+    const explicitUndefined = generateFactId(KEY, { ...BASE_LINEAGE, n_samples: undefined });
+    expect(legacy).toBe(explicitUndefined);
+    // And it must NOT equal a depth-stamped id.
+    expect(legacy).not.toBe(generateFactId(KEY, { ...BASE_LINEAGE, n_samples: 1000 }));
+  });
+});
+
+describe('Decision-brief lineage sample-depth awareness', () => {
+  const baseInput = (nSamples?: number): BriefAssemblyInput => ({
+    analysis_status: 'computed',
+    critiques: [],
+    option_comparison: [
+      { option_id: 'opt1', win_probability: 0.7, outcome: { mean: 0.7 } },
+      { option_id: 'opt2', win_probability: 0.3, outcome: { mean: 0.3 } },
+    ] as any,
+    robustness: { level: 'moderate', score: 0.5 } as any,
+    response_hash: 'resp-hash',
+    meta: { seed_used: '42', ...(nSamples !== undefined ? { n_samples: nSamples } : {}) },
+  });
+
+  it('config_version differs for different n_samples', () => {
+    const b1 = assembleBrief(baseInput(1000));
+    const b2 = assembleBrief(baseInput(4000));
+    expect(b1?.lineage.config_version).not.toBe(b2?.lineage.config_version);
+  });
+
+  it('lineage records n_samples when present, omits it when absent', () => {
+    expect(assembleBrief(baseInput(4000))?.lineage.n_samples).toBe(4000);
+    expect(assembleBrief(baseInput(undefined))?.lineage.n_samples).toBeUndefined();
+  });
+
+  it('omitted depth reproduces the legacy (default-1000) config_version', () => {
+    // Backward compat: a brief with no depth hashes the same as an explicit 1000.
+    expect(assembleBrief(baseInput(undefined))?.lineage.config_version).toBe(
+      assembleBrief(baseInput(1000))?.lineage.config_version
+    );
+  });
+});

--- a/tests/stability-thresholds-passthrough.test.ts
+++ b/tests/stability-thresholds-passthrough.test.ts
@@ -305,7 +305,7 @@ describe('stability_thresholds passthrough + hash_version in _meta', () => {
 
     expect(body._meta).toBeDefined();
     expect(body._meta.hash_version).toBe(HASH_VERSION);
-    expect(body._meta.hash_version).toBe(6);
+    expect(body._meta.hash_version).toBe(7); // Track S: bumped 6→7 (n_samples in canonical form)
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/standard-n-samples-default.test.ts
+++ b/tests/standard-n-samples-default.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Track S PR-E — Standard MC sample depth default 1000→4000, with env rollback.
+ *
+ * Machine-enforced acceptance proof:
+ *  - default unset → standard depth resolves to 4000;
+ *  - STANDARD_N_SAMPLES=1000 → resolves to 1000 (emergency rollback);
+ *  - response hash differs between 1000 and 4000;
+ *  - flip probes stay at their independent depth (do NOT inherit base 4000).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  resolveStandardNSamples,
+  STANDARD_N_SAMPLES_DEFAULT,
+} from '../src/config/sampling.js';
+import { resolveFlipProbeNSamples } from '../src/analysis/flip-thresholds.js';
+import { hashRequest } from '../src/normalisation/canonicalise.js';
+import type { RunRequestV3, EngineGraphV3 } from '../src/types/engine-v3.js';
+
+const ENV_KEY = 'STANDARD_N_SAMPLES';
+// The malformed-env cases below intentionally trip the once-per-process warning;
+// stub console.warn so the expected operator warning doesn't clutter test output.
+beforeEach(() => { vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+afterEach(() => { delete process.env[ENV_KEY]; vi.restoreAllMocks(); });
+
+const GRAPH: EngineGraphV3 = {
+  nodes: [
+    { id: 'factor-a', kind: 'factor', label: 'Factor A' },
+    { id: 'goal', kind: 'goal', label: 'Goal' },
+  ],
+  edges: [{ from: 'factor-a', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } }],
+};
+const REQ = {
+  graph: GRAPH,
+  options: [{ id: 'opt1', label: 'O1', interventions: { 'factor-a': { value: 1.5, source: 'user_specified' } } }],
+  goal_node_id: 'goal',
+  seed: '42',
+} as unknown as RunRequestV3;
+
+describe('PR-E standard sample depth', () => {
+  it('default (env unset) resolves to 4000', () => {
+    delete process.env[ENV_KEY];
+    expect(STANDARD_N_SAMPLES_DEFAULT).toBe(4000);
+    expect(resolveStandardNSamples()).toBe(4000);
+  });
+
+  it('STANDARD_N_SAMPLES=1000 rolls back to 1000', () => {
+    process.env[ENV_KEY] = '1000';
+    expect(resolveStandardNSamples()).toBe(1000);
+  });
+
+  it('honours other in-bounds overrides', () => {
+    process.env[ENV_KEY] = '2000';
+    expect(resolveStandardNSamples()).toBe(2000);
+    process.env[ENV_KEY] = '100';
+    expect(resolveStandardNSamples()).toBe(100);
+    process.env[ENV_KEY] = '10000';
+    expect(resolveStandardNSamples()).toBe(10000);
+  });
+
+  it('falls back safely on malformed, empty, or out-of-bounds env (no parseInt misparse, no bound bypass)', () => {
+    // parseInt would yield 1 / 4 / 1000 for the first three — all unsafe.
+    for (const bad of ['oops', '', '   ', '1,000', '4_000', '1000abc', '1.5', '-500', '1e3', '99', '0', '10001', '50000']) {
+      process.env[ENV_KEY] = bad;
+      expect(resolveStandardNSamples()).toBe(STANDARD_N_SAMPLES_DEFAULT); // 4000
+    }
+  });
+
+  it('response hash differs between 1000 and 4000 (same graph + seed)', () => {
+    const h1000 = hashRequest(REQ, GRAPH, '42', undefined, undefined, 1000);
+    const h4000 = hashRequest(REQ, GRAPH, '42', undefined, undefined, 4000);
+    expect(h1000).not.toBe(h4000);
+  });
+
+  it('flip probes do NOT inherit the new 4000 base depth (stay decoupled)', () => {
+    // Base default is now 4000; flip probes must remain at their independent depth.
+    expect(resolveFlipProbeNSamples(STANDARD_N_SAMPLES_DEFAULT)).toBe(1000);
+    expect(resolveFlipProbeNSamples(resolveStandardNSamples())).toBe(1000);
+  });
+});

--- a/tests/tier2-data-responsibility.test.ts
+++ b/tests/tier2-data-responsibility.test.ts
@@ -483,7 +483,7 @@ describe('Tier 2: Data Responsibility (P.4, P.5, P.8)', () => {
 // P.6: Hash determinism (pure unit tests)
 // ---------------------------------------------------------------------------
 
-describe('P.6: Hash version 6 — ISL-derived fields excluded', () => {
+describe('P.6: Hash version 7 — ISL-derived fields excluded', () => {
   const HASH_GRAPH: EngineGraphV3 = {
     nodes: [
       { id: 'factor-a', kind: 'factor', label: 'Factor A' },
@@ -508,13 +508,14 @@ describe('P.6: Hash version 6 — ISL-derived fields excluded', () => {
     } as RunRequestV3;
   }
 
-  it('P6-1: HASH_VERSION is 6', () => {
-    expect(HASH_VERSION).toBe(6);
+  it('P6-1: HASH_VERSION is 7', () => {
+    // Track S: bumped 6→7 (n_samples added to canonical form).
+    expect(HASH_VERSION).toBe(7);
   });
 
-  it('P6-2: version field in canonical form is 6', () => {
+  it('P6-2: version field in canonical form is 7', () => {
     const canonical = JSON.parse(canonicaliseRequest(makeReq(), HASH_GRAPH, '42'));
-    expect(canonical.version).toBe(6);
+    expect(canonical.version).toBe(7);
   });
 
   it('P6-3: same request with different factor_stability → same hash', () => {
@@ -563,9 +564,9 @@ describe('P.6: Hash version 6 — ISL-derived fields excluded', () => {
     expect(canonical).not.toContain('"factor_stability"');
   });
 
-  it('P6-7: __hash_version=6 present in serialised hash input (via version field)', () => {
+  it('P6-7: __hash_version=7 present in serialised hash input (via version field)', () => {
     const canonical = JSON.parse(canonicaliseRequest(makeReq(), HASH_GRAPH, '42'));
-    expect(canonical.version).toBe(6);
+    expect(canonical.version).toBe(7);
   });
 
   it('P6-8: same input always produces same hash (determinism)', () => {

--- a/tests/v2-fact-objects.test.ts
+++ b/tests/v2-fact-objects.test.ts
@@ -253,6 +253,40 @@ describe('fact_objects in /v2/run (ENABLE_FACTS_ASSEMBLY=1)', () => {
       expect(fact.content_hash).toBeDefined();
     }
   });
+
+  // Track S: end-to-end wiring of the resolved n_samples through /v2/run. Guards
+  // against a regression where run.ts stops threading nSamples into the response
+  // meta, the response_hash, or the stored fact lineage. Uses EXPLICIT depths so
+  // it is independent of the standard-default value.
+  async function runAt(nSamples: number) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: { ...PAYLOAD, n_samples: nSamples },
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  it('threads the resolved n_samples into response meta and fact lineage', async () => {
+    const body = await runAt(2000);
+    expect(body.meta.n_samples).toBe(2000);
+    expect(body.fact_objects.length).toBeGreaterThan(0);
+    for (const fact of body.fact_objects) {
+      expect(fact.lineage.n_samples).toBe(2000);
+    }
+  });
+
+  it('produces a different response_hash for a different n_samples (same graph + seed)', async () => {
+    const at2000 = await runAt(2000);
+    const at4000 = await runAt(4000);
+    expect(at2000.meta.n_samples).toBe(2000);
+    expect(at4000.meta.n_samples).toBe(4000);
+    expect(at2000.response_hash).not.toBe(at4000.response_hash);
+    // fact lineage depth tracks the request depth at the route level
+    expect(at4000.fact_objects.every((f: any) => f.lineage.n_samples === 4000)).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/v2-fact-objects.test.ts
+++ b/tests/v2-fact-objects.test.ts
@@ -26,6 +26,10 @@ const FACTOR_SENSITIVITY = [
   { factor_id: 'factor-b', factor_label: 'Factor B', elasticity: -0.65, direction: 'negative', attribution_stability: 'moderate', elasticity_std: 0.1, rank_flip_rate: 0.1 },
 ];
 
+// Track S: records every ISL request body the route sends, so route tests can
+// assert the resolved n_samples actually reaches the ISL request (not just meta).
+const islRequestBodies: any[] = [];
+
 const mockISLService = {
   isEnabled(): boolean { return true; },
   async isAvailable(): Promise<boolean> { return true; },
@@ -69,6 +73,7 @@ const mockISLService = {
   },
   async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
   async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null; isl_echoed_request_id?: string }> {
+    islRequestBodies.push(body);
     const options = body.options || [];
     return {
       data: {
@@ -259,6 +264,7 @@ describe('fact_objects in /v2/run (ENABLE_FACTS_ASSEMBLY=1)', () => {
   // meta, the response_hash, or the stored fact lineage. Uses EXPLICIT depths so
   // it is independent of the standard-default value.
   async function runAt(nSamples: number) {
+    islRequestBodies.length = 0; // capture only this run's ISL requests
     const res = await app.inject({
       method: 'POST',
       url: '/v2/run',
@@ -269,8 +275,15 @@ describe('fact_objects in /v2/run (ENABLE_FACTS_ASSEMBLY=1)', () => {
     return JSON.parse(res.body);
   }
 
-  it('threads the resolved n_samples into response meta and fact lineage', async () => {
+  // The base analysis request carries the full analysis_types; flip-probe
+  // requests (analysis_types: ['comparison']) are separate and decoupled.
+  const baseISLRequest = () =>
+    islRequestBodies.find((b) => Array.isArray(b.analysis_types) && b.analysis_types.includes('robustness'));
+
+  it('threads the resolved n_samples into the ISL request, response meta, and fact lineage', async () => {
     const body = await runAt(2000);
+    // The depth actually reaches the ISL request body (not just response meta).
+    expect(baseISLRequest()?.n_samples).toBe(2000);
     expect(body.meta.n_samples).toBe(2000);
     expect(body.fact_objects.length).toBeGreaterThan(0);
     for (const fact of body.fact_objects) {
@@ -280,7 +293,9 @@ describe('fact_objects in /v2/run (ENABLE_FACTS_ASSEMBLY=1)', () => {
 
   it('produces a different response_hash for a different n_samples (same graph + seed)', async () => {
     const at2000 = await runAt(2000);
+    expect(baseISLRequest()?.n_samples).toBe(2000);
     const at4000 = await runAt(4000);
+    expect(baseISLRequest()?.n_samples).toBe(4000);
     expect(at2000.meta.n_samples).toBe(2000);
     expect(at4000.meta.n_samples).toBe(4000);
     expect(at2000.response_hash).not.toBe(at4000.response_hash);

--- a/tools/seed-sweep.mjs
+++ b/tools/seed-sweep.mjs
@@ -1,0 +1,500 @@
+#!/usr/bin/env node
+/**
+ * Track S — Monte Carlo seed-sweep & ISL determinism harness (read-only).
+ *
+ * Gathers stability evidence for surfaced probabilities by driving the LIVE
+ * /v2/run endpoint (which forwards n_samples + seed to the remote ISL service,
+ * where the actual Monte Carlo runs). Local tests mock ISL with seed-invariant
+ * canned responses and therefore CANNOT produce stability evidence — hence this
+ * harness targets a deployed service. It performs NO deployment and only issues
+ * POST /v2/run requests (no Idempotency-Key, so each call genuinely re-runs ISL).
+ *
+ * Modes:
+ *   validate  — one call per fixture; confirm analysis_status=computed and report
+ *               which fixtures produce flip_thresholds (need observed_state).
+ *   precheck  — ISL seed-determinism gate: repeated IDENTICAL (seed,depth) calls
+ *               on one fixture. Compares full-precision outcome.mean +
+ *               recommendation_stability + displayed win_probability. If repeated
+ *               identical calls vary materially the full sweep is not interpretable.
+ *   sweep     — full matrix: fixtures x depths x seeds. Aggregates win-prob spread,
+ *               winner/ranking stability, near-tie behaviour, factor-sensitivity
+ *               stability, robustness-band stability, latency p50/p95, timeouts.
+ *
+ * Usage:
+ *   node tools/seed-sweep.mjs --mode=validate
+ *   node tools/seed-sweep.mjs --mode=precheck [--fixture=clear-winner] [--depth=1000] [--repeats=8]
+ *   node tools/seed-sweep.mjs --mode=sweep [--depths=1000,2000,4000] [--seeds=...] [--fixtures=...]
+ *
+ * Flags:
+ *   --base=URL        default https://plot-lite-service-staging.onrender.com
+ *   --out=DIR         default tools/seed-sweep-out
+ *   --min-interval=MS min ms between requests (rate-limit pacing; default 1100 → <60rpm)
+ *   --flip            in sweep mode, also run the flip-stability subset
+ *
+ * Output: <out>/<mode>-<timestamp>.json (raw + aggregates) and, for sweep, a .md report.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const m = a.match(/^--([^=]+)(?:=(.*))?$/);
+    return m ? [m[1], m[2] ?? true] : [a, true];
+  })
+);
+
+const BASE = String(args.base ?? 'https://plot-lite-service-staging.onrender.com').replace(/\/$/, '');
+const OUT_DIR = String(args.out ?? 'tools/seed-sweep-out');
+const MIN_INTERVAL_MS = Number(args['min-interval'] ?? 1100); // <60 rpm safety
+const MODE = String(args.mode ?? 'validate');
+const STAMP = new Date().toISOString().replace(/[:.]/g, '-');
+
+const DEFAULT_SEEDS = [11, 101, 202, 303, 404, 505, 606, 707, 808, 909, 1234, 4242];
+const DEFAULT_DEPTHS = [1000, 2000, 4000];
+
+const SEEDS = args.seeds ? String(args.seeds).split(',').map(Number) : DEFAULT_SEEDS;
+const DEPTHS = args.depths ? String(args.depths).split(',').map(Number) : DEFAULT_DEPTHS;
+
+// ---------------------------------------------------------------------------
+// Fixtures — 4 categories. F4 carries observed_state (→ parameter_uncertainties
+// → flip candidates) AND a goal_constraint, covering "constrained" + flip subset.
+// ---------------------------------------------------------------------------
+const FIXTURES = {
+  'clear-winner': {
+    desc: 'One option strongly dominant (expect ~0.16/0.84).',
+    graph: {
+      nodes: [
+        { id: 'factor-a', kind: 'factor', label: 'Factor A' },
+        { id: 'factor-b', kind: 'factor', label: 'Factor B' },
+        { id: 'goal', kind: 'goal', label: 'Goal' },
+      ],
+      edges: [
+        { from: 'factor-a', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
+        { from: 'factor-b', to: 'goal', exists_probability: 0.9, strength: { mean: 0.7, std: 0.1 } },
+      ],
+    },
+    options: [
+      { id: 'opt1', label: 'Option 1', interventions: { 'factor-a': { value: 1.5, source: 'user_specified' } } },
+      { id: 'opt2', label: 'Option 2', interventions: { 'factor-b': { value: 2.0, source: 'user_specified' } } },
+    ],
+    goal_node_id: 'goal',
+  },
+  'near-tie': {
+    desc: 'Symmetric graph + symmetric interventions (expect ~50/50).',
+    graph: {
+      nodes: [
+        { id: 'factor-a', kind: 'factor', label: 'Factor A' },
+        { id: 'factor-b', kind: 'factor', label: 'Factor B' },
+        { id: 'goal', kind: 'goal', label: 'Goal' },
+      ],
+      edges: [
+        { from: 'factor-a', to: 'goal', exists_probability: 0.85, strength: { mean: 0.6, std: 0.1 } },
+        { from: 'factor-b', to: 'goal', exists_probability: 0.85, strength: { mean: 0.6, std: 0.1 } },
+      ],
+    },
+    options: [
+      { id: 'opt1', label: 'Option 1', interventions: { 'factor-a': { value: 2.0, source: 'user_specified' } } },
+      { id: 'opt2', label: 'Option 2', interventions: { 'factor-b': { value: 2.0, source: 'user_specified' } } },
+    ],
+    goal_node_id: 'goal',
+  },
+  'multi-option': {
+    desc: 'Three options on three factors of increasing strength.',
+    graph: {
+      nodes: [
+        { id: 'factor-a', kind: 'factor', label: 'Factor A' },
+        { id: 'factor-b', kind: 'factor', label: 'Factor B' },
+        { id: 'factor-c', kind: 'factor', label: 'Factor C' },
+        { id: 'goal', kind: 'goal', label: 'Goal' },
+      ],
+      edges: [
+        { from: 'factor-a', to: 'goal', exists_probability: 0.8, strength: { mean: 0.4, std: 0.1 } },
+        { from: 'factor-b', to: 'goal', exists_probability: 0.8, strength: { mean: 0.55, std: 0.1 } },
+        { from: 'factor-c', to: 'goal', exists_probability: 0.8, strength: { mean: 0.7, std: 0.1 } },
+      ],
+    },
+    options: [
+      { id: 'opt1', label: 'Option 1', interventions: { 'factor-a': { value: 2.0, source: 'user_specified' } } },
+      { id: 'opt2', label: 'Option 2', interventions: { 'factor-b': { value: 2.0, source: 'user_specified' } } },
+      { id: 'opt3', label: 'Option 3', interventions: { 'factor-c': { value: 2.0, source: 'user_specified' } } },
+    ],
+    goal_node_id: 'goal',
+  },
+  constrained: {
+    desc: 'Factors with observed_state (→ flip candidates) + a goal_constraint.',
+    graph: {
+      nodes: [
+        { id: 'factor-a', kind: 'factor', label: 'Factor A', observed_state: { value: 1.0, std: 0.3 } },
+        { id: 'factor-b', kind: 'factor', label: 'Factor B', observed_state: { value: 1.0, std: 0.3 } },
+        { id: 'goal', kind: 'goal', label: 'Goal' },
+      ],
+      edges: [
+        { from: 'factor-a', to: 'goal', exists_probability: 0.85, strength: { mean: 0.5, std: 0.1 } },
+        { from: 'factor-b', to: 'goal', exists_probability: 0.85, strength: { mean: 0.65, std: 0.1 } },
+      ],
+    },
+    options: [
+      { id: 'opt1', label: 'Option 1', interventions: { 'factor-a': { value: 1.5, source: 'user_specified' } } },
+      { id: 'opt2', label: 'Option 2', interventions: { 'factor-b': { value: 1.8, source: 'user_specified' } } },
+    ],
+    goal_node_id: 'goal',
+    goal_constraints: [{ constraint_id: 'c1', node_id: 'goal', operator: '>=', value: 0.3 }],
+  },
+};
+
+// Representative larger graph (closer to upper PoC size) for the PR-E latency
+// gate: 20 factors → goal, plus inter-factor edges for propagation depth, 4
+// options. No observed_state (pure base analysis — isolates the depth effect).
+FIXTURES.large = (() => {
+  const N = 20;
+  const nodes = [{ id: 'goal', kind: 'goal', label: 'Goal' }];
+  const edges = [];
+  for (let i = 0; i < N; i++) {
+    const id = `f${String(i).padStart(2, '0')}`;
+    nodes.push({ id, kind: 'factor', label: `Factor ${i}` });
+    edges.push({ from: id, to: 'goal', exists_probability: 0.7 + (i % 3) * 0.1, strength: { mean: 0.2 + (i % 5) * 0.12, std: 0.1 } });
+  }
+  // inter-factor edges (f_i → f_{i+5}) add propagation depth
+  for (let i = 0; i + 5 < N; i += 2) {
+    edges.push({ from: `f${String(i).padStart(2, '0')}`, to: `f${String(i + 5).padStart(2, '0')}`, exists_probability: 0.6, strength: { mean: 0.3, std: 0.1 } });
+  }
+  const options = [0, 5, 10, 15].map((base, k) => ({
+    id: `opt${k + 1}`,
+    label: `Option ${k + 1}`,
+    interventions: {
+      [`f${String(base).padStart(2, '0')}`]: { value: 1.5 + k * 0.2, source: 'user_specified' },
+      [`f${String(base + 1).padStart(2, '0')}`]: { value: 1.2, source: 'user_specified' },
+    },
+  }));
+  return { desc: `${N}-factor PoC-scale graph, 4 options (base-analysis latency gate).`, graph: { nodes, edges }, options, goal_node_id: 'goal' };
+})();
+
+// ---------------------------------------------------------------------------
+// HTTP with pacing + 429 backoff
+// ---------------------------------------------------------------------------
+let lastCallAt = 0;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function pace() {
+  const now = Date.now();
+  const wait = MIN_INTERVAL_MS - (now - lastCallAt);
+  if (wait > 0) await sleep(wait);
+  lastCallAt = Date.now();
+}
+
+async function runOnce(fixtureKey, seed, nSamples, { includeThresholds = false } = {}) {
+  const fx = FIXTURES[fixtureKey];
+  const body = {
+    graph: fx.graph,
+    options: fx.options,
+    goal_node_id: fx.goal_node_id,
+    seed: String(seed),
+    n_samples: nSamples,
+  };
+  if (fx.goal_constraints) body.goal_constraints = fx.goal_constraints;
+  if (includeThresholds) body.include_thresholds = true;
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    await pace();
+    const t0 = Date.now();
+    let res, json, status;
+    try {
+      res = await fetch(`${BASE}/v2/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      status = res.status;
+      if (status === 429) {
+        const backoff = 5000 * (attempt + 1);
+        process.stderr.write(`  429 rate-limited; backoff ${backoff}ms\n`);
+        await sleep(backoff);
+        continue;
+      }
+      json = await res.json();
+    } catch (err) {
+      process.stderr.write(`  fetch error (attempt ${attempt}): ${err.message}\n`);
+      await sleep(2000 * (attempt + 1));
+      continue;
+    }
+    const wallMs = Date.now() - t0;
+    return extractSignals(json, { http_status: status, wall_ms: wallMs, seed, n_samples: nSamples, fixture: fixtureKey });
+  }
+  return { fixture: fixtureKey, seed, n_samples: nSamples, http_status: 'FAILED', error: 'exhausted retries' };
+}
+
+function argmaxWinner(optionComparison) {
+  let best = null;
+  for (const o of optionComparison ?? []) {
+    const wp = o.win_probability;
+    if (wp == null || !Number.isFinite(wp)) continue;
+    if (!best || wp > best.wp || (wp === best.wp && (o.option_id ?? o.id) < best.id)) {
+      best = { id: o.option_id ?? o.id, wp };
+    }
+  }
+  return best?.id ?? null;
+}
+
+function extractSignals(json, ctx) {
+  const oc = json.option_comparison ?? [];
+  const rob = json.robustness ?? {};
+  const fs = json.factor_sensitivity ?? [];
+  const flips = json.flip_thresholds ?? [];
+  const winProbs = {};
+  const outcomeMeans = {};
+  for (const o of oc) {
+    const id = o.option_id ?? o.id;
+    if (id == null) continue;
+    winProbs[id] = o.win_probability ?? null;
+    outcomeMeans[id] = o.outcome?.mean ?? null;
+  }
+  // ranking by win_probability (desc, tie-break by id)
+  const ranking = Object.entries(winProbs)
+    .filter(([, v]) => v != null && Number.isFinite(v))
+    .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))
+    .map(([id]) => id);
+
+  return {
+    ...ctx,
+    analysis_status: json.analysis_status ?? null,
+    response_hash: json.response_hash ?? null,
+    meta_n_samples: json.meta?.n_samples ?? null,
+    seed_used: json.meta?.seed_used ?? null,
+    isl_ms: json.meta?.isl_ms ?? null,
+    latency_ms: json.meta?.latency_ms ?? null,
+    processing_time_ms: json.processing_time_ms ?? null,
+    winner: rob.recommended_option_id ?? argmaxWinner(oc),
+    ranking,
+    win_probabilities: winProbs,
+    outcome_means: outcomeMeans,
+    recommendation_stability: rob.recommendation_stability ?? null,
+    robustness_level: rob.level ?? null,
+    robustness_confidence: rob.confidence ?? null,
+    near_tie: rob.near_tie?.is_tie ?? null,
+    near_tie_gap: rob.near_tie?.gap ?? null,
+    factor_elasticities: fs.map((f) => f.elasticity ?? null),
+    factor_ranks: fs.map((f) => f.importance_rank ?? null),
+    flip_status: json.flip_thresholds_status ?? null,
+    flip_count: flips.length,
+    flip_timeouts: flips.filter((f) => f.flip_reason === 'timeout').length,
+    flip_values: flips.map((f) => ({ factor: f.factor_id ?? f.node_id ?? null, flip_value: f.flip_value ?? null, reason: f.flip_reason ?? null })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stats helpers
+// ---------------------------------------------------------------------------
+const pct = (arr, p) => {
+  const a = arr.filter((x) => Number.isFinite(x)).sort((x, y) => x - y);
+  if (!a.length) return null;
+  const idx = Math.min(a.length - 1, Math.max(0, Math.ceil((p / 100) * a.length) - 1));
+  return a[idx];
+};
+const mean = (arr) => { const a = arr.filter(Number.isFinite); return a.length ? a.reduce((s, x) => s + x, 0) / a.length : null; };
+const stddev = (arr) => { const a = arr.filter(Number.isFinite); if (a.length < 2) return 0; const m = mean(a); return Math.sqrt(a.reduce((s, x) => s + (x - m) ** 2, 0) / (a.length - 1)); };
+const spread = (arr) => { const a = arr.filter(Number.isFinite); return a.length ? Math.max(...a) - Math.min(...a) : null; };
+const modal = (arr) => { const c = {}; let best = null; for (const x of arr) { const k = String(x); c[k] = (c[k] ?? 0) + 1; if (!best || c[k] > c[best]) best = k; } return { value: best, count: c[best] ?? 0, total: arr.length }; };
+const round = (x, n = 4) => (x == null || !Number.isFinite(x) ? x : Number(x.toFixed(n)));
+
+function writeOut(name, data) {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const p = join(OUT_DIR, name);
+  writeFileSync(p, typeof data === 'string' ? data : JSON.stringify(data, null, 2));
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Modes
+// ---------------------------------------------------------------------------
+async function modeValidate() {
+  process.stderr.write(`[validate] base=${BASE}\n`);
+  const results = [];
+  for (const key of Object.keys(FIXTURES)) {
+    const r = await runOnce(key, 42, 1000, { includeThresholds: true });
+    results.push(r);
+    process.stderr.write(
+      `  ${key.padEnd(13)} status=${r.analysis_status} winner=${r.winner} winp=${JSON.stringify(r.win_probabilities)} flips=${r.flip_count}(${r.flip_status})\n`
+    );
+  }
+  const p = writeOut(`validate-${STAMP}.json`, { base: BASE, results });
+  process.stderr.write(`[validate] wrote ${p}\n`);
+}
+
+async function modePrecheck() {
+  const fixture = String(args.fixture ?? 'clear-winner');
+  const depth = Number(args.depth ?? 1000);
+  const repeats = Number(args.repeats ?? 8);
+  const seed = Number(args.seed ?? 42);
+  process.stderr.write(`[precheck] fixture=${fixture} depth=${depth} seed=${seed} repeats=${repeats}\n`);
+
+  const calls = [];
+  for (let i = 0; i < repeats; i++) {
+    const r = await runOnce(fixture, seed, depth);
+    calls.push(r);
+    process.stderr.write(
+      `  #${i} winp=${JSON.stringify(r.win_probabilities)} mean=${JSON.stringify(Object.fromEntries(Object.entries(r.outcome_means).map(([k, v]) => [k, round(v, 6)])))} recstab=${round(r.recommendation_stability, 6)} hash=${r.response_hash}\n`
+    );
+  }
+
+  // Compare across identical calls
+  const optIds = Object.keys(calls[0].win_probabilities ?? {});
+  const winpSpread = {};
+  const meanSpread = {};
+  for (const id of optIds) {
+    winpSpread[id] = spread(calls.map((c) => c.win_probabilities[id]));
+    meanSpread[id] = spread(calls.map((c) => c.outcome_means[id]));
+  }
+  const recStabSpread = spread(calls.map((c) => c.recommendation_stability));
+  const hashes = new Set(calls.map((c) => c.response_hash));
+  const winners = new Set(calls.map((c) => c.winner));
+
+  const maxWinp = Math.max(...Object.values(winpSpread).map((x) => x ?? 0));
+  const maxMean = Math.max(...Object.values(meanSpread).map((x) => x ?? 0));
+
+  // Verdict
+  let verdict, note;
+  if (maxWinp === 0 && maxMean < 1e-9) {
+    verdict = 'PASS-DETERMINISTIC';
+    note = 'ISL is bit-for-bit seed-deterministic at fixed seed/depth. Full sweep fully interpretable.';
+  } else if (maxWinp === 0) {
+    verdict = 'PASS-DISPLAY-STABLE';
+    note = `Displayed win_probability is identical across identical calls (sub-display ISL noise ${maxMean.toExponential(2)} in outcome.mean). Sweep interpretable at display precision; attribute sub-0.01 wobble to ISL noise.`;
+  } else if (maxWinp <= 0.01) {
+    verdict = 'MARGINAL';
+    note = `Displayed win_probability varies by up to ${(maxWinp * 100).toFixed(1)}pp across IDENTICAL calls — at the 0.01 quantisation boundary. Sweep spread within ~1pp is not attributable to seed. Proceed with caution.`;
+  } else {
+    verdict = 'HALT';
+    note = `Displayed win_probability varies by up to ${(maxWinp * 100).toFixed(1)}pp across IDENTICAL (seed,depth) calls. ISL is NOT acceptably seed-deterministic — the seed sweep would conflate seed sensitivity with ISL run-to-run noise. HALT and report.`;
+  }
+
+  const summary = {
+    fixture, depth, seed, repeats,
+    distinct_response_hashes: [...hashes],
+    distinct_winners: [...winners],
+    win_probability_spread_pp: Object.fromEntries(Object.entries(winpSpread).map(([k, v]) => [k, round((v ?? 0) * 100, 3)])),
+    outcome_mean_spread: Object.fromEntries(Object.entries(meanSpread).map(([k, v]) => [k, round(v, 9)])),
+    recommendation_stability_spread: round(recStabSpread, 9),
+    max_displayed_winp_spread_pp: round(maxWinp * 100, 3),
+    max_outcome_mean_spread: round(maxMean, 9),
+    verdict, note,
+  };
+  const p = writeOut(`precheck-${STAMP}.json`, { base: BASE, summary, calls });
+  process.stderr.write(`\n[precheck] VERDICT=${verdict}\n  ${note}\n[precheck] wrote ${p}\n`);
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+async function modeSweep() {
+  const fixtures = args.fixtures ? String(args.fixtures).split(',') : Object.keys(FIXTURES);
+  process.stderr.write(`[sweep] fixtures=${fixtures.join(',')} depths=${DEPTHS.join(',')} seeds=${SEEDS.length} (${SEEDS.join(',')})\n`);
+  const raw = [];
+  const total = fixtures.length * DEPTHS.length * SEEDS.length;
+  let i = 0;
+  for (const fx of fixtures) {
+    for (const depth of DEPTHS) {
+      for (const seed of SEEDS) {
+        const r = await runOnce(fx, seed, depth, { includeThresholds: !!args.flip });
+        raw.push(r);
+        i++;
+        if (i % 10 === 0 || i === total) process.stderr.write(`  ${i}/${total} (${fx} d=${depth} s=${seed} status=${r.analysis_status})\n`);
+      }
+    }
+  }
+
+  // Aggregate per (fixture, depth)
+  const cells = [];
+  for (const fx of fixtures) {
+    for (const depth of DEPTHS) {
+      const rows = raw.filter((r) => r.fixture === fx && r.n_samples === depth && r.analysis_status === 'computed');
+      if (!rows.length) { cells.push({ fixture: fx, depth, n: 0, note: 'no computed rows' }); continue; }
+      const optIds = Object.keys(rows[0].win_probabilities);
+      const winnerModal = modal(rows.map((r) => r.winner));
+      const rankingModal = modal(rows.map((r) => r.ranking.join('>')));
+      const perOption = {};
+      for (const id of optIds) {
+        const wps = rows.map((r) => r.win_probabilities[id]).filter(Number.isFinite);
+        perOption[id] = {
+          mean_pp: round(mean(wps) * 100, 2),
+          min_pp: round(Math.min(...wps) * 100, 2),
+          max_pp: round(Math.max(...wps) * 100, 2),
+          spread_pp: round(spread(wps) * 100, 2),
+          stddev_pp: round(stddev(wps) * 100, 2),
+        };
+      }
+      // winner win-prob spread (the headline number)
+      const winnerWps = rows.map((r) => r.win_probabilities[r.winner]).filter(Number.isFinite);
+      const walls = rows.map((r) => r.wall_ms);
+      const islms = rows.map((r) => r.isl_ms).filter(Number.isFinite);
+      cells.push({
+        fixture: fx, depth, n: rows.length,
+        winner_modal: winnerModal.value, winner_stability: round(winnerModal.count / winnerModal.total, 3),
+        ranking_modal: rankingModal.value, ranking_stability: round(rankingModal.count / rankingModal.total, 3),
+        winner_winp_spread_pp: round(spread(winnerWps) * 100, 2),
+        winner_winp_stddev_pp: round(stddev(winnerWps) * 100, 2),
+        per_option: perOption,
+        near_tie_fraction: round(mean(rows.map((r) => (r.near_tie ? 1 : 0))), 3),
+        near_tie_gap_spread: round(spread(rows.map((r) => r.near_tie_gap)), 4),
+        robustness_band: modal(rows.map((r) => r.robustness_level)),
+        recommendation_stability_mean: round(mean(rows.map((r) => r.recommendation_stability)), 4),
+        recommendation_stability_spread: round(spread(rows.map((r) => r.recommendation_stability)), 4),
+        rank1_elasticity_spread: round(spread(rows.map((r) => r.factor_elasticities[0])), 4),
+        latency_wall_p50_ms: pct(walls, 50), latency_wall_p95_ms: pct(walls, 95),
+        isl_p50_ms: pct(islms, 50), isl_p95_ms: pct(islms, 95),
+        flip_timeouts_total: rows.reduce((s, r) => s + (r.flip_timeouts ?? 0), 0),
+        non_computed: raw.filter((r) => r.fixture === fx && r.n_samples === depth && r.analysis_status !== 'computed').length,
+      });
+    }
+  }
+
+  // Latency by depth (across all fixtures)
+  const latencyByDepth = DEPTHS.map((depth) => {
+    const rows = raw.filter((r) => r.n_samples === depth && r.analysis_status === 'computed');
+    return {
+      depth, n: rows.length,
+      wall_p50_ms: pct(rows.map((r) => r.wall_ms), 50),
+      wall_p95_ms: pct(rows.map((r) => r.wall_ms), 95),
+      isl_p50_ms: pct(rows.map((r) => r.isl_ms).filter(Number.isFinite), 50),
+      isl_p95_ms: pct(rows.map((r) => r.isl_ms).filter(Number.isFinite), 95),
+    };
+  });
+
+  const out = { base: BASE, seeds: SEEDS, depths: DEPTHS, fixtures, cells, latencyByDepth, raw };
+  const pj = writeOut(`sweep-${STAMP}.json`, out);
+  const pm = writeOut(`sweep-${STAMP}.md`, renderReport(out));
+  process.stderr.write(`[sweep] wrote ${pj}\n[sweep] wrote ${pm}\n`);
+  console.log(renderReport(out));
+}
+
+function renderReport(out) {
+  const L = [];
+  L.push(`# Track S — Seed-sweep evidence`);
+  L.push(``);
+  L.push(`- Target: \`${out.base}/v2/run\` (live ISL behind it). Read-only; no deploy.`);
+  L.push(`- Seeds (${out.seeds.length}): ${out.seeds.join(', ')}`);
+  L.push(`- Depths: ${out.depths.join(', ')}`);
+  L.push(``);
+  L.push(`## Latency by depth (all fixtures, computed only)`);
+  L.push(`| depth | n | wall p50 | wall p95 | isl p50 | isl p95 |`);
+  L.push(`|---|---|---|---|---|---|`);
+  for (const d of out.latencyByDepth) L.push(`| ${d.depth} | ${d.n} | ${d.wall_p50_ms}ms | ${d.wall_p95_ms}ms | ${d.isl_p50_ms}ms | ${d.isl_p95_ms}ms |`);
+  L.push(``);
+  L.push(`## Stability per fixture × depth`);
+  L.push(`Thresholds: ±3pp ok for display; >±5pp ⇒ fragile. p50≤3s/p95≤6s preferred; p95>8s hard warn.`);
+  L.push(`| fixture | depth | n | winner | win-stab | rank-stab | winner winp spread (pp) | winner winp σ (pp) | near-tie frac | robustness | rec-stab spread | wall p95 | flip TO |`);
+  L.push(`|---|---|---|---|---|---|---|---|---|---|---|---|---|`);
+  for (const c of out.cells) {
+    if (!c.n) { L.push(`| ${c.fixture} | ${c.depth} | 0 | — | — | — | — | — | — | — | — | — | — |`); continue; }
+    L.push(`| ${c.fixture} | ${c.depth} | ${c.n} | ${c.winner_modal} | ${c.winner_stability} | ${c.ranking_stability} | ${c.winner_winp_spread_pp} | ${c.winner_winp_stddev_pp} | ${c.near_tie_fraction} | ${c.robustness_band.value}(${c.robustness_band.count}/${c.robustness_band.total}) | ${c.recommendation_stability_spread} | ${c.latency_wall_p95_ms}ms | ${c.flip_timeouts_total} |`);
+  }
+  L.push(``);
+  return L.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+const MODES = { validate: modeValidate, precheck: modePrecheck, sweep: modeSweep };
+const fn = MODES[MODE];
+if (!fn) { process.stderr.write(`unknown --mode=${MODE}\n`); process.exit(1); }
+fn().catch((e) => { process.stderr.write(`FATAL: ${e.stack || e}\n`); process.exit(1); });


### PR DESCRIPTION
## Track S — PR-E: raise standard MC sample depth 1,000 → 4,000 (PR 2 of 2)

**Deploy-alone, number-changing default change.** Standard base-analysis Monte Carlo depth becomes **4,000** (was 1,000), with an env rollback to 1,000.

> **Stacked on #187 (H1–H4 hardening)** — in particular needs H3 flip-probe decoupling. Until PR 1 merges to `staging`, this PR's diff shows both commits; the net-new commit here is `b76b38e` (the default change). Review/merge PR 1 first.

### Config key + rollback
- **`STANDARD_N_SAMPLES`** env var. Default `4000`. Set `STANDARD_N_SAMPLES=1000` on the staging service to revert instantly — no code change. Only a plain integer within `100–10000` is accepted; invalid, comma-formatted (e.g. `1,000`), empty, or out-of-bounds values fall back to the default (4,000) and warn once. An explicit request `n_samples` always wins.

### Evidence — stability (live staging ISL seed-sweep, 12 seeds × 4 fixtures)
Winner win-probability spread across seeds (percentage points):

| fixture | 1000 | 2000 | **4000** | 8000 |
|---|---|---|---|---|
| clear-winner | 3.05 | 1.90 | **1.19** | 1.19 |
| near-tie | 5.35 | 2.70 | **1.84** | 1.15 |
| multi-option | 6.57 | 3.92 | **2.54** | 1.70 |
| constrained | 5.85 | 4.08 | **2.24** | 1.51 |

1,000 is unstable/fragile on the harder fixtures (3/4 exceed ±3pp; three exceed ±5pp). **4,000 is the first depth where all fixtures meet the provisional ±3pp target.** 8,000 gives diminishing returns. ISL is bit-for-bit seed-deterministic, so this spread is genuine seed sensitivity.

### Evidence — large-graph latency gate (20-factor PoC-scale graph, 10 seeds)
| depth | wall p50 | wall p95 | ISL p50 | ISL p95 |
|---|---|---|---|---|
| 1000 | 2209 ms | 2479 ms | 2071 ms | 2210 ms |
| **4000** | **2541 ms** | **3130 ms** | 2451 ms | 2913 ms |

4× depth costs **+332 ms p50 / +651 ms p95** (ISL has fixed per-call overhead). 4,000 stays at **p50 2.54 s (< 3 s target), p95 3.13 s (≪ 6 s preferred, ≪ 8 s hard-warn)** → no unacceptable increase.

### Correctness
- Flip probes stay decoupled: `resolveFlipProbeNSamples(4000) === 1000` — base raise does **not** push probes into timeout.
- The route threads the **resolved** depth to: ISL request, `meta.n_samples`, `response_hash`, stored fact lineage, decision-brief lineage, debug/meta.
- The canonical-hash fallback constant stays **env-independent** (anchored to the fixed `STANDARD_N_SAMPLES_DEFAULT`) so hashing remains deterministic across environments; only the live route resolves the env override.
- Schema bounds unchanged (`n_samples` 100–10000). V1 `k_samples` default untouched. `V2_RUN_ALLOWED_KEYS` not hand-edited.

### Acceptance / proof (`tests/standard-n-samples-default.test.ts`)
default unset → 4000 · `STANDARD_N_SAMPLES=1000` → 1000 · `hash(1000) ≠ hash(4000)` · flip probes stay at 1000.

### Open decision (Neil/Jinghui)
The ±3pp / ±5pp thresholds are **provisional** engineering values. This is **simulation-stability** evidence, **not** calibration. Confirm acceptable MC error for displayed probabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
