### PR TITLE
fix(plot): P0a — suppress VOI/EVPI for option-pinned levers (graph+ISL merge)

### DIFF
--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -954,6 +954,17 @@ export function mergeIslConfidenceIntoGraphFactors(
         // durable guarantee is the explicit zero_reason predicate at each
         // tunability/evidence surface; this is defence-in-depth. (A1b brief §1/§3.)
         elasticity: 0,
+        // P0a: a lever's value_of_information is 0 by the same contract.
+        // `value_of_information` is computed pre-merge in
+        // computeFactorSensitivityFromGraph from the lever's non-zero topological
+        // influence (and carried through by the `...gf` spread above); the EVPI
+        // enrichment loop in routes/v2/run.ts derives evpi_percentage_points from
+        // it, so without this a lever would publish a positive EVPI and surface as
+        // a top "investigation priority / resolvable uncertainty" in consumers
+        // (e.g. the UI factor card). Resolving knowledge of an option-pinned value
+        // the user sets is not an information gain, so VOI is 0 — same suppression
+        // posture as sensitivity_score/elasticity above, NOT a new EVPI definition.
+        value_of_information: 0,
       }),
     };
   });

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -4305,6 +4305,15 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           const winProbSpread = winProbs.length >= 2 ? winProbs[0] - winProbs[1] : 0;
           if (winProbSpread > 0) {
             for (const f of factorSensitivity) {
+              // P0a: never emit EVPI for an option-pinned lever
+              // (zero_reason === 'intervention_override'). Its VOI is forced to 0
+              // in mergeIslConfidenceIntoGraphFactors, and computeEvpiPercentagePoints(0, …)
+              // returns a confident 0 (not undefined) — which would still render an
+              // EVPI chip and rank the lever as an "investigation priority". Skip it
+              // entirely so evpi_percentage_points is ABSENT (preserving the
+              // missing-vs-zero contract), not 0. Belt-and-braces with the
+              // producer-side VOI zeroing; suppression only, no EVPI rename/redefine.
+              if (f.zero_reason === 'intervention_override') continue;
               const evpiPp = computeEvpiPercentagePoints(f.value_of_information, winProbSpread);
               if (evpiPp !== undefined) {
                 f.evpi_percentage_points = evpiPp;

--- a/tests/isl-confidence-merge.test.ts
+++ b/tests/isl-confidence-merge.test.ts
@@ -509,6 +509,44 @@ describe('mergeIslConfidenceIntoGraphFactors', () => {
   });
 
   // -------------------------------------------------------------------------
+  // T10e (P0a, producer) — matched intervention_override levers get a
+  // defensive `value_of_information: 0`. The graph computes a non-zero VOI for a
+  // lever from its topological influence (computeFactorSensitivityFromGraph),
+  // and the `...gf` spread carries it through the merge; without the override
+  // the lever would publish a positive VOI, from which the /v2/run EVPI loop
+  // derives a positive evpi_percentage_points (lever surfaces as a top
+  // "investigation priority"). sensitivity_score/elasticity/zero_reason (A1/A1b)
+  // and influence_score (structural) are unaffected; non-lever VOI is unchanged.
+  // RED pre-P0a: matched levers keep the graph-derived value_of_information.
+  // -------------------------------------------------------------------------
+  it('T10e (P0a): matched intervention_override levers get value_of_information:0; non-lever VOI unchanged', () => {
+    const graphFactors: FactorSensitivityResultV3[] = [
+      makeGraphFactor('fac_leadership_capacity', { sensitivity_score: 0.4475, elasticity: 1, influence_score: 1, value_of_information: 0.42, importance_rank: 1, direction: 'positive' }),
+      makeGraphFactor('fac_dev_capacity', { sensitivity_score: 0.23, elasticity: 0.51, influence_score: 0.51, value_of_information: 0.21, importance_rank: 2, direction: 'positive' }),
+      makeGraphFactor('fac_time_pressure', { sensitivity_score: -0.2285, elasticity: 0.51, influence_score: 0.51, value_of_information: 0.18, importance_rank: 3, direction: 'negative' }),
+    ];
+    const islUnfiltered: FactorSensitivityResultV3[] = [
+      makeIslFactor('fac_leadership_capacity', { sensitivity_score: 0, zero_reason: 'intervention_override', attribution_stability: 'negligible' }),
+      makeIslFactor('fac_dev_capacity', { sensitivity_score: 0, zero_reason: 'intervention_override', attribution_stability: 'negligible' }),
+      makeIslFactor('fac_time_pressure', { sensitivity_score: 1, attribution_stability: 'low' }),
+    ];
+
+    const graphById = new Map(graphFactors.map(f => [f.factor_id, { ...f }]));
+    const merged = mergeIslConfidenceIntoGraphFactors(graphFactors, islUnfiltered);
+
+    for (const id of ['fac_leadership_capacity', 'fac_dev_capacity']) {
+      const m = merged.find(f => f.factor_id === id)!;
+      expect(m.value_of_information).toBe(0);               // RED pre-P0a: graph-derived non-zero (0.42 / 0.21)
+      expect(m.zero_reason).toBe('intervention_override');  // A1 invariant preserved
+      expect(m.influence_score).toBe(graphById.get(id)!.influence_score); // structural importance untouched
+    }
+    // Non-lever VOI byte-identical to graph input (no over-suppression).
+    const tp = merged.find(f => f.factor_id === 'fac_time_pressure')!;
+    expect(tp.value_of_information).toBe(0.18);
+    expect(tp.zero_reason).not.toBe('intervention_override');
+  });
+
+  // -------------------------------------------------------------------------
   // T11 — heart-of-the-fix regression (audit row A1-PRIMARY)
   // -------------------------------------------------------------------------
 

--- a/tests/lane-a1-intervention-override-egress.integration.test.ts
+++ b/tests/lane-a1-intervention-override-egress.integration.test.ts
@@ -200,6 +200,47 @@ describe('Lane A1 — /v2/run egress preserves intervention_override lever sensi
     }
   });
 
+  it('P0a: levers carry NO evpi_percentage_points (absent, not 0) and value_of_information 0; non-levers retain the EVPI field', async () => {
+    // winProbSpread here = 0.62 - 0.38 = 0.24 > 0, so the heuristic EVPI loop in
+    // routes/v2/run.ts fires over the merged factor_sensitivity (graph+isl_merge).
+    const res = await fetch(`${baseUrl}/v2/run`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '42' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    const factors = body.factor_sensitivity as any[];
+
+    // NEGATIVE (RED pre-P0a: lever VOI=0 → computeEvpiPercentagePoints returns a
+    // confident 0, so the lever previously egressed evpi_percentage_points: 0):
+    // every lever must now have the field ABSENT (skipped), and VOI not positive.
+    for (const id of LEVERS) {
+      const f = factors.find((x: any) => x.factor_id === id);
+      expect(f.evpi_percentage_points, `${id} evpi absent`).toBeUndefined();
+      expect(f.evpi_method, `${id} evpi_method absent`).toBeUndefined();
+      expect(f.value_of_information ?? 0, `${id} VOI not positive`).toBeLessThanOrEqual(0);
+    }
+
+    // POSITIVE (no over-suppression / no silent blanking): non-levers are NOT
+    // skipped — they retain the evpi_percentage_points field (here 0, since this
+    // fixture carries no fragile edges so graph VOI is 0; the dedicated egress
+    // test asserts a strictly-positive non-lever EVPI). Field presence is the
+    // honest guarantee: levers lose it, non-levers keep it.
+    for (const id of NON_LEVERS) {
+      const f = factors.find((x: any) => x.factor_id === id);
+      expect(f.evpi_percentage_points, `${id} evpi present`).toBeDefined();
+      expect(f.evpi_method, `${id} evpi labelled heuristic`).toBe('heuristic');
+    }
+
+    // The lever fac_leadership_capacity has the HIGHEST raw graph influence_score
+    // (it is the strongest topological driver), yet it does NOT surface with an
+    // EVPI — it cannot be ranked as the investigation/validation priority.
+    const maxInfluence = factors.reduce((m, f) => Math.max(m, f.influence_score ?? 0), 0);
+    const topInfluence = factors.find((f) => (f.influence_score ?? 0) === maxInfluence);
+    expect(LEVERS).toContain(topInfluence.factor_id);
+    expect(topInfluence.evpi_percentage_points).toBeUndefined();
+  });
+
   const LEVER_LABELS = ['Technical Leadership Capacity', 'Additional Developer Capacity', 'Annual Hiring Cost'];
   const NONLEVER_LABELS = ['Launch Deadline Pressure', 'Existing Team Size'];
 

--- a/tests/lane-p0a-lever-evpi-egress.integration.test.ts
+++ b/tests/lane-p0a-lever-evpi-egress.integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Lane P0a — option-pinned lever VOI/EVPI suppression at the /v2/run egress.
+ *
+ * RED-before / GREEN-after at the PUBLIC PLoT egress boundary, with a STRICTLY
+ * POSITIVE non-lever EVPI so the contrast is unambiguous (the sibling
+ * lane-a1 egress test carries no fragile edges, so its non-lever EVPI is 0).
+ *
+ * Two producer sites are exercised end-to-end:
+ *   1. mergeIslConfidenceIntoGraphFactors forces a lever's value_of_information
+ *      to 0 (alongside the A1/A1b sensitivity_score:0 / elasticity:0 invariant).
+ *   2. the EVPI enrichment loop in routes/v2/run.ts SKIPS levers, so a lever's
+ *      evpi_percentage_points is ABSENT (not a confident 0).
+ *
+ * Fixture shape:
+ *   - `fac_lever` is a GRAPH factor that ISL marks intervention_override (a
+ *     decision lever pinned by both options). Its graph influence is the
+ *     strongest, so pre-suppression it would be the #1 "investigation priority".
+ *   - `fac_isl_voi` is an ISL-ONLY non-lever carrying a finite positive ISL
+ *     value_of_information, so the append path (mapIslFactorEntry) gives it a
+ *     positive public VOI → positive evpi_percentage_points. It is the honest
+ *     EVPI target that MUST survive.
+ *
+ * Suppression only — no EVPI rename, no new scientific claim, no schema change.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const LEVER_ID = 'fac_lever';
+const ISL_VOI_ID = 'fac_isl_voi';
+
+// ISL factor_sensitivity: a graph lever (intervention_override) + an ISL-only
+// non-lever with a finite positive VOI. node_id-keyed, ISL shape.
+const ISL_FACTOR_SENSITIVITY = [
+  { node_id: LEVER_ID, sensitivity: 0, value_of_information: 0.9, direction: 'positive' as const, zero_reason: 'intervention_override' },
+  { node_id: ISL_VOI_ID, sensitivity: 0.5, value_of_information: 0.6, direction: 'positive' as const },
+];
+
+function robustnessPayload(options: any[]) {
+  return {
+    options: options.map((opt: any, idx: number) => ({
+      option_id: opt.id,
+      win_probability: idx === 0 ? 0.7 : 0.3, // spread 0.4 > 0 ⇒ heuristic EVPI loop fires
+      outcome: { mean: 0.7 - idx * 0.2, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+      rank: idx + 1,
+    })),
+    edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const, edge_sensitivity_status: 'available' as const,
+    factors: ISL_FACTOR_SENSITIVITY,
+    factor_sensitivity: ISL_FACTOR_SENSITIVITY,
+    value_of_information: ISL_FACTOR_SENSITIVITY.map(f => ({ factor_id: f.node_id, voi: f.value_of_information })),
+    factors_provenance: 'isl' as const, factor_sensitivity_status: 'available' as const,
+    overall_robustness: 'robust' as const, robustness_score: 0.8, fragile_edges: [], robust_edges: [],
+    latency_ms: 50, source: 'isl' as const,
+  };
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return { status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl' };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return robustnessPayload(options);
+  },
+  async analyseFactorSensitivity() {
+    return { factors: ISL_FACTOR_SENSITIVITY, value_of_information: ISL_FACTOR_SENSITIVITY.map(f => ({ factor_id: f.node_id, voi: f.value_of_information })), robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'isl' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    return { data: robustnessPayload(body.options || []) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+const { createServer } = await import('../src/createServer.js');
+
+// fac_lever is a graph factor (strongest edge to goal); fac_plain is a non-lever
+// graph factor. Both options pin fac_lever (option-controlled lever).
+const PAYLOAD = {
+  graph: {
+    nodes: [
+      { id: 'goal', kind: 'goal', label: 'Goal' },
+      { id: LEVER_ID, kind: 'factor', label: 'Pinned Lever', observed_state: { value: 0.6 } },
+      { id: 'fac_plain', kind: 'factor', label: 'Background Factor', observed_state: { value: 0.5 } },
+    ],
+    edges: [
+      { from: LEVER_ID, to: 'goal', exists_probability: 0.95, strength: { mean: 0.9, std: 0.1 } },
+      { from: 'fac_plain', to: 'goal', exists_probability: 0.7, strength: { mean: 0.3, std: 0.1 } },
+    ],
+  },
+  options: [
+    { id: 'opt_a', label: 'A', interventions: { [LEVER_ID]: { value: 1, source: 'user_specified' } } },
+    { id: 'opt_b', label: 'B', interventions: { [LEVER_ID]: { value: 0, source: 'user_specified' } } },
+  ],
+  goal_node_id: 'goal',
+  seed: '42',
+};
+
+describe('Lane P0a — /v2/run egress suppresses lever VOI/EVPI, preserves non-lever EVPI', () => {
+  let app: FastifyInstance;
+  let body: any;
+  let factors: any[];
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    const res = await app.inject({
+      method: 'POST', url: '/v2/run',
+      headers: { 'content-type': 'application/json' },
+      payload: PAYLOAD,
+    });
+    expect(res.statusCode).toBe(200);
+    body = res.json();
+    factors = (body.factor_sensitivity ?? []) as any[];
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  it('the lever egresses with zero_reason intervention_override and value_of_information 0 (site 1)', () => {
+    const lever = factors.find((f) => f.factor_id === LEVER_ID);
+    expect(lever, 'lever present in egress').toBeDefined();
+    expect(lever.zero_reason).toBe('intervention_override');
+    expect(lever.value_of_information ?? 0).toBe(0); // RED pre-P0a: graph-derived VOI carried through
+  });
+
+  it('the lever has NO evpi_percentage_points — absent, not a confident 0 (site 2)', () => {
+    const lever = factors.find((f) => f.factor_id === LEVER_ID);
+    expect(lever.evpi_percentage_points, 'lever evpi absent').toBeUndefined();
+    expect(lever.evpi_method, 'lever evpi_method absent').toBeUndefined();
+  });
+
+  it('a non-lever still carries a STRICTLY POSITIVE evpi_percentage_points (no over-suppression)', () => {
+    const nonLever = factors.find((f) => f.factor_id === ISL_VOI_ID);
+    expect(nonLever, 'non-lever present in egress').toBeDefined();
+    expect(nonLever.value_of_information).toBeGreaterThan(0);
+    expect(nonLever.evpi_percentage_points).toBeGreaterThan(0);
+    expect(nonLever.evpi_method).toBe('heuristic');
+  });
+
+  it('the only factor bearing EVPI is a non-lever — the pinned lever is never the EVPI/investigation priority', () => {
+    const withEvpi = factors.filter((f) => f.evpi_percentage_points !== undefined && f.evpi_percentage_points !== null);
+    expect(withEvpi.length, 'at least one EVPI target exists').toBeGreaterThan(0);
+    for (const f of withEvpi) {
+      expect(f.zero_reason).not.toBe('intervention_override');
+    }
+    // The lever retains its (graph) structural importance — it is suppressed
+    // from the EVPI surface specifically, not blanked from the response.
+    const lever = factors.find((f) => f.factor_id === LEVER_ID);
+    expect(typeof lever.influence_score).toBe('number');
+    expect(lever.influence_score).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What & why

An `intervention_override` factor is an **option-pinned decision lever**, not an independently tunable uncertainty. A1/A1b already force its `sensitivity_score` and `elasticity` to `0`, but **`value_of_information` was still carried through the graph+ISL merge** (computed pre-merge from the lever's topological influence), and the `/v2/run` EVPI enrichment loop derived a **positive `evpi_percentage_points`** from it. Result: a lever could publish a positive EVPI on the wire and surface as the top *"investigation priority / resolvable uncertainty"* on consumers — e.g. the UI factor-card EVPI chip, which sorts EVPI-descending.

This is the P0a slice of the credibility/lever-suppression workstream (CEE #308 + PLoT A1/A1b/A1c). **Suppression only** — no EVPI/VOI rename, no new scientific claim, no schema/contract change.

## Change (two producer-side sites)

1. **`src/lib/factor-influence.ts`** — in the `zero_reason === 'intervention_override'` override block of `mergeIslConfidenceIntoGraphFactors`, also force `value_of_information: 0`, mirroring the existing `sensitivity_score: 0` / `elasticity: 0` invariant.
2. **`src/routes/v2/run.ts`** — the EVPI enrichment loop **skips** levers, so `evpi_percentage_points` is **ABSENT** (not a confident `0` — `computeEvpiPercentagePoints(0, spread)` returns `0`, which would still render an EVPI chip). Preserves the missing-vs-zero contract; belt-and-braces with the VOI zeroing.

The `isl`-only fallback (`transformFactorSensitivity`) already filtered levers entirely. This closes the **`graph+isl_merge`** path — the live demo path (confirmed via `factor_sensitivity_source` in the integration logs).

## No contract drift

`value_of_information` and `evpi_percentage_points` are already **optional** (`?: number`, `minimum: 0`); `absent`/`0` were already valid. No `@talchain/schemas`, OpenAPI, or field-meaning change — the field's **value** for a lever changes (to absent/0), its **meaning** does not (a user-pinned value's information gain is genuinely ~0).

## Tests (RED-before / GREEN-after)

- **`isl-confidence-merge` T10e (unit)** — merged lever `value_of_information` forced to `0`; non-lever VOI unchanged.
- **`lane-a1-...egress` (integration)** — levers carry **no** `evpi_percentage_points` (absent) + VOI `0`; non-levers **retain** the EVPI field; highest-influence lever bears no EVPI.
- **`lane-p0a-lever-evpi-egress` (new integration)** — a **strictly-positive** non-lever EVPI survives while the pinned lever is suppressed → proves **no over-suppression / no silent blanking**.

RED-before verified by reverting only the two src edits (4 tests fail). Authoritative pre-push gate green: **5081 passed | 25 skipped**, typecheck clean, no stale `.js`, OpenAPI lint pass.

## Out of scope (tracked separately)

CEE re-projected fragile-edge/flip prose (P0b), UI defense-in-depth guard (P1c), `detectHeadlineType` duplicate (P1b, stop-condition). Deployed-staging replay (scenario 1 fixture; scenario 2 `42c16703` pending payload capture) is post-merge confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)