### PR TITLE
Lane 2: ISL V2 science channel — read live wire locations, EVPI hygiene, dup-edge preflight

### DIFF
--- a/docs/lanes/LANE2-isl-v2-science-channel-2026-07-07.md
+++ b/docs/lanes/LANE2-isl-v2-science-channel-2026-07-07.md
@@ -1,0 +1,102 @@
+# Lane 2 evidence report — ISL V2 science channel (PLoT)
+
+- **Branch:** `claude-lane2/isl-v2-science-channel` (from `origin/staging` @ `e01c03c` — PR #197 hook-timeout merge)
+- **Date:** 2026-07-07
+- **Scope:** PLoT reads five science fields at V1-shaped locations the live ISL V2 wire never emits; repoint/delete them, add EVPI hygiene, confidence_tier reconciliation, duplicate-edge preflight, warning tolerance, and a liveness fixture gate.
+- **Contracts:** FROZEN — no boundary field shapes changed. Wire-visible deltas are value-level only (fields that already existed now populate honestly; see below).
+
+## 0. Fixture provenance (FIRST ACTION)
+
+The lane brief named `isl-staging-capture.json` / `isl-v2-request.json` in the session scratchpad. **Those standalone files did not exist** (scratchpad contained `plot.jsonl` / `isl.jsonl` / `cee.jsonl` boundary logs). The raw payloads were recovered from PLoT `boundary.response` log entries (`plot.jsonl` lines 70 and 100), which embed the full ISL request/response for two live `/api/v1/robustness/analyze/v2` calls (deployed ISL build `f3f5d92`, 2026-07-06T23:32/23:39Z):
+
+- `tests/fixtures/isl-v2-live-20260706/isl-v2-request.json` + `isl-staging-capture.json` (capture A — plain run)
+- `…-request-b.json` + `…-capture-b.json` (capture B — with `goal_constraints`)
+
+Sanitisation: scanned for IPs / emails / hostnames / keys — none present; data is synthetic (hiring-decision demo graph). Committed as `c1835e4` before any code change.
+
+## 1. Wire truth (machine-checked in `tests/isl-v2-envelope.unit.test.ts`)
+
+| Field | V1-shaped read (dead) | Live V2 location | Fixture proof |
+|---|---|---|---|
+| edge E-values | top-level `edge_e_values` (run.ts) | **nested `robustness.edge_e_values`** (13 entries) | both captures |
+| edge sensitivity | top-level `sensitivity` | **NOT EMITTED — V2 wire drops it, no replacement** | both captures |
+| validation status | top-level `validation_status` | **NOT EMITTED** | both captures |
+| computed timestamp | top-level `computed_at` | **top-level `timestamp`** | both captures |
+| factor VOI | `factor_sensitivity[].value_of_information` | **top-level `factor_evpi[]`** (per-factor EVPI) | both captures |
+
+Additional wire facts discovered and pinned:
+
+- `edge_e_values[].flip_direction` live vocabulary is `increase`/`decrease` (typed union previously claimed `positive_to_negative | negative_to_positive | removal`) → PLoT types widened to `string`; passthrough verbatim (ISL owns semantics).
+- `is_unflippable: true` entries (4 of 13) **omit `e_value` entirely**. PLoT's numeric-egress guard drops them from outward `edge_e_values` (logged via `edge_e_values_dropped_nonfinite`). Representing unflippable edges outward needs contract work → followup.
+- `factor_evpi` carries a **raw negative** entry live: `fac_hiring_cost` `evpi=-0.0015` / `-0.15pp` (MC sampling noise) — the hygiene target for item C.
+
+## 2. What changed (by lane item)
+
+**A — V2 envelope repoint** (`src/integrations/isl/v2-envelope.ts` new; `src/routes/v2/run.ts`; `src/integrations/isl/types/isl-types.ts`)
+- `getIslEdgeEValues()`: nested-first accessor (legacy top-level tolerated for old fixtures). Both read sites (primary ~run.ts:4290, fallback ~run.ts:1815) repointed → **`edge_e_values` now populates on the live path (was structurally `[]` forever)**.
+- `getIslComputedAt()`: reads V2 `timestamp` → `meta.computed_at` now carries the ISL wire timestamp (was silently falling back to PLoT clock).
+- Top-level `sensitivity` reads **deleted** (primary + fallback + CEE `top_edge_drivers`). NO substitute invented. Empty `edge_sensitivity` on a computed analysis is now explicitly marked with new info-level inference warning `EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE` (uses the existing open-vocabulary `inference_warnings` field — no schema change).
+- `validation_status`/`validation_confidence` reads deleted from the CEE review request (structurally undefined live → behaviour-identical); `sensitive_parameters.sensitivity` repointed to `sensitivity_score ?? sensitivity`.
+
+**B — VOI honesty** (`v2-envelope.ts`, `src/config/flags.ts`)
+- `factor_sensitivity[].value_of_information` read kept but documented as V1-only/dead (public VOI comes from the graph heuristic — unchanged).
+- `mapIslFactorEvpi()` guarded internal mapping proves `factor_evpi` arrives; behind **`ISL_FACTOR_EVPI_INTERNAL` (default OFF everywhere)** it logs sanitised diagnostics only. **NOT wired into any user-facing VOI/EVPI surface (P-5 pending).** Public response byte-identical flag on/off; liveness test pins zero leakage.
+
+**C — EVPI hygiene** (`src/lib/evpi-emission.ts`)
+- `classifyEvpiPercentagePointsForEmission()`: never emits a negative outward; raw < 0.05pp (incl. all negatives) → `below_resolution: true` + no outward value (labelled, **not clamped to zero**); raw kept in diagnostics fields only. Existing surfaces already sanitise (`sanitiseIslVoi`, `computeEvpiPercentagePoints` clamp) — verified, unchanged.
+
+**D — confidence_tier reconciliation** (`src/trust/confidence-tier.ts`, run.ts assembly)
+- `reconcileConfidenceTier()`: caps `strong` → `fair` when the same response carries `robustness.is_robust === false` or `level ∈ {low, very_low}`. Lower tiers never raised; absent robustness leaves tier unchanged. Applied at the single `confidence_tier` emission site.
+
+**E — duplicate-edge preflight** (`src/integrations/isl/preflight.ts`, run.ts before `toISLRobustnessRequest`)
+- Exact-identical duplicates (every field equal) coalesced to one edge; logged through existing `repairs_applied` (`COALESCE_DUPLICATE_EDGE: …` reason).
+- Non-identical duplicates (same `(from,to,type)`, differing values) → **422 typed blocker** critique `DUPLICATE_EDGE_CONFLICT` naming the pair and divergent fields; ISL is never called. Never silent dedupe.
+
+**F — CONSTRAINT_SAMPLES_UNNOISED** — the warning-forwarding path is open-vocabulary (any `code` string passes; unknown severities degrade to `info`). Verified + pinned by test; no code change needed beyond the tests.
+
+**G — liveness fixture gate** (`tests/isl-v2-liveness.fixture.test.ts`) — every science feature requested on the wire must be non-empty OR explicitly marked; silent empty arrays fail.
+
+## 3. RED → GREEN proof
+
+- With the old top-level `edge_e_values` read temporarily restored (one-line revert), the liveness test **fails**: `edge_e_values` length 0 ≠ 9 (`Tests 1 failed | 11 skipped`).
+- With the fix: `Tests 12 passed (12)`.
+- Envelope unit tests independently pin the absence of every V1 location and the presence of every V2 location on the raw captures (23 tests).
+- Duplicate-edge unit suite caught a real key-collision bug in the first implementation (space-delimited key: `("a b","c")` vs `("a","b c")`) — fixed with JSON-encoded keys; regression test retained.
+
+## 4. Test results
+
+| Suite | Result |
+|---|---|
+| `npm run typecheck` (`tsc -p tsconfig.json --noEmit`) | PASS (after fresh `npm ci`; also passes on untouched baseline except pre-existing notes below) |
+| `tests/isl-v2-envelope.unit.test.ts` | 23 passed |
+| `tests/isl-v2-liveness.fixture.test.ts` | 12 passed (RED without fix A) |
+| `tests/duplicate-edge-preflight.test.ts` | 11 passed (unit + route-level incl. 422 blocker) |
+| `tests/confidence-tier-reconcile.test.ts` | 8 passed |
+| `tests/stability-thresholds-passthrough.test.ts` (updated IW1–IW4 to filter by code) | PASS |
+| `tests/b1-confidence-tier.test.ts`, `tests/b8-8-3c-field-segregation.test.ts` | PASS |
+| `tests/golden/golden.test.ts` + `tests/golden/integration.test.ts` (pricing canary) | PASS — fixture files untouched, present-0 passthrough byte-identical |
+| `tests/passthrough-enrichment`, `enrichment-emission-contract`, `boundary-isl-to-ui.contract` | 43 passed |
+| `tests/lane-p0a-lever-evpi-egress.integration`, `v2-contract.smoke`, coaching readiness-tone | PASS (v2-contract.smoke requires `npm run build` first — `spawnServer` runs `node dist/main.js`; fails standalone in a fresh tree without build, pre-existing infra behaviour) |
+
+Honest notes:
+- Running many server-spawning suites **in one parallel vitest invocation** intermittently hits the 10s hook timeout (contention); each suite passes when run in smaller batches. The repo's own gate (`npm test` via `tools/run-all-tests.js`, exercised by the pre-push hook) is the authoritative pass.
+- Pre-existing lint warnings (3: `no-console` in preflight.ts, 2 unused type imports in run.ts) exist on the untouched `origin/staging` baseline — verified via `git stash` + eslint; no new lint debt added.
+- Known pre-existing CI reds on every PR (not chased, per lane brief): `audit` (fast-uri/fastify advisories) and `gates (windows-latest)` (invalid path `tools/sdk-smoke:python.mjs`).
+
+## 5. Wire-visible deltas (live path)
+
+1. `edge_e_values`: `[]` → 9 enriched entries (field existed; now populated).
+2. `meta.computed_at`: PLoT receive-clock → ISL wire `timestamp`.
+3. `inference_warnings`: + `EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE` (info) on computed responses with empty edge sensitivity.
+4. `confidence_tier`: capped at `fair` when the same response is non-robust (was possible to emit contradictory `strong`).
+5. New 422 (`DUPLICATE_EDGE_CONFLICT`) for conflicting duplicate edges; exact-identical duplicates coalesced with a `repairs_applied` record (previously the request would 422 opaquely at ISL).
+
+No field added/removed/renamed on any boundary payload.
+
+## 6. Followups (recorded, NOT implemented)
+
+1. **ISL contract work: edge-level sensitivity** — the V2 wire genuinely drops it; PLoT must not invent a substitute. Needs an ISL-side decision/field.
+2. **Unflippable E-value entries** — live wire omits `e_value` on `is_unflippable: true` entries; PLoT's outward `EnrichedEdgeEValue` requires `e_value`, so 4/13 entries are dropped (logged). Representing "unflippable" outward (e.g. optional `e_value` + `is_unflippable` passthrough) is a contract change → blocked by freeze.
+3. **P-5 (Paul)** — wire `factor_evpi` (true counterfactual EVPI) into user-facing VOI/EVPI, replacing the graph heuristic; the guarded mapping + hygiene is ready behind `ISL_FACTOR_EVPI_INTERNAL`.
+4. **OpenAPI spec** — `edge_e_values` (and several emitted fields) are absent from the hand-authored `contracts/openapi.yaml`; spec lags the wire. No shape change made this lane, so no spec edit; a reconciliation pass is due.
+5. `buildISLResponseSummary.sensitivity_count` (logging only) still reads the dead top-level field — harmless truthful 0; tidy on next touch.

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -103,4 +103,17 @@ export const FLAGS = {
     if (raw === '1' || raw === 'true') return true;
     return process.env.NODE_ENV === 'test' || process.env.RENDER_SERVICE_NAME?.includes('staging') === true;
   },
+
+  // ISL V2 science channel: per-factor counterfactual EVPI (factor_evpi wire field)
+  /**
+   * INTERNAL DIAGNOSTICS ONLY (default OFF everywhere, including test/staging).
+   * When enabled, /v2/run logs a sanitised summary of the ISL V2 `factor_evpi`
+   * wire field (via `mapIslFactorEvpi`). It NEVER changes the public response:
+   * wiring factor_evpi into user-facing VOI/EVPI is decision P-5 (pending) and
+   * MUST NOT happen behind this flag.
+   */
+  get ISL_FACTOR_EVPI_INTERNAL() {
+    const raw = process.env.ISL_FACTOR_EVPI_INTERNAL;
+    return raw === '1' || raw === 'true';
+  },
 } as const;

--- a/src/integrations/isl/preflight.ts
+++ b/src/integrations/isl/preflight.ts
@@ -266,3 +266,177 @@ export function logPreflightResult(
   };
   console.log(JSON.stringify(entry));
 }
