### PR TITLE
fix(gate): add 900s timeout to pre-push hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/claude-pre-push-gate.sh"
+            "command": "bash scripts/claude-pre-push-gate.sh",
+            "timeout": 900
           }
         ]
       }


### PR DESCRIPTION
This fixes the PLoT push blocker where the Claude Code PreToolUse git-push hook had no explicit timeout. The validation gate takes around 5 minutes, but the harness default kills it after around 60 seconds, blocking pushes despite the gate passing.

This change adds `timeout: 900` so the gate can run to completion. It strengthens the normal gated push path; it does not bypass validation.

Scope:
- config-only
- changes exactly `.claude/settings.json`
- no production code
- no tests
- no package or lockfile changes
- no docs or generated changes