### PR TITLE
fix(gate): resilient pre-push against core.bare corruption + invariant guard (draft, do-not-merge)

### DIFF
--- a/scripts/pre-push-validate.sh
+++ b/scripts/pre-push-validate.sh
@@ -21,6 +21,39 @@ YELLOW='\033[1;33m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+# ---------------------------------------------------------------------------
+# Hook-environment hygiene.
+#
+# git exports GIT_DIR (and friends) when it invokes a hook such as pre-push.
+# Every git command below must resolve THIS worktree from the current
+# directory, never an inherited GIT_DIR that points at some other worktree's
+# gitdir — so unset them up front. Harmless for manual runs.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE 2>/dev/null || true
+
+# Self-heal a provably-wrong `core.bare`.
+#
+# This repo has `extensions.worktreeConfig=true`, which makes `core.bare`
+# worktree-scoped. A concurrent or interrupted git write (a killed process
+# leaving a *.lock, parallel worktree ops) can leave `core.bare=true` in a
+# worktree scope, overriding the correct shared `false`. When that happens,
+# EVERY work-tree git command — starting with the `rev-parse --show-toplevel`
+# below — dies with the opaque "fatal: this operation must be run in a work
+# tree", silently blocking all pushes from that worktree until someone finds
+# and clears it.
+#
+# We are standing in a checked-out worktree with source files, so a `bare`
+# view is definitively a corruption, not a real bare repo. Detect it and
+# correct it loudly (worktree-scoped when the extension is on), rather than
+# failing with an inscrutable message.
+if [ -f "package.json" ] && [ "$(git config --get core.bare 2>/dev/null || echo false)" = "true" ]; then
+  echo -e "  ${YELLOW}WARN${NC} core.bare=true in a checked-out worktree — corruption (see extensions.worktreeConfig). Self-healing to false." >&2
+  if [ "$(git config --get extensions.worktreeConfig 2>/dev/null || echo false)" = "true" ]; then
+    git config --worktree core.bare false 2>/dev/null || git config core.bare false
+  else
+    git config core.bare false
+  fi
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 

--- a/tests/git-config-invariants.test.ts
+++ b/tests/git-config-invariants.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Git-config invariants — regression guard for the `core.bare` corruption.
+ *
+ * Background: this repo runs with `extensions.worktreeConfig=true`, which makes
+ * `core.bare` worktree-scoped. A concurrent or interrupted git write can leave
+ * `core.bare=true` in a worktree scope, overriding the correct shared `false`.
+ * When that happens EVERY work-tree git command (starting with the pre-push
+ * gate's `git rev-parse --show-toplevel`) dies with "fatal: this operation must
+ * be run in a work tree", silently blocking all pushes from that worktree.
+ *
+ * These tests fail LOUDLY inside the suite if the invariant is violated — so a
+ * corruption is caught in CI/local test runs rather than only surfacing as a
+ * mysterious blocked push. They also prove the invariant is currently held and
+ * that nothing in the suite itself leaves `core.bare` set.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+// Repo root: the working directory of the test run (vitest root === repo root).
+const REPO_ROOT = process.cwd();
+
+// Read git config WITHOUT trusting an inherited GIT_DIR/GIT_WORK_TREE — those
+// are set when git runs a hook and would otherwise point elsewhere.
+function gitConfig(args: string[]): string {
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  try {
+    return execFileSync('git', ['config', ...args], {
+      cwd: REPO_ROOT,
+      env,
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return ''; // unset key → non-zero exit → treat as empty
+  }
+}
+
+describe('git config invariants (core.bare corruption guard)', () => {
+  it('is a checked-out worktree, not a bare repo (package.json present at root)', () => {
+    expect(existsSync(resolve(REPO_ROOT, 'package.json'))).toBe(true);
+  });
+
+  it('core.bare is NOT true — a checked-out worktree must never resolve as bare', () => {
+    const bare = gitConfig(['--get', 'core.bare']) || 'false';
+    expect(
+      bare,
+      'core.bare resolved true in a checked-out worktree — this is the ' +
+        'extensions.worktreeConfig corruption; run `git config --worktree ' +
+        'core.bare false` (or `git config core.bare false`) to clear it.',
+    ).not.toBe('true');
+  });
+
+  it('git can resolve the work tree (the operation the pre-push gate depends on)', () => {
+    const env = { ...process.env };
+    delete env.GIT_DIR;
+    delete env.GIT_WORK_TREE;
+    const top = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: REPO_ROOT,
+      env,
+      encoding: 'utf8',
+    }).trim();
+    expect(top.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
**Do not merge — review-only draft.** Defense-in-depth for the `fatal: this operation must be run in a work tree` corruption that silently blocked pushes. Gate-script + test only; **no runtime changes**. Does not touch #194; complements the root-cause fix on #195.

## Root cause (corrected — it IS a test, found via the real hook)
The trigger is a test fixture: **`tests/file-dep-policy.test.ts`** (on the #195 re-vendor branch) ran `git -C <tempdir> init/add` **without clearing `GIT_DIR`**. git exports `GIT_DIR` when it invokes a hook (pre-push), and **`GIT_DIR` takes precedence over `-C <dir>`** — so under the hook the fixture's git ops targeted the *real* repo's gitdir instead of the temp dir, flipping `core.bare=true`. Because this repo has **`extensions.worktreeConfig=true`**, `core.bare` is worktree-scoped, so the flip is invisible to a main-path `git config core.bare false`. Every subsequent work-tree git command then dies at `git rev-parse --show-toplevel`, blocking pushes.

*(This corrects my initial commit note that claimed "not a test writing git config" — running the real hook, not just `bash scripts/pre-push-validate.sh`, surfaced the leaking fixture. The manual run was clean only because it had no exported `GIT_DIR`.)*

The **root-cause fix** lives on #195 (isolate the fixture's git env — commit `2ecae76`). **This PR is the gate-level backstop** so *no future* `GIT_DIR`-leaking test/tool can corrupt a push, plus a regression guard.

## What this PR does
- **`scripts/pre-push-validate.sh`**: `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE` before its first git command (hook-env hygiene), and **self-heal** a provably-wrong `core.bare` (a checked-out worktree with `package.json` cannot legitimately be bare) — worktree-scoped when the extension is on. Turns an opaque block into a logged auto-correction.
- **`tests/git-config-invariants.test.ts`** (3 tests): asserts the repo isn't bare, `core.bare` is never `true`, and the work tree resolves — fails loudly in the suite instead of only as a blocked push. (Would have caught this immediately.)

## Verification
- Reproduced the flip via the **real `.husky/pre-push` hook** (with `GIT_DIR` set): `core.bare` false → true, gate FAIL. With #195's fixture fixed, the same hook passes and `core.bare` stays false.
- This branch's own gate: exit 0, **5097 passed / 25 skipped / 0 failed**, 6/6.
- Pushed through the real hook with **no `--no-verify`**; self-heal kept `core.bare` false.
- Shares `scripts/pre-push-validate.sh` with #195 but in a different region — verified **clean 3-way auto-merge (0 conflicts)**, so merge order is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)