+
+// -----------------------------------------------------------------------------
+// Duplicate-edge preflight (ISL 422s duplicate (from, to, type) edges)
+// -----------------------------------------------------------------------------
+
+/**
+ * Structural edge shape consumed by the duplicate-edge preflight.
+ * Matches EngineEdgeV3 (normalised graph) — the shape forwarded to ISL.
+ */
+export interface DuplicateCheckEdge {
+  from: string;
+  to: string;
+  exists_probability: number;
+  strength: { mean: number; std: number };
+  label?: string;
+  edge_type?: 'directed' | 'bidirected';
+}
+
+/** A coalesced EXACT-duplicate group (identical on every field). */
+export interface CoalescedDuplicate {
+  from: string;
+  to: string;
+  edge_type: string;
+  /** Total identical copies found (>= 2); one is kept, the rest dropped */
+  count: number;
+}
+
+/** A NON-identical duplicate conflict — same (from, to, type), differing payload. */
+export interface DuplicateEdgeConflict {
+  from: string;
+  to: string;
+  edge_type: string;
+  /** Number of edges sharing this (from, to, type) key */
+  count: number;
+  /** Fields whose values differ across the conflicting edges */
+  divergent_fields: string[];
+}
+
+/** Result of the duplicate-edge preflight. */
+export interface DuplicateEdgePreflightResult {
+  /** Edges with exact-identical duplicates coalesced (order preserved, first kept) */
+  edges: DuplicateCheckEdge[];
+  /** Exact-identical groups that were coalesced (for repairs_applied) */
+  coalesced: CoalescedDuplicate[];
+  /**
+   * Non-identical duplicates. NEVER silently deduped — PLoT cannot know which
+   * belief/weight/provenance the user meant, so this is a typed actionable
+   * blocker for the caller (producers own semantics; PLoT must not invent a
+   * merge).
+   */
+  conflicts: DuplicateEdgeConflict[];
+}
+
+/**
+ * Canonical duplicate key: (from, to, edge_type). Matches the uniqueness
+ * constraint ISL now enforces with a 422 on /robustness/analyze/v2.
+ * JSON-encoded so IDs containing delimiter characters cannot collide
+ * (e.g. from="a b",to="c" vs from="a",to="b c").
+ */
+function duplicateEdgeKey(e: DuplicateCheckEdge): string {
+  return JSON.stringify([e.from, e.to, e.edge_type ?? 'directed']);
+}
+
+/** Canonical full-payload fingerprint used to detect EXACT-identical edges. */
+function edgeFingerprint(e: DuplicateCheckEdge): string {
+  return JSON.stringify({
+    from: e.from,
+    to: e.to,
+    edge_type: e.edge_type ?? 'directed',
+    exists_probability: e.exists_probability,
+    strength_mean: e.strength?.mean,
+    strength_std: e.strength?.std,
+    label: e.label ?? null,
+  });
+}
+
+/** Field-level diff across a conflicting duplicate group (for the blocker message). */
+function divergentFields(group: DuplicateCheckEdge[]): string[] {
+  const fields: Array<[string, (e: DuplicateCheckEdge) => unknown]> = [
+    ['exists_probability', (e) => e.exists_probability],
+    ['strength.mean', (e) => e.strength?.mean],
+    ['strength.std', (e) => e.strength?.std],
+    ['label', (e) => e.label ?? null],
+  ];
+  const out: string[] = [];
+  for (const [name, get] of fields) {
+    const first = JSON.stringify(get(group[0]));
+    if (group.some((e) => JSON.stringify(get(e)) !== first)) out.push(name);
+  }
+  return out;
+}
+
+/**
+ * Duplicate-edge preflight, run BEFORE building the ISL request.
+ *
+ * - EXACT identical duplicates (every field equal) are coalesced to a single
+ *   edge; each coalesced group is reported so the caller can log it through
+ *   the existing repairs_applied mechanism (observable, not silent).
+ * - NON-identical duplicates — same (from, to, type) but differing
+ *   weight/belief/label — are returned as conflicts. The caller MUST block
+ *   with a typed actionable critique; silently deduping would pick one of
+ *   the user's contradictory claims and discard the other without consent.
+ *
+ * Edge order is preserved; the first occurrence of each duplicate group keeps
+ * its position (relevant for downstream index-based references and for ISL
+ * determinism).
+ */
+export function preflightDuplicateEdges(
+  edges: DuplicateCheckEdge[],
+): DuplicateEdgePreflightResult {
+  const groups = new Map<string, DuplicateCheckEdge[]>();
+  for (const e of edges) {
+    const key = duplicateEdgeKey(e);
+    const group = groups.get(key);
+    if (group) group.push(e);
+    else groups.set(key, [e]);
+  }
+
+  const coalesced: CoalescedDuplicate[] = [];
+  const conflicts: DuplicateEdgeConflict[] = [];
+  const dropFingerprints = new Map<string, number>(); // fingerprint -> copies still to drop
+
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    const firstFp = edgeFingerprint(group[0]);
+    const allIdentical = group.every((e) => edgeFingerprint(e) === firstFp);
+    const edgeType = group[0].edge_type ?? 'directed';
+    if (allIdentical) {
+      coalesced.push({
+        from: group[0].from,
+        to: group[0].to,
+        edge_type: edgeType,
+        count: group.length,
+      });
+      dropFingerprints.set(
+        firstFp,
+        (dropFingerprints.get(firstFp) ?? 0) + group.length - 1,
+      );
+    } else {
+      conflicts.push({
+        from: group[0].from,
+        to: group[0].to,
+        edge_type: edgeType,
+        count: group.length,
+        divergent_fields: divergentFields(group),
+      });
+    }
+  }
+
+  // Nothing to coalesce (or only conflicts): return input untouched.
+  if (coalesced.length === 0) {
+    return { edges, coalesced, conflicts };
+  }
+
+  // Drop all-but-first copy of each exact-identical group, preserving order.
+  const seenKeep = new Set<string>();
+  const result: DuplicateCheckEdge[] = [];
+  for (const e of edges) {
+    const fp = edgeFingerprint(e);
+    const toDrop = dropFingerprints.get(fp);
+    if (toDrop !== undefined) {
+      if (seenKeep.has(fp)) {
+        if (toDrop > 0) {
+          dropFingerprints.set(fp, toDrop - 1);
+          continue; // drop this exact-identical copy
+        }
+      } else {
+        seenKeep.add(fp); // first copy: keep
+      }
+    }
+    result.push(e);
+  }
+  return { edges: result, coalesced, conflicts };
+}

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -241,18 +241,68 @@ export interface ISLEdgeSensitivityItem {
 /**
  * ISL edge E-value from robustness analysis.
  * Measures evidence strength for each edge's causal effect direction.
+ *
+ * V2 wire location: NESTED at `robustness.edge_e_values` (verified against the
+ * live staging capture `tests/fixtures/isl-v2-live-20260706/isl-staging-capture.json`,
+ * ISL build f3f5d92). The top-level `edge_e_values` field is a V1-era location the
+ * live V2 envelope never emits — read via `getIslEdgeEValues()` in
+ * `../v2-envelope.js`, never directly.
  */
 export interface ISLEdgeEValue {
   /** Edge ID in ISL format (e.g., "from->to") */
   edge_id: string;
+  /** Source node ID (present on V2 nested entries; absent on legacy shapes) */
+  from_id?: string;
+  /** Target node ID (present on V2 nested entries; absent on legacy shapes) */
+  to_id?: string;
   /** E-value (evidence strength) */
   e_value: number;
-  /** Direction the edge would need to flip to change the recommendation */
-  flip_direction: 'positive_to_negative' | 'negative_to_positive' | 'removal';
+  /**
+   * Direction the edge would need to flip to change the recommendation.
+   * Live V2 wire emits 'increase' | 'decrease'; legacy documented values were
+   * 'positive_to_negative' | 'negative_to_positive' | 'removal'. Typed open
+   * because ISL owns this vocabulary and PLoT passes it through verbatim.
+   */
+  flip_direction: string;
   /** Current mean effect of this edge */
   current_mean: number;
   /** Mean effect at the flip point */
   flip_mean: number;
+  /**
+   * True when no finite change to this edge can flip the recommendation
+   * (V2 nested entries only). NOT emitted outward by PLoT — contracts frozen;
+   * recorded as a followup for contract work.
+   */
+  is_unflippable?: boolean;
+}
+
+/**
+ * ISL per-factor EVPI entry from the V2 wire (top-level `factor_evpi`).
+ *
+ * Verified live (staging capture 2026-07-06, build f3f5d92): entries carry
+ * true counterfactual EVPI per factor. NOT wired into any user-facing VOI/EVPI
+ * surface yet (decision P-5 pending) — consumed only by the guarded internal
+ * mapping in `../v2-envelope.js`.
+ *
+ * Raw `evpi` / `evpi_percentage_points` can drift slightly negative from Monte
+ * Carlo sampling noise (observed live: -0.0015 / -0.15pp). Negative values are
+ * sampling artefacts, never real signals — see `src/lib/evpi-emission.ts`.
+ */
+export interface ISLFactorEvpiEntry {
+  /** Factor node ID */
+  factor_id: string;
+  /** EVPI as a fraction of the decision metric (can be MC-noise negative) */
+  evpi: number;
+  /** EVPI in percentage points of the decision metric (can be MC-noise negative) */
+  evpi_percentage_points: number;
+  /** Current value of the decision metric */
+  current_metric: number;
+  /** Decision metric under perfect information about this factor */
+  perfect_metric: number;
+  /** Which metric EVPI is measured on (e.g., 'p_win_recommended') */
+  metric_type: string;
+  /** Number of Monte Carlo samples used for the EVPI estimate */
+  n_evpi_samples: number;
 }
 
 /**
@@ -411,7 +461,16 @@ export interface ISLRobustnessAnalyzeV2Response {
   /** Request ID echo */
   request_id?: string;
 
-  /** Edge sensitivity (when 'sensitivity' in analysis_types) */
+  /**
+   * Edge sensitivity (when 'sensitivity' in analysis_types).
+   *
+   * @deprecated DEAD ON THE LIVE V2 WIRE. Verified against the live staging
+   * capture (2026-07-06, build f3f5d92): the V2 envelope never emits top-level
+   * edge sensitivity and carries NO nested replacement — the V2 wire genuinely
+   * drops edge-level sensitivity. Do NOT invent a substitute; restoring it is
+   * ISL contract work (recorded followup). Factor-level sensitivity is
+   * unaffected (`factor_sensitivity`).
+   */
   sensitivity?: ISLEdgeSensitivityItem[];
 
   /** Factor-level sensitivity scores */
@@ -446,6 +505,13 @@ export interface ISLRobustnessAnalyzeV2Response {
      * ISL returns strings in "from->to" format.
      */
     robust_edges?: string[];
+    /**
+     * Edge E-values — CANONICAL V2 wire location (verified live 2026-07-06,
+     * build f3f5d92). The top-level `edge_e_values` sibling is a V1-era
+     * location the live V2 envelope never emits. Read via
+     * `getIslEdgeEValues()` in `../v2-envelope.js`.
+     */
+    edge_e_values?: ISLEdgeEValue[];
     /** Explanation of robustness assessment - V1 format (optional in V2) */
     explanation?: string;
   };
@@ -471,17 +537,42 @@ export interface ISLRobustnessAnalyzeV2Response {
   /** Confidence in the recommendation */
   recommendation_confidence?: number;
 
-  /** Validation status from causal graph analysis */
+  /**
+   * Validation status from causal graph analysis.
+   *
+   * @deprecated DEAD ON THE LIVE V2 WIRE (verified 2026-07-06, build f3f5d92):
+   * the V2 envelope never emits this field. All reads removed; kept for
+   * fixture/legacy tolerance only.
+   */
   validation_status?: 'identifiable' | 'uncertain' | 'cannot_identify';
 
-  /** Confidence in the validation assessment */
+  /**
+   * Confidence in the validation assessment.
+   *
+   * @deprecated DEAD ON THE LIVE V2 WIRE — see `validation_status`.
+   */
   validation_confidence?: 'high' | 'medium' | 'low';
 
   /**
    * Edge E-values measuring evidence strength for each edge's causal direction.
-   * Present when ISL provides E-value analysis.
+   *
+   * @deprecated V1-era TOP-LEVEL location — the live V2 wire nests E-values at
+   * `robustness.edge_e_values` (verified 2026-07-06, build f3f5d92). Read via
+   * `getIslEdgeEValues()` which prefers the nested location.
    */
   edge_e_values?: ISLEdgeEValue[];
+
+  /**
+   * Per-factor counterfactual EVPI (V2 wire, top-level; verified live
+   * 2026-07-06). NOT user-facing yet — P-5 pending. See `ISLFactorEvpiEntry`.
+   */
+  factor_evpi?: ISLFactorEvpiEntry[];
+
+  /**
+   * Response timestamp (ISO 8601) — the V2 wire's equivalent of the V1-era
+   * `computed_at` field (which V2 never emits; verified live 2026-07-06).
+   */
+  timestamp?: string;
 
   /**
    * Conditional winner analysis per factor.

--- a/src/integrations/isl/v2-envelope.ts
+++ b/src/integrations/isl/v2-envelope.ts
@@ -1,0 +1,159 @@
+/**
+ * ISL V2 envelope accessors — single source of truth for WHERE science
+ * fields live on the live V2 wire.
+ *
+ * PLoT pins `response_version=2` on every ISL call (client.ts). The live V2
+ * envelope (verified against the raw staging capture at
+ * `tests/fixtures/isl-v2-live-20260706/isl-staging-capture.json`, ISL build
+ * f3f5d92, captured 2026-07-06) differs from the V1-era shapes several run.ts
+ * reads assumed:
+ *
+ *   | field                | V1-era read (dead live)     | live V2 location            |
+ *   |----------------------|-----------------------------|------------------------------|
+ *   | edge E-values        | top-level `edge_e_values`   | `robustness.edge_e_values`   |
+ *   | edge sensitivity     | top-level `sensitivity`     | NOT EMITTED (wire drops it)  |
+ *   | validation status    | top-level `validation_status` | NOT EMITTED                |
+ *   | computed timestamp   | top-level `computed_at`     | top-level `timestamp`        |
+ *   | factor VOI           | `factor_sensitivity[].value_of_information` | top-level `factor_evpi[]` (per-factor EVPI) |
+ *
+ * All V2-location reads MUST go through these accessors so the location is
+ * fixed in exactly one place.
+ */
+
+import type {
+  ISLEdgeEValue,
+  ISLFactorEvpiEntry,
+  ISLRobustnessAnalyzeV2Response,
+} from './types/isl-types.js';
+import {
+  classifyEvpiPercentagePointsForEmission,
+  type EvpiEmissionClassification,
+} from '../../lib/evpi-emission.js';
+
+/**
+ * Read edge E-values from an ISL response.
+ *
+ * Canonical V2 location is NESTED at `robustness.edge_e_values`; the V1-era
+ * top-level `edge_e_values` is kept as a legacy fallback for old fixtures
+ * only (the live V2 wire never emits it). Returns `undefined` when neither
+ * location carries a non-empty array, so callers keep their existing
+ * "computed-empty vs absent" semantics.
+ */
+export function getIslEdgeEValues(
+  islResult: Partial<ISLRobustnessAnalyzeV2Response> | null | undefined,
+): ISLEdgeEValue[] | undefined {
+  const nested = islResult?.robustness?.edge_e_values;
+  if (Array.isArray(nested)) return nested;
+  const legacyTopLevel = islResult?.edge_e_values;
+  if (Array.isArray(legacyTopLevel)) return legacyTopLevel;
+  return undefined;
+}
+
+/**
+ * Read the ISL-side computation timestamp from an ISL response.
+ *
+ * The live V2 wire carries `timestamp` (top-level, ISO 8601); the V1-era
+ * `computed_at` field is never emitted on V2 and is kept only as a legacy
+ * fallback for old fixtures. Returns `undefined` when neither is a string,
+ * so the caller can fall back to its own clock (existing behaviour).
+ */
+export function getIslComputedAt(
+  islResult:
+    | (Partial<ISLRobustnessAnalyzeV2Response> & { computed_at?: unknown })
+    | null
+    | undefined,
+): string | undefined {
+  const ts = islResult?.timestamp;
+  if (typeof ts === 'string' && ts.length > 0) return ts;
+  const legacy = islResult?.computed_at;
+  if (typeof legacy === 'string' && legacy.length > 0) return legacy;
+  return undefined;
+}
+
+/**
+ * Internal (non-user-facing) representation of a sanitised per-factor EVPI
+ * entry from the V2 `factor_evpi` wire field.
+ *
+ * EVPI hygiene contract (Howard 1966 non-negativity; see evpi-emission.ts):
+ * - `emit_pp` is the ONLY value any surface may ever show outward — it is
+ *   either a finite value >= the emission resolution, or `undefined`.
+ * - Negative and below-resolution raw values set `below_resolution: true`
+ *   ("too small to measure at this sampling depth"), NEVER a clamped 0 and
+ *   NEVER a negative — the raw value stays in `raw_*` diagnostics only.
+ */
+export interface InternalFactorEvpi {
+  factor_id: string;
+  /** Outward-safe EVPI in percentage points; undefined when below resolution */
+  emit_pp: number | undefined;
+  /** True when the raw estimate is below the emission resolution (incl. all negatives) */
+  below_resolution: boolean;
+  /** Raw wire value (diagnostics only — may be negative; MUST NOT be emitted) */
+  raw_evpi: number;
+  /** Raw wire value in percentage points (diagnostics only — may be negative) */
+  raw_evpi_percentage_points: number;
+  metric_type: string;
+  n_evpi_samples: number;
+}
+
+/** Result of mapping the V2 `factor_evpi` wire field. */
+export interface FactorEvpiMappingResult {
+  /** Sanitised entries (one per valid wire entry) */
+  entries: InternalFactorEvpi[];
+  /** Count of wire entries dropped for structural invalidity (non-finite/missing) */
+  dropped_invalid: number;
+}
+
+/**
+ * Guarded internal mapping for the V2 `factor_evpi` field.
+ *
+ * IMPORTANT — P-5 pending: this data MUST NOT be wired into any user-facing
+ * VOI/EVPI surface yet. The mapping exists to (a) prove the data arrives on
+ * the live wire (fixture test) and (b) centralise the negative/below-resolution
+ * hygiene so the eventual wiring cannot leak a raw negative EVPI outward.
+ *
+ * Behind `FLAGS.ISL_FACTOR_EVPI_INTERNAL` (default OFF) the route logs
+ * diagnostics only; the public response is byte-identical either way.
+ */
+export function mapIslFactorEvpi(
+  islResult: Partial<ISLRobustnessAnalyzeV2Response> | null | undefined,
+): FactorEvpiMappingResult {
+  const raw = islResult?.factor_evpi;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return { entries: [], dropped_invalid: 0 };
+  }
+
+  const entries: InternalFactorEvpi[] = [];
+  let droppedInvalid = 0;
+
+  for (const e of raw as Array<Partial<ISLFactorEvpiEntry>>) {
+    if (
+      !e ||
+      typeof e.factor_id !== 'string' ||
+      typeof e.evpi !== 'number' ||
+      !Number.isFinite(e.evpi) ||
+      typeof e.evpi_percentage_points !== 'number' ||
+      !Number.isFinite(e.evpi_percentage_points)
+    ) {
+      droppedInvalid += 1;
+      continue;
+    }
+
+    const classification: EvpiEmissionClassification =
+      classifyEvpiPercentagePointsForEmission(e.evpi_percentage_points);
+
+    entries.push({
+      factor_id: e.factor_id,
+      emit_pp: classification.emit,
+      below_resolution: classification.below_resolution,
+      raw_evpi: e.evpi,
+      raw_evpi_percentage_points: e.evpi_percentage_points,
+      metric_type: typeof e.metric_type === 'string' ? e.metric_type : 'unknown',
+      n_evpi_samples:
+        typeof e.n_evpi_samples === 'number' && Number.isFinite(e.n_evpi_samples)
+          ? e.n_evpi_samples
+          : 0,
+    });
+  }
+
+  return { entries, dropped_invalid: droppedInvalid };
+}

--- a/src/lib/evpi-emission.ts
+++ b/src/lib/evpi-emission.ts
@@ -67,3 +67,62 @@ export function computeEvpiPercentagePoints(
   const raw = voi * winProbSpread * 100;
   return Math.max(0, Math.round(raw * 10) / 10);
 }
+
+/**
+ * Emission resolution for EVPI percentage-points values.
+ *
+ * PLoT rounds emitted EVPI to 1 decimal place (see
+ * `computeEvpiPercentagePoints`), so any value below half of that rounding
+ * step (0.05pp) is indistinguishable from zero at the emitted precision.
+ * Raw estimates below this threshold — including ALL negatives, which are
+ * Monte Carlo sampling artefacts (Howard 1966 non-negativity) — are
+ * "below resolution": too small to measure at this sampling depth.
+ */
+export const EVPI_EMISSION_RESOLUTION_PP = 0.05;
+
+/** Classification of a raw EVPI percentage-points value for outward emission. */
+export interface EvpiEmissionClassification {
+  /**
+   * The outward-safe value (rounded to 0.1pp), or `undefined` when the raw
+   * value is below resolution. NEVER negative, NEVER a clamped 0 standing in
+   * for a negative.
+   */
+  emit: number | undefined;
+  /**
+   * True when the raw value is below the emission resolution (including all
+   * negatives). Surfaces that can express it should label the factor
+   * "below resolution" rather than showing 0 — a clamped 0 falsely claims
+   * "measured as exactly worthless" when the honest statement is "too small
+   * to measure at this sampling depth".
+   */
+  below_resolution: boolean;
+  /** The raw input value, for diagnostics only (may be negative). */
+  raw: number;
+}
+
+/**
+ * Classify a raw EVPI percentage-points value (e.g. from the ISL V2
+ * `factor_evpi[].evpi_percentage_points` wire field) for outward emission.
+ *
+ * Contract (raw negative EVPI observed flowing in staging logs; the live
+ * capture at tests/fixtures/isl-v2-live-20260706 carries fac_hiring_cost
+ * -0.15pp):
+ * - Negative values are NEVER emitted outward, in any form.
+ * - Below-resolution values (raw < EVPI_EMISSION_RESOLUTION_PP, which
+ *   includes all negatives) are labelled, not clamped to zero: `emit` is
+ *   `undefined` and `below_resolution` is true.
+ * - At-or-above-resolution values are rounded to 0.1pp for emission.
+ * - Non-finite input yields `{ emit: undefined, below_resolution: false }` —
+ *   absence of a measurement is not a below-resolution measurement.
+ */
+export function classifyEvpiPercentagePointsForEmission(
+  rawPp: number,
+): EvpiEmissionClassification {
+  if (typeof rawPp !== 'number' || !Number.isFinite(rawPp)) {
+    return { emit: undefined, below_resolution: false, raw: rawPp };
+  }
+  if (rawPp < EVPI_EMISSION_RESOLUTION_PP) {
+    return { emit: undefined, below_resolution: true, raw: rawPp };
+  }
+  return { emit: Math.round(rawPp * 10) / 10, below_resolution: false, raw: rawPp };
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -96,6 +96,8 @@ import {
 } from '../../integrations/isl/adapters/robustness-analysis.js';
 import type { RobustnessDataForCee, NormalizedEdgeInfo } from '../../integrations/isl/types/plot-types.js';
 import type { ISLConstraintResult, ISLEdgeEValue, ISLConditionalWinner } from '../../integrations/isl/types/isl-types.js';
+import { getIslEdgeEValues, getIslComputedAt, mapIslFactorEvpi } from '../../integrations/isl/v2-envelope.js';
+import { preflightDuplicateEdges } from '../../integrations/isl/preflight.js';
 import { orchestrateCeeReview } from '../../cee/orchestrator.js';
 import { orchestrateDecisionReview, type DecisionReviewInput, type DecisionReviewConfig } from '../../cee/decision-review-orchestrator.js';
 import {
@@ -132,7 +134,7 @@ import { sanitiseIslVoi, computeEvpiPercentagePoints } from '../../lib/evpi-emis
 import { NEAR_TIE_THRESHOLD } from '../../trust/result-coherence.js';
 import { assessGraphIdentifiability, toIdentifiabilityResponse, detectUnmeasuredConfounding } from '../../trust/identifiability-v2.js';
 import { classifyEdgeSeverity } from '../../trust/edge-severity.js';
-import { deriveConfidenceTier } from '../../trust/confidence-tier.js';
+import { deriveConfidenceTier, reconcileConfidenceTier } from '../../trust/confidence-tier.js';
 import { detectDominantFactor } from '../../trust/factor-dominance.js';
 import type { IdentifiabilityAssessment } from '../../types/engine-v3.js';
 import {
@@ -610,6 +612,16 @@ function mapIslFactorEntry(f: any, normContext?: NormalisationContext): FactorSe
   // reused for both the `value_of_information` field and the `confidence`
   // fallback chain below. See `src/lib/evpi-emission.ts` for the full
   // contract rationale (Howard 1966 non-negativity, MC sampling artefacts).
+  //
+  // V2 wire truth (verified live 2026-07-06, build f3f5d92):
+  // `factor_sensitivity[].value_of_information` is a V1-only field the live
+  // V2 envelope NEVER emits — this read is structurally undefined on the live
+  // path, so factor VOI always comes from the graph heuristic
+  // (computeFactorSensitivityFromGraph). The V2 wire carries true per-factor
+  // EVPI at top-level `factor_evpi` instead; wiring it into user-facing VOI is
+  // decision P-5 (pending) — see mapIslFactorEvpi in
+  // src/integrations/isl/v2-envelope.ts. The read is kept (not deleted) only
+  // to tolerate legacy fixtures.
   const sanitisedVoi = sanitiseIslVoi(f.value_of_information);
 
   const entry: FactorSensitivityResultV3 = {
@@ -1792,13 +1804,23 @@ function buildResponse(
     }
     return map;
   })();
+  // ISL V2 wire truth (verified live 2026-07-06, build f3f5d92 — see
+  // src/integrations/isl/v2-envelope.ts): the pinned response_version=2
+  // envelope NEVER emits top-level `sensitivity`; edge-level sensitivity is
+  // genuinely dropped by the V2 wire with no nested replacement. The former
+  // `islResult?.sensitivity` fallback read here was structurally dead. Do NOT
+  // invent a substitute (ISL contract followup); edge_sensitivity stays
+  // "computed, empty" and is explicitly marked via the
+  // EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE inference warning below.
   const edgeSensitivity = sensitivityData?.edgeSensitivity
-    ?? transformEdgeSensitivity(islResult?.sensitivity, fallbackNodeLabelMap);
+    ?? transformEdgeSensitivity(undefined, fallbackNodeLabelMap);
   const factorSensitivity = sensitivityData?.factorSensitivity
     ?? transformFactorSensitivity(islResult?.factor_sensitivity);
-  // Fallback transforms for edge_e_values and conditional_winners when sensitivityData not pre-computed
+  // Fallback transforms for edge_e_values and conditional_winners when sensitivityData not pre-computed.
+  // Edge E-values are NESTED at robustness.edge_e_values on the V2 wire (the
+  // former top-level read was structurally dead) — read via the accessor.
   const edgeEValues = sensitivityData?.edgeEValues
-    ?? transformEdgeEValues(islResult?.edge_e_values, fallbackNodeLabelMap);
+    ?? transformEdgeEValues(getIslEdgeEValues(islResult), fallbackNodeLabelMap);
   const conditionalWinners = sensitivityData?.conditionalWinners
     ?? transformConditionalWinners(islResult?.conditional_winners, fallbackNodeLabelMap, fallbackOptionLabelMap);
 
@@ -1946,6 +1968,22 @@ function buildResponse(
         severity: 'info',
       });
     }
+  }
+
+  // Liveness honesty: edge-level sensitivity is requested on every ISL call
+  // (analysis_types always includes 'sensitivity') but the live V2 wire does
+  // not emit it (verified 2026-07-06, build f3f5d92). An empty edge_sensitivity
+  // on a computed analysis would otherwise be a SILENT empty array —
+  // indistinguishable from "computed and found nothing". Mark it explicitly so
+  // consumers (and the liveness fixture test) can tell wire-gap from absence.
+  // Factor-level sensitivity is unaffected. No substitute is invented — the
+  // gap is ISL contract work (recorded followup).
+  if (analysisStatus === 'computed' && islResult && !hasNonEmptyArray(edgeSensitivity)) {
+    inferenceWarnings.push({
+      code: INFERENCE_WARNING_CODES.EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE,
+      message: 'Edge-level sensitivity was requested but the ISL V2 response format does not carry it — edge_sensitivity is empty by wire contract, not by computation failure. Factor-level sensitivity is unaffected.',
+      severity: 'info',
+    });
   }
 
   // Merge ISL-originated inference_warnings into the PLoT array.
