### PR TITLE
fix(plot): A1c — suppress lever-sourced fragile edges from 4 action surfaces

### DIFF
--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -34,7 +34,7 @@ import type { RunResponseV3 } from '../types/engine-v3.js';
 import { STANDARD_N_SAMPLES_DEFAULT } from '../config/sampling.js';
 // A1b: intervention-controlled levers are not independently tunable; exclude them
 // from the |elasticity|-ranked tunability surfaces (top_drivers, what_would_change).
-import { filterInterventionOverrides } from '../lib/intervention-override.js';
+import { filterInterventionOverrides, interventionOverrideFactorIds, filterLeverSourcedFragileEdges } from '../lib/intervention-override.js';
 
 // =============================================================================
 // Constants
@@ -311,9 +311,13 @@ function buildKeyAssumptions(input: BriefAssemblyInput): string[] {
 }
 
 function buildWhatWouldChange(input: BriefAssemblyInput): string[] {
-  // Primary: fragile edges
-  const fragileEdges = input.robustness?.fragile_edges;
-  if (fragileEdges && fragileEdges.length > 0) {
+  // A1c: lever-id set from zero_reason (BriefAssemblyInput carries no interventionTargetIds).
+  const leverIds = interventionOverrideFactorIds(input.factor_sensitivity ?? []);
+  // Primary: fragile edges — A1c excludes edges SOURCED from an option-pinned lever
+  // ("lever → X" here would imply the user can tune the pinned lever). Non-lever
+  // fragile edges are kept; if none remain, fall through to the (A1b-filtered) factor path.
+  const fragileEdges = filterLeverSourcedFragileEdges(input.robustness?.fragile_edges ?? [], leverIds, (e) => e.from_id);
+  if (fragileEdges.length > 0) {
     return fragileEdges
       .map(e => {
         const from = e.from_label?.trim() || e.from_id;

--- a/src/coaching/headlines.ts
+++ b/src/coaching/headlines.ts
@@ -8,6 +8,8 @@ import type { CoachingInputs, HeadlineType, StoryHeadlines, FragileEdgeContext }
 import { getThresholds } from './thresholds.js';
 // A1b: intervention-controlled levers are not tunable evidence/VoI gaps.
 import { filterInterventionOverrides } from './sensitivity-filter.js';
+// A1c: exclude fragile edges SOURCED from an option-pinned lever from the high_uncertainty headline.
+import { isLeverSourcedEdge } from '../lib/intervention-override.js';
 
 const HEADLINE_TEMPLATES = {
   clear_winner: '{option} outperforms by {deltaPoints} points with high confidence',
@@ -78,9 +80,15 @@ export function generateHeadlines(inputs: CoachingInputs): StoryHeadlines {
   // existence from headline reasoning). Used at both VoI sites below.
   const tunable = filterInterventionOverrides(factorSensitivity);
 
-  // Get top fragile edge (highest switch probability)
+  // Get top fragile edge (highest switch probability).
+  // A1c: exclude fragile edges SOURCED from an option-pinned lever — naming
+  // "lever → X ... could swing the outcome" in the high_uncertainty headline
+  // implies the user can tune a pinned lever. Non-lever fragile edges are kept;
+  // if none qualify, topFragile is undefined → the headline type shifts off
+  // high_uncertainty (no lever named, no fragile edge forced).
+  const leverIds = inputs.interventionTargetIds ?? new Set<string>();
   const topFragile = fragileEdges
-    .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min)
+    .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min && !isLeverSourcedEdge(e.fromId, leverIds))
     .sort((a, b) => b.switchProb - a.switchProb)[0];
 
   const topFragileSwitchProb = topFragile?.switchProb ?? 0;
@@ -253,9 +261,12 @@ export function detectHeadlineType(inputs: CoachingInputs): HeadlineType {
   // explicit predicate is the durable guarantee).
   const tunable = filterInterventionOverrides(factorSensitivity);
 
-  // Get top fragile edge (highest switch probability)
+  // Get top fragile edge (highest switch probability).
+  // A1c: exclude lever-sourced fragile edges from the high_uncertainty CLASSIFIER
+  // too, so the headline TYPE stays consistent with the (filtered) headline text.
+  const leverIds = inputs.interventionTargetIds ?? new Set<string>();
   const topFragile = fragileEdges
-    .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min)
+    .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min && !isLeverSourcedEdge(e.fromId, leverIds))
     .sort((a, b) => b.switchProb - a.switchProb)[0];
 
   const topFragileSwitchProb = topFragile?.switchProb ?? 0;

--- a/src/coaching/m1-coaching.ts
+++ b/src/coaching/m1-coaching.ts
@@ -14,6 +14,8 @@ import type {
 } from '../types/engine-v3.js';
 import { normaliseCoachingInputs } from './normalise-inputs.js';
 import { generateHeadlines, getFragileEdgeContext } from './headlines.js';
+// A1c: exclude lever-sourced fragile edges from top_fragile_edge.
+import { filterLeverSourcedFragileEdges } from '../lib/intervention-override.js';
 import { computeEvidenceGaps } from './evidence-gaps.js';
 import { generateCritiques } from './critiques.js';
 import { generateNextActions, computeReadiness } from './next-actions.js';
@@ -99,8 +101,13 @@ export function generateM1Coaching(
       );
     }
 
-    // Get fragile edge context if relevant
-    const topFragileEdge = getFragileEdgeContext(inputs.fragileEdges);
+    // Get fragile edge context if relevant.
+    // A1c: top_fragile_edge must not surface an edge SOURCED from an option-pinned
+    // lever; filter before selection (fallback: undefined when no non-lever edge).
+    const a1cLeverIds = inputs.interventionTargetIds ?? new Set<string>();
+    const topFragileEdge = getFragileEdgeContext(
+      filterLeverSourcedFragileEdges(inputs.fragileEdges, a1cLeverIds, (e) => e.fromId),
+    );
 
     // Phase 3: Differentiators (C1-C3)
     const assumptionsLedger = safeCompute(

--- a/src/coaching/next-actions.ts
+++ b/src/coaching/next-actions.ts
@@ -11,6 +11,8 @@ import type { CoachingInputs, Critique, NextAction, Readiness, HeadlineType, Evi
 import { getThresholds } from './thresholds.js';
 import { computeKeyDrivers } from './key-drivers.js';
 import { deriveReadinessTone, type ReadinessToneReason, type ReadinessToneResult } from './readiness-tone.js';
+// A1c: the P3 fragile-edge action must not name an edge sourced from an option-pinned lever.
+import { filterLeverSourcedFragileEdges } from '../lib/intervention-override.js';
 
 export function generateNextActions(
   inputs: CoachingInputs,
@@ -24,6 +26,12 @@ export function generateNextActions(
   // Compute readiness (unchanged semantics — downstream consumers depend on it).
   const readiness = computeReadiness(headlineType, critiques, evidenceGaps, thresholds);
 
+  // A1c: the P3 "Validate the {edge} assumption" action must not name an edge
+  // SOURCED from an option-pinned lever; pick the top non-lever fragile edge
+  // (fallback: undefined → the P3 fragile-edge action is skipped).
+  const a1cLeverIds = inputs.interventionTargetIds ?? new Set<string>();
+  const a1cTunableFragileEdges = filterLeverSourcedFragileEdges(inputs.fragileEdges, a1cLeverIds, (e) => e.fromId);
+
   // Build context for action interpolation
   const context = {
     readiness,
@@ -31,7 +39,7 @@ export function generateNextActions(
     critiques,
     evidenceGaps,
     topGap: evidenceGaps[0],
-    topFragileEdge: inputs.fragileEdges[0],
+    topFragileEdge: a1cTunableFragileEdges[0],
     winner: inputs.options[0],
     optionCount: inputs.options.length,
     stability: inputs.robustness.recommendationStability,

--- a/src/lib/intervention-override.ts
+++ b/src/lib/intervention-override.ts
@@ -24,3 +24,48 @@ export function filterInterventionOverrides<T extends { zero_reason?: string | n
 ): T[] {
   return factors.filter((f) => !isInterventionOverride(f));
 }
+
+/**
+ * Build the set of intervention-override (option-pinned lever) node ids from a
+ * factor list. Used where the lever set must be derived from `zero_reason`
+ * (e.g. decision-brief, which does not carry `interventionTargetIds`). Coaching
+ * surfaces should prefer the canonical request-side `interventionTargetIds`.
+ */
+export function interventionOverrideFactorIds(
+  factors: ReadonlyArray<{ factor_id?: string; node_id?: string; zero_reason?: string | null }>,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const f of factors) {
+    if (isInterventionOverride(f)) {
+      const id = f.factor_id ?? f.node_id;
+      if (id) ids.add(id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * A1c: a fragile edge is "lever-sourced" when its SOURCE node is an
+ * intervention-controlled lever. Naming such an edge in an action-guidance
+ * surface ("what would change" / "could swing" / "validate the … assumption")
+ * implies the user can tune/act on an option-pinned lever, which is false.
+ * SOURCE-only by design: a lever as edge TARGET (`X → lever`) describes
+ * something acting on the lever, not tuning it, so it is left untouched.
+ */
+export function isLeverSourcedEdge(fromId: string | undefined | null, leverIds: ReadonlySet<string>): boolean {
+  return fromId != null && leverIds.has(fromId);
+}
+
+/**
+ * Drop fragile edges whose SOURCE node is an intervention-override lever.
+ * `getFromId` adapts the edge shape (raw `from_id` vs normalised `fromId`).
+ * Empty lever set → returns the list unchanged.
+ */
+export function filterLeverSourcedFragileEdges<E>(
+  edges: ReadonlyArray<E>,
+  leverIds: ReadonlySet<string>,
+  getFromId: (e: E) => string | undefined | null,
+): E[] {
+  if (leverIds.size === 0) return edges.slice();
+  return edges.filter((e) => !isLeverSourcedEdge(getFromId(e), leverIds));
+}

--- a/tests/lane-a1c-fragile-edge-egress.integration.test.ts
+++ b/tests/lane-a1c-fragile-edge-egress.integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Lane A1c — /v2/run egress: lever-SOURCED fragile edges are suppressed from the
+ * four action-guidance surfaces, with fallback to the non-lever fragile edge.
+ * Scope containment: assumptions_ledger STILL names the lever-sourced edges
+ * (A1c must NOT touch it). This mirrors the post-deploy runtime replay.
+ *
+ * ISL mock returns robustness.fragile_edges sourced from levers (the residue) +
+ * one non-lever fragile edge. Levers: fac_leadership_capacity / fac_dev_capacity /
+ * fac_hiring_cost (option-pinned by all options). Non-lever: fac_time_pressure.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Deliver Productive, Quality Launch Within Budget' },
+    { id: 'fac_leadership_capacity', kind: 'factor', label: 'Technical Leadership Capacity', observed_state: { value: 0.6 } },
+    { id: 'fac_dev_capacity', kind: 'factor', label: 'Additional Developer Capacity', observed_state: { value: 0.5 } },
+    { id: 'fac_hiring_cost', kind: 'factor', label: 'Annual Hiring Cost', observed_state: { value: 0.4 } },
+    { id: 'fac_time_pressure', kind: 'factor', label: 'Launch Deadline Pressure', observed_state: { value: 0.5 } },
+    { id: 'out_delivery_speed', kind: 'outcome', label: 'On-Time Delivery Likelihood' },
+    { id: 'out_code_quality', kind: 'outcome', label: 'Code Quality and Technical Standards' },
+    { id: 'risk_launch_miss', kind: 'risk', label: 'Launch Date Miss' },
+  ],
+  edges: [
+    { from: 'fac_leadership_capacity', to: 'out_code_quality', exists_probability: 0.88, strength: { mean: 0.6, std: 0.15 } },
+    { from: 'fac_dev_capacity', to: 'out_delivery_speed', exists_probability: 0.8, strength: { mean: 0.45, std: 0.16 } },
+    { from: 'fac_hiring_cost', to: 'goal', exists_probability: 0.9, strength: { mean: -0.3, std: 0.1 } },
+    { from: 'fac_time_pressure', to: 'risk_launch_miss', exists_probability: 0.9, strength: { mean: 0.55, std: 0.12 } },
+    { from: 'out_delivery_speed', to: 'goal', exists_probability: 0.95, strength: { mean: 0.45, std: 0.1 } },
+    { from: 'out_code_quality', to: 'goal', exists_probability: 0.92, strength: { mean: 0.3, std: 0.1 } },
+    { from: 'risk_launch_miss', to: 'goal', exists_probability: 0.9, strength: { mean: -0.35, std: 0.12 } },
+  ],
+};
+const OPTIONS = [
+  { id: 'opt_hire', label: 'Hire', interventions: { fac_leadership_capacity: { value: 1, source: 'user_specified' }, fac_dev_capacity: { value: 1, source: 'user_specified' }, fac_hiring_cost: { value: 1, source: 'user_specified' } } },
+  { id: 'opt_tech_lead', label: 'Tech lead', interventions: { fac_leadership_capacity: { value: 1, source: 'user_specified' }, fac_dev_capacity: { value: 0, source: 'user_specified' }, fac_hiring_cost: { value: 0.5, source: 'user_specified' } } },
+];
+
+// factor_sensitivity: 3 levers (intervention_override) + non-lever.
+const FACTOR_SENSITIVITY = [
+  { node_id: 'fac_time_pressure', label: 'Launch Deadline Pressure', sensitivity_score: 1, elasticity: 1, influence_score: 0.53, direction: 'negative', attribution_stability: 'low', importance_rank: 1 },
+  { node_id: 'fac_leadership_capacity', label: 'Technical Leadership Capacity', sensitivity_score: 0, elasticity: 0, influence_score: 1, direction: 'negative', zero_reason: 'intervention_override', attribution_stability: 'negligible', importance_rank: 5 },
+  { node_id: 'fac_dev_capacity', label: 'Additional Developer Capacity', sensitivity_score: 0, elasticity: 0, influence_score: 0.74, direction: 'negative', zero_reason: 'intervention_override', attribution_stability: 'negligible', importance_rank: 3 },
+  { node_id: 'fac_hiring_cost', label: 'Annual Hiring Cost', sensitivity_score: 0, elasticity: 0, influence_score: 0.41, direction: 'negative', zero_reason: 'intervention_override', attribution_stability: 'negligible', importance_rank: 4 },
+];
+// fragile edges: 2 lever-SOURCED (residue) + 1 non-lever, all above thresholds.
+const FRAGILE_EDGES = [
+  { edge_id: 'fac_dev_capacity->out_delivery_speed', from_id: 'fac_dev_capacity', to_id: 'out_delivery_speed', switch_probability: 0.6, marginal_switch_probability: 0.6, alternative_winner_id: 'opt_tech_lead', severity: 'high' },
+  { edge_id: 'fac_leadership_capacity->out_code_quality', from_id: 'fac_leadership_capacity', to_id: 'out_code_quality', switch_probability: 0.5, marginal_switch_probability: 0.5, alternative_winner_id: 'opt_tech_lead', severity: 'high' },
+  { edge_id: 'fac_time_pressure->risk_launch_miss', from_id: 'fac_time_pressure', to_id: 'risk_launch_miss', switch_probability: 0.4, marginal_switch_probability: 0.4, alternative_winner_id: 'opt_tech_lead', severity: 'medium' },
+];
+const robustness = { level: 'low', is_robust: false, recommendation_stability: 0.4, score: 0.4, fragile_edges: FRAGILE_EDGES, robust_edges: [] };
+function mockOpts(options: any[]) {
+  return options.map((o: any, i: number) => ({ option_id: o.id, outcome: { mean: 0.7 - i * 0.2, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1 }, rank: i + 1, win_probability: i === 0 ? 0.62 : 0.38 }));
+}
+const svc: any = {
+  isEnabled: () => true, isAvailable: async () => true,
+  validateCausal: async () => ({ status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'm', reasoning: 't' }, source: 'isl' }),
+  analyseSensitivity: async () => ({ overall_robustness: 'low', sensitive_parameters: [], recommendations: [], source: 'isl' }),
+  analyseRobustness: async (_g: any, _goal: string, o: any[]) => ({ options: mockOpts(o), edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2', edge_sensitivity_status: 'available', factor_sensitivity: FACTOR_SENSITIVITY, factors: [], value_of_information: [], factors_provenance: 'isl:/api/v1/robustness/analyze/v2', factor_sensitivity_status: 'available', overall_robustness: 'low', robustness_score: 0.4, robustness, fragile_edges: FRAGILE_EDGES, robust_edges: [], latency_ms: 50, source: 'isl' }),
+  analyseFactorSensitivity: async () => ({ factors: [], value_of_information: [], robustness_label: 'low', robustness_score: 0.4, latency_ms: 0, source: 'unavailable' }),
+  computeCounterfactual: async () => { throw new Error('x'); },
+  callAnalysisEndpoint: async (_e: string, b: any) => ({ data: { options: mockOpts(b.options || []), edges: [], factor_sensitivity: FACTOR_SENSITIVITY, robustness, overall_robustness: 'low', robustness_score: 0.4, fragile_edges: FRAGILE_EDGES, robust_edges: [] }, error: null }),
+};
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => svc, islService: svc };
+});
+import { createServer } from '../src/createServer.js';
+
+describe('Lane A1c — /v2/run egress suppresses lever-sourced fragile edges from 4 action surfaces', () => {
+  let app: FastifyInstance; let baseUrl: string;
+  const ENV = ['RATE_LIMIT_ENABLED', 'CEE_ORCHESTRATOR_ENABLED'] as const;
+  const saved: Record<string, string | undefined> = {};
+  const LEVER_LABELS = ['Technical Leadership Capacity', 'Additional Developer Capacity', 'Annual Hiring Cost'];
+  const LEVER_IDS = ['fac_leadership_capacity', 'fac_dev_capacity', 'fac_hiring_cost'];
+  const namesLever = (s: string) => LEVER_LABELS.some((l) => s.includes(l));
+
+  beforeAll(async () => {
+    for (const k of ENV) saved[k] = process.env[k];
+    process.env.RATE_LIMIT_ENABLED = '0'; process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer(); await app.listen({ port: 0, host: '127.0.0.1' });
+    const a: any = app.server.address(); baseUrl = `http://127.0.0.1:${a.port}`;
+  });
+  afterAll(async () => { await app?.close(); for (const k of ENV) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } });
+
+  it('4 action surfaces exclude lever-sourced edges (name the non-lever edge); assumptions_ledger STILL names levers', async () => {
+    const res = await fetch(`${baseUrl}/v2/run`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '42' }) });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    const m1 = body.m1_coaching ?? {};
+
+    // Surface 1: decision_brief.what_would_change — no lever; non-lever edge present.
+    const wwc = body.decision_brief?.what_would_change ?? [];
+    expect(wwc.some((s: string) => namesLever(s))).toBe(false);
+    expect(wwc.some((s: string) => s.includes('Launch Deadline Pressure'))).toBe(true); // non-lever fragile edge surfaced
+
+    // Surface 2: high_uncertainty story headline — no lever.
+    const headlines = Object.values(m1.story_headlines ?? {}).join(' || ');
+    expect(namesLever(headlines)).toBe(false);
+
+    // Surface 3: top_fragile_edge — not a lever-sourced edge.
+    expect(m1.top_fragile_edge ? namesLever(m1.top_fragile_edge.label ?? '') : false).toBe(false);
+
+    // Surface 4: next_actions — no edge action names a lever.
+    for (const a of (m1.next_actions ?? [])) {
+      if (a.target_type === 'edge') expect(namesLever(a.action ?? '')).toBe(false);
+    }
+
+    // SCOPE CONTAINMENT (tightening 3): assumptions_ledger STILL names a lever-sourced edge.
+    const al = m1.assumptions_ledger?.assumptions ?? [];
+    const alText = JSON.stringify(al);
+    expect(LEVER_IDS.some((id) => alText.includes(id)), 'assumptions_ledger still names a lever residue (A1c untouched)').toBe(true);
+  });
+});

--- a/tests/lane-a1c-fragile-edge-suppression.test.ts
+++ b/tests/lane-a1c-fragile-edge-suppression.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Lane A1c — suppress lever-SOURCED fragile edges from the four PLoT
+ * action-guidance surfaces (decision_brief.what_would_change, story_headlines
+ * [high_uncertainty], m1_coaching.top_fragile_edge, m1_coaching.next_actions).
+ *
+ * SOURCE-only by design: a lever as edge TARGET is left untouched.
+ * Per-surface filtering (NOT normaliseCoachingInputs — that is shared with
+ * assumptions_ledger + readiness surfaces, which must remain unchanged).
+ * Fallback: select the top NON-lever fragile edge; if none, each surface uses
+ * its existing safe fallback (factor path / headline-type shift / undefined /
+ * skip P3). Never blank with a lever, never invent.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isLeverSourcedEdge,
+  filterLeverSourcedFragileEdges,
+  interventionOverrideFactorIds,
+} from '../src/lib/intervention-override.js';
+import { assembleBrief, type BriefAssemblyInput } from '../src/assembly/decision-brief.js';
+import { generateHeadlines, detectHeadlineType, getFragileEdgeContext } from '../src/coaching/headlines.js';
+import { generateNextActions } from '../src/coaching/next-actions.js';
+import type { CoachingInputs, NormalisedFragileEdge, NormalisedFactorSensitivity } from '../src/coaching/types.js';
+
+const LEVER = 'fac_dev_capacity';
+const LEVER_LABEL = 'Additional Developer Capacity';
+const NONLEVER = 'fac_time_pressure';
+const NONLEVER_LABEL = 'Launch Deadline Pressure';
+
+// ---------------------------------------------------------------------------
+// Leaf predicate — source-only + source-id accessor (tightening 2)
+// ---------------------------------------------------------------------------
+describe('A1c leaf — isLeverSourcedEdge / filterLeverSourcedFragileEdges (source-only)', () => {
+  const leverIds = new Set([LEVER]);
+  it('matches a lever SOURCE id (the predicate fired on from-id), not a non-lever source', () => {
+    expect(isLeverSourcedEdge(LEVER, leverIds)).toBe(true);    // source matched
+    expect(isLeverSourcedEdge(NONLEVER, leverIds)).toBe(false);
+    expect(isLeverSourcedEdge(undefined, leverIds)).toBe(false);
+  });
+  it('drops lever-SOURCED edges; KEEPS lever-as-TARGET and non-lever (source-only)', () => {
+    const edges = [
+      { id: 'lever-source', from: LEVER, to: 'out_x' },        // lever is SOURCE → drop
+      { id: 'lever-target', from: 'fac_other', to: LEVER },    // lever is TARGET → keep
+      { id: 'non-lever', from: 'fac_other', to: 'out_y' },     // keep
+    ];
+    const kept = filterLeverSourcedFragileEdges(edges, leverIds, (e) => e.from).map((e) => e.id);
+    expect(kept).toEqual(['lever-target', 'non-lever']);       // source-lever dropped; target-lever kept
+  });
+  it('interventionOverrideFactorIds builds the set from zero_reason', () => {
+    const ids = interventionOverrideFactorIds([
+      { factor_id: LEVER, zero_reason: 'intervention_override' },
+      { factor_id: NONLEVER, zero_reason: null },
+    ]);
+    expect([...ids]).toEqual([LEVER]);
+  });
+  it('empty lever set is a no-op', () => {
+    const edges = [{ from: LEVER, to: 'x' }];
+    expect(filterLeverSourcedFragileEdges(edges, new Set(), (e) => e.from)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Surface 1 — decision_brief.what_would_change
+// ---------------------------------------------------------------------------
+function rawEdge(from: string, fromLabel: string, to: string, toLabel: string, sp = 0.5) {
+  return { edge_id: `${from}->${to}`, from_id: from, from_label: fromLabel, to_id: to, to_label: toLabel, switch_probability: sp, severity: 'high' };
+}
+function briefInput(fragile: any[], factors: any[]): BriefAssemblyInput {
+  return {
+    analysis_status: 'computed',
+    critiques: [],
+    option_comparison: [{ option_id: 'o1', label: 'A', win_probability: 0.6 }, { option_id: 'o2', label: 'B', win_probability: 0.4 }],
+    robustness: { level: 'moderate', fragile_edges: fragile, robust_edges: [] } as any,
+    factor_sensitivity: factors,
+    meta: { seed_used: '1' },
+  } as BriefAssemblyInput;
+}
+const LEVER_FACTORS = [
+  { factor_id: LEVER, factor_label: LEVER_LABEL, elasticity: 0, zero_reason: 'intervention_override', direction: 'positive' },
+  { factor_id: NONLEVER, factor_label: NONLEVER_LABEL, elasticity: 0.5, direction: 'negative' },
+];
+
+describe('A1c — decision_brief.what_would_change', () => {
+  it('excludes lever-SOURCED fragile edge; keeps non-lever edge (RED pre-A1c: lever named)', () => {
+    const brief = assembleBrief(briefInput(
+      [rawEdge(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery'), rawEdge(NONLEVER, NONLEVER_LABEL, 'risk_miss', 'Launch Miss')],
+      LEVER_FACTORS,
+    ))!;
+    expect(brief.what_would_change.some((s) => s.includes(LEVER_LABEL))).toBe(false);   // lever-sourced edge gone
+    expect(brief.what_would_change.some((s) => s.includes(NONLEVER_LABEL))).toBe(true); // non-lever edge kept
+  });
+  it('lever-as-TARGET edge is kept (source-only)', () => {
+    const brief = assembleBrief(briefInput([rawEdge('fac_other', 'Other', LEVER, LEVER_LABEL)], LEVER_FACTORS))!;
+    expect(brief.what_would_change.some((s) => s.includes(`→ ${LEVER_LABEL}`))).toBe(true);
+  });
+  it('FALLBACK PROOF: all fragile edges lever-sourced → factor-path fallback fires (names non-lever factor, not empty, not lever)', () => {
+    const brief = assembleBrief(briefInput(
+      [rawEdge(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery')],  // only lever-sourced edge
+      LEVER_FACTORS,
+    ))!;
+    // PRIMARY (fragile) path yields nothing → FACTOR fallback path used → non-lever factor label present.
+    expect(brief.what_would_change).toContain(NONLEVER_LABEL);
+    expect(brief.what_would_change.some((s) => s.includes(LEVER_LABEL))).toBe(false);
+    expect(brief.what_would_change.every((s) => !s.includes('→'))).toBe(true); // factor labels, not edge "X → Y" strings
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Surfaces 2-4 — coaching (headlines / top_fragile_edge / next_actions)
+// ---------------------------------------------------------------------------
+function nfe(from: string, fromLabel: string, to: string, toLabel: string, sp: number): NormalisedFragileEdge {
+  return { edgeId: `${from}::${to}`, fromId: from, toId: to, fromLabel, toLabel, displayLabel: `${fromLabel} → ${toLabel}`, switchProb: sp, altWinnerId: 'o2', altWinnerLabel: 'B' };
+}
+function nf(id: string, label: string): NormalisedFactorSensitivity {
+  return { node_id: id, label, elasticity: 0, importance_rank: 1, confidence: 0.9, direction: 'positive', influence_score: 0, zero_reason: undefined };
+}
+function ci(fragile: NormalisedFragileEdge[], over: Partial<CoachingInputs> = {}): CoachingInputs {
+  return {
+    graph: { nodes: [{ id: 'goal', kind: 'goal', label: 'Goal' }], edges: [] } as any,
+    options: [{ id: 'o1', label: 'A', winProbability: 0.6, outcomeMean: 0.7, outcomeP10: undefined, outcomeP90: undefined },
+              { id: 'o2', label: 'B', winProbability: 0.4, outcomeMean: 0.5, outcomeP10: undefined, outcomeP90: undefined }],
+    factorSensitivity: [nf(NONLEVER, NONLEVER_LABEL)],
+    fragileEdges: fragile,
+    robustness: { level: 'moderate', recommendationStability: 0.8, isRobust: true },
+    interventionTargetIds: new Set([LEVER]),
+    ...over,
+  } as CoachingInputs;
+}
+
+describe('A1c — story_headlines[high_uncertainty]', () => {
+  it('names a NON-lever fragile edge, not the lever-sourced one (RED pre-A1c: lever named)', () => {
+    // lever edge higher switchProb; non-lever also above high_uncertainty_fragile (0.25)
+    const inputs = ci([nfe(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery', 0.6), nfe(NONLEVER, NONLEVER_LABEL, 'risk_miss', 'Launch Miss', 0.5)]);
+    const text = Object.values(generateHeadlines(inputs)).join(' || ');
+    expect(text).not.toContain(LEVER_LABEL);
+    expect(text).toContain(NONLEVER_LABEL);
+    expect(detectHeadlineType(inputs)).toBe('high_uncertainty'); // classifier consistent (non-lever drives it)
+  });
+  it('FALLBACK PROOF: only lever-sourced fragile edges → headline TYPE shifts OFF high_uncertainty; no lever named', () => {
+    const inputs = ci([nfe(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery', 0.6)]); // sole edge, lever-sourced
+    expect(detectHeadlineType(inputs)).not.toBe('high_uncertainty');                       // type shifted (no qualifying fragile edge)
+    expect(Object.values(generateHeadlines(inputs)).join(' || ')).not.toContain(LEVER_LABEL);
+  });
+});
+
+describe('A1c — top_fragile_edge (m1-coaching composition)', () => {
+  // Mirrors src/coaching/m1-coaching.ts:103 exactly.
+  const top = (fragile: NormalisedFragileEdge[]) => getFragileEdgeContext(filterLeverSourcedFragileEdges(fragile, new Set([LEVER]), (e) => e.fromId));
+  it('excludes lever-sourced; surfaces top non-lever edge', () => {
+    const t = top([nfe(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery', 0.6), nfe(NONLEVER, NONLEVER_LABEL, 'risk_miss', 'Launch Miss', 0.5)]);
+    expect(t?.label).toBe(`${NONLEVER_LABEL} → Launch Miss`);
+  });
+  it('FALLBACK PROOF: only lever-sourced fragile edges → undefined (no fake replacement)', () => {
+    expect(top([nfe(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery', 0.6)])).toBeUndefined();
+  });
+});
+
+describe('A1c — next_actions (P3 fragile-edge action)', () => {
+  const p3 = (fragile: NormalisedFragileEdge[]) =>
+    generateNextActions(ci(fragile), 'high_uncertainty', [], []).find((a) => a.target_type === 'edge');
+  it('P3 names a NON-lever fragile edge, not the lever-sourced one', () => {
+    const a = p3([nfe(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery', 0.6), nfe(NONLEVER, NONLEVER_LABEL, 'risk_miss', 'Launch Miss', 0.5)]);
+    expect(a?.target_id).toBe(`${NONLEVER}::risk_miss`);
+    expect(a?.action).not.toContain(LEVER_LABEL);
+    expect(a?.action).toContain(NONLEVER_LABEL);
+  });
+  it('FALLBACK PROOF: only lever-sourced fragile edges → P3 fragile-edge action SKIPPED (no edge action, no lever named)', () => {
+    const actions = generateNextActions(ci([nfe(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery', 0.6)]), 'high_uncertainty', [], []);
+    expect(actions.find((a) => a.target_type === 'edge')).toBeUndefined();
+    expect(actions.every((a) => !a.action.includes(LEVER_LABEL))).toBe(true);
+  });
+});

--- a/tests/lane-a1c-fragile-edge-suppression.test.ts
+++ b/tests/lane-a1c-fragile-edge-suppression.test.ts
@@ -140,6 +140,27 @@ describe('A1c — story_headlines[high_uncertainty]', () => {
     expect(detectHeadlineType(inputs)).not.toBe('high_uncertainty');                       // type shifted (no qualifying fragile edge)
     expect(Object.values(generateHeadlines(inputs)).join(' || ')).not.toContain(LEVER_LABEL);
   });
+  it('VoI-DRIVEN high_uncertainty + only lever-sourced fragile edges → generic "key assumptions", never the lever', () => {
+    // Distinct branch from the type-shift fallback above: here a NON-lever factor with
+    // high VoI (|elasticity|·(1−confidence)=0.64 > headline_high_uncertainty_voi 0.30)
+    // holds the headline TYPE at high_uncertainty via the VoI arm of selectHeadlineType,
+    // independent of fragile edges. The sole fragile edge is lever-sourced → A1c drops it
+    // → topFragile undefined → the high_uncertainty template substitutes the generic
+    // 'key assumptions', NOT the lever label. RED pre-A1c: without the filter the lever
+    // edge (switchProb 0.6 ≥ 0.15) becomes topFragile and its label is named here.
+    const highVoiNonLever: NormalisedFactorSensitivity = {
+      node_id: NONLEVER, label: NONLEVER_LABEL, elasticity: 0.8, importance_rank: 1,
+      confidence: 0.2, direction: 'positive', influence_score: 0.8, zero_reason: undefined,
+    };
+    const inputs = ci(
+      [nfe(LEVER, LEVER_LABEL, 'out_delivery', 'On-Time Delivery', 0.6)], // only edge is lever-sourced
+      { factorSensitivity: [highVoiNonLever] },
+    );
+    expect(detectHeadlineType(inputs)).toBe('high_uncertainty');        // VoI-driven → type HOLDS
+    const text = Object.values(generateHeadlines(inputs)).join(' || ');
+    expect(text).toContain('key assumptions');                          // generic fallback copy
+    expect(text).not.toContain(LEVER_LABEL);                            // never the lever (the A1c guarantee)
+  });
 });
 
 describe('A1c — top_fragile_edge (m1-coaching composition)', () => {


### PR DESCRIPTION
## Lane A1c — suppress lever-sourced fragile edges from 4 action surfaces

**READY FOR MERGE.** Prior review approved at `ca7f62a`; the only post-review delta is a test-only hardening commit (`0796360`), so no new review loop is required. Base: `staging` (`438bb35`, the A1b merge #191).

### Doctrine
Option-pinned intervention levers (ISL `zero_reason:"intervention_override"`, `sensitivity_score:0`) are **not independently tunable**. A1 (PR #190) stopped the `factor_sensitivity` merge from re-leaking them; A1b (PR #191) stopped the `|elasticity|`-ranked tunability surfaces (top_drivers / what_would_change-factor-path / evidence-priority / headline VoI / dominant-factor critique). **A1c closes the remaining leak: fragile/robustness edges *sourced from* a lever, named in PLoT's action-guidance prose** as if the user could tune or validate that pinned lever.

Suppress lever-**SOURCED** fragile edges from **exactly these four** PLoT action-guidance surfaces:
1. `decision_brief.what_would_change`
2. `m1_coaching.story_headlines[high_uncertainty]` (headline text **and** the `detectHeadlineType` classifier, so type stays consistent with text)
3. `m1_coaching.top_fragile_edge`
4. `m1_coaching.next_actions` (the P3 "Validate the … assumption" edge action)

**SOURCE-only by design.** A lever as edge **TARGET** (`X → lever`) describes something acting *on* the lever, not tuning it — left untouched. **Per-surface filtering only** — NOT in `normaliseCoachingInputs`, because its `fragileEdges` are shared with `assumptions-ledger.ts`, `readiness-tone.ts`, `readiness-signals.ts`, which are **out of scope and must stay unchanged**. **Fallback** = each surface's existing safe path using the top *non-lever* fragile edge; never blank with a lever, never invent, **no relabel** ("structural"/"option-determined" would be a different lane, S1).

### Lever-id source per surface (tightening 2 — source-id accessor)
| Surface | Lever-id set | Edge source-id accessor |
|---|---|---|
| decision_brief.what_would_change | `interventionOverrideFactorIds(input.factor_sensitivity)` — from `zero_reason` (BriefAssemblyInput carries no `interventionTargetIds`) | `(e) => e.from_id` (raw ISL shape) |
| story_headlines / top_fragile_edge / next_actions | `inputs.interventionTargetIds` (canonical request-side set) | `(e) => e.fromId` (normalised coaching shape) |

The leaf predicate `isLeverSourcedEdge(fromId, leverIds)` matches on the **source** id only — proven by a unit test asserting it returns `true` for the lever source, `false` for a non-lever source AND `false` when the lever is the target.

### Files changed (src — 86 insertions, 11 deletions; +2 test files)
- `src/lib/intervention-override.ts` — new leaf helpers: `interventionOverrideFactorIds`, `isLeverSourcedEdge`, `filterLeverSourcedFragileEdges<E>(edges, leverIds, getFromId)` (the `getFromId` adapter handles `from_id` vs `fromId`; empty lever set → unchanged).
- `src/assembly/decision-brief.ts` — `buildWhatWouldChange` filters the primary fragile-edge path; falls through to the A1b-filtered factor path when no non-lever edge remains.
- `src/coaching/headlines.ts` — `generateHeadlines` + `detectHeadlineType` exclude lever-sourced edges from `topFragile` selection.
- `src/coaching/m1-coaching.ts` — `top_fragile_edge` filters before `getFragileEdgeContext`.
- `src/coaching/next-actions.ts` — P3 edge action uses the filtered list (`topFragileEdge: a1cTunableFragileEdges[0]`).

### Per-surface fallback proof (tightening 1) — clean-base RED → PR-head GREEN
Each surface has a GREEN test proving (a) the specific lever is excluded / a non-lever edge named, and (b) the **specific fallback** fires when *all* fragile edges are lever-sourced:

| Surface | Exclude/name test | Fallback proven |
|---|---|---|
| what_would_change | lever-sourced edge gone, non-lever kept; lever-as-target kept | all-lever → **factor path** (names non-lever factor, no `→` edge string, no lever) |
| story_headlines[high_uncertainty] | names non-lever; `detectHeadlineType==='high_uncertainty'` | only-lever → **type shifts off** high_uncertainty; no lever named |
| top_fragile_edge | top non-lever edge surfaced | only-lever → **undefined** (no fake replacement) |
| next_actions P3 | P3 names non-lever (`target_id` = non-lever edge) | only-lever → **P3 edge action skipped**; no lever named |

**Clean pre-A1c base RED** (detached worktree at `438bb35` with only the extended leaf + the 2 test files copied in, consumers unpatched): `Tests 7 failed | 7 passed (14)`. The 7 RED = all four surfaces' exclude+fallback assertions and the egress test (levers named on the unpatched base). The 7 GREEN = the leaf helpers + source-only/target-kept + the `top_fragile_edge` *composition* tests (which call the helper directly — their wiring RED is covered by the egress failure). This isolates per-surface suppression as the cause of the flip.

**PR head:** all 14 A1c tests GREEN; `tsc --noEmit` clean.

### Scope-containment (tightening 3 — positive)
`tests/lane-a1c-fragile-edge-egress.integration.test.ts` drives a real `/v2/run` (`createServer()`, ISL `vi.mock` returns 2 lever-sourced fragile edges + 1 non-lever + the 3-lever `factor_sensitivity`). It asserts the 4 action surfaces exclude the lever labels **and** that `m1_coaching.assumptions_ledger` **STILL names a lever-sourced residue** (`fac_*` id present) — proving A1c did not reach into the ledger.

### Verification (current head `0796360` — single authoritative set)
- `tsc --noEmit`: clean.
- A1c suite: **15/15 GREEN**.
- **Full `npm test`: 5075 passed / 25 skipped / 0 failed**.
- Hardening commit (`0796360`) is **test-only** and **RED-on-revert** (a real guard).
- Pre-push gate: PASS (tsc, full suite, no stale .js, no `file:` deps, OpenAPI spectral lint).

### Runtime acceptance (tightening 4 — post-deploy, NOT yet run)
After this lands on staging, replay the pinned scenario (`c5eeee8a` / request `77b2891a`, the 3-lever fixture) against the staging `/v2/run` and confirm **positive fallback**, not just absence:
- `decision_brief.what_would_change` names a **non-lever** driver/edge (e.g. "Launch Deadline Pressure"), not TLC/ADC/Hiring-Cost.
- `story_headlines` high_uncertainty headline (if present) names a non-lever edge, else the type has shifted.
- `top_fragile_edge` is a non-lever edge or absent.
- `next_actions` has no edge action naming a lever.
- `assumptions_ledger` still references the lever residue (scope unchanged).

### Downstream / consumer note
PLoT action-guidance prose no longer *names* lever-sourced fragile edges. The underlying robustness data (`islResult.robustness.fragile_edges`) is **unchanged** — assumptions_ledger and readiness surfaces still see the full edge set. No wire-schema change; `zero_reason`/`interventionTargetIds` remain the only lever signal. If CEE/UI prose still names a lever as tunable after this, that is Gate-Zero / CEE residue, reported separately.

### Out of scope / hard stops respected
No schema change, no field-meaning change, no CEE feed, no `assumptions_ledger` change, no VOI/EVPI, no `edge_e_values`/A2, no relabelling. Stop-and-report rails honoured (no 5th action-guidance feed path naming a lever was found; target-lever edges were not widened into). No merge/deploy without authorisation; Codex review first.

---

## Post-review corrections (current head `0796360`)

**Only post-review change is test-only.** `ca7f62a..0796360` = a single commit touching only `tests/lane-a1c-fragile-edge-suppression.test.ts` (+21 lines): the VoI-driven high_uncertainty hardening test. No `src/` change. Evidence at head `0796360`:
- A1c suite: **15/15 green**; full `npm test`: **5075 passed / 25 skipped / 0 failed**; `tsc --noEmit` clean; pre-push gate green.
- The hardening test is **RED-on-revert** (reverting the `headlines.ts` filter makes the headline name the lever) — a real guard, not decoration.

**`detectHeadlineType` framing correction.** The exported `detectHeadlineType` in `headlines.ts` (which this PR also filters) is **not currently the production `headline_type` driver** — production uses a local simplified `detectHeadlineType` in `m1-coaching.ts` that does not emit `high_uncertainty`. Therefore:
- the `headlines.ts detectHeadlineType` edit is **defensive / forward-protective only** (consistent with A1b's "filter at all classification sites"; it pre-protects the future unification lane);
- it is **not load-bearing** for production `headline_type` today;
- **A1c correctness does not depend on that dead-path classifier edit** — the four surfaces suppress lever-sourced fragile edges directly (`what_would_change`, `story_headlines` text via `generateHeadlines`, `top_fragile_edge`, `next_actions`), and the `headline_type` enum names no lever;
- the duplicate `detectHeadlineType` is a **separate technical lane** (see the Gemini HIGH thread reply), not folded into A1c. The defensive edit is **kept** (reverting now would churn, since the unification lane will likely need the same filter).

**Open residues — classification (not all "S1-blocked").** Out of A1c scope; resolve in a separate technical/product-semantics lane where confidence is high; escalate to Neil/Jinghui only where a fix needs a scientific interpretation or a positive claim:
- *Decidable now (technical/product lanes):* duplicate `detectHeadlineType` / readiness mismatch; CEE `scenario_contexts` fragile-edge feed (PLoT→CEE contract / F.6 ownership); partial-intervention `zero_reason`-vs-`interventionTargetIds` divergence (canonical lever-definition consistency); suppression of misleading action wording (removing only a false tunability implication).
- *Escalate only if needed:* EVPI/VOI naming/definition (may be a misnamed proxy); positive relabelling ("structural" / "option-determined"); assumptions-ledger node-confidence relabelling that makes a new claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

