### PR TITLE
chore(isl): forward-safe non-negative VOI hardening on internal robustness-enrichment builder

### DIFF
--- a/src/integrations/isl/adapters/robustness-enrichment.ts
+++ b/src/integrations/isl/adapters/robustness-enrichment.ts
@@ -13,6 +13,7 @@ import type {
   RobustnessDataForCee,
 } from '../types/plot-types.js';
 import type { ISLFactorSensitivityItem } from '../types/isl-types.js';
+import { sanitiseIslVoi } from '../../../lib/evpi-emission.js';
 
 // =============================================================================
 // Edge ID Parsing Helpers
@@ -182,7 +183,22 @@ export function enrichFactorSensitivity(
     factor_id: factor.node_id,
     factor_label: getNodeLabel(graph, factor.node_id),
     sensitivity: sensitivityValue,
-    value_of_information: factor.value_of_information,
+    // Forward-safe internal hardening: apply the non-negative VOI contract
+    // (Howard 1966) on this enrichment builder for consistency with the three
+    // sibling surfaces that already sanitise ISL VOI — `mapIslFactorEntry`
+    // (src/routes/v2/run.ts:590), `adaptFactorSensitivityResponse`
+    // (./factor-sensitivity.ts:49), and `adaptRobustnessAnalysis`
+    // (./robustness-analysis.ts:330). ISL emits VOI via a Monte Carlo estimator
+    // that can drift slightly negative from sampling noise; `sanitiseIslVoi`
+    // maps negative/non-finite values to `undefined` (absence means "no
+    // measurable value of information", not zero).
+    //
+    // NOTE: this field is NOT currently consumed by any outbound CEE request —
+    // `buildCeeReviewRequest` reads `RobustnessDataForCee` only via
+    // `fragile_edges`, and `CeeReviewRequest` carries no VOI field. The guard
+    // keeps the builder result contract-compliant should VOI ever be wired into
+    // a CEE payload; it changes no CEE-visible data today.
+    value_of_information: sanitiseIslVoi(factor.value_of_information),
     direction: factor.direction,
   };
 }

--- a/tests/robustness-enrichment.test.ts
+++ b/tests/robustness-enrichment.test.ts
@@ -231,6 +231,83 @@ describe('enrichFactorSensitivity', () => {
 
     expect(result.sensitivity).toBe(0);
   });
+
+  // ---------------------------------------------------------------------------
+  // VOI sanitisation on the internal robustness-enrichment builder (Howard 1966
+  // non-negative contract). Mirrors the guard already applied by the three
+  // sibling surfaces (mapIslFactorEntry, adaptFactorSensitivityResponse,
+  // adaptRobustnessAnalysis). Forward-safe hardening: this builder result is
+  // NOT consumed by any outbound CEE request today (buildCeeReviewRequest reads
+  // only fragile_edges; CeeReviewRequest has no VOI field).
+  // ---------------------------------------------------------------------------
+
+  it('preserves a positive finite VOI verbatim', () => {
+    const factor = {
+      node_id: 'fac_price',
+      sensitivity: 0.85,
+      value_of_information: 0.42,
+      direction: 'negative' as const,
+    };
+
+    const result = enrichFactorSensitivity(factor, TEST_GRAPH);
+
+    expect(result.value_of_information).toBe(0.42);
+  });
+
+  it('preserves an explicit VOI of 0 (missing-vs-zero distinction)', () => {
+    // VOI = 0 is a valid ISL result ("perfect information would not change the
+    // recommendation") and must be preserved, NOT coerced to undefined.
+    const factor = {
+      node_id: 'fac_price',
+      sensitivity: 0.4,
+      value_of_information: 0,
+      direction: 'positive' as const,
+    };
+
+    const result = enrichFactorSensitivity(factor, TEST_GRAPH);
+
+    expect(result.value_of_information).toBe(0);
+  });
+
+  it('sanitises a negative VOI to undefined (Monte Carlo artefact)', () => {
+    const factor = {
+      node_id: 'fac_price',
+      sensitivity: 0.4,
+      value_of_information: -0.07,
+      direction: 'negative' as const,
+    };
+
+    const result = enrichFactorSensitivity(factor, TEST_GRAPH);
+
+    expect(result.value_of_information).toBeUndefined();
+  });
+
+  it('sanitises NaN, Infinity and -Infinity VOI to undefined', () => {
+    for (const voi of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const factor = {
+        node_id: 'fac_price',
+        sensitivity: 0.4,
+        value_of_information: voi,
+        direction: 'positive' as const,
+      };
+
+      const result = enrichFactorSensitivity(factor, TEST_GRAPH);
+
+      expect(result.value_of_information).toBeUndefined();
+    }
+  });
+
+  it('leaves an absent VOI absent', () => {
+    const factor = {
+      node_id: 'fac_price',
+      sensitivity: 0.4,
+      direction: 'positive' as const,
+    };
+
+    const result = enrichFactorSensitivity(factor, TEST_GRAPH);
+
+    expect(result.value_of_information).toBeUndefined();
+  });
 });
 
 // =============================================================================