@@ -2169,9 +2207,15 @@ function buildResponse(
     // NOTE: Deterministic (no LLM), but excluded from canonical hash as non-semantic metadata
     ...(m1Coaching && { m1_coaching: m1Coaching }),
 
-    // Confidence tier derived from M1 coaching readiness (B1)
+    // Confidence tier derived from M1 coaching readiness (B1), then reconciled
+    // against the robustness assessment carried in this SAME response:
+    // never emit 'strong' alongside robustness.is_robust === false or
+    // level 'low'/'very_low' — cap at the provisional 'fair' tier.
+    // (Producer-side honesty: confidence_tier is PLoT-assembled enrichment.)
     // NOTE: Deterministic. Excluded from response_hash (derived from coaching).
-    ...(m1Coaching?.readiness && { confidence_tier: deriveConfidenceTier(m1Coaching.readiness) }),
+    ...(m1Coaching?.readiness && {
+      confidence_tier: reconcileConfidenceTier(deriveConfidenceTier(m1Coaching.readiness), robustness),
+    }),
 
     // Dominant factor detection (B1) — computed from factor_sensitivity
     // NOTE: Deterministic. Excluded from response_hash.
@@ -2482,11 +2526,15 @@ function buildCeeReviewRequest(
     const r = islResult.robustness;
     islRobustness = {
       overall_robustness: r.label as 'robust' | 'moderate' | 'fragile',
-      validation_status: islResult.validation_status,
-      validation_confidence: islResult.validation_confidence,
+      // validation_status / validation_confidence reads removed: the live V2
+      // wire never emits them (verified 2026-07-06, build f3f5d92) so both
+      // were structurally undefined here — the CEE request carried no such
+      // keys. Omitting the reads is behaviour-identical on the live path.
       sensitive_parameters: islResult.factor_sensitivity?.slice(0, 5).map((f: any) => ({
         parameter: f.node_id,
-        sensitivity: f.sensitivity,
+        // Schema v2.6 canonical field is 'sensitivity_score'; the bare
+        // 'sensitivity' key is V1-era and dead on the live V2 wire.
+        sensitivity: f.sensitivity_score ?? f.sensitivity,
         impact_direction: f.direction ?? 'positive',
       })),
       recommendations: robustnessData?.fragile_edges?.slice(0, 3).map(e =>
@@ -2526,10 +2574,10 @@ function buildCeeReviewRequest(
           p90: opt.confidence_interval?.[1] ?? opt.outcome?.p90 ?? 0,
         }));
       })(),
