### PR TITLE
fix(plot): A1b — suppress intervention_override elasticity/tunability re-leak

### DIFF
--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -32,6 +32,9 @@ import type {
 import { DECISION_BRIEF_VERSION } from '../types/decision-brief.js';
 import type { RunResponseV3 } from '../types/engine-v3.js';
 import { STANDARD_N_SAMPLES_DEFAULT } from '../config/sampling.js';
+// A1b: intervention-controlled levers are not independently tunable; exclude them
+// from the |elasticity|-ranked tunability surfaces (top_drivers, what_would_change).
+import { filterInterventionOverrides } from '../lib/intervention-override.js';
 
 // =============================================================================
 // Constants
@@ -256,8 +259,10 @@ function buildOptions(input: BriefAssemblyInput): BriefOption[] {
 }
 
 function buildTopDrivers(input: BriefAssemblyInput): BriefDriver[] {
-  const factors = input.factor_sensitivity;
-  if (!factors || factors.length === 0) return [];
+  // A1b: exclude intervention-controlled levers — top_drivers ranks by
+  // abs(elasticity) and would otherwise present option-pinned levers as tunable.
+  const factors = filterInterventionOverrides(input.factor_sensitivity ?? []);
+  if (factors.length === 0) return [];
 
   // Sort by absolute elasticity descending, ties broken by factor_id (node_id) bytewise ascending
   const withElasticity = factors
@@ -320,8 +325,9 @@ function buildWhatWouldChange(input: BriefAssemblyInput): string[] {
   }
 
   // Fallback: factor_sensitivity labels (top drivers by |elasticity|)
-  const factors = input.factor_sensitivity;
-  if (factors && factors.length > 0) {
+  // A1b: exclude intervention-controlled levers from this |elasticity|-ranked fallback.
+  const factors = filterInterventionOverrides(input.factor_sensitivity ?? []);
+  if (factors.length > 0) {
     return factors
       .filter(f => f.elasticity !== undefined && f.elasticity !== null)
       .sort((a, b) => Math.abs(b.elasticity!) - Math.abs(a.elasticity!))

--- a/src/coaching/critiques.ts
+++ b/src/coaching/critiques.ts
@@ -6,6 +6,7 @@
 
 import type { CoachingInputs, Critique, CritiqueType } from './types.js';
 import { getThresholds } from './thresholds.js';
+import { isInterventionOverride } from './sensitivity-filter.js';
 
 export function generateCritiques(inputs: CoachingInputs): Critique[] {
   const critiques: Critique[] = [];
@@ -65,9 +66,19 @@ function checkMissingRiskPathway(inputs: CoachingInputs): Critique | null {
   const { factorSensitivity, graph } = inputs;
 
   // Primary check: factor_sensitivity direction field from ISL
+  const MATERIALITY_THRESHOLD = 0.01;
   const negativeFactors = factorSensitivity.filter((f) => f.direction === 'negative');
-  const materialNegativeFactors = negativeFactors.filter(
-    (f) => Math.abs(f.elasticity ?? 0) > 0.01
+  // A1b: for intervention-controlled levers the producer zeroes `elasticity`
+  // (defence-in-depth), so materiality for a lever must use its PRESERVED
+  // structural magnitude `influence_score` — NOT the zeroed elasticity (would
+  // drop a material lever from the negative set → false MISSING_RISK_PATHWAY) and
+  // NOT unconditional materiality (would wrongly keep a negligible lever). For
+  // graph factors influence_score === elasticity === normalised_influence, so the
+  // 0.01 threshold is on the same scale and recovers the exact pre-A1b decision.
+  const materialNegativeFactors = negativeFactors.filter((f) =>
+    isInterventionOverride(f)
+      ? Math.abs(f.influence_score ?? 0) > MATERIALITY_THRESHOLD
+      : Math.abs(f.elasticity ?? 0) > MATERIALITY_THRESHOLD
   );
 
   if (materialNegativeFactors.length > 0) return null;

--- a/src/coaching/critiques.ts
+++ b/src/coaching/critiques.ts
@@ -6,7 +6,7 @@
 
 import type { CoachingInputs, Critique, CritiqueType } from './types.js';
 import { getThresholds } from './thresholds.js';
-import { isInterventionOverride } from './sensitivity-filter.js';
+import { isInterventionOverride, filterInterventionOverrides } from './sensitivity-filter.js';
 
 export function generateCritiques(inputs: CoachingInputs): Critique[] {
   const critiques: Critique[] = [];
@@ -40,7 +40,13 @@ export function generateCritiques(inputs: CoachingInputs): Critique[] {
 }
 
 function checkDominantFactor(inputs: CoachingInputs, thresholds: ReturnType<typeof getThresholds>): Critique | null {
-  const { factorSensitivity } = inputs;
+  // A1b: DOMINANT_FACTOR is a tunability critique — it names the dominant factor in
+  // a "what would change if {x} had less influence?" challenge. Exclude option-pinned
+  // levers via the explicit zero_reason predicate (the durable guarantee — NOT
+  // reliant on producer elasticity:0) so a lever is never named as the dominant
+  // tunable factor. Single application point: inputs.factorSensitivity is the raw
+  // coaching array, not already filtered.
+  const factorSensitivity = filterInterventionOverrides(inputs.factorSensitivity);
   if (factorSensitivity.length === 0) return null;
 
   const absElasticities = factorSensitivity.map((f) => Math.abs(f.elasticity ?? 0));

--- a/src/coaching/headlines.ts
+++ b/src/coaching/headlines.ts
@@ -246,6 +246,13 @@ export function detectHeadlineType(inputs: CoachingInputs): HeadlineType {
   const stability = robustness.recommendationStability;
   const hasFactorSensitivity = factorSensitivity.length > 0;
 
+  // A1b: VoI classification must not be driven by option-pinned levers. Exclude
+  // levers for the VoI site ONLY — the hasFactorSensitivity existence check above
+  // keeps the original array. Mirrors generateHeadlines so both classify
+  // consistently, and does not rely on the producer elasticity:0 alone (the
+  // explicit predicate is the durable guarantee).
+  const tunable = filterInterventionOverrides(factorSensitivity);
+
   // Get top fragile edge (highest switch probability)
   const topFragile = fragileEdges
     .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min)
@@ -254,7 +261,7 @@ export function detectHeadlineType(inputs: CoachingInputs): HeadlineType {
   const topFragileSwitchProb = topFragile?.switchProb ?? 0;
 
   // Compute evidence gap influence
-  const topGapVoI = computeTopGapInfluence(factorSensitivity);
+  const topGapVoI = computeTopGapInfluence(tunable);
 
   return selectHeadlineType(
     winProbDelta,

--- a/src/coaching/headlines.ts
+++ b/src/coaching/headlines.ts
@@ -6,6 +6,8 @@
 
 import type { CoachingInputs, HeadlineType, StoryHeadlines, FragileEdgeContext } from './types.js';
 import { getThresholds } from './thresholds.js';
+// A1b: intervention-controlled levers are not tunable evidence/VoI gaps.
+import { filterInterventionOverrides } from './sensitivity-filter.js';
 
 const HEADLINE_TEMPLATES = {
   clear_winner: '{option} outperforms by {deltaPoints} points with high confidence',
@@ -70,6 +72,12 @@ export function generateHeadlines(inputs: CoachingInputs): StoryHeadlines {
   const stability = robustness.recommendationStability;
   const hasFactorSensitivity = factorSensitivity.length > 0;
 
+  // A1b: VoI/evidence derivation must not name option-pinned levers as tunable
+  // gaps. Exclude levers for the VoI sites ONLY — the hasFactorSensitivity
+  // existence check above keeps the original array (we do not erase lever
+  // existence from headline reasoning). Used at both VoI sites below.
+  const tunable = filterInterventionOverrides(factorSensitivity);
+
   // Get top fragile edge (highest switch probability)
   const topFragile = fragileEdges
     .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min)
@@ -78,7 +86,7 @@ export function generateHeadlines(inputs: CoachingInputs): StoryHeadlines {
   const topFragileSwitchProb = topFragile?.switchProb ?? 0;
 
   // Compute evidence gap influence (simplified for now)
-  const topGapVoI = computeTopGapInfluence(factorSensitivity);
+  const topGapVoI = computeTopGapInfluence(tunable);
 
   // Select headline type
   const headlineType = selectHeadlineType(
@@ -120,7 +128,7 @@ export function generateHeadlines(inputs: CoachingInputs): StoryHeadlines {
       break;
     case 'needs_evidence': {
       // Find factor with highest VoI (impact × uncertainty)
-      const topGap = factorSensitivity
+      const topGap = tunable
         .map((f) => ({
           label: f.label,
           voi: Math.abs(f.elasticity ?? f.influence_score ?? 0) * (1 - (f.confidence ?? 0.5)),

--- a/src/coaching/sensitivity-filter.ts
+++ b/src/coaching/sensitivity-filter.ts
@@ -6,18 +6,10 @@
  * to the review prompt or the UI.
  *
  * This is a PLoT output filter only — ISL request/response is not mutated.
+ *
+ * The implementation lives in the import-free neutral leaf
+ * `src/lib/intervention-override.ts` (single definition; A1b). This module
+ * re-exports it so existing coaching-side importers are unaffected.
  */
 
-/**
- * Filter out factor sensitivity entries that represent intervention overrides.
- * These are decision levers (elasticity=0 because the user controls them),
- * not uncertainty drivers.
- *
- * @param factors Array of factor sensitivity entries with optional zero_reason
- * @returns Filtered array excluding intervention_override entries
- */
-export function filterInterventionOverrides<T extends { zero_reason?: string | null }>(
-  factors: T[]
-): T[] {
-  return factors.filter((f) => f.zero_reason !== 'intervention_override');
-}
+export { isInterventionOverride, filterInterventionOverrides } from '../lib/intervention-override.js';

--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -947,6 +947,13 @@ export function mergeIslConfidenceIntoGraphFactors(
         // tunable sensitivity. (influence_score / source stay graph-derived.)
         sensitivity_score: 0,
         zero_reason: 'intervention_override',
+        // A1b: defensive public producer value — NOT a measured elasticity and
+        // NO claim of low sensitivity/stability. Set to 0 (not omitted) so
+        // downstream `elasticity ?? influence_score` fallbacks short-circuit to 0
+        // instead of re-leaking the preserved non-zero influence_score. The
+        // durable guarantee is the explicit zero_reason predicate at each
+        // tunability/evidence surface; this is defence-in-depth. (A1b brief §1/§3.)
+        elasticity: 0,
       }),
     };
   });

--- a/src/lib/intervention-override.ts
+++ b/src/lib/intervention-override.ts
@@ -1,0 +1,26 @@
+/**
+ * Intervention-override predicate — shared neutral leaf (A1b).
+ *
+ * A factor with `zero_reason === 'intervention_override'` is an option-pinned
+ * decision lever (the user controls its value via `options[i].interventions`),
+ * NOT an independently tunable uncertainty driver. Tunability / evidence / VoI /
+ * "what would change" surfaces must exclude such levers.
+ *
+ * This module is the single definition, kept import-free so any layer (lib,
+ * assembly, routes, coaching) can depend on it without creating an import cycle.
+ * It keys ONLY on `zero_reason` — it does NOT read `source`, re-derive lever
+ * status from graph topology or option interventions, expose a public field, or
+ * define a new classification taxonomy.
+ */
+
+/** True iff the factor is an intervention-controlled lever (option-pinned). */
+export function isInterventionOverride(f: { zero_reason?: string | null }): boolean {
+  return f.zero_reason === 'intervention_override';
+}
+
+/** Drop intervention-controlled levers from a factor list. */
+export function filterInterventionOverrides<T extends { zero_reason?: string | null }>(
+  factors: T[],
+): T[] {
+  return factors.filter((f) => !isInterventionOverride(f));
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -1994,7 +1994,9 @@ function buildResponse(
   // Gated behind ENABLE_REVIEW_PASS. Excluded from response_hash.
   const assembledReviewCards: ProposalCardV1[] = [];
   if (FLAGS.ENABLE_REVIEW_PASS) {
-    const epFactors: FactorInput[] = (factorSensitivity ?? []).map((fs: any) => ({
+    // A1b: exclude intervention-controlled levers from the evidence-priority card
+    // (ranked by abs(elasticity)) — option-pinned levers are not tunable evidence gaps.
+    const epFactors: FactorInput[] = filterInterventionOverrides(factorSensitivity ?? []).map((fs: any) => ({
       factor_id: fs.factor_id,
       factor_label: fs.factor_label ?? fs.factor_id,
       elasticity: fs.elasticity ?? fs.sensitivity_score ?? 0,

--- a/tests/isl-confidence-merge.test.ts
+++ b/tests/isl-confidence-merge.test.ts
@@ -470,6 +470,45 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
   });
 
   // -------------------------------------------------------------------------
+  // T10d (Lane A1b, producer) — matched intervention_override levers get a
+  // defensive `elasticity: 0` (so downstream `elasticity ?? influence_score`
+  // fallbacks short-circuit instead of re-leaking the preserved influence_score).
+  // sensitivity_score/zero_reason (A1) and influence_score/source/importance_rank
+  // remain as A1 left them; non-lever elasticity is byte-identical.
+  // RED pre-A1b: matched levers keep the graph-derived elasticity (`...gf`).
+  // -------------------------------------------------------------------------
+  it('T10d (Lane A1b): matched intervention_override levers get elasticity:0; non-levers + influence_score/importance_rank unchanged', () => {
+    const graphFactors: FactorSensitivityResultV3[] = [
+      makeGraphFactor('fac_leadership_capacity', { sensitivity_score: 0.4475, elasticity: 1, influence_score: 1, importance_rank: 1, direction: 'positive' }),
+      makeGraphFactor('fac_dev_capacity', { sensitivity_score: 0.23, elasticity: 0.5139664804469275, influence_score: 0.5139664804469275, importance_rank: 2, direction: 'positive' }),
+      makeGraphFactor('fac_time_pressure', { sensitivity_score: -0.2285, elasticity: 0.5106145251396648, influence_score: 0.5106145251396648, importance_rank: 3, direction: 'negative' }),
+    ];
+    const graphById = new Map(graphFactors.map(f => [f.factor_id, { ...f }]));
+    const islUnfiltered: FactorSensitivityResultV3[] = [
+      makeIslFactor('fac_leadership_capacity', { sensitivity_score: 0, zero_reason: 'intervention_override', attribution_stability: 'negligible' }),
+      makeIslFactor('fac_dev_capacity', { sensitivity_score: 0, zero_reason: 'intervention_override', attribution_stability: 'negligible' }),
+      makeIslFactor('fac_time_pressure', { sensitivity_score: 1, attribution_stability: 'low' }),
+    ];
+
+    const merged = mergeIslConfidenceIntoGraphFactors(graphFactors, islUnfiltered);
+
+    const LEVERS = ['fac_leadership_capacity', 'fac_dev_capacity'];
+    for (const id of LEVERS) {
+      const m = merged.find(f => f.factor_id === id)!;
+      expect(m.elasticity).toBe(0);                          // RED pre-A1b: graph-derived non-zero
+      expect(m.sensitivity_score).toBe(0);                  // A1 invariant preserved
+      expect(m.zero_reason).toBe('intervention_override');  // A1 invariant preserved
+      expect(m.influence_score).toBe(graphById.get(id)!.influence_score); // unchanged (graph)
+      expect(m.importance_rank).toBe(graphById.get(id)!.importance_rank); // unchanged
+      expect(m.source).toBe('graph');                       // unchanged
+    }
+    // Non-lever elasticity byte-identical to graph input.
+    const tp = merged.find(f => f.factor_id === 'fac_time_pressure')!;
+    expect(tp.elasticity).toBe(graphById.get('fac_time_pressure')!.elasticity);
+    expect(tp.zero_reason).not.toBe('intervention_override');
+  });
+
+  // -------------------------------------------------------------------------
   // T11 — heart-of-the-fix regression (audit row A1-PRIMARY)
   // -------------------------------------------------------------------------
 

--- a/tests/lane-a1-intervention-override-egress.integration.test.ts
+++ b/tests/lane-a1-intervention-override-egress.integration.test.ts
@@ -139,13 +139,15 @@ describe('Lane A1 — /v2/run egress preserves intervention_override lever sensi
 
   // Save/restore (not delete) so an ambient value — e.g. under CI — is preserved
   // and we don't leak an env change to other tests sharing the worker.
-  const ENV_KEYS = ['RATE_LIMIT_ENABLED', 'CEE_ORCHESTRATOR_ENABLED'] as const;
+  const ENV_KEYS = ['RATE_LIMIT_ENABLED', 'CEE_ORCHESTRATOR_ENABLED', 'ENABLE_REVIEW_PASS'] as const;
   const savedEnv: Record<string, string | undefined> = {};
 
   beforeAll(async () => {
     for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
     process.env.RATE_LIMIT_ENABLED = '0';
     process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    // Emit the evidence_priority review card so the A1b exclusion is asserted, not skipped.
+    process.env.ENABLE_REVIEW_PASS = '1';
     app = await createServer();
     await app.listen({ port: 0, host: '127.0.0.1' });
     const addr = app.server.address();
@@ -230,12 +232,12 @@ describe('Lane A1 — /v2/run egress preserves intervention_override lever sensi
     const wwc = body.decision_brief.what_would_change ?? [];
     for (const lab of LEVER_LABELS) expect(wwc).not.toContain(lab);
 
-    // evidence-priority review card (if emitted): levers excluded.
-    const epCard = (body.review_cards ?? []).find((c: any) => /evidence/i.test(c.card_type ?? c.type ?? c.kind ?? ''));
-    if (epCard?.items) {
-      const epLabels = epCard.items.map((i: any) => i.factor_label ?? i.factor_id);
-      for (const lab of LEVER_LABELS) expect(epLabels).not.toContain(lab);
-    }
+    // evidence-priority review card (ENABLE_REVIEW_PASS on → emitted): levers excluded.
+    const epCard = (body.review_cards ?? []).find((c: any) => c.card_type === 'evidence_priority');
+    expect(epCard, 'evidence_priority card emitted').toBeDefined();
+    const epIds = (epCard.items ?? []).map((i: any) => i.factor_id);
+    for (const id of LEVERS) expect(epIds, `evidence-priority excludes ${id}`).not.toContain(id);
+    expect(epIds.length, 'a non-lever remains in evidence-priority').toBeGreaterThan(0);
 
     // story_headlines (if emitted): no lever named.
     const sh = body.m1_coaching?.story_headlines;

--- a/tests/lane-a1-intervention-override-egress.integration.test.ts
+++ b/tests/lane-a1-intervention-override-egress.integration.test.ts
@@ -197,4 +197,51 @@ describe('Lane A1 — /v2/run egress preserves intervention_override lever sensi
       expect(f.zero_reason ?? null).not.toBe('intervention_override');
     }
   });
+
+  const LEVER_LABELS = ['Technical Leadership Capacity', 'Additional Developer Capacity', 'Annual Hiring Cost'];
+  const NONLEVER_LABELS = ['Launch Deadline Pressure', 'Existing Team Size'];
+
+  it('A1b: levers absent from decision_brief.top_drivers / what_would_change; elasticity:0; non-levers present', async () => {
+    const res = await fetch(`${baseUrl}/v2/run`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '42' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    const factors = body.factor_sensitivity;
+
+    // Producer: lever elasticity defensively zeroed (RED pre-A1b: graph-derived non-zero).
+    for (const id of LEVERS) {
+      expect(factors.find((x: any) => x.factor_id === id).elasticity, `${id} elasticity`).toBe(0);
+    }
+    // Non-lever elasticity unchanged (non-zero).
+    for (const id of NON_LEVERS) {
+      expect(factors.find((x: any) => x.factor_id === id).elasticity).not.toBe(0);
+    }
+
+    // decision_brief.top_drivers: levers excluded, non-lever(s) present (RED pre-A1b: levers rank top).
+    expect(body.decision_brief, 'decision_brief present').toBeDefined();
+    const td = (body.decision_brief.top_drivers ?? []).map((d: any) => d.factor_label);
+    expect(td.length).toBeGreaterThan(0);
+    for (const lab of LEVER_LABELS) expect(td, `top_drivers excludes ${lab}`).not.toContain(lab);
+    expect(NONLEVER_LABELS.some((lab) => td.includes(lab)), 'a non-lever surfaces as a top driver').toBe(true);
+
+    // decision_brief.what_would_change (factor fallback; fragile_edges empty): levers excluded.
+    const wwc = body.decision_brief.what_would_change ?? [];
+    for (const lab of LEVER_LABELS) expect(wwc).not.toContain(lab);
+
+    // evidence-priority review card (if emitted): levers excluded.
+    const epCard = (body.review_cards ?? []).find((c: any) => /evidence/i.test(c.card_type ?? c.type ?? c.kind ?? ''));
+    if (epCard?.items) {
+      const epLabels = epCard.items.map((i: any) => i.factor_label ?? i.factor_id);
+      for (const lab of LEVER_LABELS) expect(epLabels).not.toContain(lab);
+    }
+
+    // story_headlines (if emitted): no lever named.
+    const sh = body.m1_coaching?.story_headlines;
+    if (sh) {
+      const text = Object.values(sh).join(' || ');
+      for (const lab of LEVER_LABELS) expect(text, `headlines do not name ${lab}`).not.toContain(lab);
+    }
+  });
 });

--- a/tests/lane-a1b-elasticity-suppression.test.ts
+++ b/tests/lane-a1b-elasticity-suppression.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { assembleBrief, type BriefAssemblyInput } from '../src/assembly/decision-brief.js';
-import { generateHeadlines } from '../src/coaching/headlines.js';
+import { generateHeadlines, detectHeadlineType } from '../src/coaching/headlines.js';
 import { generateCritiques } from '../src/coaching/critiques.js';
 import { computeKeyDrivers } from '../src/coaching/key-drivers.js';
 import { buildEvidencePriorityCard, type FactorInput } from '../src/review-pass/evidence-priority.js';
@@ -125,6 +125,23 @@ describe('A1b — headlines do not name levers as VoI/evidence gaps (existence c
     const factors = [normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: 1, confidence: 0.1, influence_score: 1, zero_reason: 'intervention_override' })];
     const headlines = generateHeadlines(coachingInputs(factors));
     expect(Object.keys(headlines).length).toBeGreaterThan(0); // winner headline still emitted
+  });
+
+  // Codex finding: detectHeadlineType (used by orchestrator) is the SAME headline
+  // VoI classification surface and must apply the predicate too — otherwise a
+  // high-elasticity lever drives high_uncertainty there while generateHeadlines
+  // (filtered) disagrees. RED pre-fix: detectHeadlineType returned high_uncertainty.
+  it('detectHeadlineType: high-elasticity intervention_override lever does NOT classify as high_uncertainty (no fragile edge)', () => {
+    const factors = [
+      normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: 1, confidence: 0.05, influence_score: 1, zero_reason: 'intervention_override' }),
+      normFactor({ node_id: 'fac_team_size', label: 'Existing Team Size', elasticity: 0.05, confidence: 0.9, influence_score: 0.05, direction: 'positive' }),
+    ];
+    // stability defined + clear winner delta + NO fragile edges → without the
+    // lever's stale VoI, the type is not high_uncertainty.
+    const inputs = coachingInputs(factors, { robustness: { level: 'high', recommendationStability: 0.85, isRobust: true } as any });
+    expect(detectHeadlineType(inputs)).not.toBe('high_uncertainty');
+    // Consistency: generateHeadlines on the same input must not name the lever.
+    expect(Object.values(generateHeadlines(inputs)).join(' || ')).not.toContain(LEVER);
   });
 });
 

--- a/tests/lane-a1b-elasticity-suppression.test.ts
+++ b/tests/lane-a1b-elasticity-suppression.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Lane A1b — elasticity / tunability re-leak suppression (unit).
+ *
+ * A1 made intervention-controlled levers egress `sensitivity_score: 0` +
+ * `zero_reason: 'intervention_override'`, but graph-derived `elasticity` still
+ * drove the tunability / evidence / VoI / "what would change" surfaces. A1b
+ * excludes levers at those surfaces (predicate keyed on `zero_reason`) and the
+ * producer defensively zeroes `elasticity`. `influence_score` / `importance_rank`
+ * are NOT touched (structural — key_drivers / assumptions_ledger keep the lever).
+ *
+ * Each block is RED-before (the lever leaks on pre-A1b code) / GREEN-after.
+ * Levers here carry a NON-ZERO `elasticity` so the tests prove the explicit
+ * predicate (not merely the producer `elasticity: 0`) excludes them.
+ */
+import { describe, it, expect } from 'vitest';
+import { assembleBrief, type BriefAssemblyInput } from '../src/assembly/decision-brief.js';
+import { generateHeadlines } from '../src/coaching/headlines.js';
+import { generateCritiques } from '../src/coaching/critiques.js';
+import { computeKeyDrivers } from '../src/coaching/key-drivers.js';
+import { buildEvidencePriorityCard, type FactorInput } from '../src/review-pass/evidence-priority.js';
+import { filterInterventionOverrides } from '../src/lib/intervention-override.js';
+import type { CoachingInputs, NormalisedFactorSensitivity } from '../src/coaching/types.js';
+
+const LEVER = 'Technical Leadership Capacity';
+const NONLEVER = 'Launch Deadline Pressure';
+
+// ---------------------------------------------------------------------------
+// decision_brief.top_drivers + what_would_change (public, abs(elasticity)-ranked)
+// ---------------------------------------------------------------------------
+function briefInput(factor_sensitivity: any[]): BriefAssemblyInput {
+  return {
+    analysis_status: 'computed',
+    critiques: [],
+    option_comparison: [
+      { option_id: 'opt1', label: 'A', win_probability: 0.6 },
+      { option_id: 'opt2', label: 'B', win_probability: 0.4 },
+    ],
+    // fragile_edges empty → what_would_change uses the factor_sensitivity fallback
+    robustness: { level: 'moderate', fragile_edges: [], robust_edges: [] } as any,
+    meta: { seed_used: '1' },
+    factor_sensitivity,
+  } as BriefAssemblyInput;
+}
+
+describe('A1b — decision_brief excludes intervention_override levers', () => {
+  // Lever has the HIGHEST abs(elasticity); pre-A1b it would be the #1 top driver.
+  const factors = [
+    { factor_id: 'fac_leadership_capacity', factor_label: LEVER, elasticity: 1, influence_score: 1, direction: 'positive', zero_reason: 'intervention_override' },
+    { factor_id: 'fac_time_pressure', factor_label: NONLEVER, elasticity: 0.51, influence_score: 0.51, direction: 'negative', zero_reason: null },
+  ];
+
+  it('top_drivers: lever excluded, non-lever present (RED pre-A1b: lever ranks #1)', () => {
+    const brief = assembleBrief(briefInput(factors))!;
+    const labels = brief.top_drivers.map(d => d.factor_label);
+    expect(labels).not.toContain(LEVER);
+    expect(labels).toContain(NONLEVER);
+  });
+
+  it('what_would_change fallback: lever excluded, non-lever present', () => {
+    const brief = assembleBrief(briefInput(factors))!;
+    expect(brief.what_would_change).not.toContain(LEVER);
+    expect(brief.what_would_change).toContain(NONLEVER);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evidence-priority (review_cards) — mirrors run.ts epFactors construction
+// ---------------------------------------------------------------------------
+describe('A1b — evidence-priority excludes intervention_override levers', () => {
+  it('lever absent from evidence-priority items (RED pre-A1b: lever ranks by |elasticity|)', () => {
+    const merged = [
+      { factor_id: 'fac_leadership_capacity', factor_label: LEVER, elasticity: 1, confidence: 0.1, zero_reason: 'intervention_override' },
+      { factor_id: 'fac_time_pressure', factor_label: NONLEVER, elasticity: 0.51, confidence: 0.1, zero_reason: null },
+    ];
+    // Exactly as run.ts builds epFactors: filter THEN map to FactorInput.
+    const epFactors: FactorInput[] = filterInterventionOverrides(merged).map((fs: any) => ({
+      factor_id: fs.factor_id,
+      factor_label: fs.factor_label,
+      elasticity: fs.elasticity ?? 0,
+      confidence: fs.confidence,
+    }));
+    const card = buildEvidencePriorityCard(epFactors);
+    const ids = (card?.items ?? []).map(i => i.factor_id);
+    expect(ids).not.toContain('fac_leadership_capacity');
+    expect(ids).toContain('fac_time_pressure');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// headlines — VoI/evidence naming (needs_evidence topGap), scoped to VoI only
+// ---------------------------------------------------------------------------
+function normFactor(over: Partial<NormalisedFactorSensitivity>): NormalisedFactorSensitivity {
+  return { node_id: 'n', label: 'L', elasticity: 0, importance_rank: 1, confidence: 0.5, direction: 'positive', influence_score: 0, zero_reason: undefined, ...over };
+}
+function coachingInputs(factorSensitivity: NormalisedFactorSensitivity[], over: Partial<CoachingInputs> = {}): CoachingInputs {
+  return {
+    graph: { nodes: [{ id: 'goal', kind: 'goal', label: 'Goal' }, { id: 'fac', kind: 'factor', label: 'Fac' }], edges: [] } as any,
+    options: [
+      { id: 'opt1', label: 'A', winProbability: 0.6, outcomeMean: 0.7, outcomeP10: undefined, outcomeP90: undefined },
+      { id: 'opt2', label: 'B', winProbability: 0.4, outcomeMean: 0.5, outcomeP10: undefined, outcomeP90: undefined },
+    ],
+    factorSensitivity,
+    fragileEdges: [],
+    robustness: { level: undefined, recommendationStability: undefined, isRobust: undefined }, // stability undefined → needs_evidence
+    interventionTargetIds: new Set<string>(),
+    ...over,
+  } as CoachingInputs;
+}
+
+describe('A1b — headlines do not name levers as VoI/evidence gaps (existence check untouched)', () => {
+  it('needs_evidence topGap names a non-lever, not the lever (RED pre-A1b: lever named)', () => {
+    // Lever has the highest VoI (|elasticity|*(1-confidence)); pre-A1b it is named.
+    const factors = [
+      normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: 1, confidence: 0.1, influence_score: 1, zero_reason: 'intervention_override' }),
+      normFactor({ node_id: 'fac_time_pressure', label: NONLEVER, elasticity: 0.4, confidence: 0.2, influence_score: 0.4, direction: 'negative' }),
+    ];
+    const headlines = generateHeadlines(coachingInputs(factors));
+    const allText = Object.values(headlines).join(' || ');
+    expect(allText).not.toContain(LEVER);
+    expect(allText).toContain(NONLEVER);
+  });
+
+  it('existence check unaffected: headlines still produced when only a lever is present', () => {
+    // hasFactorSensitivity must remain true (we do not erase lever existence).
+    const factors = [normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: 1, confidence: 0.1, influence_score: 1, zero_reason: 'intervention_override' })];
+    const headlines = generateHeadlines(coachingInputs(factors));
+    expect(Object.keys(headlines).length).toBeGreaterThan(0); // winner headline still emitted
+  });
+});
+
+// ---------------------------------------------------------------------------
+// structural surfaces (S1) — key_drivers keeps the lever (must NOT change)
+// ---------------------------------------------------------------------------
+describe('A1b — key_drivers (structural) still includes the lever (out of scope)', () => {
+  it('lever appears in key_drivers via influence_score (unchanged)', () => {
+    const factors = [
+      normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: 0, importance_rank: 1, influence_score: 1, zero_reason: 'intervention_override' }),
+      normFactor({ node_id: 'fac_time_pressure', label: NONLEVER, elasticity: 0.51, importance_rank: 2, influence_score: 0.51, direction: 'negative' }),
+    ];
+    const drivers = computeKeyDrivers(coachingInputs(factors));
+    const ids = drivers.map(d => d.factor_id);
+    expect(ids).toContain('fac_leadership_capacity'); // structural importance preserved
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkMissingRiskPathway guard — material lever via influence_score, both
+// elasticity:0 and elasticity:undefined (lever branch ignores elasticity)
+// ---------------------------------------------------------------------------
+const MISSING = 'MISSING_RISK_PATHWAY';
+function hasMissingRiskCritique(inputs: CoachingInputs): boolean {
+  return generateCritiques(inputs).some(c => c.type === MISSING);
+}
+// graph with NO risk→goal edge so the structural fallback cannot suppress.
+const NO_RISK_GRAPH = { nodes: [{ id: 'goal', kind: 'goal', label: 'Goal' }, { id: 'fac', kind: 'factor', label: 'Fac' }], edges: [] } as any;
+
+describe('A1b — checkMissingRiskPathway materiality guard', () => {
+  for (const elastic of [0, undefined] as const) {
+    it(`material negative lever (influence_score>0.01) STILL suppresses the critique [elasticity:${String(elastic)}]`, () => {
+      // RED pre-A1b: base uses abs(elasticity)>0.01 → lever (elasticity 0/undef) not
+      // material → critique falsely FIRES. GREEN: guard uses influence_score → material.
+      const factors = [normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: elastic, influence_score: 0.5, direction: 'negative', zero_reason: 'intervention_override' })];
+      expect(hasMissingRiskCritique(coachingInputs(factors, { graph: NO_RISK_GRAPH }))).toBe(false);
+    });
+
+    it(`negligible negative lever (influence_score<=0.01) does NOT over-suppress → critique fires [elasticity:${String(elastic)}]`, () => {
+      const factors = [normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: elastic, influence_score: 0.005, direction: 'negative', zero_reason: 'intervention_override' })];
+      expect(hasMissingRiskCritique(coachingInputs(factors, { graph: NO_RISK_GRAPH }))).toBe(true);
+    });
+  }
+
+  it('non-lever negative behaviour unchanged: material suppresses, negligible fires', () => {
+    const material = [normFactor({ node_id: 'fac_time_pressure', label: NONLEVER, elasticity: 0.5, influence_score: 0.5, direction: 'negative' })];
+    expect(hasMissingRiskCritique(coachingInputs(material, { graph: NO_RISK_GRAPH }))).toBe(false);
+    const negligible = [normFactor({ node_id: 'fac_time_pressure', label: NONLEVER, elasticity: 0.005, influence_score: 0.005, direction: 'negative' })];
+    expect(hasMissingRiskCritique(coachingInputs(negligible, { graph: NO_RISK_GRAPH }))).toBe(true);
+  });
+
+  it('genuinely missing negative/risk pathway still fires (no negatives at all)', () => {
+    const factors = [normFactor({ node_id: 'fac_team', label: 'Team', elasticity: 0.5, influence_score: 0.5, direction: 'positive' })];
+    expect(hasMissingRiskCritique(coachingInputs(factors, { graph: NO_RISK_GRAPH }))).toBe(true);
+  });
+});

--- a/tests/lane-a1b-elasticity-suppression.test.ts
+++ b/tests/lane-a1b-elasticity-suppression.test.ts
@@ -198,3 +198,44 @@ describe('A1b — checkMissingRiskPathway materiality guard', () => {
     expect(hasMissingRiskCritique(coachingInputs(factors, { graph: NO_RISK_GRAPH }))).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// checkDominantFactor — DOMINANT_FACTOR is a tunability critique ("what would
+// change if {x} had less influence?"); option-pinned levers must never be named
+// as the dominant tunable factor. Excluded via the explicit predicate (durable
+// guarantee), not producer elasticity:0. Levers here carry a NON-ZERO elasticity
+// so the test proves the predicate, not the producer value.
+// ---------------------------------------------------------------------------
+describe('A1b — checkDominantFactor excludes intervention_override levers', () => {
+  function dominantCritique(inputs: CoachingInputs) {
+    return generateCritiques(inputs).find(c => c.type === 'DOMINANT_FACTOR');
+  }
+
+  it('a high-elasticity lever is NOT named as the dominant factor (RED pre-A1b: lever named)', () => {
+    const factors = [
+      normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: 10, importance_rank: 1, influence_score: 1, zero_reason: 'intervention_override' }),
+      normFactor({ node_id: 'fac_time_pressure', label: NONLEVER, elasticity: 0.1, importance_rank: 2, influence_score: 0.1, direction: 'negative' }),
+    ];
+    const dom = dominantCritique(coachingInputs(factors));
+    expect(dom?.targets ?? []).not.toContain('fac_leadership_capacity');
+    expect(dom?.challenge_question ?? '').not.toContain(LEVER);
+    expect(dom?.suggested_action ?? '').not.toContain(LEVER);
+  });
+
+  it('a non-lever factor can still be named as dominant (predicate does not break detection)', () => {
+    const factors = [
+      normFactor({ node_id: 'fac_time_pressure', label: NONLEVER, elasticity: 10, importance_rank: 1, influence_score: 1, direction: 'negative' }),
+      normFactor({ node_id: 'fac_team_size', label: 'Existing Team Size', elasticity: 0.1, importance_rank: 2, influence_score: 0.1, direction: 'positive' }),
+    ];
+    const dom = dominantCritique(coachingInputs(factors));
+    expect(dom, 'DOMINANT_FACTOR fires for a real non-lever dominance').toBeDefined();
+    expect(dom!.targets).toContain('fac_time_pressure');
+  });
+
+  it('unrelated critique behaviour unchanged: NARROW_FRAMING still fires with a lever present', () => {
+    // Filter is LOCAL to checkDominantFactor — other critiques are unaffected.
+    const factors = [normFactor({ node_id: 'fac_leadership_capacity', label: LEVER, elasticity: 10, importance_rank: 1, influence_score: 1, zero_reason: 'intervention_override' })];
+    const types = generateCritiques(coachingInputs(factors)).map(c => c.type);
+    expect(types).toContain('NARROW_FRAMING'); // 2 options, no status-quo → fires regardless of factors
+  });
+});


### PR DESCRIPTION
## Lane A1b — suppress intervention_override elasticity / tunability re-leak

**Head:** `5739ae1de23f434730ed04af9e33d52c70907e6b` · **Base:** `staging` @ `0b6999f` (merged A1). Draft — do not merge/deploy. A2 held.

Follows **A1** ([#190](https://github.com/Talchain/plot-lite-service/pull/190), merged). A1 preserved `sensitivity_score: 0` + `zero_reason: "intervention_override"` on intervention-controlled levers, but graph-derived **`elasticity`** still drove the tunability / evidence / VoI / "what would change" surfaces. A1b closes that.

**Route:** producer `elasticity: 0` (defence-in-depth) **+** explicit `zero_reason === 'intervention_override'` exclusion at each named surface (the durable guarantee). `influence_score` / `importance_rank` / `source` unchanged. The explicit predicate — not the producer value — is the guarantee.

### Implementation
- **NEW `src/lib/intervention-override.ts`** — import-free leaf: `isInterventionOverride` + `filterInterventionOverrides`, keyed ONLY on `zero_reason`. `src/coaching/sensitivity-filter.ts` re-exports it.
- **Producer** `src/lib/factor-influence.ts` (merge): `elasticity: 0` for levers (NOT a measured elasticity; so `elasticity ?? influence_score` fallbacks short-circuit to 0 instead of re-leaking `influence_score`).
- **Exclusion, one application point per surface:** `decision_brief.top_drivers` + `what_would_change` (decision-brief.ts); evidence-priority `epFactors` (run.ts); headlines VoI sites in **`generateHeadlines`** and **`detectHeadlineType`** (existence check kept on the original array); critiques **`checkMissingRiskPathway`** (per-element guard — levers use `influence_score`, not the zeroed elasticity) and **`checkDominantFactor`** (excludes levers so a lever is never named the dominant tunable factor).

### Definitive A1b tunability surface census
Every site that ranks / names / classifies / computes / structurally-presents factors by `elasticity`, `elasticity_display`, `sensitivity_score` (as tunability), `value_of_information`, `evpi_percentage_points`, or the `computeTopGapInfluence` / `computeNormalisedImpact` helpers:

| Site (file/function) | What it does | A1b in-scope | Predicate applied | Producer `elasticity:0` only defence-in-depth | S1 structural | VOI/EVPI doctrine residue |
|---|---|---|---|---|---|---|
| `assembly/decision-brief buildTopDrivers` | ranks+names by `abs(elasticity)` → `top_drivers` | ✅ | ✅ | ✅ | – | – |
| `assembly/decision-brief buildWhatWouldChange` (fallback) | ranks+names → `what_would_change` | ✅ | ✅ | ✅ | – | – |
| `routes/v2/run epFactors` → evidence-priority card | ranks by `abs(elasticity)` → `review_cards` | ✅ | ✅ | ✅ | – | – |
| `coaching/headlines generateHeadlines` (topGap VoI + naming) | computes+names VoI gap | ✅ | ✅ (`tunable`) | ✅ | – | – |
| `coaching/headlines detectHeadlineType` (topGap VoI) | classifies headline type by VoI | ✅ | ✅ (`tunable`) | ✅ | – | – |
| `coaching/critiques checkMissingRiskPathway` | materiality by elasticity | ✅ | ✅ (per-element guard → `influence_score` for levers) | n/a (uses influence_score) | – | – |
| `coaching/critiques checkDominantFactor` | ranks+names dominant by `abs(elasticity)` | ✅ | ✅ **(new, 5739ae1)** | ✅ | – | – |
| `coaching/headlines computeTopGapInfluence` (helper) | VoI magnitude | helper | both callers filtered | – | – | – |
| `coaching/normalise-inputs computeNormalisedImpact` (helper) | `influence_score ?? elasticity` | helper | evidence-gaps filtered; key-drivers structural | – | – | – |
| `coaching/evidence-gaps` | ranks VoI, names gaps | covered | ✅ pre-existing `interventionTargetIds` | – | – | – |
| flip-thresholds (`coaching/flip-thresholds` + `routes/v2/run`) | ranks by elasticity → flip candidates | covered | ✅ pre-existing `getFactorsOverriddenByAllOptions` | ✅ (lever 0 < `MIN_ELASTICITY_THRESHOLD` 0.01) | – | – |
| `coaching/key-drivers` | ranks by `influence_score` | ❌ structural | no (intentional) | n/a | ✅ (S1) | – |
| `coaching/assumptions-ledger classifyFactorImpact` | classifies by `importance_rank` (+ elasticity fallback) | ❌ structural | no (intentional) | partial (fallback → 0) | ✅ (S1) | – |
| `elasticity_display` | — | n/a | dropped at ISL→PLoT boundary (not a PLoT public field) | – | – | – |
| public `value_of_information` / `evpi_percentage_points` | EVPI/VOI metadata fields | ❌ EVPI/VOI | **STOP-and-report — not fixed** | not zeroed | – | ✅ |

**No third missed A1b tunability surface remains.**

### Out of scope (unchanged)
`key_drivers` / `assumptions_ledger` (structural, `influence_score`/`importance_rank`-driven); EVPI/VOI; `edge_e_values`; edge elasticity; `source`; `influence_score`/`importance_rank` writes; schemas/OpenAPI; CEE/UI/ISL/prompts/Gate Zero.

### VOI/EVPI residue — S1/Gate-Zero doctrine-blocked (NOT fixed here)
A lever can still egress non-zero `value_of_information` / `evpi_percentage_points` while carrying `zero_reason: "intervention_override"` — a real field-level residue. It is tied to the unresolved EVPI/VOI definition & naming question (including the frozen-policy proxy issue) and cannot be cleanly suppressed opportunistically inside A1b without the S1 doctrine/RCA ruling. Per the hard constraint, VOI/EVPI is **not** touched here; flagged for S1/Gate Zero.

### RED-before / GREEN-after (clean pre-A1b base, not stash-on-committed)
Demonstrated on a temporary worktree at **`0b6999f`** (A1 merged, no A1b src; only the test artifacts added). On that clean base, **7 unit leak tests + the egress block fail**; on PR head they pass. Covered surfaces:
- **headline naming** (`needs_evidence` topGap) — RED→GREEN
- **`detectHeadlineType`** (high-elasticity lever no longer → `high_uncertainty`) — RED→GREEN
- **`checkDominantFactor`** (lever no longer named dominant; non-lever still nameable; `NARROW_FRAMING` unchanged) — RED→GREEN
- **`checkMissingRiskPathway`** (material lever still suppresses, under `elasticity:0` and `undefined`) — RED→GREEN
- **`decision_brief.top_drivers` / `what_would_change`** — RED→GREEN
- **egress evidence-priority** — on clean base the `evidence_priority` card included `[fac_leadership_capacity, fac_dev_capacity, fac_hiring_cost]`; PR head **excludes** all three.
- **producer `elasticity:0`** at egress (clean base lever elasticity `1` → head `0`).

Structural/pin tests (key_drivers keeps the lever; existence check; negligible-lever/non-lever/missing-pathway) correctly pass on both bases.

### Verification
- `tsc --noEmit` clean.
- **Full `npm test`: 5060 passed / 25 skipped / 0 failed.** One transient `openapi.examples` flake on a first run (passes in isolation; no spec/v1 files in this diff) — full suite green on re-run. (`inflight.plugin` / `openapi.render` / `openapi.examples` are a known flaky-suite cluster, tracked as a separate test-infra lane.)

### Changed files (vs `0b6999f`)
- `src/lib/intervention-override.ts` (new)
- `src/coaching/sensitivity-filter.ts`, `src/lib/factor-influence.ts`, `src/assembly/decision-brief.ts`, `src/routes/v2/run.ts`, `src/coaching/headlines.ts`, `src/coaching/critiques.ts`
- tests: `tests/isl-confidence-merge.test.ts`, `tests/lane-a1-intervention-override-egress.integration.test.ts`, `tests/lane-a1b-elasticity-suppression.test.ts` (new)

No VOI/EVPI, A2, `edge_e_values`, edge-elasticity, CEE/UI/ISL, schema/OpenAPI, prompt, or Gate-Zero change. `origin/staging` untouched at `0b6999f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