@@ -332,5 +409,45 @@ describe('buildRobustnessDataForCee', () => {
     expect(result).not.toBeNull();
     expect(result!.recommended_option).toBeUndefined();
     expect(result!.fragile_edges).toHaveLength(1);
+  });
+
+  it('sanitises a negative VOI while preserving a positive sibling in the builder result', () => {
+    // End-to-end through the buildRobustnessDataForCee builder (an internal
+    // enrichment result; not consumed by the outbound CEE request today): a
+    // negative MC artefact must become undefined, while a valid positive VOI on
+    // a sibling factor is preserved verbatim.
+    const islRobustness = {
+      recommendation_stability: 0.87,
+      fragile_edges: ['fac_price->goal_revenue'],
+      robust_edges: [],
+    };
+
+    const islFactorSensitivity = [
+      {
+        node_id: 'fac_price',
+        sensitivity: 0.85,
+        value_of_information: -0.07, // MC sampling artefact → must sanitise to undefined
+        direction: 'negative' as const,
+      },
+      {
+        node_id: 'fac_market_size',
+        sensitivity: 0.6,
+        value_of_information: 0.42, // valid → preserved
+        direction: 'positive' as const,
+      },
+    ];
+
+    const result = buildRobustnessDataForCee(
+      islRobustness,
+      islFactorSensitivity,
+      'opt_premium',
+      TEST_GRAPH,
+      TEST_OPTIONS
+    );
+
+    expect(result).not.toBeNull();
+    const byId = new Map(result!.factor_sensitivity!.map((f) => [f.factor_id, f]));
+    expect(byId.get('fac_price')!.value_of_information).toBeUndefined();
+    expect(byId.get('fac_market_size')!.value_of_information).toBe(0.42);
   });
 });


### PR DESCRIPTION
> **Re-scoped + slimmed after review.** An earlier draft framed this as closing a CEE VOI leak; the reviewer correctly showed the field is not consumed by any outbound CEE request. The prior amend also only changed commit metadata — the source-comment/test corrections did not ship. Both are now fixed in the tree at `3699d43`.

## What this change is

`enrichFactorSensitivity` (builder of `RobustnessDataForCee`) emitted **raw** ISL `value_of_information` without the non-negative sanitisation applied on every sibling VOI surface. This wraps it in the existing `sanitiseIslVoi` helper so negative / non-finite Monte-Carlo artefacts become `undefined` (Howard 1966; absence means "no measurable value of information", not zero).

**Production change: 1 file** (`src/integrations/isl/adapters/robustness-enrichment.ts`) — import + one wrapped field, with a source comment that now states plainly this is internal/forward-safe and **not** CEE-visible.

## Not CEE-visible (verified trace)

- `buildCeeReviewRequest` ([run.ts:2308](src/routes/v2/run.ts#L2308)) reads `RobustnessDataForCee` **only** via `fragile_edges`.
- `sensitive_parameters` is rebuilt from **raw** `islResult.factor_sensitivity` → `{parameter, sensitivity, impact_direction}`, no VOI.
- `CeeReviewRequest` ([cee/types.ts:264](src/cee/types.ts#L264)) has **no** VOI field.

So `RobustnessDataForCee.factor_sensitivity[].value_of_information` reaches no outbound CEE request today. Wiring VOI into the CEE contract is out of this PLoT/ISL-only lane (CEE-consumed schema + builder edit) — noted as a possible V5/CEE follow-up.

## Diff / base

- Branch `claude/sleepy-raman-9cc56c` at `3699d43`; parent `origin/staging` `78aea76`.
- **2 files, +134/−1**: 1 src + the focused builder regression test. No CEE/UI/prompts/schema/OpenAPI/deploy/flag/package/lock/generated changes.

## Tests (full suite green: 4981 passed / 25 skipped / 0 failed)

Focused builder regression pins on the changed function (`enrichFactorSensitivity` + `buildRobustnessDataForCee`): negative / `NaN` / `±Infinity` VOI → `undefined`; positive and explicit-`0` preserved (missing-vs-zero).

**Slimmed per review:** the route-level EVPI-provenance test and the intervention-override negative control were **removed from this PR** — they are broader-brief regression pins with no release-gate tie to this one-line change, and the override filter is already covered by `tests/coaching/sensitivity-filter.test.ts`. Deferred to the residual-brief PR.

## Handoff notes

- **V5/CEE:** no current consumer impact (field not in any CEE request contract). If VOI is ever added to a CEE payload, PLoT already emits it non-negative; CEE should treat absence as "not measurable," not zero.
- **V5/UI:** "robust to X" wording is CEE/UI-generated, not PLoT/ISL (confirmed absent from source). PLoT already strips `intervention_override` factors. V5/UI-owned; no PLoT change.
- **Neil/ISL3:** `epsilon_std:0` / `auto_noise_applied:false` are honest passthrough/defaults; auto-noise policy is a separate science/ISL3 lane.

## Known-unrelated red gates
GitHub audit and Windows gates are baseline (deps unchanged; Windows-invalid `tools/sdk-smoke:python.mjs` exists on `staging`) — not caused by this PR; need a separate waiver/remediation if they block merge.

## Guardrails
Draft only — not ready, not merged, no deploy, no flag change. No CEE/V5/UI/prompt/PMS/CEE-schema/migration/generated-OpenAPI/package/lockfile/node_modules changes. No EVPI precision/sample-count change. No field rename. No broad refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