-      top_edge_drivers: islResult?.sensitivity?.slice(0, 5).map((s: any) => ({
-        id: `${s.edge_from}::${s.edge_to}`,
-        sensitivity: s.elasticity,
-      })),
+      // top_edge_drivers read removed: it consumed top-level `sensitivity`,
+      // which the live V2 wire never emits (verified 2026-07-06) — the key was
+      // structurally absent from every live CEE request. No substitute is
+      // invented (edge-level sensitivity is an ISL contract followup).
       ranked_actions: options.map((o, i) => ({
         id: o.id,
         rank: i + 1,
@@ -3831,6 +3879,57 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // Runs on normalized graph so edge strengths are in canonical form.
         preflight.warnings.push(...validateInboundStrengthSum(filteredGraph));
 
+        // =================================================================
+        // Duplicate-edge preflight (ISL now 422s duplicate (from,to,type) edges)
+        // =================================================================
+        // EXACT identical duplicates are coalesced (logged via repairs_applied);
+        // NON-identical duplicates (differing weight/belief/label) are a typed
+        // actionable blocker — PLoT must not silently pick one of the user's
+        // contradictory claims.
+        {
+          const dupResult = preflightDuplicateEdges(filteredGraph.edges);
+          if (dupResult.conflicts.length > 0) {
+            req.log.warn({
+              event: 'duplicate_edge_conflict',
+              request_id: requestId,
+              conflicts: dupResult.conflicts,
+            });
+            return reply.status(422).send(buildBlockedResponse(
+              'Conflicting duplicate edges',
+              dupResult.conflicts.map((c) => ({
+                id: randomUUID(),
+                code: 'DUPLICATE_EDGE_CONFLICT',
+                severity: 'blocker' as const,
+                message: `Edges ${c.from} -> ${c.to} (${c.edge_type}) appear ${c.count} times with different values (${c.divergent_fields.join(', ')}). Keep one edge per relationship, or merge the beliefs into a single edge.`,
+                source: 'validation' as const,
+                affected_node_ids: [c.from, c.to],
+                blocks_analysis: true,
+              })),
+              filteredGraph,
+              normalizedOptions,
+              requestId,
+              requestComputedAt,
+            ));
+          }
+          if (dupResult.coalesced.length > 0) {
+            filteredGraph.edges = dupResult.edges as typeof filteredGraph.edges;
+            for (const c of dupResult.coalesced) {
+              repairs.push({
+                field: `edges[${c.from}->${c.to}]`,
+                action: 'removed',
+                from_value: c.count,
+                to_value: 1,
+                reason: `COALESCE_DUPLICATE_EDGE: ${c.count} exact-identical ${c.edge_type} edges ${c.from} -> ${c.to} coalesced to one before ISL call (ISL rejects duplicate (from,to,type) edges)`,
+              });
+            }
+            req.log.info({
+              event: 'duplicate_edges_coalesced',
+              request_id: requestId,
+              groups: dupResult.coalesced,
+            });
+          }
+        }
+
         // Build ISL request (using normalised options and constraints)
         // CIL Phase 1: ALWAYS forward seed to ISL for deterministic Monte Carlo runs.
         // Derived seeds must be forwarded to ensure end-to-end determinism: if only computed
@@ -3967,9 +4066,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             islSuccess = true;
             islStatusCode = 200;
             islEchoedRequestId = response.isl_echoed_request_id ?? null;
-            // Capture timestamp when ISL response received (before any PLoT processing)
-            // Use ISL's computed_at if provided, otherwise capture now
-            computedAt = islResult?.computed_at ?? new Date().toISOString();
+            // Capture timestamp when ISL response received (before any PLoT processing).
+            // The V2 wire carries this as top-level `timestamp` (the V1-era
+            // `computed_at` is never emitted on V2 — verified live 2026-07-06,
+            // build f3f5d92); fall back to PLoT's own clock when absent.
+            computedAt = getIslComputedAt(islResult) ?? new Date().toISOString();
 
             // PLoT is seed authority: ignore ISL's returned seed_used.
             // Log mismatch at DEBUG level for observability (no side effects).
@@ -4022,6 +4123,33 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               // Capture ISL build version if present
               isl_build: islResult?.build ?? null,
             });
+
+            // === INTERNAL (flag-gated, default OFF): V2 factor_evpi arrival proof ===
+            // The V2 wire carries per-factor counterfactual EVPI at top-level
+            // `factor_evpi` (verified live 2026-07-06). Decision P-5 (pending):
+            // it MUST NOT feed any user-facing VOI/EVPI surface yet. Behind the
+            // flag we log a sanitised summary ONLY — negative/below-resolution
+            // raw values are never logged as emittable numbers (see
+            // mapIslFactorEvpi hygiene). The public response is byte-identical
+            // whether this flag is on or off.
+            if (FLAGS.ISL_FACTOR_EVPI_INTERNAL) {
+              const factorEvpiMapping = mapIslFactorEvpi(islResult);
+              req.log.info({
+                event: 'isl_factor_evpi_internal',
+                request_id: requestId,
+                count: factorEvpiMapping.entries.length,
+                dropped_invalid: factorEvpiMapping.dropped_invalid,
+                below_resolution_count: factorEvpiMapping.entries.filter((e) => e.below_resolution).length,
+                entries: factorEvpiMapping.entries.map((e) => ({
+                  factor_id: e.factor_id,
+                  emit_pp: e.emit_pp ?? null,
+                  below_resolution: e.below_resolution,
+                  raw_evpi_percentage_points: e.raw_evpi_percentage_points,
+                  metric_type: e.metric_type,
+                  n_evpi_samples: e.n_evpi_samples,
+                })),
+              });
+            }
           } else {
             islStatusCode = 500;
             islFallbackExecuted = true;
@@ -4216,10 +4344,22 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
 
         // Transform sensitivity arrays FIRST - these are the final arrays that will be returned
         // Status check must use the SAME arrays to prevent status/response misalignment
-        const edgeSensitivity = transformEdgeSensitivity(islResult.sensitivity, earlyNodeLabelMap, normalisationContext);
+        //
+        // V2 wire truth (verified live 2026-07-06, build f3f5d92 — see
+        // src/integrations/isl/v2-envelope.ts): the pinned response_version=2
+        // envelope NEVER emits top-level `sensitivity` and carries no nested
+        // replacement — edge-level sensitivity is genuinely dropped by the V2
+        // wire. The former `islResult.sensitivity` read was structurally dead.
+        // Do NOT invent a substitute (ISL contract followup); edge_sensitivity
+        // is "computed, empty" and explicitly marked via the
+        // EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE inference warning.
+        const edgeSensitivity = transformEdgeSensitivity(undefined, earlyNodeLabelMap, normalisationContext);
 
-        // Transform ISL edge_e_values (when present) with label enrichment
-        const edgeEValues = transformEdgeEValues(islResult.edge_e_values, earlyNodeLabelMap, normalisationContext);
+        // Transform ISL edge_e_values with label enrichment. NESTED at
+        // robustness.edge_e_values on the V2 wire (the former top-level read
+        // was structurally dead — every live response came back "empty").
+        const islEdgeEValuesRaw = getIslEdgeEValues(islResult);
+        const edgeEValues = transformEdgeEValues(islEdgeEValuesRaw, earlyNodeLabelMap, normalisationContext);
 
         // Transform ISL conditional_winners (when present) with label enrichment
         const conditionalWinners = transformConditionalWinners(
@@ -4233,7 +4373,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // non-finite / out-of-range numerics. These surfaces have no per-feature status
         // to degrade, so emit a warning when entries are silently removed rather than
         // hiding the upstream defect. (Counts only — no payload.)
-        const eValuesDropped = (islResult.edge_e_values?.length ?? 0) - edgeEValues.length;
+        const eValuesDropped = (islEdgeEValuesRaw?.length ?? 0) - edgeEValues.length;
         if (eValuesDropped > 0) {
           req.log.warn({ event: 'edge_e_values_dropped_nonfinite', request_id: requestId, dropped: eValuesDropped, kept: edgeEValues.length });
         }

--- a/src/trust/confidence-tier.ts
+++ b/src/trust/confidence-tier.ts
@@ -24,3 +24,43 @@ export function deriveConfidenceTier(readiness: Readiness): ConfidenceTier {
       return 'needs_work';
   }
 }
+
+/**
+ * Robustness signals consumed by the reconciliation cap. Structural subset of
+ * `RobustnessAssessmentV3` (the assembled response robustness object).
+ */
+export interface RobustnessTierSignals {
+  /** ISL V2 boolean robustness flag (passthrough) */
+  is_robust?: boolean;
+  /** ISL V2 robustness level (passthrough) */
+  level?: 'high' | 'medium' | 'low' | 'very_low' | string;
+}
+
+/**
+ * Producer-side confidence_tier reconciliation.
+ *
+ * `confidence_tier` is PLoT-assembled enrichment derived from M1 coaching
+ * readiness alone — it knows nothing about the robustness assessment carried
+ * in the SAME response. A response claiming `confidence_tier: 'strong'`
+ * alongside `robustness.is_robust: false` (or `level: 'low' | 'very_low'`)
+ * is internally contradictory: the science says the recommendation is not
+ * robust while the coaching-derived tier tells the user it is solid.
+ *
+ * Rule: never emit 'strong' when the same response's robustness carries
+ * `is_robust === false` or a low/very_low level — cap at the provisional
+ * middle tier 'fair'. Lower tiers ('fair', 'needs_work') are never raised;
+ * absent robustness signals leave the tier unchanged (absence of evidence is
+ * not contradiction).
+ */
+export function reconcileConfidenceTier(
+  tier: ConfidenceTier,
+  robustness: RobustnessTierSignals | null | undefined,
+): ConfidenceTier {
+  if (tier !== 'strong') return tier;
+  if (!robustness) return tier;
+  const contradicted =
+    robustness.is_robust === false ||
+    robustness.level === 'low' ||
+    robustness.level === 'very_low';
+  return contradicted ? 'fair' : tier;
+}

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1437,8 +1437,14 @@ export interface EnrichedEdgeEValue {
   to_label: string;
   /** E-value (evidence strength) */
   e_value: number;
-  /** Direction the edge would need to flip to change the recommendation */
-  flip_direction: 'positive_to_negative' | 'negative_to_positive' | 'removal';
+  /**
+   * Direction the edge would need to flip to change the recommendation.
+   * ISL owns this vocabulary and PLoT passes it through verbatim: the live V2
+   * wire emits 'increase' | 'decrease' (verified 2026-07-06, build f3f5d92);
+   * legacy documented values were 'positive_to_negative' |
+   * 'negative_to_positive' | 'removal'. Typed open to match the wire.
+   */
+  flip_direction: string;
   /** Current mean effect of this edge */
   current_mean: number;
   /** Mean effect at the flip point */
@@ -1857,6 +1863,15 @@ export interface StabilityThresholds {
 export const INFERENCE_WARNING_CODES = {
   /** ISL returned factor-level 3C fields but stability_thresholds was absent or malformed */
   STABILITY_THRESHOLDS_MISSING: 'STABILITY_THRESHOLDS_MISSING',
+  /**
+   * Edge-level sensitivity was requested (analysis_types includes 'sensitivity')
+   * but the ISL V2 wire does not emit it (verified live 2026-07-06, build
+   * f3f5d92): edge_sensitivity is empty by wire contract, NOT by computation
+   * failure. Factor-level sensitivity is unaffected. Restoring edge-level
+   * sensitivity is ISL contract work (recorded followup); PLoT does not
+   * invent a substitute.
+   */
+  EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE: 'EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];

--- a/tests/confidence-tier-reconcile.test.ts
+++ b/tests/confidence-tier-reconcile.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Producer-side confidence_tier reconciliation (Lane 2, item D).
+ *
+ * confidence_tier is PLoT-assembled enrichment derived from M1 coaching
+ * readiness. A response must never claim 'strong' while its OWN robustness
+ * assessment says is_robust=false or level low/very_low — the live capture
+ * (tests/fixtures/isl-v2-live-20260706) is exactly such a response
+ * (is_robust=false, level='low').
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveConfidenceTier,
+  reconcileConfidenceTier,
+} from '../src/trust/confidence-tier.js';
+
+describe('reconcileConfidenceTier', () => {
+  it("caps 'strong' to 'fair' when is_robust === false", () => {
+    expect(reconcileConfidenceTier('strong', { is_robust: false })).toBe('fair');
+  });
+
+  it("caps 'strong' to 'fair' when level === 'low'", () => {
+    expect(reconcileConfidenceTier('strong', { level: 'low' })).toBe('fair');
+  });
+
+  it("caps 'strong' to 'fair' when level === 'very_low'", () => {
+    expect(reconcileConfidenceTier('strong', { level: 'very_low' })).toBe('fair');
+  });
+
+  it('caps on the live-capture combination (is_robust=false AND level=low)', () => {
+    expect(reconcileConfidenceTier('strong', { is_robust: false, level: 'low' })).toBe('fair');
+  });
+
+  it("leaves 'strong' when robustness agrees (is_robust=true, level high/medium)", () => {
+    expect(reconcileConfidenceTier('strong', { is_robust: true, level: 'high' })).toBe('strong');
+    expect(reconcileConfidenceTier('strong', { is_robust: true, level: 'medium' })).toBe('strong');
+  });
+
+  it("leaves 'strong' when robustness signals are absent (absence is not contradiction)", () => {
+    expect(reconcileConfidenceTier('strong', undefined)).toBe('strong');
+    expect(reconcileConfidenceTier('strong', null)).toBe('strong');
+    expect(reconcileConfidenceTier('strong', {})).toBe('strong');
+  });
+
+  it('never raises a lower tier, regardless of robustness', () => {
+    expect(reconcileConfidenceTier('fair', { is_robust: true, level: 'high' })).toBe('fair');
+    expect(reconcileConfidenceTier('needs_work', { is_robust: true, level: 'high' })).toBe('needs_work');
+    expect(reconcileConfidenceTier('fair', { is_robust: false })).toBe('fair');
+    expect(reconcileConfidenceTier('needs_work', { level: 'low' })).toBe('needs_work');
+  });
+
+  it("composes with deriveConfidenceTier: readiness 'ready' + fragile robustness → 'fair'", () => {
+    const tier = deriveConfidenceTier('ready');
+    expect(tier).toBe('strong');
+    expect(reconcileConfidenceTier(tier, { is_robust: false, level: 'low' })).toBe('fair');
+  });
+});

--- a/tests/duplicate-edge-preflight.test.ts
+++ b/tests/duplicate-edge-preflight.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Duplicate-edge preflight (Lane 2, item E).
+ *
+ * ISL now 422s duplicate (from, to, type) edges. Before calling ISL, PLoT:
+ *  - coalesces EXACT identical duplicates only, logged via the existing
+ *    repairs_applied mechanism (observable, never silent);
+ *  - blocks NON-identical duplicates (differing weight/belief) with a typed
+ *    actionable critique — PLoT must not silently pick one of the user's
+ *    contradictory claims.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import {
+  preflightDuplicateEdges,
+  type DuplicateCheckEdge,
+} from '../src/integrations/isl/preflight.js';
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+const edge = (
+  from: string,
+  to: string,
+  mean = 0.5,
+  std = 0.1,
+  existsProbability = 0.8,
+  edgeType?: 'directed' | 'bidirected',
+): DuplicateCheckEdge => ({
+  from,
+  to,
+  exists_probability: existsProbability,
+  strength: { mean, std },
+  ...(edgeType ? { edge_type: edgeType } : {}),
+});
+
+describe('preflightDuplicateEdges (unit)', () => {
+  it('returns input untouched when there are no duplicates', () => {
+    const edges = [edge('a', 'b'), edge('b', 'c'), edge('a', 'c')];
+    const result = preflightDuplicateEdges(edges);
+    expect(result.edges).toBe(edges);
+    expect(result.coalesced).toEqual([]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('coalesces EXACT identical duplicates to one edge, reporting the group', () => {
+    const edges = [edge('a', 'b'), edge('a', 'b'), edge('b', 'c')];
+    const result = preflightDuplicateEdges(edges);
+    expect(result.conflicts).toEqual([]);
+    expect(result.coalesced).toEqual([
+      { from: 'a', to: 'b', edge_type: 'directed', count: 2 },
+    ]);
+    expect(result.edges).toHaveLength(2);
+    expect(result.edges.map((e) => `${e.from}->${e.to}`)).toEqual(['a->b', 'b->c']);
+  });
+
+  it('coalesces triple identical duplicates, preserving first position', () => {
+    const edges = [edge('x', 'y'), edge('a', 'b'), edge('x', 'y'), edge('x', 'y')];
+    const result = preflightDuplicateEdges(edges);
+    expect(result.coalesced).toEqual([
+      { from: 'x', to: 'y', edge_type: 'directed', count: 3 },
+    ]);
+    expect(result.edges.map((e) => `${e.from}->${e.to}`)).toEqual(['x->y', 'a->b']);
+  });
+
+  it('flags NON-identical duplicates as conflicts and does NOT dedupe them', () => {
+    const edges = [edge('a', 'b', 0.5), edge('a', 'b', 0.9), edge('b', 'c')];
+    const result = preflightDuplicateEdges(edges);
+    expect(result.coalesced).toEqual([]);
+    expect(result.conflicts).toEqual([
+      {
+        from: 'a',
+        to: 'b',
+        edge_type: 'directed',
+        count: 2,
+        divergent_fields: ['strength.mean'],
+      },
+    ]);
+    // Conflicting edges are NOT silently removed
+    expect(result.edges).toHaveLength(3);
+  });
+
+  it('reports every divergent field for a conflicting group', () => {
+    const a = edge('a', 'b', 0.5, 0.1, 0.8);
+    const b = { ...edge('a', 'b', 0.9, 0.2, 0.6), label: 'other' };
+    const result = preflightDuplicateEdges([a, b]);
+    expect(result.conflicts[0].divergent_fields).toEqual([
+      'exists_probability',
+      'strength.mean',
+      'strength.std',
+      'label',
+    ]);
+  });
+
+  it('treats directed and bidirected edges between the same pair as DIFFERENT keys', () => {
+    const edges = [edge('a', 'b'), edge('a', 'b', 0.5, 0.1, 0.8, 'bidirected')];
+    const result = preflightDuplicateEdges(edges);
+    expect(result.coalesced).toEqual([]);
+    expect(result.conflicts).toEqual([]);
+    expect(result.edges).toHaveLength(2);
+  });
+
+  it('handles a mixed graph: identical group coalesced AND conflicting group reported', () => {
+    const edges = [
+      edge('a', 'b'),
+      edge('a', 'b'), // identical dupe → coalesce
+      edge('c', 'd', 0.1),
+      edge('c', 'd', 0.2), // conflicting dupe → conflict
+    ];
+    const result = preflightDuplicateEdges(edges);
+    expect(result.coalesced).toHaveLength(1);
+    expect(result.conflicts).toHaveLength(1);
+  });
+
+  it('does not confuse key delimiters (from="a b", to="c" vs from="a", to="b c")', () => {
+    const result = preflightDuplicateEdges([edge('a b', 'c'), edge('a', 'b c')]);
+    expect(result.coalesced).toEqual([]);
+    expect(result.conflicts).toEqual([]);
+    expect(result.edges).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route-level tests: /v2/run with a mocked ISL service
+// ---------------------------------------------------------------------------
+
+let lastIslRequestBody: any = null;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    lastIslRequestBody = body;
+    const options = body.options || [];
+    return {
+      data: {
+        analysis_status: 'computed',
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.6 + idx * 0.1, std: 0.05, p10: 0.4, p50: 0.6, p90: 0.8, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+          win_probability: idx === 0 ? 0.7 : 0.3,
+          status: 'computed',
+        })),
+        factor_sensitivity: [],
+        robustness: { confidence: 0.8, level: 'high', is_robust: true, fragile_edges: [], robust_edges: [] },
+        inference_warnings: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+const NODES = [
+  { id: 'factor-a', kind: 'factor', label: 'Factor A', observed_state: { value: 0.5 } },
+  { id: 'factor-b', kind: 'factor', label: 'Factor B', observed_state: { value: 0.4 } },
+  { id: 'goal', kind: 'goal', label: 'Goal' },
+];
+
+const OPTIONS = [
+  { id: 'opt-a', label: 'Option A', interventions: { 'factor-a': { value: 0.8, source: 'user_specified' } } },
+  { id: 'opt-b', label: 'Option B', interventions: { 'factor-b': { value: 0.7, source: 'user_specified' } } },
+];
+
+const EDGE_A = { from: 'factor-a', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } };
+const EDGE_B = { from: 'factor-b', to: 'goal', exists_probability: 0.9, strength: { mean: 0.3, std: 0.1 } };
+
+describe('duplicate-edge preflight via /v2/run', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('coalesces exact-identical duplicate edges before calling ISL and logs a repair', async () => {
+    lastIslRequestBody = null;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: {
+        graph: { nodes: NODES, edges: [EDGE_A, { ...EDGE_A }, EDGE_B] },
+        options: OPTIONS,
+        goal_node_id: 'goal',
+        seed: '42',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    // ISL received exactly ONE factor-a -> goal edge (would 422 on two)
+    expect(lastIslRequestBody).not.toBeNull();
+    const sentPairs = lastIslRequestBody.graph.edges.map((e: any) => `${e.from}->${e.to}`);
+    expect(sentPairs.filter((p: string) => p === 'factor-a->goal')).toHaveLength(1);
+    expect(sentPairs).toHaveLength(2);
+
+    // Coalescing is observable via the existing repairs_applied mechanism
+    const body = JSON.parse(res.body);
+    const repairs = body._meta?.repairs_applied ?? [];
+    const coalesceRepairs = repairs.filter((r: any) =>
+      String(r.reason ?? '').startsWith('COALESCE_DUPLICATE_EDGE'),
+    );
+    expect(coalesceRepairs).toHaveLength(1);
+    expect(coalesceRepairs[0].reason).toContain('factor-a -> goal');
+  });
+
+  it('blocks NON-identical duplicate edges with a typed actionable critique (422), never silent dedupe', async () => {
+    lastIslRequestBody = null;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: {
+        graph: {
+          nodes: NODES,
+          edges: [EDGE_A, { ...EDGE_A, strength: { mean: 0.9, std: 0.1 } }, EDGE_B],
+        },
+        options: OPTIONS,
+        goal_node_id: 'goal',
+        seed: '42',
+      },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = JSON.parse(res.body);
+    expect(body.analysis_status).toBe('blocked');
+    const critique = (body.critiques ?? []).find((c: any) => c.code === 'DUPLICATE_EDGE_CONFLICT');
+    expect(critique).toBeDefined();
+    expect(critique.severity).toBe('blocker');
+    expect(critique.blocks_analysis).toBe(true);
+    // Actionable: names the edge pair and the divergent field
+    expect(critique.message).toContain('factor-a -> goal');
+    expect(critique.message).toContain('strength.mean');
+    // ISL must never have been called with the conflicting graph
+    expect(lastIslRequestBody).toBeNull();
+  });
+
+  it('clean graphs pass through with no coalesce repairs and no conflict critiques', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: {
+        graph: { nodes: NODES, edges: [EDGE_A, EDGE_B] },
+        options: OPTIONS,
+        goal_node_id: 'goal',
+        seed: '42',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    const repairs = body._meta?.repairs_applied ?? [];
+    expect(repairs.filter((r: any) => String(r.reason ?? '').startsWith('COALESCE_DUPLICATE_EDGE'))).toHaveLength(0);
+    expect((body.critiques ?? []).filter((c: any) => c.code === 'DUPLICATE_EDGE_CONFLICT')).toHaveLength(0);
+  });
+});

--- a/tests/fixtures/isl-v2-live-20260706/isl-staging-capture-b.json
+++ b/tests/fixtures/isl-v2-live-20260706/isl-staging-capture-b.json
@@ -1,0 +1,499 @@
+{
+  "version": "2.0",
+  "endpoint_version": "analyze/v2",
+  "engine_version": "1.0.0",
+  "build": "f3f5d92",
+  "timestamp": "2026-07-06T23:39:06.212426Z",
+  "analysis_status": "computed",
+  "robustness_status": "computed",
+  "factor_sensitivity_status": "computed",
+  "critiques": [],
+  "request_echo": {
+    "graph_node_count": 9,
+    "graph_edge_count": 13,
+    "options_count": 4,
+    "goal_node_id_hash": "d9f77e1cb872",
+    "n_samples": 4000,
+    "response_version_requested": 2,
+    "include_diagnostics": false
+  },
+  "options": [
+    {
+      "id": "opt_one_dev",
+      "label": "Hire One Developer (Reduced Commitment)",
+      "outcome": {
+        "mean": 0.10179725550865354,
+        "std": 0.11941813998438616,
+        "p10": -0.046497474297611675,
+        "p50": 0.10615207437561272,
+        "p90": 0.24657456603769748,
+        "n_samples": 4000,
+        "n_valid_samples": 4000,
+        "validity_ratio": 1,
+        "percentiles_source": "samples"
+      },
+      "win_probability": 0.0007083333333333334,
+      "constraint_analysis": {
+        "constraints": [
+          {
+            "node_id": "fac_hiring_cost",
+            "operator": "<=",
+            "threshold": 1,
+            "label": "Budget ceiling for new hires",
+            "prob_satisfied": 0.977,
+            "failure_margin_median": 0.149336186358907,
+            "near_miss_fraction": 0.41304347826086957,
+            "binding": false,
+            "value": 1
+          }
+        ],
+        "joint_probability": 0.977
+      },
+      "status": "computed"
+    },
+    {
+      "id": "opt_status_quo",
+      "label": "No New Hire (Status Quo)",
+      "outcome": {
+        "mean": -0.00039679435638067785,
+        "std": 0.0911193335327987,
+        "p10": -0.10769108623911076,
+        "p50": 0.00011162160103608826,
+        "p90": 0.10336789783872895,
+        "n_samples": 4000,
+        "n_valid_samples": 4000,
+        "validity_ratio": 1,
+        "percentiles_source": "samples"
+      },
+      "win_probability": 0.002833333333333333,
+      "constraint_analysis": {
+        "constraints": [
+          {
+            "node_id": "fac_hiring_cost",
+            "operator": "<=",
+            "threshold": 1,
+            "label": "Budget ceiling for new hires",
+            "prob_satisfied": 0.977,
+            "failure_margin_median": 0.149336186358907,
+            "near_miss_fraction": 0.41304347826086957,
+            "binding": false,
+            "value": 1
+          }
+        ],
+        "joint_probability": 0.977
+      },
+      "status": "computed"
+    },
+    {
+      "id": "opt_tech_lead",
+      "label": "Hire One Tech Lead",
+      "outcome": {
+        "mean": 0.25559011544614935,
+        "std": 0.17185431793611658,
+        "p10": 0.03934250803901223,
+        "p50": 0.2523671951931171,
+        "p90": 0.47137358299516724,
+        "n_samples": 4000,
+        "n_valid_samples": 4000,
+        "validity_ratio": 1,
+        "percentiles_source": "samples"
+      },
+      "win_probability": 0.59025,
+      "constraint_analysis": {
+        "constraints": [
+          {
+            "node_id": "fac_hiring_cost",
+            "operator": "<=",
+            "threshold": 1,
+            "label": "Budget ceiling for new hires",
+            "prob_satisfied": 0.977,
+            "failure_margin_median": 0.149336186358907,
+            "near_miss_fraction": 0.41304347826086957,
+            "binding": false,
+            "value": 1
+          }
+        ],
+        "joint_probability": 0.977
+      },
+      "status": "computed"
+    },
+    {
+      "id": "opt_two_devs",
+      "label": "Hire Two Developers",
+      "outcome": {
+        "mean": 0.20399130537368776,
+        "std": 0.1784758980587605,
+        "p10": -0.03424836348148578,
+        "p50": 0.21703179877108886,
+        "p90": 0.42035080806243247,
+        "n_samples": 4000,
+        "n_valid_samples": 4000,
+        "validity_ratio": 1,
+        "percentiles_source": "samples"
+      },
+      "win_probability": 0.40620833333333334,
+      "constraint_analysis": {
+        "constraints": [
+          {
+            "node_id": "fac_hiring_cost",
+            "operator": "<=",
+            "threshold": 1,
+            "label": "Budget ceiling for new hires",
+            "prob_satisfied": 0.977,
+            "failure_margin_median": 0.149336186358907,
+            "near_miss_fraction": 0.41304347826086957,
+            "binding": false,
+            "value": 1
+          }
+        ],
+        "joint_probability": 0.977
+      },
+      "status": "computed"
+    }
+  ],
+  "robustness": {
+    "level": "low",
+    "confidence": 0.5809173280554281,
+    "fragile_edges": [
+      {
+        "edge_id": "fac_dev_headcount->out_throughput",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_throughput",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.075,
+        "marginal_switch_probability": 0.42
+      },
+      {
+        "edge_id": "out_throughput->goal_productivity",
+        "from_id": "out_throughput",
+        "to_id": "goal_productivity",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.281,
+        "marginal_switch_probability": 0.03
+      },
+      {
+        "edge_id": "fac_dev_headcount->out_technical_quality",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_technical_quality",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.375,
+        "marginal_switch_probability": 0.05
+      },
+      {
+        "edge_id": "fac_dev_headcount->risk_coordination",
+        "from_id": "fac_dev_headcount",
+        "to_id": "risk_coordination",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.487,
+        "marginal_switch_probability": 0
+      },
+      {
+        "edge_id": "out_technical_quality->goal_productivity",
+        "from_id": "out_technical_quality",
+        "to_id": "goal_productivity",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.569,
+        "marginal_switch_probability": 0.21
+      },
+      {
+        "edge_id": "fac_tech_lead->out_technical_quality",
+        "from_id": "fac_tech_lead",
+        "to_id": "out_technical_quality",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.61,
+        "marginal_switch_probability": 0.23
+      },
+      {
+        "edge_id": "risk_coordination->goal_productivity",
+        "from_id": "risk_coordination",
+        "to_id": "goal_productivity",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.307,
+        "marginal_switch_probability": 0.28
+      }
+    ],
+    "is_robust": false,
+    "fragile_edges_v1": [
+      "fac_dev_headcount->out_technical_quality",
+      "out_throughput->goal_productivity",
+      "out_technical_quality->goal_productivity",
+      "fac_dev_headcount->risk_coordination",
+      "risk_coordination->goal_productivity",
+      "fac_dev_headcount->out_throughput",
+      "fac_tech_lead->out_technical_quality"
+    ],
+    "robust_edges": [
+      "fac_team_maturity->risk_coordination",
+      "fac_hiring_cost->risk_cost_burden",
+      "fac_team_maturity->out_throughput",
+      "risk_cost_burden->goal_productivity"
+    ],
+    "recommendation_stability": 0.59025,
+    "edge_e_values": [
+      {
+        "edge_id": "fac_dev_headcount->out_technical_quality",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_technical_quality",
+        "e_value": 3.6404,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": 0.12,
+        "flip_mean": 0.436845
+      },
+      {
+        "edge_id": "fac_dev_headcount->out_throughput",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_throughput",
+        "e_value": 1.2228,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": 0.5072815533980582,
+        "flip_mean": 0.620287
+      },
+      {
+        "edge_id": "fac_dev_headcount->risk_coordination",
+        "from_id": "fac_dev_headcount",
+        "to_id": "risk_coordination",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "decrease",
+        "current_mean": 0.3,
+        "flip_mean": -0.069032
+      },
+      {
+        "edge_id": "fac_hiring_cost->risk_cost_burden",
+        "from_id": "fac_hiring_cost",
+        "to_id": "risk_cost_burden",
+        "is_unflippable": true,
+        "flip_direction": "increase",
+        "current_mean": 0.7,
+        "flip_mean": 0.7
+      },
+      {
+        "edge_id": "fac_team_maturity->out_throughput",
+        "from_id": "fac_team_maturity",
+        "to_id": "out_throughput",
+        "is_unflippable": true,
+        "flip_direction": "increase",
+        "current_mean": 0.18446601941747573,
+        "flip_mean": 0.18446601941747573
+      },
+      {
+        "edge_id": "fac_team_maturity->risk_coordination",
+        "from_id": "fac_team_maturity",
+        "to_id": "risk_coordination",
+        "is_unflippable": true,
+        "flip_direction": "increase",
+        "current_mean": -0.18,
+        "flip_mean": -0.18
+      },
+      {
+        "edge_id": "fac_tech_lead->out_technical_quality",
+        "from_id": "fac_tech_lead",
+        "to_id": "out_technical_quality",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "decrease",
+        "current_mean": 0.6,
+        "flip_mean": 0.376344
+      },
+      {
+        "edge_id": "fac_tech_lead->out_throughput",
+        "from_id": "fac_tech_lead",
+        "to_id": "out_throughput",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "decrease",
+        "current_mean": 0.258252427184466,
+        "flip_mean": 0.130179
+      },
+      {
+        "edge_id": "fac_tech_lead->risk_coordination",
+        "from_id": "fac_tech_lead",
+        "to_id": "risk_coordination",
+        "e_value": 1.8117,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": -0.15,
+        "flip_mean": 0.27175
+      },
+      {
+        "edge_id": "out_technical_quality->goal_productivity",
+        "from_id": "out_technical_quality",
+        "to_id": "goal_productivity",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "decrease",
+        "current_mean": 0.3,
+        "flip_mean": 0.169789
+      },
+      {
+        "edge_id": "out_throughput->goal_productivity",
+        "from_id": "out_throughput",
+        "to_id": "goal_productivity",
+        "e_value": 1.4044,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": 0.55,
+        "flip_mean": 0.772441
+      },
+      {
+        "edge_id": "risk_coordination->goal_productivity",
+        "from_id": "risk_coordination",
+        "to_id": "goal_productivity",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": -0.2,
+        "flip_mean": -0.028855
+      },
+      {
+        "edge_id": "risk_cost_burden->goal_productivity",
+        "from_id": "risk_cost_burden",
+        "to_id": "goal_productivity",
+        "is_unflippable": true,
+        "flip_direction": "increase",
+        "current_mean": -0.25,
+        "flip_mean": -0.25
+      }
+    ]
+  },
+  "factor_sensitivity": [
+    {
+      "node_id": "fac_hiring_cost",
+      "label": "Hiring and Salary Cost",
+      "sensitivity_score": 1,
+      "importance_score": 1,
+      "elasticity": -0.014698333393406733,
+      "elasticity_display": -0.014698333393406733,
+      "direction": "negative",
+      "confidence": 0.3815,
+      "confidence_source": "bootstrap_sampling",
+      "importance_rank": 1,
+      "observed_value": 0,
+      "interpretation": "Decision is robust to Hiring and Salary Cost value variation",
+      "baseline_near_zero": false,
+      "influence_score": 0.5248077179966281,
+      "influence_rank": 3,
+      "elasticity_std": 0.01101973,
+      "attribution_stability": "low",
+      "rank_flip_rate": 0.3,
+      "stability_method": "bootstrap_20"
+    },
+    {
+      "node_id": "fac_team_maturity",
+      "label": "Team Technical Maturity",
+      "sensitivity_score": 0.662581761847986,
+      "importance_score": 0.6666666666666667,
+      "elasticity": 0.00973884763603252,
+      "elasticity_display": 0.00973884763603252,
+      "direction": "positive",
+      "confidence": 0.3891,
+      "confidence_source": "bootstrap_sampling",
+      "importance_rank": 2,
+      "interpretation": "Decision is robust to Team Technical Maturity value variation",
+      "value_defaulted": true,
+      "baseline_near_zero": false,
+      "influence_score": 0.34772802242162665,
+      "influence_rank": 4,
+      "elasticity_std": 0.00657316,
+      "attribution_stability": "low",
+      "rank_flip_rate": 0.05,
+      "stability_method": "bootstrap_20"
+    },
+    {
+      "node_id": "fac_dev_headcount",
+      "label": "Developer Headcount Added",
+      "sensitivity_score": 0,
+      "importance_score": 0.33333333333333337,
+      "elasticity": 0,
+      "elasticity_display": 0,
+      "direction": "negative",
+      "confidence": 0.1,
+      "confidence_source": "bootstrap_sampling",
+      "importance_rank": 3,
+      "observed_value": 0,
+      "interpretation": "Decision is robust to Developer Headcount Added value variation",
+      "zero_reason": "intervention_override",
+      "baseline_near_zero": false,
+      "influence_score": 1,
+      "influence_rank": 1,
+      "elasticity_std": 0,
+      "attribution_stability": "negligible",
+      "rank_flip_rate": 0,
+      "stability_method": "bootstrap_20"
+    },
+    {
+      "node_id": "fac_tech_lead",
+      "label": "Tech Lead in Place",
+      "sensitivity_score": 0,
+      "importance_score": 0,
+      "elasticity": 0,
+      "elasticity_display": 0,
+      "direction": "negative",
+      "confidence": 0.1,
+      "confidence_source": "bootstrap_sampling",
+      "importance_rank": 4,
+      "observed_value": 0,
+      "interpretation": "Decision is robust to Tech Lead in Place value variation",
+      "zero_reason": "intervention_override",
+      "baseline_near_zero": false,
+      "influence_score": 0.8898237003456604,
+      "influence_rank": 2,
+      "elasticity_std": 0,
+      "attribution_stability": "negligible",
+      "rank_flip_rate": 0,
+      "stability_method": "bootstrap_20"
+    }
+  ],
+  "inference_warnings": [],
+  "stability_thresholds": {
+    "high_moderate_boundary": 0.1,
+    "moderate_low_boundary": 0.3,
+    "version": "v1.0-operational-defaults",
+    "provisional": true
+  },
+  "factor_evpi": [
+    {
+      "factor_id": "fac_hiring_cost",
+      "evpi": 0.022,
+      "evpi_percentage_points": 2.2,
+      "current_metric": 0.978,
+      "perfect_metric": 1,
+      "metric_type": "p_joint_goal",
+      "n_evpi_samples": 500
+    },
+    {
+      "factor_id": "fac_dev_headcount",
+      "evpi": 0.002,
+      "evpi_percentage_points": 0.2,
+      "current_metric": 0.978,
+      "perfect_metric": 0.98,
+      "metric_type": "p_joint_goal",
+      "n_evpi_samples": 500
+    },
+    {
+      "factor_id": "fac_team_maturity",
+      "evpi": 0.002,
+      "evpi_percentage_points": 0.2,
+      "current_metric": 0.978,
+      "perfect_metric": 0.98,
+      "metric_type": "p_joint_goal",
+      "n_evpi_samples": 500
+    },
+    {
+      "factor_id": "fac_tech_lead",
+      "evpi": -0.004,
+      "evpi_percentage_points": -0.4,
+      "current_metric": 0.978,
+      "perfect_metric": 0.974,
+      "metric_type": "p_joint_goal",
+      "n_evpi_samples": 500
+    }
+  ],
+  "auto_noise_applied": false,
+  "request_id": "06616631-461c-46bc-8490-efaed2b56d20",
+  "processing_time_ms": 1620,
+  "seed_used": "2034401427",
+  "seed_source": "client_provided"
+}

--- a/tests/fixtures/isl-v2-live-20260706/isl-staging-capture.json
+++ b/tests/fixtures/isl-v2-live-20260706/isl-staging-capture.json
@@ -1,0 +1,435 @@
+{
+  "version": "2.0",
+  "endpoint_version": "analyze/v2",
+  "engine_version": "1.0.0",
+  "build": "f3f5d92",
+  "timestamp": "2026-07-06T23:32:39.636888Z",
+  "analysis_status": "computed",
+  "robustness_status": "computed",
+  "factor_sensitivity_status": "computed",
+  "critiques": [],
+  "request_echo": {
+    "graph_node_count": 9,
+    "graph_edge_count": 13,
+    "options_count": 4,
+    "goal_node_id_hash": "d9f77e1cb872",
+    "n_samples": 4000,
+    "response_version_requested": 2,
+    "include_diagnostics": false
+  },
+  "options": [
+    {
+      "id": "opt_one_dev",
+      "label": "Hire One Developer (Reduced Commitment)",
+      "outcome": {
+        "mean": 0.10179725550865354,
+        "std": 0.11941813998438616,
+        "p10": -0.046497474297611675,
+        "p50": 0.10615207437561272,
+        "p90": 0.24657456603769748,
+        "n_samples": 4000,
+        "n_valid_samples": 4000,
+        "validity_ratio": 1,
+        "percentiles_source": "samples"
+      },
+      "win_probability": 0.0007083333333333334,
+      "status": "computed"
+    },
+    {
+      "id": "opt_status_quo",
+      "label": "No New Hire (Status Quo)",
+      "outcome": {
+        "mean": -0.00039679435638067785,
+        "std": 0.0911193335327987,
+        "p10": -0.10769108623911076,
+        "p50": 0.00011162160103608826,
+        "p90": 0.10336789783872895,
+        "n_samples": 4000,
+        "n_valid_samples": 4000,
+        "validity_ratio": 1,
+        "percentiles_source": "samples"
+      },
+      "win_probability": 0.002833333333333333,
+      "status": "computed"
+    },
+    {
+      "id": "opt_tech_lead",
+      "label": "Hire One Tech Lead",
+      "outcome": {
+        "mean": 0.25559011544614935,
+        "std": 0.17185431793611658,
+        "p10": 0.03934250803901223,
+        "p50": 0.2523671951931171,
+        "p90": 0.47137358299516724,
+        "n_samples": 4000,
+        "n_valid_samples": 4000,
+        "validity_ratio": 1,
+        "percentiles_source": "samples"
+      },
+      "win_probability": 0.59025,
+      "status": "computed"
+    },
+    {
+      "id": "opt_two_devs",
+      "label": "Hire Two Developers",
+      "outcome": {
+        "mean": 0.20399130537368776,
+        "std": 0.1784758980587605,
+        "p10": -0.03424836348148578,
+        "p50": 0.21703179877108886,
+        "p90": 0.42035080806243247,
+        "n_samples": 4000,
+        "n_valid_samples": 4000,
+        "validity_ratio": 1,
+        "percentiles_source": "samples"
+      },
+      "win_probability": 0.40620833333333334,
+      "status": "computed"
+    }
+  ],
+  "robustness": {
+    "level": "low",
+    "confidence": 0.5809173280554281,
+    "fragile_edges": [
+      {
+        "edge_id": "fac_dev_headcount->out_throughput",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_throughput",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.075,
+        "marginal_switch_probability": 0.42
+      },
+      {
+        "edge_id": "out_throughput->goal_productivity",
+        "from_id": "out_throughput",
+        "to_id": "goal_productivity",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.281,
+        "marginal_switch_probability": 0.03
+      },
+      {
+        "edge_id": "fac_dev_headcount->out_technical_quality",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_technical_quality",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.375,
+        "marginal_switch_probability": 0.05
+      },
+      {
+        "edge_id": "fac_dev_headcount->risk_coordination",
+        "from_id": "fac_dev_headcount",
+        "to_id": "risk_coordination",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.487,
+        "marginal_switch_probability": 0
+      },
+      {
+        "edge_id": "out_technical_quality->goal_productivity",
+        "from_id": "out_technical_quality",
+        "to_id": "goal_productivity",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.569,
+        "marginal_switch_probability": 0.21
+      },
+      {
+        "edge_id": "fac_tech_lead->out_technical_quality",
+        "from_id": "fac_tech_lead",
+        "to_id": "out_technical_quality",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.61,
+        "marginal_switch_probability": 0.23
+      },
+      {
+        "edge_id": "risk_coordination->goal_productivity",
+        "from_id": "risk_coordination",
+        "to_id": "goal_productivity",
+        "alternative_winner_id": "opt_two_devs",
+        "switch_probability": 0.307,
+        "marginal_switch_probability": 0.28
+      }
+    ],
+    "is_robust": false,
+    "fragile_edges_v1": [
+      "fac_dev_headcount->out_technical_quality",
+      "out_throughput->goal_productivity",
+      "out_technical_quality->goal_productivity",
+      "fac_dev_headcount->risk_coordination",
+      "risk_coordination->goal_productivity",
+      "fac_dev_headcount->out_throughput",
+      "fac_tech_lead->out_technical_quality"
+    ],
+    "robust_edges": [
+      "fac_team_maturity->risk_coordination",
+      "fac_hiring_cost->risk_cost_burden",
+      "fac_team_maturity->out_throughput",
+      "risk_cost_burden->goal_productivity"
+    ],
+    "recommendation_stability": 0.59025,
+    "edge_e_values": [
+      {
+        "edge_id": "fac_dev_headcount->out_technical_quality",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_technical_quality",
+        "e_value": 3.6404,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": 0.12,
+        "flip_mean": 0.436845
+      },
+      {
+        "edge_id": "fac_dev_headcount->out_throughput",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_throughput",
+        "e_value": 1.2228,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": 0.5072815533980582,
+        "flip_mean": 0.620287
+      },
+      {
+        "edge_id": "fac_dev_headcount->risk_coordination",
+        "from_id": "fac_dev_headcount",
+        "to_id": "risk_coordination",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "decrease",
+        "current_mean": 0.3,
+        "flip_mean": -0.069032
+      },
+      {
+        "edge_id": "fac_hiring_cost->risk_cost_burden",
+        "from_id": "fac_hiring_cost",
+        "to_id": "risk_cost_burden",
+        "is_unflippable": true,
+        "flip_direction": "increase",
+        "current_mean": 0.7,
+        "flip_mean": 0.7
+      },
+      {
+        "edge_id": "fac_team_maturity->out_throughput",
+        "from_id": "fac_team_maturity",
+        "to_id": "out_throughput",
+        "is_unflippable": true,
+        "flip_direction": "increase",
+        "current_mean": 0.18446601941747573,
+        "flip_mean": 0.18446601941747573
+      },
+      {
+        "edge_id": "fac_team_maturity->risk_coordination",
+        "from_id": "fac_team_maturity",
+        "to_id": "risk_coordination",
+        "is_unflippable": true,
+        "flip_direction": "increase",
+        "current_mean": -0.18,
+        "flip_mean": -0.18
+      },
+      {
+        "edge_id": "fac_tech_lead->out_technical_quality",
+        "from_id": "fac_tech_lead",
+        "to_id": "out_technical_quality",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "decrease",
+        "current_mean": 0.6,
+        "flip_mean": 0.376344
+      },
+      {
+        "edge_id": "fac_tech_lead->out_throughput",
+        "from_id": "fac_tech_lead",
+        "to_id": "out_throughput",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "decrease",
+        "current_mean": 0.258252427184466,
+        "flip_mean": 0.130179
+      },
+      {
+        "edge_id": "fac_tech_lead->risk_coordination",
+        "from_id": "fac_tech_lead",
+        "to_id": "risk_coordination",
+        "e_value": 1.8117,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": -0.15,
+        "flip_mean": 0.27175
+      },
+      {
+        "edge_id": "out_technical_quality->goal_productivity",
+        "from_id": "out_technical_quality",
+        "to_id": "goal_productivity",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "decrease",
+        "current_mean": 0.3,
+        "flip_mean": 0.169789
+      },
+      {
+        "edge_id": "out_throughput->goal_productivity",
+        "from_id": "out_throughput",
+        "to_id": "goal_productivity",
+        "e_value": 1.4044,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": 0.55,
+        "flip_mean": 0.772441
+      },
+      {
+        "edge_id": "risk_coordination->goal_productivity",
+        "from_id": "risk_coordination",
+        "to_id": "goal_productivity",
+        "e_value": 1,
+        "is_unflippable": false,
+        "flip_direction": "increase",
+        "current_mean": -0.2,
+        "flip_mean": -0.028855
+      },
+      {
+        "edge_id": "risk_cost_burden->goal_productivity",
+        "from_id": "risk_cost_burden",
+        "to_id": "goal_productivity",
+        "is_unflippable": true,
+        "flip_direction": "increase",
+        "current_mean": -0.25,
+        "flip_mean": -0.25
+      }
+    ]
+  },
+  "factor_sensitivity": [
+    {
+      "node_id": "fac_hiring_cost",
+      "label": "Hiring and Salary Cost",
+      "sensitivity_score": 1,
+      "importance_score": 1,
+      "elasticity": -0.014698333393406733,
+      "elasticity_display": -0.014698333393406733,
+      "direction": "negative",
+      "confidence": 0.3815,
+      "confidence_source": "bootstrap_sampling",
+      "importance_rank": 1,
+      "observed_value": 0,
+      "interpretation": "Decision is robust to Hiring and Salary Cost value variation",
+      "baseline_near_zero": false,
+      "influence_score": 0.5248077179966281,
+      "influence_rank": 3,
+      "elasticity_std": 0.01101973,
+      "attribution_stability": "low",
+      "rank_flip_rate": 0.3,
+      "stability_method": "bootstrap_20"
+    },
+    {
+      "node_id": "fac_team_maturity",
+      "label": "Team Technical Maturity",
+      "sensitivity_score": 0.662581761847986,
+      "importance_score": 0.6666666666666667,
+      "elasticity": 0.00973884763603252,
+      "elasticity_display": 0.00973884763603252,
+      "direction": "positive",
+      "confidence": 0.3891,
+      "confidence_source": "bootstrap_sampling",
+      "importance_rank": 2,
+      "interpretation": "Decision is robust to Team Technical Maturity value variation",
+      "value_defaulted": true,
+      "baseline_near_zero": false,
+      "influence_score": 0.34772802242162665,
+      "influence_rank": 4,
+      "elasticity_std": 0.00657316,
+      "attribution_stability": "low",
+      "rank_flip_rate": 0.05,
+      "stability_method": "bootstrap_20"
+    },
+    {
+      "node_id": "fac_dev_headcount",
+      "label": "Developer Headcount Added",
+      "sensitivity_score": 0,
+      "importance_score": 0.33333333333333337,
+      "elasticity": 0,
+      "elasticity_display": 0,
+      "direction": "negative",
+      "confidence": 0.1,
+      "confidence_source": "bootstrap_sampling",
+      "importance_rank": 3,
+      "observed_value": 0,
+      "interpretation": "Decision is robust to Developer Headcount Added value variation",
+      "zero_reason": "intervention_override",
+      "baseline_near_zero": false,
+      "influence_score": 1,
+      "influence_rank": 1,
+      "elasticity_std": 0,
+      "attribution_stability": "negligible",
+      "rank_flip_rate": 0,
+      "stability_method": "bootstrap_20"
+    },
+    {
+      "node_id": "fac_tech_lead",
+      "label": "Tech Lead in Place",
+      "sensitivity_score": 0,
+      "importance_score": 0,
+      "elasticity": 0,
+      "elasticity_display": 0,
+      "direction": "negative",
+      "confidence": 0.1,
+      "confidence_source": "bootstrap_sampling",
+      "importance_rank": 4,
+      "observed_value": 0,
+      "interpretation": "Decision is robust to Tech Lead in Place value variation",
+      "zero_reason": "intervention_override",
+      "baseline_near_zero": false,
+      "influence_score": 0.8898237003456604,
+      "influence_rank": 2,
+      "elasticity_std": 0,
+      "attribution_stability": "negligible",
+      "rank_flip_rate": 0,
+      "stability_method": "bootstrap_20"
+    }
+  ],
+  "inference_warnings": [],
+  "stability_thresholds": {
+    "high_moderate_boundary": 0.1,
+    "moderate_low_boundary": 0.3,
+    "version": "v1.0-operational-defaults",
+    "provisional": true
+  },
+  "factor_evpi": [
+    {
+      "factor_id": "fac_dev_headcount",
+      "evpi": 0.0185,
+      "evpi_percentage_points": 1.85,
+      "current_metric": 0.5795,
+      "perfect_metric": 0.598,
+      "metric_type": "p_win_recommended",
+      "n_evpi_samples": 500
+    },
+    {
+      "factor_id": "fac_team_maturity",
+      "evpi": 0.0145,
+      "evpi_percentage_points": 1.45,
+      "current_metric": 0.5795,
+      "perfect_metric": 0.594,
+      "metric_type": "p_win_recommended",
+      "n_evpi_samples": 500
+    },
+    {
+      "factor_id": "fac_tech_lead",
+      "evpi": 0.0085,
+      "evpi_percentage_points": 0.85,
+      "current_metric": 0.5795,
+      "perfect_metric": 0.588,
+      "metric_type": "p_win_recommended",
+      "n_evpi_samples": 500
+    },
+    {
+      "factor_id": "fac_hiring_cost",
+      "evpi": -0.0015,
+      "evpi_percentage_points": -0.15,
+      "current_metric": 0.5795,
+      "perfect_metric": 0.578,
+      "metric_type": "p_win_recommended",
+      "n_evpi_samples": 500
+    }
+  ],
+  "auto_noise_applied": false,
+  "request_id": "4211dad2-de7b-4b0f-aac9-3eab9b4574be",
+  "processing_time_ms": 1463,
+  "seed_used": "2034401427",
+  "seed_source": "client_provided"
+}

--- a/tests/fixtures/isl-v2-live-20260706/isl-v2-request-b.json
+++ b/tests/fixtures/isl-v2-live-20260706/isl-v2-request-b.json
@@ -1,0 +1,298 @@
+{
+  "request_id": "06616631-461c-46bc-8490-efaed2b56d20",
+  "graph": {
+    "nodes": [
+      {
+        "id": "fac_dev_headcount",
+        "kind": "factor",
+        "label": "Developer Headcount Added",
+        "observed_state": {
+          "value": 0,
+          "unit": "FTE",
+          "raw_value": 0,
+          "cap": 2,
+          "factor_type": "demand",
+          "uncertainty_drivers": [
+            "Candidate pipeline quality",
+            "Ramp-up time before full contribution"
+          ]
+        },
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "fac_hiring_cost",
+        "kind": "factor",
+        "label": "Hiring and Salary Cost",
+        "observed_state": {
+          "value": 0,
+          "unit": "\u00a3",
+          "raw_value": 0,
+          "cap": 200000,
+          "factor_type": "cost",
+          "uncertainty_drivers": [
+            "Market salary rates for tech leads vs developers",
+            "Recruitment agency fees unknown"
+          ]
+        },
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "fac_team_maturity",
+        "kind": "factor",
+        "label": "Team Technical Maturity",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "fac_tech_lead",
+        "kind": "factor",
+        "label": "Tech Lead in Place",
+        "observed_state": {
+          "value": 0,
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Availability of suitable candidates",
+            "Time to hire and onboard"
+          ]
+        },
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "goal_productivity",
+        "kind": "goal",
+        "label": "Increase Team Productivity",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "out_technical_quality",
+        "kind": "outcome",
+        "label": "Technical Quality and Architecture",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "out_throughput",
+        "kind": "outcome",
+        "label": "Development Throughput",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "risk_coordination",
+        "kind": "risk",
+        "label": "Team Coordination Overhead",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "risk_cost_burden",
+        "kind": "risk",
+        "label": "Salary and Overhead Cost Burden",
+        "intercept": 0,
+        "epsilon_std": 0
+      }
+    ],
+    "edges": [
+      {
+        "from": "fac_dev_headcount",
+        "to": "out_technical_quality",
+        "exists_probability": 0.6,
+        "strength": {
+          "mean": 0.12,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "fac_dev_headcount",
+        "to": "out_throughput",
+        "exists_probability": 0.85,
+        "strength": {
+          "mean": 0.5072815533980582,
+          "std": 0.16601941747572813
+        }
+      },
+      {
+        "from": "fac_dev_headcount",
+        "to": "risk_coordination",
+        "exists_probability": 0.8,
+        "strength": {
+          "mean": 0.3,
+          "std": 0.12
+        }
+      },
+      {
+        "from": "fac_hiring_cost",
+        "to": "risk_cost_burden",
+        "exists_probability": 0.95,
+        "strength": {
+          "mean": 0.7,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "fac_team_maturity",
+        "to": "out_throughput",
+        "exists_probability": 0.8,
+        "strength": {
+          "mean": 0.18446601941747573,
+          "std": 0.09223300970873786
+        }
+      },
+      {
+        "from": "fac_team_maturity",
+        "to": "risk_coordination",
+        "exists_probability": 0.72,
+        "strength": {
+          "mean": -0.18,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "fac_tech_lead",
+        "to": "out_technical_quality",
+        "exists_probability": 0.85,
+        "strength": {
+          "mean": 0.6,
+          "std": 0.15
+        }
+      },
+      {
+        "from": "fac_tech_lead",
+        "to": "out_throughput",
+        "exists_probability": 0.75,
+        "strength": {
+          "mean": 0.258252427184466,
+          "std": 0.129126213592233
+        }
+      },
+      {
+        "from": "fac_tech_lead",
+        "to": "risk_coordination",
+        "exists_probability": 0.7,
+        "strength": {
+          "mean": -0.15,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "out_technical_quality",
+        "to": "goal_productivity",
+        "exists_probability": 0.88,
+        "strength": {
+          "mean": 0.3,
+          "std": 0.12
+        }
+      },
+      {
+        "from": "out_throughput",
+        "to": "goal_productivity",
+        "exists_probability": 0.95,
+        "strength": {
+          "mean": 0.55,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "risk_coordination",
+        "to": "goal_productivity",
+        "exists_probability": 0.85,
+        "strength": {
+          "mean": -0.2,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "risk_cost_burden",
+        "to": "goal_productivity",
+        "exists_probability": 0.9,
+        "strength": {
+          "mean": -0.25,
+          "std": 0.12
+        }
+      }
+    ]
+  },
+  "options": [
+    {
+      "id": "opt_one_dev",
+      "label": "Hire One Developer (Reduced Commitment)",
+      "interventions": {
+        "fac_tech_lead": 0,
+        "fac_dev_headcount": 0.5
+      }
+    },
+    {
+      "id": "opt_status_quo",
+      "label": "No New Hire (Status Quo)",
+      "interventions": {
+        "fac_tech_lead": 0,
+        "fac_dev_headcount": 0
+      }
+    },
+    {
+      "id": "opt_tech_lead",
+      "label": "Hire One Tech Lead",
+      "interventions": {
+        "fac_tech_lead": 1,
+        "fac_dev_headcount": 0
+      }
+    },
+    {
+      "id": "opt_two_devs",
+      "label": "Hire Two Developers",
+      "interventions": {
+        "fac_tech_lead": 0,
+        "fac_dev_headcount": 1
+      }
+    }
+  ],
+  "goal_node_id": "goal_productivity",
+  "n_samples": 4000,
+  "analysis_types": [
+    "comparison",
+    "sensitivity",
+    "robustness"
+  ],
+  "parameter_uncertainties": [
+    {
+      "node_id": "fac_dev_headcount",
+      "distribution": "normal",
+      "mean": 0,
+      "std": 0.5
+    },
+    {
+      "node_id": "fac_hiring_cost",
+      "distribution": "normal",
+      "mean": 0,
+      "std": 0.5
+    },
+    {
+      "node_id": "fac_tech_lead",
+      "distribution": "normal",
+      "mean": 0,
+      "std": 0.5
+    },
+    {
+      "node_id": "fac_team_maturity",
+      "distribution": "normal",
+      "mean": 0.5,
+      "std": 0.14433756729740646
+    }
+  ],
+  "include_e_values": true,
+  "include_voi": true,
+  "goal_constraints": [
+    {
+      "constraint_id": "gc-63be341c-aff7-4dfe-9a9f-06373faa9c17",
+      "node_id": "fac_hiring_cost",
+      "operator": "<=",
+      "value": 1,
+      "label": "Budget ceiling for new hires"
+    }
+  ],
+  "seed": "2034401427"
+}

--- a/tests/fixtures/isl-v2-live-20260706/isl-v2-request.json
+++ b/tests/fixtures/isl-v2-live-20260706/isl-v2-request.json
@@ -1,0 +1,289 @@
+{
+  "request_id": "4211dad2-de7b-4b0f-aac9-3eab9b4574be",
+  "graph": {
+    "nodes": [
+      {
+        "id": "fac_dev_headcount",
+        "kind": "factor",
+        "label": "Developer Headcount Added",
+        "observed_state": {
+          "value": 0,
+          "unit": "FTE",
+          "raw_value": 0,
+          "cap": 2,
+          "factor_type": "demand",
+          "uncertainty_drivers": [
+            "Candidate pipeline quality",
+            "Ramp-up time before full contribution"
+          ]
+        },
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "fac_hiring_cost",
+        "kind": "factor",
+        "label": "Hiring and Salary Cost",
+        "observed_state": {
+          "value": 0,
+          "unit": "\u00a3",
+          "raw_value": 0,
+          "cap": 200000,
+          "factor_type": "cost",
+          "uncertainty_drivers": [
+            "Market salary rates for tech leads vs developers",
+            "Recruitment agency fees unknown"
+          ]
+        },
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "fac_team_maturity",
+        "kind": "factor",
+        "label": "Team Technical Maturity",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "fac_tech_lead",
+        "kind": "factor",
+        "label": "Tech Lead in Place",
+        "observed_state": {
+          "value": 0,
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Availability of suitable candidates",
+            "Time to hire and onboard"
+          ]
+        },
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "goal_productivity",
+        "kind": "goal",
+        "label": "Increase Team Productivity",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "out_technical_quality",
+        "kind": "outcome",
+        "label": "Technical Quality and Architecture",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "out_throughput",
+        "kind": "outcome",
+        "label": "Development Throughput",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "risk_coordination",
+        "kind": "risk",
+        "label": "Team Coordination Overhead",
+        "intercept": 0,
+        "epsilon_std": 0
+      },
+      {
+        "id": "risk_cost_burden",
+        "kind": "risk",
+        "label": "Salary and Overhead Cost Burden",
+        "intercept": 0,
+        "epsilon_std": 0
+      }
+    ],
+    "edges": [
+      {
+        "from": "fac_dev_headcount",
+        "to": "out_technical_quality",
+        "exists_probability": 0.6,
+        "strength": {
+          "mean": 0.12,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "fac_dev_headcount",
+        "to": "out_throughput",
+        "exists_probability": 0.85,
+        "strength": {
+          "mean": 0.5072815533980582,
+          "std": 0.16601941747572813
+        }
+      },
+      {
+        "from": "fac_dev_headcount",
+        "to": "risk_coordination",
+        "exists_probability": 0.8,
+        "strength": {
+          "mean": 0.3,
+          "std": 0.12
+        }
+      },
+      {
+        "from": "fac_hiring_cost",
+        "to": "risk_cost_burden",
+        "exists_probability": 0.95,
+        "strength": {
+          "mean": 0.7,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "fac_team_maturity",
+        "to": "out_throughput",
+        "exists_probability": 0.8,
+        "strength": {
+          "mean": 0.18446601941747573,
+          "std": 0.09223300970873786
+        }
+      },
+      {
+        "from": "fac_team_maturity",
+        "to": "risk_coordination",
+        "exists_probability": 0.72,
+        "strength": {
+          "mean": -0.18,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "fac_tech_lead",
+        "to": "out_technical_quality",
+        "exists_probability": 0.85,
+        "strength": {
+          "mean": 0.6,
+          "std": 0.15
+        }
+      },
+      {
+        "from": "fac_tech_lead",
+        "to": "out_throughput",
+        "exists_probability": 0.75,
+        "strength": {
+          "mean": 0.258252427184466,
+          "std": 0.129126213592233
+        }
+      },
+      {
+        "from": "fac_tech_lead",
+        "to": "risk_coordination",
+        "exists_probability": 0.7,
+        "strength": {
+          "mean": -0.15,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "out_technical_quality",
+        "to": "goal_productivity",
+        "exists_probability": 0.88,
+        "strength": {
+          "mean": 0.3,
+          "std": 0.12
+        }
+      },
+      {
+        "from": "out_throughput",
+        "to": "goal_productivity",
+        "exists_probability": 0.95,
+        "strength": {
+          "mean": 0.55,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "risk_coordination",
+        "to": "goal_productivity",
+        "exists_probability": 0.85,
+        "strength": {
+          "mean": -0.2,
+          "std": 0.1
+        }
+      },
+      {
+        "from": "risk_cost_burden",
+        "to": "goal_productivity",
+        "exists_probability": 0.9,
+        "strength": {
+          "mean": -0.25,
+          "std": 0.12
+        }
+      }
+    ]
+  },
+  "options": [
+    {
+      "id": "opt_one_dev",
+      "label": "Hire One Developer (Reduced Commitment)",
+      "interventions": {
+        "fac_tech_lead": 0,
+        "fac_dev_headcount": 0.5
+      }
+    },
+    {
+      "id": "opt_status_quo",
+      "label": "No New Hire (Status Quo)",
+      "interventions": {
+        "fac_tech_lead": 0,
+        "fac_dev_headcount": 0
+      }
+    },
+    {
+      "id": "opt_tech_lead",
+      "label": "Hire One Tech Lead",
+      "interventions": {
+        "fac_tech_lead": 1,
+        "fac_dev_headcount": 0
+      }
+    },
+    {
+      "id": "opt_two_devs",
+      "label": "Hire Two Developers",
+      "interventions": {
+        "fac_tech_lead": 0,
+        "fac_dev_headcount": 1
+      }
+    }
+  ],
+  "goal_node_id": "goal_productivity",
+  "n_samples": 4000,
+  "analysis_types": [
+    "comparison",
+    "sensitivity",
+    "robustness"
+  ],
+  "parameter_uncertainties": [
+    {
+      "node_id": "fac_dev_headcount",
+      "distribution": "normal",
+      "mean": 0,
+      "std": 0.5
+    },
+    {
+      "node_id": "fac_hiring_cost",
+      "distribution": "normal",
+      "mean": 0,
+      "std": 0.5
+    },
+    {
+      "node_id": "fac_tech_lead",
+      "distribution": "normal",
+      "mean": 0,
+      "std": 0.5
+    },
+    {
+      "node_id": "fac_team_maturity",
+      "distribution": "normal",
+      "mean": 0.5,
+      "std": 0.14433756729740646
+    }
+  ],
+  "include_e_values": true,
+  "include_voi": true,
+  "seed": "2034401427"
+}

--- a/tests/isl-v2-envelope.unit.test.ts
+++ b/tests/isl-v2-envelope.unit.test.ts
@@ -1,0 +1,243 @@
+/**
+ * ISL V2 envelope accessors — wire-location truth pinned against the RAW live
+ * staging capture (tests/fixtures/isl-v2-live-20260706, ISL build f3f5d92,
+ * captured 2026-07-06 from PLoT boundary logs).
+ *
+ * These tests are the machine-checked record of WHY the V1-shaped reads in
+ * run.ts were dead:
+ *  - top-level `edge_e_values` / `sensitivity` / `validation_status` /
+ *    `computed_at` NEVER appear on the live V2 wire;
+ *  - edge E-values are NESTED at robustness.edge_e_values;
+ *  - the timestamp is top-level `timestamp`;
+ *  - per-factor EVPI arrives at top-level `factor_evpi` (including a raw
+ *    NEGATIVE entry — MC sampling noise — that must never leak outward).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  getIslEdgeEValues,
+  getIslComputedAt,
+  mapIslFactorEvpi,
+} from '../src/integrations/isl/v2-envelope.js';
+import {
+  classifyEvpiPercentagePointsForEmission,
+  EVPI_EMISSION_RESOLUTION_PP,
+} from '../src/lib/evpi-emission.js';
+
+const FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'isl-v2-live-20260706',
+);
+
+const captureA = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-staging-capture.json'), 'utf8'),
+);
+const captureB = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-staging-capture-b.json'), 'utf8'),
+);
+const requestA = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-v2-request.json'), 'utf8'),
+);
+
+describe('live V2 wire shape (fixture integrity — raw capture, do not "fix")', () => {
+  it('request pinned response_version=2 semantics: e-values and VOI were requested', () => {
+    expect(requestA.include_e_values).toBe(true);
+    expect(requestA.include_voi).toBe(true);
+    expect(requestA.analysis_types).toEqual(['comparison', 'sensitivity', 'robustness']);
+  });
+
+  it.each([['A', captureA], ['B', captureB]])(
+    'capture %s: V1-shaped top-level fields are ABSENT on the live V2 wire',
+    (_name, capture) => {
+      expect('edge_e_values' in capture).toBe(false);
+      expect('sensitivity' in capture).toBe(false);
+      expect('validation_status' in capture).toBe(false);
+      expect('computed_at' in capture).toBe(false);
+    },
+  );
+
+  it.each([['A', captureA], ['B', captureB]])(
+    'capture %s: V2 locations are PRESENT (nested e-values, factor_evpi, timestamp)',
+    (_name, capture) => {
+      expect(Array.isArray(capture.robustness.edge_e_values)).toBe(true);
+      expect(capture.robustness.edge_e_values.length).toBeGreaterThan(0);
+      expect(Array.isArray(capture.factor_evpi)).toBe(true);
+      expect(capture.factor_evpi.length).toBeGreaterThan(0);
+      expect(typeof capture.timestamp).toBe('string');
+      expect(capture.version).toBe('2.0');
+      expect(capture.endpoint_version).toBe('analyze/v2');
+    },
+  );
+
+  it('capture A: nested edge_e_values entries carry the documented V2 shape', () => {
+    let flippable = 0;
+    let unflippable = 0;
+    for (const e of captureA.robustness.edge_e_values) {
+      expect(typeof e.edge_id).toBe('string');
+      expect(typeof e.from_id).toBe('string');
+      expect(typeof e.to_id).toBe('string');
+      expect(Number.isFinite(e.current_mean)).toBe(true);
+      expect(Number.isFinite(e.flip_mean)).toBe(true);
+      expect(typeof e.flip_direction).toBe('string');
+      expect(typeof e.is_unflippable).toBe('boolean');
+      // WIRE FACT: e_value is OMITTED on is_unflippable entries (no finite
+      // flip exists, so no e-value). PLoT's numeric-egress guard therefore
+      // drops unflippable entries from the outward edge_e_values array —
+      // representing them outward needs contract work (recorded followup).
+      if (e.is_unflippable) {
+        expect('e_value' in e).toBe(false);
+        unflippable += 1;
+      } else {
+        expect(Number.isFinite(e.e_value)).toBe(true);
+        flippable += 1;
+      }
+    }
+    expect(flippable).toBe(9);
+    expect(unflippable).toBe(4);
+  });
+
+  it('capture A: factor_evpi carries a raw NEGATIVE entry (MC noise) — the hygiene target', () => {
+    const negative = captureA.factor_evpi.filter((f: any) => f.evpi < 0);
+    expect(negative.length).toBeGreaterThan(0);
+    expect(negative[0].factor_id).toBe('fac_hiring_cost');
+    expect(negative[0].evpi).toBe(-0.0015);
+    expect(negative[0].evpi_percentage_points).toBe(-0.15);
+  });
+});
+
+describe('getIslEdgeEValues', () => {
+  it('reads the NESTED robustness.edge_e_values location on the live capture', () => {
+    const result = getIslEdgeEValues(captureA);
+    expect(result).toBe(captureA.robustness.edge_e_values);
+    expect(result!.length).toBe(13);
+  });
+
+  it('prefers nested over legacy top-level when both exist', () => {
+    const nested = [{ edge_id: 'a->b', e_value: 2, current_mean: 0.1, flip_mean: 0.2, flip_direction: 'increase' }];
+    const legacy = [{ edge_id: 'x->y', e_value: 9, current_mean: 0.9, flip_mean: 0.8, flip_direction: 'removal' }];
+    const result = getIslEdgeEValues({ robustness: { edge_e_values: nested } as any, edge_e_values: legacy as any });
+    expect(result).toBe(nested);
+  });
+
+  it('falls back to the legacy top-level location for old fixtures', () => {
+    const legacy = [{ edge_id: 'x->y', e_value: 9, current_mean: 0.9, flip_mean: 0.8, flip_direction: 'removal' }];
+    expect(getIslEdgeEValues({ edge_e_values: legacy as any })).toBe(legacy);
+  });
+
+  it('returns undefined when neither location carries an array', () => {
+    expect(getIslEdgeEValues({})).toBeUndefined();
+    expect(getIslEdgeEValues(undefined)).toBeUndefined();
+    expect(getIslEdgeEValues(null)).toBeUndefined();
+    expect(getIslEdgeEValues({ robustness: {} as any })).toBeUndefined();
+  });
+});
+
+describe('getIslComputedAt', () => {
+  it('reads top-level timestamp on the live capture', () => {
+    expect(getIslComputedAt(captureA)).toBe(captureA.timestamp);
+    expect(getIslComputedAt(captureA)).toBe('2026-07-06T23:32:39.636888Z');
+  });
+
+  it('falls back to legacy computed_at for old fixtures', () => {
+    expect(getIslComputedAt({ computed_at: '2026-01-01T00:00:00Z' })).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('returns undefined when neither is a non-empty string (caller falls back to own clock)', () => {
+    expect(getIslComputedAt({})).toBeUndefined();
+    expect(getIslComputedAt({ timestamp: '' as any })).toBeUndefined();
+    expect(getIslComputedAt({ timestamp: 123 as any })).toBeUndefined();
+    expect(getIslComputedAt(undefined)).toBeUndefined();
+  });
+});
+
+describe('mapIslFactorEvpi (guarded internal mapping — P-5 pending, NOT user-facing)', () => {
+  it('proves the live wire delivers factor_evpi: 4 sanitised entries from capture A', () => {
+    const { entries, dropped_invalid } = mapIslFactorEvpi(captureA);
+    expect(entries).toHaveLength(4);
+    expect(dropped_invalid).toBe(0);
+    expect(entries.map((e) => e.factor_id).sort()).toEqual([
+      'fac_dev_headcount',
+      'fac_hiring_cost',
+      'fac_team_maturity',
+      'fac_tech_lead',
+    ]);
+  });
+
+  it('negative raw EVPI (fac_hiring_cost -0.15pp) → below_resolution, NEVER an emittable negative', () => {
+    const { entries } = mapIslFactorEvpi(captureA);
+    const hiring = entries.find((e) => e.factor_id === 'fac_hiring_cost')!;
+    expect(hiring.below_resolution).toBe(true);
+    expect(hiring.emit_pp).toBeUndefined();
+    // Raw values retained for diagnostics only
+    expect(hiring.raw_evpi).toBe(-0.0015);
+    expect(hiring.raw_evpi_percentage_points).toBe(-0.15);
+  });
+
+  it('no entry ever exposes a negative emittable value', () => {
+    const { entries } = mapIslFactorEvpi(captureA);
+    for (const e of entries) {
+      if (e.emit_pp !== undefined) {
+        expect(e.emit_pp).toBeGreaterThanOrEqual(EVPI_EMISSION_RESOLUTION_PP);
+      }
+    }
+  });
+
+  it('above-resolution entries emit rounded percentage points', () => {
+    const { entries } = mapIslFactorEvpi(captureA);
+    const dev = entries.find((e) => e.factor_id === 'fac_dev_headcount')!;
+    expect(dev.below_resolution).toBe(false);
+    expect(dev.emit_pp).toBe(1.9); // raw 1.85pp rounded to 0.1pp
+    expect(dev.metric_type).toBe('p_win_recommended');
+    expect(dev.n_evpi_samples).toBe(500);
+  });
+
+  it('tolerates absent/empty/garbage input without crashing', () => {
+    expect(mapIslFactorEvpi({})).toEqual({ entries: [], dropped_invalid: 0 });
+    expect(mapIslFactorEvpi(undefined)).toEqual({ entries: [], dropped_invalid: 0 });
+    expect(mapIslFactorEvpi({ factor_evpi: [] })).toEqual({ entries: [], dropped_invalid: 0 });
+    const garbage = mapIslFactorEvpi({
+      factor_evpi: [
+        null,
+        { factor_id: 'ok', evpi: 0.01, evpi_percentage_points: 1.0, current_metric: 0.5, perfect_metric: 0.51, metric_type: 'x', n_evpi_samples: 10 },
+        { factor_id: 'bad', evpi: Number.NaN, evpi_percentage_points: 1.0 },
+        { evpi: 0.01, evpi_percentage_points: 1.0 },
+      ] as any,
+    });
+    expect(garbage.entries).toHaveLength(1);
+    expect(garbage.dropped_invalid).toBe(3);
+  });
+});
+
+describe('classifyEvpiPercentagePointsForEmission', () => {
+  it('labels negatives below-resolution instead of clamping to zero', () => {
+    const c = classifyEvpiPercentagePointsForEmission(-0.15);
+    expect(c.emit).toBeUndefined();
+    expect(c.below_resolution).toBe(true);
+    expect(c.raw).toBe(-0.15);
+  });
+
+  it('labels tiny positives below-resolution (indistinguishable from zero at 0.1pp)', () => {
+    const c = classifyEvpiPercentagePointsForEmission(0.03);
+    expect(c.emit).toBeUndefined();
+    expect(c.below_resolution).toBe(true);
+  });
+
+  it('emits rounded values at/above resolution', () => {
+    expect(classifyEvpiPercentagePointsForEmission(1.85).emit).toBe(1.9);
+    expect(classifyEvpiPercentagePointsForEmission(0.85).emit).toBe(0.9);
+    expect(classifyEvpiPercentagePointsForEmission(EVPI_EMISSION_RESOLUTION_PP).below_resolution).toBe(false);
+  });
+
+  it('non-finite input is absence, not a below-resolution measurement', () => {
+    for (const v of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const c = classifyEvpiPercentagePointsForEmission(v);
+      expect(c.emit).toBeUndefined();
+      expect(c.below_resolution).toBe(false);
+    }
+  });
+});

--- a/tests/isl-v2-liveness.fixture.test.ts
+++ b/tests/isl-v2-liveness.fixture.test.ts
@@ -1,0 +1,369 @@
+/**
+ * ISL V2 science-channel LIVENESS test (Lane 2, item G).
+ *
+ * Drives /v2/run with the RAW live staging capture
+ * (tests/fixtures/isl-v2-live-20260706, ISL build f3f5d92, 2026-07-06) mocked
+ * as the ISL response, and asserts that EVERY science feature requested on
+ * the wire (analysis_types comparison/sensitivity/robustness +
+ * include_e_values + include_voi) is either NON-EMPTY in the public response
+ * or EXPLICITLY marked unavailable/skipped/error.
+ *
+ * SILENT EMPTY ARRAYS FAIL. Before the V2-envelope fix, edge_e_values was
+ * structurally [] on every live response (the read targeted a V1-era
+ * top-level field the V2 wire never emits) and this test goes RED.
+ *
+ * Also covers:
+ *  - item C: no negative EVPI/VOI value anywhere in the public response;
+ *  - item D: confidence_tier never 'strong' on this capture
+ *    (robustness.is_robust=false, level='low');
+ *  - item F: the new ISL warning code CONSTRAINT_SAMPLES_UNNOISED passes
+ *    through without crash or drop;
+ *  - flag hygiene: raw factor_evpi never leaks into the public response.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'isl-v2-live-20260706',
+);
+
+const captureA = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-staging-capture.json'), 'utf8'),
+);
+const requestA = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-v2-request.json'), 'utf8'),
+);
+
+// When set, the mock appends this warning to the fixture's inference_warnings
+// (the raw capture itself stays untouched).
+let injectWarning: { code: string; message: string; severity?: string } | null = null;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(): Promise<{ data: T | null; error: string | null }> {
+    const payload = JSON.parse(JSON.stringify(captureA));
+    if (injectWarning) {
+      payload.inference_warnings = [...(payload.inference_warnings ?? []), injectWarning];
+    }
+    return { data: payload as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// PLoT request body derived from the captured ISL request (same graph shape,
+// mapped back from ISL wire format to PLoT /v2/run format).
+// ---------------------------------------------------------------------------
+
+function buildPlotBody() {
+  return {
+    graph: {
+      nodes: requestA.graph.nodes.map((n: any) => ({
+        id: n.id,
+        kind: n.kind,
+        label: n.label,
+        ...(n.observed_state?.value !== undefined && n.observed_state?.value !== null
+          ? { observed_state: { value: n.observed_state.value } }
+          : {}),
+      })),
+      edges: requestA.graph.edges.map((e: any) => ({
+        from: e.from,
+        to: e.to,
+        exists_probability: e.exists_probability,
+        strength: { mean: e.strength.mean, std: e.strength.std },
+      })),
+    },
+    options: requestA.options.map((o: any) => ({
+      id: o.id,
+      label: o.label,
+      interventions: Object.fromEntries(
+        Object.entries(o.interventions).map(([nodeId, value]) => [
+          nodeId,
+          { value, source: 'user_specified' },
+        ]),
+      ),
+    })),
+    goal_node_id: requestA.goal_node_id,
+    seed: String(requestA.seed),
+  };
+}
+
+/** Recursively collect [path, value] pairs for keys matching a predicate. */
+function collectFields(
+  value: unknown,
+  matcher: (key: string) => boolean,
+  path = '$',
+  out: Array<[string, unknown]> = [],
+): Array<[string, unknown]> {
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => collectFields(v, matcher, `${path}[${i}]`, out));
+  } else if (value !== null && typeof value === 'object') {
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (matcher(k)) out.push([`${path}.${k}`, v]);
+      collectFields(v, matcher, `${path}.${k}`, out);
+    }
+  }
+  return out;
+}
+
+describe('ISL V2 science-channel liveness (live capture, build f3f5d92)', () => {
+  let app: FastifyInstance;
+  let body: any;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    // Flag hygiene under test: the internal factor_evpi mapping stays OFF
+    delete process.env.ISL_FACTOR_EVPI_INTERNAL;
+    app = await createServer();
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: buildPlotBody(),
+    });
+    expect(res.statusCode).toBe(200);
+    body = JSON.parse(res.body);
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Liveness matrix: every requested science feature is non-empty OR
+  // explicitly marked. Silent empty arrays FAIL.
+  // -------------------------------------------------------------------------
+
+  it("analysis_types 'comparison' → option_comparison non-empty and status computed", () => {
+    expect(body.option_comparison_status).toBe('computed');
+    expect(Array.isArray(body.option_comparison)).toBe(true);
+    expect(body.option_comparison.length).toBe(4);
+  });
+
+  it("analysis_types 'robustness' → robustness populated and status computed", () => {
+    expect(body.robustness_status).toBe('computed');
+    expect(body.robustness).toBeDefined();
+    expect(body.robustness.fragile_edges.length).toBe(7);
+    expect(body.robustness.robust_edges.length).toBe(4);
+    // V2 summary passthrough
+    expect(body.robustness.is_robust).toBe(false);
+    expect(body.robustness.level).toBe('low');
+    expect(typeof body.robustness.confidence).toBe('number');
+  });
+
+  it("analysis_types 'sensitivity' (factor-level) → factor_sensitivity non-empty and drivers computed", () => {
+    expect(body.drivers_status).toBe('computed');
+    expect(Array.isArray(body.factor_sensitivity)).toBe(true);
+    expect(body.factor_sensitivity.length).toBeGreaterThan(0);
+  });
+
+  it("analysis_types 'sensitivity' (edge-level) → empty ONLY WITH the explicit V2-wire marker", () => {
+    // The V2 wire genuinely drops edge-level sensitivity (no substitute is
+    // invented — ISL contract followup). Empty is tolerable ONLY because it
+    // is explicitly marked; a silent empty array fails here.
+    expect(Array.isArray(body.edge_sensitivity)).toBe(true);
+    if (body.edge_sensitivity.length === 0) {
+      const marker = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE',
+      );
+      expect(marker).toHaveLength(1);
+      expect(marker[0].severity).toBe('info');
+    }
+  });
+
+  it('include_e_values → edge_e_values NON-EMPTY (the pre-fix silent-empty defect)', () => {
+    // RED before the V2-envelope fix: the old read targeted top-level
+    // edge_e_values, which the live V2 wire never emits → always [].
+    expect(Array.isArray(body.edge_e_values)).toBe(true);
+    // 13 wire entries; the 4 is_unflippable entries carry no e_value on the
+    // wire and are dropped by the numeric-egress guard (logged, followup).
+    expect(body.edge_e_values.length).toBe(9);
+    for (const e of body.edge_e_values) {
+      expect(typeof e.edge_id).toBe('string');
+      expect(e.edge_id).toContain('::');
+      expect(typeof e.from_label).toBe('string');
+      expect(typeof e.to_label).toBe('string');
+      expect(Number.isFinite(e.e_value)).toBe(true);
+      expect(Number.isFinite(e.current_mean)).toBe(true);
+      expect(Number.isFinite(e.flip_mean)).toBe(true);
+    }
+  });
+
+  it('include_voi → factor VOI present via graph heuristic OR explicitly absent with zero_reason', () => {
+    // VOI on the live wire arrives ONLY as factor_evpi (not wired to users —
+    // P-5 pending). The public value_of_information comes from the graph
+    // heuristic; every factor entry must either carry a VOI value or carry an
+    // explicit zero_reason — silent absence on every entry fails.
+    const withVoi = body.factor_sensitivity.filter(
+      (f: any) => typeof f.value_of_information === 'number',
+    );
+    const explained = body.factor_sensitivity.filter(
+      (f: any) => f.value_of_information == null && f.zero_reason != null,
+    );
+    expect(withVoi.length + explained.length).toBe(body.factor_sensitivity.length);
+    expect(withVoi.length).toBeGreaterThan(0);
+  });
+
+  it('meta.computed_at carries the ISL wire timestamp (V2 `timestamp`, not PLoT clock)', () => {
+    expect(body.meta.computed_at).toBe('2026-07-06T23:32:39.636888Z');
+  });
+
+  // -------------------------------------------------------------------------
+  // Item C: negative-EVPI hygiene at the PLoT surface
+  // -------------------------------------------------------------------------
+
+  it('no negative EVPI/VOI value anywhere in the public response', () => {
+    const fields = collectFields(body, (k) =>
+      k === 'evpi' ||
+      k === 'evpi_percentage_points' ||
+      k === 'value_of_information',
+    );
+    for (const [path, value] of fields) {
+      if (typeof value === 'number') {
+        expect(value, `${path} must never be negative`).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it('raw factor_evpi never leaks into the public response (flag off — P-5 pending)', () => {
+    expect(collectFields(body, (k) => k === 'factor_evpi')).toHaveLength(0);
+    // The raw negative wire EVPI values must not appear under any EVPI/VOI
+    // key anywhere in the payload. (NOTE: a plain substring check would
+    // false-positive — the graph legitimately carries an edge mean of -0.15;
+    // the leak check must be structural, keyed to EVPI/VOI fields.)
+    const evpiFields = collectFields(body, (k) =>
+      k === 'evpi' || k === 'evpi_percentage_points' || k === 'value_of_information' ||
+      k === 'raw_evpi' || k === 'raw_evpi_percentage_points',
+    );
+    for (const [path, value] of evpiFields) {
+      expect(value, `${path} must not carry the raw wire negatives`).not.toBe(-0.0015);
+      expect(value, `${path} must not carry the raw wire negatives`).not.toBe(-0.15);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Item D: confidence_tier reconciliation on a non-robust response
+  // -------------------------------------------------------------------------
+
+  it("confidence_tier is never 'strong' when the same response says is_robust=false / level=low", () => {
+    // This capture is the contradiction case: is_robust=false, level='low'.
+    if (body.confidence_tier !== undefined) {
+      expect(body.confidence_tier).not.toBe('strong');
+    }
+    // Sanity: the robustness signals the cap keys off are present
+    expect(body.robustness.is_robust).toBe(false);
+    expect(body.robustness.level).toBe('low');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Item F: CONSTRAINT_SAMPLES_UNNOISED tolerance (fresh server, same fixture)
+// ---------------------------------------------------------------------------
+
+describe('CONSTRAINT_SAMPLES_UNNOISED warning tolerance', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    injectWarning = null;
+  });
+
+  it('passes the new ISL warning code through without crash or drop', async () => {
+    injectWarning = {
+      code: 'CONSTRAINT_SAMPLES_UNNOISED',
+      message: 'Constraint node samples were not auto-noised for this run',
+      severity: 'info',
+    };
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v2/run',
+        headers: { 'Content-Type': 'application/json' },
+        payload: buildPlotBody(),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      const forwarded = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_SAMPLES_UNNOISED',
+      );
+      expect(forwarded).toHaveLength(1);
+      expect(forwarded[0]).toEqual({
+        code: 'CONSTRAINT_SAMPLES_UNNOISED',
+        message: 'Constraint node samples were not auto-noised for this run',
+        severity: 'info',
+      });
+      // The rest of the science payload is unaffected (no drop)
+      expect(body.analysis_status).toBe('computed');
+      expect(body.edge_e_values.length).toBe(9);
+      expect(body.option_comparison.length).toBe(4);
+    } finally {
+      injectWarning = null;
+    }
+  }, 60_000);
+
+  it('unknown severity values degrade to info, never crash', async () => {
+    injectWarning = {
+      code: 'CONSTRAINT_SAMPLES_UNNOISED',
+      message: 'Constraint node samples were not auto-noised for this run',
+      severity: 'bizarre_future_severity',
+    };
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v2/run',
+        headers: { 'Content-Type': 'application/json' },
+        payload: buildPlotBody(),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      const forwarded = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_SAMPLES_UNNOISED',
+      );
+      expect(forwarded).toHaveLength(1);
+      expect(forwarded[0].severity).toBe('info');
+    } finally {
+      injectWarning = null;
+    }
+  }, 60_000);
+});

--- a/tests/stability-thresholds-passthrough.test.ts
+++ b/tests/stability-thresholds-passthrough.test.ts
@@ -333,10 +333,16 @@ describe('stability_thresholds passthrough + hash_version in _meta', () => {
       // stability_thresholds should be absent
       expect('stability_thresholds' in body).toBe(false);
 
-      // inference_warnings should contain the diagnostic warning
+      // inference_warnings should contain the diagnostic warning.
+      // Filter by code: the EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE marker (the
+      // V2 wire drops edge-level sensitivity) also appears on every computed
+      // response whose edge_sensitivity is empty — including this one.
       expect(body.inference_warnings).toBeDefined();
-      expect(body.inference_warnings).toHaveLength(1);
-      expect(body.inference_warnings[0]).toEqual({
+      const stabilityWarnings = body.inference_warnings.filter(
+        (w: any) => w.code === 'STABILITY_THRESHOLDS_MISSING',
+      );
+      expect(stabilityWarnings).toHaveLength(1);
+      expect(stabilityWarnings[0]).toEqual({
         code: 'STABILITY_THRESHOLDS_MISSING',
         message: 'ISL returned factor-level stability fields but stability_thresholds metadata was absent or malformed — threshold classification context unavailable',
         severity: 'info',
@@ -367,8 +373,13 @@ describe('stability_thresholds passthrough + hash_version in _meta', () => {
       // stability_thresholds should be absent
       expect('stability_thresholds' in body).toBe(false);
 
-      // inference_warnings should be empty array (sentinel contract: always present)
-      expect(body.inference_warnings).toEqual([]);
+      // No STABILITY_THRESHOLDS_MISSING warning (sentinel contract: the array
+      // is always present; it now also carries the always-on
+      // EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE marker, so filter by code).
+      expect(Array.isArray(body.inference_warnings)).toBe(true);
+      expect(
+        body.inference_warnings.filter((w: any) => w.code === 'STABILITY_THRESHOLDS_MISSING'),
+      ).toEqual([]);
     } finally {
       forceOmitThresholds = false;
       forceStrip3CFields = false;
@@ -397,10 +408,12 @@ describe('stability_thresholds passthrough + hash_version in _meta', () => {
       // Malformed thresholds should be rejected (not passed through)
       expect('stability_thresholds' in body).toBe(false);
 
-      // Warning should fire because 3C fields are present but thresholds were rejected
+      // Warning should fire because 3C fields are present but thresholds were
+      // rejected (filter by code — see IW1 note on the always-on V2-wire marker)
       expect(body.inference_warnings).toBeDefined();
-      expect(body.inference_warnings).toHaveLength(1);
-      expect(body.inference_warnings[0].code).toBe('STABILITY_THRESHOLDS_MISSING');
+      expect(
+        body.inference_warnings.filter((w: any) => w.code === 'STABILITY_THRESHOLDS_MISSING'),
+      ).toHaveLength(1);
     } finally {
       forceMalformedThresholds = null;
     }
@@ -425,9 +438,14 @@ describe('stability_thresholds passthrough + hash_version in _meta', () => {
       expect(res.status).toBe(200);
       const body = await res.json() as any;
 
-      // Should not crash — response should still be valid
-      // No 3C fields detected (non-array falls back to []), so empty array
-      expect(body.inference_warnings).toEqual([]);
+      // Should not crash — response should still be valid.
+      // No 3C fields detected (non-array falls back to []), so no
+      // STABILITY_THRESHOLDS_MISSING warning (filter by code — the array also
+      // carries the always-on EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE marker).
+      expect(Array.isArray(body.inference_warnings)).toBe(true);
+      expect(
+        body.inference_warnings.filter((w: any) => w.code === 'STABILITY_THRESHOLDS_MISSING'),
+      ).toEqual([]);
     } finally {
       forceOmitThresholds = false;
       forceFactorSensitivityShape = undefined;


### PR DESCRIPTION
## Summary

PLoT pins `response_version=2` on every ISL call but read **five** science fields at V1-shaped locations the live V2 envelope never emits — proven by the raw staging capture committed at `tests/fixtures/isl-v2-live-20260706/` (deployed ISL `f3f5d92`, captured 2026-07-06). Result: `edge_e_values` was structurally `[]` on every live response, `computed_at` silently fell back to PLoT's clock, and factor VOI always took the heuristic path.

**A — V2 envelope repoint** (`src/integrations/isl/v2-envelope.ts`): edge E-values now read from the NESTED `robustness.edge_e_values`; `computed_at` from V2 `timestamp`; dead top-level `sensitivity` / `validation_status` reads deleted (V2 wire genuinely drops edge-level sensitivity — NO substitute invented, ISL contract followup); empty `edge_sensitivity` now explicitly marked via new info warning `EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE`.

**B — VOI honesty**: guarded internal mapping `mapIslFactorEvpi` proves the V2 `factor_evpi` (true per-factor EVPI) arrives, behind `ISL_FACTOR_EVPI_INTERNAL` (default OFF, diagnostics-only). NOT wired into user-facing VOI — decision P-5 pending.

**C — EVPI hygiene**: never emit a negative EVPI outward; below-resolution (<0.05pp, incl. all negatives — live capture carries raw `fac_hiring_cost` −0.15pp) is *labelled* `below_resolution`, not clamped to zero; raw kept in diagnostics.

**D — confidence_tier reconciliation**: never emit `strong` when the same response carries `robustness.is_robust=false` or `level` low/very_low — capped at `fair` (`reconcileConfidenceTier`).

**E — duplicate-edge preflight** (ISL now 422s duplicate `(from,to,type)` edges): exact-identical duplicates coalesced (logged via `repairs_applied`); non-identical duplicates → typed 422 blocker `DUPLICATE_EDGE_CONFLICT` naming pair + divergent fields; never silent dedupe.

**F — `CONSTRAINT_SAMPLES_UNNOISED`** tolerated: warning forwarding verified open-vocabulary; pinned by passthrough tests (unknown severity degrades to info).

**G — liveness gate** (`tests/isl-v2-liveness.fixture.test.ts`): drives `/v2/run` with the raw live capture; every requested science feature must be non-empty OR explicitly marked — **silent empty arrays fail**. RED before fix A (edge_e_values `[]`), GREEN after (9 entries).

Contracts FROZEN — no boundary field shapes changed (deltas are value-level; details + followups in `docs/lanes/LANE2-isl-v2-science-channel-2026-07-07.md`).

## Evidence

- Pre-push gate (authoritative): typecheck PASS, **full suite 5192 passed | 25 skipped**, no stale .js, dep policy OK, spectral OK.
- RED→GREEN: one-line revert to the old top-level read makes the liveness test fail (`edge_e_values` 0 ≠ 9).
- Wire truth machine-checked in `tests/isl-v2-envelope.unit.test.ts` against both raw captures.
- Golden pricing-canary untouched and passing (present-0 passthrough byte-identical).

## Known pre-existing CI reds (not chased, per lane brief)

- `audit` (fast-uri/fastify advisories)
- `gates (windows-latest)` (invalid path `tools/sdk-smoke:python.mjs`)

## Followups (recorded, not implemented)

1. ISL contract work: restore edge-level sensitivity on the V2 wire.
2. Represent `is_unflippable` E-value entries outward (4/13 live entries carry no `e_value` and are dropped by the numeric-egress guard — logged).
3. P-5 (Paul): wire `factor_evpi` into user-facing VOI/EVPI (mapping + hygiene ready behind flag).
4. OpenAPI spec lags the wire (`edge_e_values` etc. absent) — reconciliation pass due.

🤖 Generated with [Claude Code](https://claude.com/claude-code)