### PR TITLE
Lane PLoT-H: producer honesty — constraint-chain suppression, stability relabel removal, real EVPI (P-5)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -6165,17 +6165,24 @@ components:
                 minimum: 0
                 description: >-
                   Estimated EVPI in percentage points of win probability.
-                  Heuristic approximation: VOI × win-probability spread × 100.
-                  Present only when both VOI and win probabilities are
-                  available. EVPI is non-negative by definition
+                  Source is disclosed by `evpi_method`:
+                  `counterfactual` = ISL per-factor counterfactual EVPI
+                  (V2 wire `factor_evpi[]`, sanitised at the boundary;
+                  active on staging/test where the promotion flag defaults
+                  on); `heuristic` = VOI × win-probability spread × 100
+                  (fallback when ISL factor_evpi is absent or the flag is
+                  off; present only when both VOI and win probabilities are
+                  available). EVPI is non-negative by definition
                   (information cannot harm a rational decision-maker on
                   average — Howard 1966); negative values returned by Monte
-                  Carlo VOI estimators are sampling artefacts, not
+                  Carlo estimators are sampling artefacts, not
                   meaningful decision signals.
-                  Two-tier enforcement: (1) negative upstream VOI is
-                  treated as unavailable at the integration boundary, so
+                  Enforcement: (1) negative upstream values are treated as
+                  unavailable at the integration boundary, so
                   `evpi_percentage_points` is OMITTED entirely for the
-                  affected factor (preserving the missing-vs-zero
+                  affected factor (counterfactual path: labelled via
+                  `evpi_status: below_resolution`; heuristic path: field
+                  simply absent — preserving the missing-vs-zero
                   distinction the rest of the response contract relies
                   on); (2) any negative computed EVPI that nevertheless
                   reaches the emitter is defensively clamped to `0`
@@ -6185,6 +6192,17 @@ components:
                 type: string
                 enum: [heuristic, counterfactual]
                 description: Method used to compute evpi_percentage_points
+              evpi_status:
+                type: string
+                enum: [below_resolution]
+                description: >-
+                  Present only when ISL's counterfactual EVPI estimate for
+                  this factor is too small to measure at the run's sampling
+                  depth (including Monte Carlo–noise negatives).
+                  `evpi_percentage_points` is deliberately absent in that
+                  case — the estimate is labelled, never emitted as a
+                  clamped 0 (which would falsely claim "measured as exactly
+                  worthless") and never emitted as a negative.
               direction:
                 type: string
         robustness:

--- a/contracts/schemas/plot-response.schema.json
+++ b/contracts/schemas/plot-response.schema.json
@@ -103,7 +103,7 @@
     "robustness": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["recommendation_stability", "fragile_edges"],
+      "required": ["fragile_edges"],
       "properties": {
         "score": {
           "type": "number"
@@ -114,7 +114,8 @@
         "recommendation_stability": {
           "type": "number",
           "minimum": 0,
-          "maximum": 1
+          "maximum": 1,
+          "description": "DEPRECATED — no longer emitted (2026-07-07): ISL derives it as the leader's win_probability relabelled (option_wins[winner]/n_samples), zero independent information. Kept for inbound tolerance of old payloads only."
         },
         "fragile_edges": {
           "type": "array",
@@ -263,12 +264,17 @@
           "evpi_percentage_points": {
             "type": "number",
             "minimum": 0,
-            "description": "Estimated EVPI in percentage points of win probability (heuristic: VOI × win prob spread × 100)"
+            "description": "Estimated EVPI in percentage points of win probability. Source disclosed by evpi_method: 'counterfactual' = ISL per-factor counterfactual EVPI (sanitised; negatives never emitted), 'heuristic' = VOI × win prob spread × 100 (fallback)"
           },
           "evpi_method": {
             "type": "string",
             "enum": ["heuristic", "counterfactual"],
             "description": "Method used to compute evpi_percentage_points"
+          },
+          "evpi_status": {
+            "type": "string",
+            "enum": ["below_resolution"],
+            "description": "Present only when ISL's counterfactual EVPI estimate for this factor is too small to measure at the run's sampling depth (includes Monte Carlo–noise negatives). evpi_percentage_points is deliberately absent in that case — labelled, never a clamped 0"
           },
           "confidence": {
             "type": "number",

--- a/docs/lanes/LANE6-producer-honesty-2026-07-07.md
+++ b/docs/lanes/LANE6-producer-honesty-2026-07-07.md
@@ -1,0 +1,263 @@
+# Lane PLoT-H — producer honesty (items A / B / C)
+
+- **Branch:** `claude-lane6/producer-honesty` (fresh worktree from `origin/staging` @ `04434eb`)
+- **Date:** 2026-07-07
+- **Live evidence source:** this morning's manual test, scenario `327bc417`
+- **Scope discipline:** no ISL request change, no ISL change, no goldens modified.
+  All wire changes are value-level (omission of optional fields) or additive
+  (new optional fields / new open-vocabulary warning code).
+
+---
+
+## Item A — out-of-domain constraint chain (P1)
+
+### Defect (live)
+
+User set success target `20` unit `%` on `out_campaign_effectiveness` (a node
+with no observed value). Chain observed live:
+
+1. PLoT `plot.constraint_out_of_domain` (warn);
+2. PLoT `constraint_normalisation original:20 → normalised:1, range_source:"default"`
+   (threshold becomes "≥ domain max" against a made-up [0,1] range —
+   `deriveRange()` bottoms out at the default tier for a node with no cap /
+   range / hints / baseline / value: `src/lib/intervention-normaliser.ts:232`);
+3. ISL `isl.constraint.default_base defaulted_to 0.0 reason no_parameter_uncertainty`,
+   surfaced only as the info-level `CONSTRAINT_NODE_DEFAULT_BASE` inference
+   warning (ISL emits no `severity` on the wire shape → PLoT's merge demotes to
+   `info`: `src/routes/v2/run.ts` warning merge);
+4. `probability_of_joint_goal: 0` for ALL options — meaningless "0% goal fit
+   everywhere", the mirror image of the old 98% fabrication.
+
+### Fix
+
+- **New module `src/lib/constraint-reliability.ts`** —
+  `detectUnreliableConstraintTargets(goalConstraints, constraintNormRanges, islResult)`.
+  A constraint target is unreliable when **either** (i) its threshold
+  normalisation used `range_source: 'default'`, **or** (ii) ISL named its node
+  in a `CONSTRAINT_NODE_DEFAULT_BASE` inference warning (nested
+  `detail.node_id` shape, exactly as ISL emits it —
+  `Inference-Service-Layer/src/services/robustness_analyzer_v2.py:729-772`,
+  read-only) or critique (`affected_node_ids`).
+- **Suppression (`src/routes/v2/run.ts`, buildResponse):** when any target is
+  unreliable, `probability_of_joint_goal` and `constraint_probabilities` are
+  **omitted for the whole run** (absence is honest; the UI already gates
+  goal-fit on absence). Raw computed values are logged in the
+  `constraint_probability_suppressed` diagnostics event only — never emitted.
+- **Warning:** one WARNING-severity `CONSTRAINT_TARGET_UNRELIABLE` inference
+  warning per affected node (new open-vocabulary code added to
+  `INFERENCE_WARNING_CODES`), naming the node label and the user action:
+  *"Set a value or range for "<node>" to make this target computable."*
+  Wording tagged `provisional_doctrine_v0` (see register below).
+- **Coaching coherence (`src/coaching/m1-coaching.ts`):** the joint-probability
+  readiness gate is skipped when targets are unreliable — otherwise coaching
+  would fabricate `GOAL_FEASIBILITY_LOW` ("the best option may not achieve the
+  target") from the placeholder 0. Additive optional parameter; existing
+  callers unaffected.
+
+### Evidence (RED→GREEN)
+
+`tests/constraint-target-unreliable.fixture.test.ts` reproduces Paul's exact
+chain (20/`%` on a valueless outcome node; ISL mock returns the live
+`CONSTRAINT_NODE_DEFAULT_BASE` wire shape + joint 0):
+
+- **RED on origin/staging @ 04434eb** (test copied into a pristine detached
+  worktree): 4 failed / 2 passed —
+  `probability_of_joint_goal` present (`opt_a … to not have property`),
+  no `CONSTRAINT_TARGET_UNRELIABLE` (`expected [] to have a length of 1`),
+  coaching contained `GOAL_FEASIBILITY_LOW`.
+- **GREEN on this branch:** 6/6, including the CONTROL (target node with a
+  derivable range + no default base → both fields still emitted, no warning —
+  suppression is conditional, not blanket).
+
+### Deliberately NOT changed (recorded)
+
+- `constraint_results[].probability` / `constraints_status` still emit (the
+  brief names exactly the two suppressed fields; the warning covers
+  interpretation). Follow-up candidate if the UI renders constraint chips from
+  `constraint_results` on unreliable targets.
+- The ISL request is unchanged (per brief).
+
+---
+
+## Item B — recommendation_stability relabel
+
+### Defect (live)
+
+`enrichment.robustness.recommendation_stability` was **byte-identical** to the
+leader's `win_probability` in BOTH manual tests (`0.59025` and `0.8541875`).
+UI printed it as "N% stability" — a fabricated second statistic.
+
+### Trace (producer → validator → consumer)
+
+- **Producer (ISL, read-only):** `robustness_analyzer_v2.py:_compute_robustness`
+  — `recommendation_stability = option_wins[most_frequent_winner] / n_samples`,
+  i.e. the leader's win share **by construction** (only divergence: a
+  multiplicative penalty when root nodes defaulted — a degradation of the same
+  quantity, not an independent signal). The wire's `robustness.confidence` is
+  itself derived from it (`min(0.99, stability × (1 − 1/√n))`), so **no
+  genuinely distinct recommendation-level stability signal exists on the V2
+  wire** — confirmed against the live capture
+  `tests/fixtures/isl-v2-live-20260706/` (`recommendation_stability 0.59025`
+  === max `win_probability 0.59025`, both captures).
+- **PLoT emission sites (all removed):**
+  1. `/v2/run` response `robustness.recommendation_stability`
+     (`src/routes/v2/run.ts` buildResponse) — **stopped emitting** (key omitted);
+  2. `buildRobustnessDataForCee`
+     (`src/integrations/isl/adapters/robustness-enrichment.ts`) — **stopped
+     forwarding**, and stability alone no longer counts as "meaningful
+     robustness data" (returns null).
+- **Contract docs updated:** `contracts/schemas/plot-response.schema.json`
+  (`robustness.required` no longer lists it; property marked DEPRECATED),
+  `src/contracts/isl-to-ui.contract.ts` (declared drop). Type fields kept
+  optional for inbound tolerance, marked `@deprecated`.
+
+### Evidence
+
+- Liveness pin (GREEN here, **RED on staging**: `expected … not to have
+  property "recommendation_stability"`):
+  `tests/isl-v2-liveness.fixture.test.ts` — asserts the wire byte-identity
+  (`captureA.robustness.recommendation_stability === max win_probability`) AND
+  the response omission.
+- `tests/robustness-enrichment.test.ts` updated: builder omits the field;
+  stability-only payload → null.
+
+### Residual (recorded, NOT changed — out of scope / higher-risk boundary)
+
+- **M2 decision-review request** (`src/cee/decision-review-request.ts:294`,
+  `decision-review-orchestrator.ts:386`) still sends
+  `recommendation_stability ?? 0` to CEE as numeric grounding for the m1
+  review validator (`m1-review-types.ts` marks it REQUIRED). Removing it is a
+  non-additive change to the PLoT→CEE request shape → left intact per rule 6;
+  the review LLM could still quote "59% stability" in prose. **Follow-up.**
+- Internal verdict derivations (`src/coaching/normalise-inputs.ts`,
+  `src/assembly/decision-brief.ts`) still read ISL's value to derive
+  robust/fragile verdict classes — they do not emit the number; unchanged.
+- Golden fixture-identity tests (`tests/golden/golden.test.ts:103`,
+  `tests/golden/integration.test.ts:210`, `near-tie.golden.test.ts`) compare
+  static capture files to each other (they do not run the route) and pin the
+  CAPTURE's passthrough era; goldens untouched per brief. The live-surface
+  non-emission is pinned by the liveness test instead.
+
+---
+
+## Item C — VOI over-zeroing + real EVPI (P-5, provisional-doctrine authorized)
+
+### Defect (live)
+
+All 5 factors had `value_of_information: 0` including unpinned ones. Root
+cause: the heuristic `|sens| × (1 − conf) × max(marginal_switch_probability)`
+(`src/lib/factor-influence.ts:computeValueOfInformation`) flattens to 0 for the
+whole surface when `marginal_switch_probability` is uniformly 0 (known
+failure mode) — so `evpi_percentage_points` (heuristic = VOI × spread × 100)
+carried no ranking information for "worth checking next".
+
+### Fix
+
+- **Flag flip (`src/config/flags.ts`):** `ISL_FACTOR_EVPI_INTERNAL` default now
+  **ON for `NODE_ENV=test` and staging (`RENDER_SERVICE_NAME` contains
+  "staging")**, **OFF for prod**; explicit env overrides both ways
+  (`'0'/'false'`, `'1'/'true'`).
+- **Promotion (`src/routes/v2/run.ts` EVPI enrichment):** when the flag is on
+  AND the ISL V2 wire carries `factor_evpi[]`, the Lane-2 guarded mapping
+  (`mapIslFactorEvpi`, `src/integrations/isl/v2-envelope.ts`) feeds
+  `factor_sensitivity[].evpi_percentage_points` with
+  `evpi_method: 'counterfactual'` **in place of** the heuristic for the run
+  (no mixed-scale ranking). Heuristic remains the fallback when `factor_evpi`
+  is absent or the flag is off — that path is byte-identical to before.
+- **Sanitisation (unchanged core + extended):** negatives are NEVER emitted;
+  below-resolution estimates (< 0.05pp, includes all MC-noise negatives) are
+  labelled with the new additive optional field
+  `factor_sensitivity[].evpi_status: 'below_resolution'` and
+  `evpi_percentage_points` stays ABSENT (never a clamped 0). ISL's **new
+  `evpi_status` wire field is honoured where present** (an explicit
+  `'below_resolution'` from the producer overrides PLoT's local threshold;
+  `'ok'` does not un-label sub-resolution raws). The field is typed optional
+  (`isl-types.ts`) — the 2026-07-06 capture predates it; ISL src has no
+  emitter yet (verified read-only grep), so this is forward tolerance.
+- **P0a preserved:** option-pinned levers (`zero_reason:
+  'intervention_override'`) never carry EVPI in any form, even when ISL
+  supplies an estimate for them (the live capture does: `fac_dev_headcount`
+  1.85pp is a lever — verified skipped).
+- **Specs updated (hand-authored):** `contracts/openapi.yaml`
+  (`evpi_percentage_points` source disclosure + new `evpi_status`),
+  `openapi/openapi-plot-lite-v1.yaml` (`FactorSensitivityV3` additions),
+  `contracts/schemas/plot-response.schema.json`, `isl-to-ui.contract.ts`
+  enriched list, `cee-no-voi.type-pin.ts` (added `evpi_status` to the
+  forbidden-on-CEE-request union).
+
+### Copy check ("EVPI" / "expected value" never user-facing)
+
+- Grep of `src/` message/label surfaces: **no PLoT-emitted user-facing string
+  contains "EVPI" or "expected value" on the VOI surface.** The strings exist
+  only in field names (`evpi_percentage_points` — pre-existing wire vocabulary),
+  code comments, and log events. The UI renders the "worth checking next" /
+  "Investigate" label class from these fields (verified read-only:
+  `DecisionGuideAI/src/components/results/utils/groupActionItems.ts` ranks by
+  `evpiPp → evpi → voi`; `analysisSnapshotFactory.ts:67` maps
+  `f.evpi_percentage_points`).
+- Pre-existing unrelated copy: `src/routes/v1/analysis-pareto.ts:76-80` says
+  "higher expected value" about **outcome expected value** on a v1 Pareto
+  surface — not the VOI/EVPI surface; left unchanged (recorded).
+
+### Evidence
+
+- **Golden pricing-canary byte-identical:** its ISL fixture has NO
+  `factor_evpi` → `mapIslFactorEvpi` returns 0 entries → fallback heuristic
+  path executes exactly the pre-change loop. `tests/golden/` all green
+  (fixtures untouched); `canonical-route-integration` (canonicalCompare
+  idempotency) green.
+- Liveness (GREEN here, **RED on staging**: 2 of the 3 new C assertions fail
+  pre-fix): counterfactual mapping (1.45pp → 1.5pp rounded, method
+  disclosed), lever exclusion, below-resolution labelling
+  (`fac_hiring_cost` −0.15pp → `evpi_status`, no pp, no 0, no negative), and
+  a flag-OFF (prod posture) block proving no counterfactual output when off.
+- Unit: `tests/isl-v2-envelope.unit.test.ts` — `evpi_status` honour/override
+  semantics.
+
+### Claim register (provisional_doctrine_v0)
+
+| # | Surface | Claim now made | Basis | Guard |
+|---|---------|----------------|-------|-------|
+| C-1 | `factor_sensitivity[].evpi_percentage_points` (+`evpi_method: 'counterfactual'`) | "checking this factor could shift the win probability by ~Npp" | ISL per-factor counterfactual EVPI (Monte Carlo, `n_evpi_samples`) | ≥0 always; rounded 0.1pp; staging/test only (prod flag OFF); method disclosed |
+| C-2 | `factor_sensitivity[].evpi_status: 'below_resolution'` | "too small to measure at this sampling depth" (NOT "measured zero") | Emission resolution 0.05pp (`evpi-emission.ts`), incl. all MC-noise negatives; ISL `evpi_status` honoured | value field absent; raw stays in diagnostics |
+| C-3 | Heuristic fallback unchanged (`evpi_method: 'heuristic'`) | unchanged pre-existing claim | VOI × spread × 100 | unchanged; canary byte-identical |
+| A-1 | `CONSTRAINT_TARGET_UNRELIABLE` warning message | "this target can't be evaluated reliably; numbers withheld; set a value/range" | detection per `constraint-reliability.ts` | wording tagged `provisional_doctrine_v0` in source |
+
+### provisional_doctrine_v0 wording surfaces (rule 9 list)
+
+1. `src/lib/constraint-reliability.ts` — `buildConstraintTargetUnreliableMessage` (tagged in source comment).
+2. `src/routes/v2/run.ts` — CONSTRAINT_TARGET_UNRELIABLE emission site (tagged in source comment).
+3. Item C carries no new user-facing prose (fields only); the doctrine tag applies to the promotion decision itself (flag docs + this report).
+
+---
+
+## Test summary
+
+| Suite | Result |
+|-------|--------|
+| `tests/constraint-target-unreliable.fixture.test.ts` (NEW) | 6/6 GREEN (4 RED on staging) |
+| `tests/constraint-reliability.unit.test.ts` (NEW) | 11/11 GREEN |
+| `tests/isl-v2-liveness.fixture.test.ts` (extended) | 16/16 GREEN (3 RED on staging) |
+| `tests/isl-v2-envelope.unit.test.ts` (extended) | 25/25 GREEN |
+| `tests/robustness-enrichment.test.ts` (updated) | 33/33 GREEN |
+| Golden batch (`tests/golden/**`, goldens untouched) | 25 files / 451 tests GREEN |
+| Boundary/gates (`boundary-isl-to-ui`, `voi-enrichment-pin`, `lane-p0a-lever-evpi-egress`, `enrichment-emission-contract`, `canonical-route-integration`) | GREEN |
+| `npx tsc --noEmit` | clean |
+| Full `npm test` | see PR body / final report |
+
+Known pre-existing CI reds (unrelated, per repo CLAUDE.md): `audit`
+(fast-uri/fastify advisories) and `gates (windows-latest)` (invalid path
+`tools/sdk-smoke:python.mjs`).
+
+## Follow-ups (recorded, not done)
+
+1. M2 decision-review request still carries `recommendation_stability ?? 0`
+   (required by the CEE-side m1 validator contract) — retiring it needs a
+   coordinated CEE change (non-additive boundary change, rule 6).
+2. `constraint_results[].probability` still emits on unreliable-target runs
+   (scope: brief named the two suppressed fields); revisit if the UI renders
+   constraint chips from it.
+3. ISL `factor_evpi[].evpi_status` has no producer yet (typed as forward
+   tolerance here); when ISL ships it, the honour-path is already tested.
+4. Prod flip of `ISL_FACTOR_EVPI_INTERNAL` is a Paul-gated decision (P-5 full
+   ratification) — staging/test ON only in this change.

--- a/openapi/openapi-plot-lite-v1.yaml
+++ b/openapi/openapi-plot-lite-v1.yaml
@@ -1170,4 +1170,24 @@ components:
           description: >
             Track S: true when ISL substituted a default for the factor value.
             Absent means "not reported / older ISL response" and is never coerced to false.
+        evpi_percentage_points:
+          type: number
+          minimum: 0
+          description: >
+            Estimated EVPI in percentage points of win probability. Source disclosed
+            by evpi_method ('counterfactual' = ISL per-factor counterfactual EVPI,
+            sanitised — negatives never emitted; 'heuristic' = VOI × win-probability
+            spread × 100 fallback). Always >= 0 when present.
+        evpi_method:
+          type: string
+          enum: [heuristic, counterfactual]
+          description: Method used to compute evpi_percentage_points.
+        evpi_status:
+          type: string
+          enum: [below_resolution]
+          description: >
+            Present only when ISL's counterfactual EVPI estimate is too small to
+            measure at the run's sampling depth (including Monte Carlo–noise
+            negatives). evpi_percentage_points is deliberately absent in that case —
+            labelled, never a clamped 0 and never a negative.
       required: [factor_id]

--- a/src/coaching/m1-coaching.ts
+++ b/src/coaching/m1-coaching.ts
@@ -44,6 +44,14 @@ import { deriveReadinessTone, type ReadinessToneResult } from './readiness-tone.
  *   intervention-override filtering. Falls back to raw ISL when omitted to
  *   preserve backward-compatible behaviour for unit tests that mock ISL
  *   responses directly.
+ * @param constraintTargetsUnreliable Producer honesty (lane PLoT-H item A):
+ *   true when any goal constraint's target is not decision-grade (default
+ *   [0,1] threshold-normalisation range and/or ISL defaulted the target base
+ *   to 0.0). The joint-probability readiness gate is SKIPPED in that case —
+ *   the joint probabilities it would read are structurally meaningless, and
+ *   gating on them would fabricate a "may not achieve the target" coaching
+ *   claim from a placeholder 0. The route suppresses the same values on the
+ *   public surface (CONSTRAINT_TARGET_UNRELIABLE).
  * @returns M1Coaching object or null if generation fails
  */
 export function generateM1Coaching(
@@ -64,7 +72,8 @@ export function generateM1Coaching(
     severity?: string;
   }>,
   goalConstraints?: GoalConstraint[],
-  factorSensitivityEnriched?: FactorSensitivityResultV3[]
+  factorSensitivityEnriched?: FactorSensitivityResultV3[],
+  constraintTargetsUnreliable?: boolean
 ): M1Coaching | null {
   const startTime = performance.now();
 
@@ -87,7 +96,10 @@ export function generateM1Coaching(
     let readiness = computeReadiness(headlineType, modelCritiques, evidenceGaps, thresholds);
 
     // Post-readiness gate: Joint constraint probability (Task 1)
-    if (goalConstraints && goalConstraints.length > 0) {
+    // Producer honesty (item A): skipped when constraint targets are
+    // unreliable — the joint probabilities are placeholder-derived and the
+    // gate would fabricate a GOAL_FEASIBILITY_LOW claim from them.
+    if (goalConstraints && goalConstraints.length > 0 && !constraintTargetsUnreliable) {
       const jointProbGate = applyJointProbabilityGate(
         readiness, islResult, thresholds, modelCritiques
       );

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -106,14 +106,26 @@ export const FLAGS = {
 
   // ISL V2 science channel: per-factor counterfactual EVPI (factor_evpi wire field)
   /**
-   * INTERNAL DIAGNOSTICS ONLY (default OFF everywhere, including test/staging).
-   * When enabled, /v2/run logs a sanitised summary of the ISL V2 `factor_evpi`
-   * wire field (via `mapIslFactorEvpi`). It NEVER changes the public response:
-   * wiring factor_evpi into user-facing VOI/EVPI is decision P-5 (pending) and
-   * MUST NOT happen behind this flag.
+   * P-5 promotion gate (provisional_doctrine_v0, lane PLoT-H item C,
+   * 2026-07-07 — supersedes the previous "internal diagnostics only" posture).
+   *
+   * When ON and the ISL V2 wire carries `factor_evpi[]`, the sanitised
+   * counterfactual EVPI (via `mapIslFactorEvpi`: negatives NEVER emitted,
+   * below-resolution labelled `evpi_status: 'below_resolution'`, honouring
+   * ISL's `evpi_status` wire field where present) is used IN PLACE of the
+   * heuristic (VOI × win-probability spread) on the factor_sensitivity
+   * "worth checking next" surface (`evpi_percentage_points`,
+   * `evpi_method: 'counterfactual'`). When `factor_evpi` is absent (e.g. the
+   * golden pricing-canary) or the flag is OFF, the heuristic fallback runs
+   * unchanged — public response byte-identical to the pre-promotion build.
+   *
+   * Default: ON for test and staging; OFF for production. Explicit env
+   * ('1'/'true' or '0'/'false') overrides in both directions.
    */
   get ISL_FACTOR_EVPI_INTERNAL() {
     const raw = process.env.ISL_FACTOR_EVPI_INTERNAL;
-    return raw === '1' || raw === 'true';
+    if (raw === '0' || raw === 'false') return false;
+    if (raw === '1' || raw === 'true') return true;
+    return process.env.NODE_ENV === 'test' || process.env.RENDER_SERVICE_NAME?.includes('staging') === true;
   },
 } as const;

--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -26,10 +26,28 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
   drops: [
     'metadata.n_samples',            // Superseded by outcome.n_samples per-option
     'recommendation_confidence',     // Removed in V3 schema migration
+    // Producer honesty (lane PLoT-H item B, 2026-07-07): ISL derives this as
+    // option_wins[winner]/n_samples — the leader's win_probability relabelled,
+    // zero independent information (verified byte-identical live: 0.59025 /
+    // 0.8541875). The UI printed it as a fabricated "N% stability" statistic.
+    // Absence is honest; the UI has an absence path.
+    'robustness.recommendation_stability',
   ],
 
-  /** No structural filtering at this boundary (filtering happens at PLoT→ISL). */
-  filtered: [],
+  /**
+   * Conditional structural filtering (producer honesty, lane PLoT-H item A):
+   * per-option `constraint_analysis.joint_probability` → probability_of_joint_goal
+   * and `constraints[].prob_satisfied` → constraint_probabilities are SUPPRESSED
+   * for the whole run when any constraint target is unreliable (default-range
+   * threshold normalisation and/or ISL CONSTRAINT_NODE_DEFAULT_BASE on the
+   * target node). Marked by the WARNING-severity CONSTRAINT_TARGET_UNRELIABLE
+   * inference warning; raw values stay in diagnostics logs only.
+   * @see src/lib/constraint-reliability.ts
+   */
+  filtered: [
+    'constraint_analysis.joint_probability (when CONSTRAINT_TARGET_UNRELIABLE)',
+    'constraint_analysis.constraints[].prob_satisfied (when CONSTRAINT_TARGET_UNRELIABLE)',
+  ],
 
   /** WHY renamed: UI schema uses different field names than ISL's response. */
   renames: [
@@ -88,6 +106,9 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     'near_tie',
     'confidence_tier',                   // B1: derived from m1_coaching.readiness (ready→strong, close_call→fair, else→needs_work)
     'dominant_factor',                   // B1: detected from factor_sensitivity (influence >0.5 AND ratio >2:1)
+    'factor_sensitivity[].evpi_percentage_points', // P-5: ISL factor_evpi[] counterfactual (sanitised, flag-gated staging/test) OR VOI×spread heuristic fallback; source disclosed via evpi_method
+    'factor_sensitivity[].evpi_method',  // P-5: 'counterfactual' (ISL factor_evpi) | 'heuristic' (VOI×spread fallback)
+    'factor_sensitivity[].evpi_status',  // P-5: 'below_resolution' label when ISL counterfactual EVPI too small to measure (incl. MC-noise negatives) — never a clamped 0
     // Tier-B always-emit contract: the following enrichment arrays are always
     // present on the response ([] when ISL returns empty or omits the field),
     // and their entries are label-enriched beyond the ISL source shape.

--- a/src/integrations/isl/adapters/robustness-enrichment.ts
+++ b/src/integrations/isl/adapters/robustness-enrichment.ts
@@ -224,14 +224,19 @@ export function buildRobustnessDataForCee(
   graph: EngineGraphV3,
   options: OptionV3[]
 ): RobustnessDataForCee | null {
-  // Check if there's any meaningful robustness data
+  // Check if there's any meaningful robustness data.
+  // recommendation_stability no longer counts as meaningful data and is no
+  // longer forwarded (lane PLoT-H item B, 2026-07-07): ISL derives it as
+  // option_wins[winner]/n_samples — the leader's win_probability relabelled,
+  // zero independent information (verified byte-identical in live tests
+  // 0.59025 / 0.8541875 and in tests/fixtures/isl-v2-live-20260706). Omission
+  // is honest absence; consumers must not print it as a distinct "stability".
   const hasFragileEdges = (islRobustness?.fragile_edges?.length ?? 0) > 0;
   const hasRobustEdges = (islRobustness?.robust_edges?.length ?? 0) > 0;
-  const hasRecommendationStability = islRobustness?.recommendation_stability !== undefined;
   const hasFactorSensitivity = (islFactorSensitivity?.length ?? 0) > 0;
 
   // Return null if no meaningful data
-  if (!hasFragileEdges && !hasRobustEdges && !hasRecommendationStability && !hasFactorSensitivity) {
+  if (!hasFragileEdges && !hasRobustEdges && !hasFactorSensitivity) {
     return null;
   }
 
@@ -248,7 +253,7 @@ export function buildRobustnessDataForCee(
   );
 
   return {
-    recommendation_stability: islRobustness?.recommendation_stability,
+    // recommendation_stability deliberately omitted — see item B note above.
     recommended_option: recommendedOptionId
       ? {
           id: recommendedOptionId,

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -303,6 +303,13 @@ export interface ISLFactorEvpiEntry {
   metric_type: string;
   /** Number of Monte Carlo samples used for the EVPI estimate */
   n_evpi_samples: number;
+  /**
+   * ISL's own emission classification for this estimate (newer ISL builds;
+   * the 2026-07-06 live capture predates it). When present and
+   * 'below_resolution', PLoT honours it: the entry is labelled
+   * below-resolution regardless of PLoT's local threshold classification.
+   */
+  evpi_status?: 'ok' | 'below_resolution' | string;
 }
 
 /**
@@ -564,7 +571,10 @@ export interface ISLRobustnessAnalyzeV2Response {
 
   /**
    * Per-factor counterfactual EVPI (V2 wire, top-level; verified live
-   * 2026-07-06). NOT user-facing yet — P-5 pending. See `ISLFactorEvpiEntry`.
+   * 2026-07-06). P-5 PROMOTED (provisional_doctrine_v0, 2026-07-07): feeds
+   * the factor_sensitivity "worth checking next" surface behind
+   * `FLAGS.ISL_FACTOR_EVPI_INTERNAL` (staging/test ON, prod OFF), sanitised
+   * via `mapIslFactorEvpi`. See `ISLFactorEvpiEntry`.
    */
   factor_evpi?: ISLFactorEvpiEntry[];
 

--- a/src/integrations/isl/types/plot-types.ts
+++ b/src/integrations/isl/types/plot-types.ts
@@ -316,7 +316,12 @@ export interface EnrichedFactorSensitivity {
  * Contains ISL robustness data enriched with human-readable labels.
  */
 export interface RobustnessDataForCee {
-  /** Recommendation stability score (0-1) */
+  /**
+   * @deprecated NO LONGER POPULATED (lane PLoT-H item B, 2026-07-07):
+   * ISL's recommendation_stability is the leader's win_probability relabelled
+   * (option_wins[winner]/n_samples) — zero independent information. Kept on
+   * the type for inbound tolerance only; buildRobustnessDataForCee omits it.
+   */
   recommendation_stability?: number;
   /** Recommended option with label */
   recommended_option?: {

--- a/src/integrations/isl/v2-envelope.ts
+++ b/src/integrations/isl/v2-envelope.ts
@@ -104,15 +104,20 @@ export interface FactorEvpiMappingResult {
 }
 
 /**
- * Guarded internal mapping for the V2 `factor_evpi` field.
+ * Guarded mapping for the V2 `factor_evpi` field.
  *
- * IMPORTANT — P-5 pending: this data MUST NOT be wired into any user-facing
- * VOI/EVPI surface yet. The mapping exists to (a) prove the data arrives on
- * the live wire (fixture test) and (b) centralise the negative/below-resolution
- * hygiene so the eventual wiring cannot leak a raw negative EVPI outward.
- *
- * Behind `FLAGS.ISL_FACTOR_EVPI_INTERNAL` (default OFF) the route logs
- * diagnostics only; the public response is byte-identical either way.
+ * P-5 PROMOTED (provisional_doctrine_v0, lane PLoT-H item C, 2026-07-07):
+ * behind `FLAGS.ISL_FACTOR_EVPI_INTERNAL` (default ON for staging/test, OFF
+ * for prod) the sanitised entries feed the factor_sensitivity
+ * "worth checking next" surface (`evpi_percentage_points`,
+ * `evpi_method: 'counterfactual'`, `evpi_status: 'below_resolution'`) IN
+ * PLACE of the VOI×spread heuristic. The hygiene is centralised here so the
+ * wiring can never leak a raw negative EVPI outward:
+ * - negatives are NEVER emitted (Monte Carlo sampling artefacts);
+ * - below-resolution estimates are labelled, never clamped to 0;
+ * - ISL's own `evpi_status` wire field is honoured where present
+ *   ('below_resolution' forces the label even if the raw value clears
+ *   PLoT's local threshold).
  */
 export function mapIslFactorEvpi(
   islResult: Partial<ISLRobustnessAnalyzeV2Response> | null | undefined,
@@ -141,10 +146,16 @@ export function mapIslFactorEvpi(
     const classification: EvpiEmissionClassification =
       classifyEvpiPercentagePointsForEmission(e.evpi_percentage_points);
 
+    // Honour ISL's own emission classification where present: an explicit
+    // 'below_resolution' from the producer overrides PLoT's local threshold
+    // (never the reverse — PLoT's threshold still applies when ISL says 'ok'
+    // or omits the field, so a sub-resolution raw value stays labelled).
+    const islSaysBelowResolution = e.evpi_status === 'below_resolution';
+
     entries.push({
       factor_id: e.factor_id,
-      emit_pp: classification.emit,
-      below_resolution: classification.below_resolution,
+      emit_pp: islSaysBelowResolution ? undefined : classification.emit,
+      below_resolution: classification.below_resolution || islSaysBelowResolution,
       raw_evpi: e.evpi,
       raw_evpi_percentage_points: e.evpi_percentage_points,
       metric_type: typeof e.metric_type === 'string' ? e.metric_type : 'unknown',

--- a/src/lib/constraint-reliability.ts
+++ b/src/lib/constraint-reliability.ts
@@ -1,0 +1,152 @@
+/**
+ * Constraint-target reliability detection (producer honesty, lane PLoT-H item A).
+ *
+ * Live defect (scenario 327bc417, 2026-07-07): a success target of "20" (unit
+ * "%") was set on a node with NO observed value. The chain was:
+ *
+ *   1. PLoT `plot.constraint_out_of_domain` (warn) — threshold 20 outside [0,1]
+ *      on a probability-domain node;
+ *   2. PLoT constraint normalisation fell back to the DEFAULT [0,1] range
+ *      (`range_source: "default"`) because the target node carries no value,
+ *      cap, range, baseline or intervention spread — so 20 clamped to 1, i.e.
+ *      "threshold >= domain max";
+ *   3. ISL `isl.constraint.default_base` — the target node defaulted to
+ *      base=0.0 (`reason: no_parameter_uncertainty`), surfaced only as the
+ *      info-level CONSTRAINT_NODE_DEFAULT_BASE inference warning;
+ *   4. Result: `probability_of_joint_goal` = 0 for EVERY option — a meaningless
+ *      "0% goal fit everywhere", the mirror image of a fabricated 98%.
+ *
+ * Neither number is decision-grade. When either leg of the chain fires for a
+ * constraint's target node, the emitted joint-goal / per-constraint
+ * probabilities must be SUPPRESSED (absence is honest — the UI already gates
+ * goal-fit rendering on absence) and a WARNING-severity inference warning must
+ * tell the user what to do. Raw computed values stay in diagnostics (logs)
+ * only.
+ *
+ * This module is detection only — suppression happens at the emission sites in
+ * `src/routes/v2/run.ts` (buildResponse). No ISL request change; no ISL change.
+ */
+
+import type { GoalConstraint } from '../types/engine-v3.js';
+import type { NormalisationRange } from './intervention-normaliser.js';
+
+/** ISL's open-vocabulary warning code for a constraint target defaulted to base=0.0. */
+export const ISL_CONSTRAINT_NODE_DEFAULT_BASE_CODE = 'CONSTRAINT_NODE_DEFAULT_BASE';
+
+/** Why a constraint target is not decision-grade. */
+export type ConstraintUnreliabilityReason =
+  /** Threshold normalisation fell back to the default [0,1] range (range_source: "default") */
+  | 'threshold_normalisation_defaulted'
+  /** ISL defaulted the target node's base to 0.0 (no observed value / no parameter uncertainty) */
+  | 'target_base_defaulted';
+
+export interface UnreliableConstraintTarget {
+  constraint_id: string;
+  node_id: string;
+  reasons: ConstraintUnreliabilityReason[];
+}
+
+/**
+ * Detect constraints whose emitted probabilities are NOT decision-grade.
+ *
+ * A constraint target is unreliable when EITHER:
+ *  - its threshold normalisation used the default [0,1] fallback range
+ *    (`constraintNormRanges` entry with `source: 'default'`), i.e. the
+ *    user-unit threshold was scaled against a made-up domain; OR
+ *  - ISL reported the target node's base was defaulted to 0.0
+ *    (CONSTRAINT_NODE_DEFAULT_BASE in `inference_warnings` — wire shape
+ *    `{ code, detail: { node_id, ... } }` — or in `critiques` via
+ *    `affected_node_ids`), i.e. the sampled quantity itself is fabricated.
+ *
+ * Detection is deliberately conservative: absent inputs (no ranges map, no
+ * islResult, no warnings) contribute nothing, so well-formed runs are
+ * untouched.
+ */
+export function detectUnreliableConstraintTargets(
+  goalConstraints: GoalConstraint[] | undefined,
+  constraintNormRanges: Map<string, NormalisationRange> | undefined,
+  islResult: unknown,
+): UnreliableConstraintTarget[] {
+  if (!goalConstraints || goalConstraints.length === 0) return [];
+
+  // Collect node ids ISL flagged as defaulted-base (both wire channels).
+  const defaultedBaseNodeIds = collectDefaultedBaseNodeIds(islResult);
+
+  const out: UnreliableConstraintTarget[] = [];
+  for (const gc of goalConstraints) {
+    const reasons: ConstraintUnreliabilityReason[] = [];
+
+    const range = constraintNormRanges?.get(gc.constraint_id);
+    if (range?.source === 'default') {
+      reasons.push('threshold_normalisation_defaulted');
+    }
+
+    if (defaultedBaseNodeIds.has(gc.node_id)) {
+      reasons.push('target_base_defaulted');
+    }
+
+    if (reasons.length > 0) {
+      out.push({ constraint_id: gc.constraint_id, node_id: gc.node_id, reasons });
+    }
+  }
+  return out;
+}
+
+/** Extract node ids named by ISL CONSTRAINT_NODE_DEFAULT_BASE signals. */
+function collectDefaultedBaseNodeIds(islResult: unknown): Set<string> {
+  const ids = new Set<string>();
+  const r = islResult as
+    | {
+        inference_warnings?: Array<{
+          code?: unknown;
+          node_id?: unknown;
+          detail?: { node_id?: unknown };
+        }>;
+        critiques?: Array<{ code?: unknown; affected_node_ids?: unknown }>;
+      }
+    | null
+    | undefined;
+  if (!r || typeof r !== 'object') return ids;
+
+  if (Array.isArray(r.inference_warnings)) {
+    for (const w of r.inference_warnings) {
+      if (w?.code !== ISL_CONSTRAINT_NODE_DEFAULT_BASE_CODE) continue;
+      const nodeId = w?.detail?.node_id ?? w?.node_id;
+      if (typeof nodeId === 'string' && nodeId.length > 0) ids.add(nodeId);
+    }
+  }
+
+  if (Array.isArray(r.critiques)) {
+    for (const c of r.critiques) {
+      if (c?.code !== ISL_CONSTRAINT_NODE_DEFAULT_BASE_CODE) continue;
+      if (Array.isArray(c.affected_node_ids)) {
+        for (const nodeId of c.affected_node_ids) {
+          if (typeof nodeId === 'string' && nodeId.length > 0) ids.add(nodeId);
+        }
+      }
+    }
+  }
+
+  return ids;
+}
+
+/**
+ * Build the user-facing CONSTRAINT_TARGET_UNRELIABLE warning message.
+ *
+ * provisional_doctrine_v0 — wording surface. Names the node and the concrete
+ * user action; never quotes the suppressed raw probabilities (those live in
+ * diagnostics logs only).
+ */
+export function buildConstraintTargetUnreliableMessage(
+  nodeLabel: string,
+  reasons: ConstraintUnreliabilityReason[],
+): string {
+  const because = reasons.includes('target_base_defaulted')
+    ? `"${nodeLabel}" has no observed value or uncertainty range, so the analysis substituted a placeholder`
+    : `the target for "${nodeLabel}" could not be scaled against any known range for that node`;
+  return (
+    `The success target on "${nodeLabel}" can't be evaluated reliably: ${because}. ` +
+    `Goal-fit probabilities were withheld for this run because they would be meaningless. ` +
+    `Set a value or range for "${nodeLabel}" to make this target computable.`
+  );
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -131,6 +131,10 @@ import { getDownstreamCallsForLog } from '../../util/downstream-tracker.js';
 import { computeFactorSensitivityFromGraph, buildFactorStability, mergeIslConfidenceIntoGraphFactors } from '../../lib/factor-influence.js';
 import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagMissingFromIsl } from '../../lib/auto-noise.js';
 import { sanitiseIslVoi, computeEvpiPercentagePoints } from '../../lib/evpi-emission.js';
+import {
+  detectUnreliableConstraintTargets,
+  buildConstraintTargetUnreliableMessage,
+} from '../../lib/constraint-reliability.js';
 import { NEAR_TIE_THRESHOLD } from '../../trust/result-coherence.js';
 import { assessGraphIdentifiability, toIdentifiabilityResponse, detectUnmeasuredConfounding } from '../../trust/identifiability-v2.js';
 import { classifyEdgeSeverity } from '../../trust/edge-severity.js';
@@ -1654,6 +1658,21 @@ function buildResponse(
   factorStability?: FactorStabilityEntry[],
   logger?: { info: (obj: object, msg?: string) => void; warn: (obj: object, msg?: string) => void }
 ): RunResponseV3 {
+  // Producer honesty (lane PLoT-H item A): detect goal constraints whose
+  // targets are NOT decision-grade — threshold normalisation fell back to the
+  // default [0,1] range and/or ISL defaulted the target node's base to 0.0.
+  // When any such target exists, probability_of_joint_goal and
+  // constraint_probabilities are SUPPRESSED for the run (absence is honest —
+  // the UI gates goal-fit on absence) and a WARNING-severity
+  // CONSTRAINT_TARGET_UNRELIABLE inference warning names the node + the fix.
+  // Raw computed values are logged (diagnostics) but never emitted.
+  const unreliableConstraintTargets = detectUnreliableConstraintTargets(
+    goalConstraints,
+    constraintNormRanges,
+    islResult,
+  );
+  const suppressConstraintProbabilities = unreliableConstraintTargets.length > 0;
+
   // Map ISL results to response format
   // ISL V2 uses 'options' field; V1 uses 'results'. Check both for compatibility.
   const islOptionData = islResult?.options ?? islResult?.results;
@@ -1741,16 +1760,14 @@ function buildResponse(
       // would otherwise serialise to a fabricated `null`, and a >1 value would render
       // an impossible probability).
       const jointProb = prob01(constraintAnalysis.joint_probability);
-      if (jointProb !== undefined) {
-        result.probability_of_joint_goal = jointProb;
-      }
 
       // Map ISL's per-constraint prob_satisfied to constraint_probabilities map
       // Uses index-position mapping (same as buildConstraintFields): ISL preserves insertion
       // order but does NOT echo constraint_id. Value-based matching breaks after normalisation
       // because ISL echoes normalised values while goalConstraints holds raw user-unit values.
+      let constraintProbs: Record<string, number> | undefined;
       if (Array.isArray(constraintAnalysis.constraints) && constraintAnalysis.constraints.length > 0) {
-        const constraintProbs: Record<string, number> = {};
+        constraintProbs = {};
         const islConstraintsHere = constraintAnalysis.constraints as ISLConstraintResult[];
         const indexToId: string[] = islConstraintsHere.map((islC, idx) => {
           const byIndex = goalConstraints?.[idx];
@@ -1773,8 +1790,29 @@ function buildResponse(
             constraintProbs[constraintId] = probSat;
           }
         }
-        result.constraint_probabilities = constraintProbs;
-        logger?.info({ event: 'constraint_probs_mapped', option_id: optionId, count: Object.keys(constraintProbs).length });
+      }
+
+      if (suppressConstraintProbabilities) {
+        // Producer honesty (item A): the computed values are structurally
+        // meaningless (default-range threshold and/or defaulted base). Emit
+        // NEITHER field — absence is honest — and keep the raw values in
+        // diagnostics logs only. CONSTRAINT_TARGET_UNRELIABLE (warning) is
+        // emitted once per affected node further below.
+        logger?.warn({
+          event: 'constraint_probability_suppressed',
+          option_id: optionId,
+          raw_probability_of_joint_goal: constraintAnalysis.joint_probability,
+          raw_constraint_probabilities: constraintProbs,
+          unreliable_targets: unreliableConstraintTargets,
+        });
+      } else {
+        if (jointProb !== undefined) {
+          result.probability_of_joint_goal = jointProb;
+        }
+        if (constraintProbs !== undefined) {
+          result.constraint_probabilities = constraintProbs;
+          logger?.info({ event: 'constraint_probs_mapped', option_id: optionId, count: Object.keys(constraintProbs).length });
+        }
       }
     }
 
@@ -1893,19 +1931,27 @@ function buildResponse(
 
     robustness = {
       // Numeric-egress guard (Codex round-3): omit robustness scalars when non-finite
-      // (score) or outside [0,1] (recommendation_stability, confidence) — these are
-      // OPTIONAL fields, so omission is honest absence, never a fabricated `null` or an
-      // impossible rate. switch_probability fabrication is NOT addressed here (see the
-      // deferred cross-layer note in the PR — it is type-required across consumers).
+      // (score) or outside [0,1] (confidence) — these are OPTIONAL fields, so omission
+      // is honest absence, never a fabricated `null` or an impossible rate.
+      // switch_probability fabrication is NOT addressed here (see the deferred
+      // cross-layer note in the PR — it is type-required across consumers).
       ...(finiteNum(islResult.robustness.score) !== undefined && { score: finiteNum(islResult.robustness.score) }),
       label,
       fragile_edges: enrichedFragileEdges,
       robust_edges: enrichedRobustEdges,
       explanation: islResult.robustness.explanation,
-      // Pass through recommendation_stability from ISL when it is a valid [0,1] rate
-      ...(prob01(islResult.robustness.recommendation_stability) !== undefined && {
-        recommendation_stability: prob01(islResult.robustness.recommendation_stability),
-      }),
+      // recommendation_stability is DELIBERATELY NOT EMITTED (lane PLoT-H
+      // item B, 2026-07-07). ISL computes it as option_wins[winner]/n_samples
+      // (robustness_analyzer_v2.py:_compute_robustness) — the leader's
+      // win_probability relabelled, zero independent information. Verified
+      // byte-identical to the leader's win_probability in both live manual
+      // tests (0.59025 / 0.8541875) and in the live capture fixture
+      // (tests/fixtures/isl-v2-live-20260706: robustness.recommendation_stability
+      // 0.59025 === max win_probability 0.59025). The UI printed it as
+      // "N% stability" — a fabricated second statistic. Omission is honest
+      // absence; the UI has an absence path. No genuinely distinct
+      // recommendation-level stability signal exists on the V2 wire (the
+      // wire's `confidence` is itself derived from this same value).
       // Pass through V2/Option C robustness summary fields from ISL
       ...(islResult.robustness.is_robust !== undefined && {
         is_robust: islResult.robustness.is_robust,
@@ -1984,6 +2030,26 @@ function buildResponse(
       message: 'Edge-level sensitivity was requested but the ISL V2 response format does not carry it — edge_sensitivity is empty by wire contract, not by computation failure. Factor-level sensitivity is unaffected.',
       severity: 'info',
     });
+  }
+
+  // Producer honesty (item A): one WARNING per affected constraint-target
+  // node when goal-fit probabilities were suppressed above. Open-vocabulary
+  // code CONSTRAINT_TARGET_UNRELIABLE; message names the node and the
+  // concrete user action (set a value/range) — raw suppressed numbers are
+  // never quoted (they live in the constraint_probability_suppressed log).
+  if (suppressConstraintProbabilities) {
+    const warnedNodeIds = new Set<string>();
+    for (const target of unreliableConstraintTargets) {
+      if (warnedNodeIds.has(target.node_id)) continue;
+      warnedNodeIds.add(target.node_id);
+      const nodeLabel = graph?.nodes?.find((n) => n.id === target.node_id)?.label ?? target.node_id;
+      inferenceWarnings.push({
+        code: INFERENCE_WARNING_CODES.CONSTRAINT_TARGET_UNRELIABLE,
+        // provisional_doctrine_v0 — wording surface (see constraint-reliability.ts)
+        message: buildConstraintTargetUnreliableMessage(nodeLabel, target.reasons),
+        severity: 'warning',
+      });
+    }
   }
 
   // Merge ISL-originated inference_warnings into the PLoT array.
@@ -4430,34 +4496,85 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           factorSensitivitySource = 'isl';
         }
 
-        // Enrich factor sensitivity with EVPI percentage points heuristic.
-        // Heuristic approximation: VOI × win probability spread × 100,
-        // clamped to ≥ 0. Not true counterfactual EVPI. To be replaced
-        // when ISL supports per-factor counterfactual EVPI. See
-        // `src/lib/evpi-emission.ts` for the non-negative contract
-        // rationale (Howard 1966; OpenAPI `evpi_percentage_points.minimum: 0`).
+        // Enrich factor sensitivity with EVPI percentage points.
+        //
+        // P-5 (provisional_doctrine_v0, lane PLoT-H item C): when ISL supplied
+        // per-factor counterfactual EVPI (V2 wire `factor_evpi[]`) AND
+        // FLAGS.ISL_FACTOR_EVPI_INTERNAL is on (default ON for staging/test,
+        // OFF for prod), the sanitised ISL values are used IN PLACE of the
+        // heuristic for the "worth checking next" ranking surface. Hygiene via
+        // mapIslFactorEvpi: negatives are NEVER emitted; below-resolution
+        // estimates (including all MC-noise negatives, honouring ISL's
+        // `evpi_status` wire field where present) are labelled
+        // `evpi_status: 'below_resolution'` with evpi_percentage_points ABSENT
+        // — never a clamped 0. Live motivation (scenario 327bc417,
+        // 2026-07-07): the heuristic |sens|×(1−conf)×max(marginal) flattened
+        // to 0 for ALL factors because marginal_switch_probability was
+        // uniformly 0, so the ranking carried no information.
+        //
+        // Fallback (factor_evpi absent or flag off): the existing heuristic
+        // VOI × win-probability-spread × 100, clamped ≥ 0. Not true
+        // counterfactual EVPI. See `src/lib/evpi-emission.ts` for the
+        // non-negative contract rationale (Howard 1966; OpenAPI
+        // `evpi_percentage_points.minimum: 0`). The golden pricing-canary
+        // fixture has no factor_evpi → always takes this path (byte-identical).
         if (factorSensitivity) {
-          const islOptions = processedIslResult?.options ?? processedIslResult?.results ?? [];
-          const winProbs = (islOptions as any[])
-            .map((o: any) => o.win_probability as number | undefined)
-            .filter((wp): wp is number => wp != null)
-            .sort((a, b) => b - a);
-          const winProbSpread = winProbs.length >= 2 ? winProbs[0] - winProbs[1] : 0;
-          if (winProbSpread > 0) {
+          const factorEvpiMapping = FLAGS.ISL_FACTOR_EVPI_INTERNAL
+            ? mapIslFactorEvpi(islResult)
+            : { entries: [], dropped_invalid: 0 };
+          const islEvpiByFactor = new Map(
+            factorEvpiMapping.entries.map((e) => [e.factor_id, e]),
+          );
+
+          if (islEvpiByFactor.size > 0) {
             for (const f of factorSensitivity) {
               // P0a: never emit EVPI for an option-pinned lever
-              // (zero_reason === 'intervention_override'). Its VOI is forced to 0
-              // in mergeIslConfidenceIntoGraphFactors, and computeEvpiPercentagePoints(0, …)
-              // returns a confident 0 (not undefined) — which would still render an
-              // EVPI chip and rank the lever as an "investigation priority". Skip it
-              // entirely so evpi_percentage_points is ABSENT (preserving the
-              // missing-vs-zero contract), not 0. Belt-and-braces with the
-              // producer-side VOI zeroing; suppression only, no EVPI rename/redefine.
+              // (zero_reason === 'intervention_override') — resolving knowledge
+              // of a value the user sets is not an information gain. Applies to
+              // the ISL counterfactual path exactly as to the heuristic path.
               if (f.zero_reason === 'intervention_override') continue;
-              const evpiPp = computeEvpiPercentagePoints(f.value_of_information, winProbSpread);
-              if (evpiPp !== undefined) {
-                f.evpi_percentage_points = evpiPp;
-                f.evpi_method = 'heuristic';
+              const entry = islEvpiByFactor.get(f.factor_id);
+              if (!entry) continue; // no ISL estimate for this factor → honest absence
+              if (entry.emit_pp !== undefined) {
+                f.evpi_percentage_points = entry.emit_pp;
+                f.evpi_method = 'counterfactual';
+              } else if (entry.below_resolution) {
+                // "Too small to measure at this sampling depth" — labelled,
+                // never a fabricated 0 and never the raw negative.
+                f.evpi_status = 'below_resolution';
+              }
+            }
+            req.log.info({
+              event: 'factor_evpi_promoted',
+              request_id: requestId,
+              source: 'isl_counterfactual',
+              entries: factorEvpiMapping.entries.length,
+              dropped_invalid: factorEvpiMapping.dropped_invalid,
+              below_resolution_count: factorEvpiMapping.entries.filter((e) => e.below_resolution).length,
+            });
+          } else {
+            const islOptions = processedIslResult?.options ?? processedIslResult?.results ?? [];
+            const winProbs = (islOptions as any[])
+              .map((o: any) => o.win_probability as number | undefined)
+              .filter((wp): wp is number => wp != null)
+              .sort((a, b) => b - a);
+            const winProbSpread = winProbs.length >= 2 ? winProbs[0] - winProbs[1] : 0;
+            if (winProbSpread > 0) {
+              for (const f of factorSensitivity) {
+                // P0a: never emit EVPI for an option-pinned lever
+                // (zero_reason === 'intervention_override'). Its VOI is forced to 0
+                // in mergeIslConfidenceIntoGraphFactors, and computeEvpiPercentagePoints(0, …)
+                // returns a confident 0 (not undefined) — which would still render an
+                // EVPI chip and rank the lever as an "investigation priority". Skip it
+                // entirely so evpi_percentage_points is ABSENT (preserving the
+                // missing-vs-zero contract), not 0. Belt-and-braces with the
+                // producer-side VOI zeroing; suppression only, no EVPI rename/redefine.
+                if (f.zero_reason === 'intervention_override') continue;
+                const evpiPp = computeEvpiPercentagePoints(f.value_of_information, winProbSpread);
+                if (evpiPp !== undefined) {
+                  f.evpi_percentage_points = evpiPp;
+                  f.evpi_method = 'heuristic';
+                }
               }
             }
           }
@@ -4687,6 +4804,16 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             reason: r.reason,
           }));
 
+          // Producer honesty (item A): mirror buildResponse's detection so the
+          // coaching joint-probability gate never reads placeholder-derived
+          // joint probabilities (same inputs → same verdict as the public
+          // suppression).
+          const coachingConstraintTargetsUnreliable = detectUnreliableConstraintTargets(
+            activeGoalConstraints,
+            constraintNormalisationRanges,
+            processedIslResult,
+          ).length > 0;
+
           m1Coaching = generateM1Coaching(
             filteredGraph,
             body.options,
@@ -4699,6 +4826,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                                  // factor_sensitivity array we publish, so evidence_gaps
                                  // confidence/influence match the public payload (audit
                                  // A1-PRIMARY: no raw-ISL signal under coaching field names).
+            coachingConstraintTargetsUnreliable,  // Item A: skip joint-prob gate on unreliable targets
           );
         } catch (err) {
           req.log.warn({

--- a/src/types/cee-no-voi.type-pin.ts
+++ b/src/types/cee-no-voi.type-pin.ts
@@ -32,7 +32,7 @@ type SensitiveParam = NonNullable<
 // both the top level (CeeReviewRequest) and the nested sensitive_parameters
 // level. Keeping one shared union prevents the two checks from drifting apart
 // (e.g. one covering 'evpi' but not 'evpi_percentage_points', or vice versa).
-type ForbiddenVoiKey = 'value_of_information' | 'voi' | 'evpi' | 'evpi_percentage_points';
+type ForbiddenVoiKey = 'value_of_information' | 'voi' | 'evpi' | 'evpi_percentage_points' | 'evpi_status';
 
 type NoVoiOnCeeRequest = Extract<keyof CeeReviewRequest, ForbiddenVoiKey>;
 type NoVoiOnSensitiveParam = Extract<keyof SensitiveParam, ForbiddenVoiKey>;

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1382,6 +1382,9 @@ export interface OptionComparisonResultV3 {
   /**
    * Probability of jointly satisfying all goal_constraints [0, 1].
    * Only present when goal_constraints provided in request.
+   * SUPPRESSED (absent) when any constraint target is unreliable
+   * (CONSTRAINT_TARGET_UNRELIABLE inference warning present) — the raw
+   * computed value would be meaningless and lives in diagnostics logs only.
    */
   probability_of_joint_goal?: number;
 
@@ -1389,6 +1392,8 @@ export interface OptionComparisonResultV3 {
    * Per-constraint probabilities for this option.
    * Map of constraint_id to probability [0, 1].
    * Only present when goal_constraints provided in request.
+   * SUPPRESSED (absent) when any constraint target is unreliable
+   * (CONSTRAINT_TARGET_UNRELIABLE inference warning present).
    */
   constraint_probabilities?: Record<string, number>;
 }
@@ -1689,10 +1694,18 @@ export interface FactorSensitivityResultV3 {
   value_of_information?: number;
   /**
    * Estimated EVPI in percentage points of win probability.
-   * Heuristic approximation: `value_of_information × win_probability_spread × 100`.
-   * Not true counterfactual EVPI. To be replaced when ISL supports
-   * per-factor counterfactual EVPI.
-   * Present only when both VOI and win probabilities are available.
+   *
+   * Two sources, disclosed via `evpi_method`:
+   * - `'counterfactual'`: ISL's per-factor counterfactual EVPI (V2 wire
+   *   `factor_evpi[]`), used IN PLACE of the heuristic when present and
+   *   `FLAGS.ISL_FACTOR_EVPI_INTERNAL` is on (staging/test default ON, prod
+   *   OFF — P-5, provisional_doctrine_v0). Sanitised: negatives are NEVER
+   *   emitted; below-resolution estimates are labelled via `evpi_status`
+   *   instead of a clamped 0.
+   * - `'heuristic'`: `value_of_information × win_probability_spread × 100`
+   *   (fallback when ISL factor_evpi is absent or the flag is off).
+   *
+   * Present only when the active source yields an emittable value.
    *
    * **Derived from this field's own `value_of_information`** — inherits its
    * public-surface provenance (ISL Monte Carlo or graph fallback with
@@ -1706,6 +1719,15 @@ export interface FactorSensitivityResultV3 {
   evpi_percentage_points?: number;
   /** Method used to compute evpi_percentage_points */
   evpi_method?: 'heuristic' | 'counterfactual';
+  /**
+   * Present ONLY when ISL supplied a counterfactual EVPI estimate for this
+   * factor that is too small to measure at the run's sampling depth
+   * (including Monte Carlo–noise negatives, which are never emitted).
+   * `'below_resolution'` means "too small to measure", NOT "measured as
+   * zero" — `evpi_percentage_points` is deliberately absent in that case.
+   * Honours ISL's `factor_evpi[].evpi_status` wire field where present.
+   */
+  evpi_status?: 'below_resolution';
   /**
    * Confidence in the sensitivity score (0-1).
    *
@@ -1872,6 +1894,16 @@ export const INFERENCE_WARNING_CODES = {
    * invent a substitute.
    */
   EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE: 'EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE',
+  /**
+   * A goal constraint's target is not decision-grade: its threshold
+   * normalisation fell back to the default [0,1] range and/or ISL defaulted
+   * the target node's base to 0.0 (no observed value / no parameter
+   * uncertainty). `probability_of_joint_goal` and `constraint_probabilities`
+   * are SUPPRESSED for the run (absence is honest; raw computed values stay
+   * in diagnostics logs only). Severity: warning.
+   * @see src/lib/constraint-reliability.ts
+   */
+  CONSTRAINT_TARGET_UNRELIABLE: 'CONSTRAINT_TARGET_UNRELIABLE',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];
@@ -1953,7 +1985,17 @@ export interface RobustnessAssessmentV3 {
   /** Robust edges - always Array<NormalizedEdgeInfoV3>, never undefined/null. Empty array when none. */
   robust_edges: NormalizedEdgeInfoV3[];
   explanation?: string;
-  /** Recommendation stability from ISL (0-1, probability recommendation holds under perturbation) */
+  /**
+   * @deprecated NO LONGER EMITTED by PLoT (lane PLoT-H item B, 2026-07-07).
+   * ISL derives this as `option_wins[winner] / n_samples` (see ISL
+   * `robustness_analyzer_v2.py:_compute_robustness`) — i.e. it is the
+   * leader's win_probability relabelled, carrying zero independent
+   * information. Verified byte-identical to the leader's win_probability in
+   * both live manual tests (0.59025 and 0.8541875) and in the live capture
+   * fixture (tests/fixtures/isl-v2-live-20260706). Consumers must use the
+   * absence path (the UI already suppresses "N% stability" on absence).
+   * Field kept on the type for inbound tolerance of old payloads only.
+   */
   recommendation_stability?: number;
   /** Boolean robustness flag from ISL V2/Option C format */
   is_robust?: boolean;

--- a/tests/cil-constraint-passthrough.test.ts
+++ b/tests/cil-constraint-passthrough.test.ts
@@ -111,9 +111,16 @@ import { createServer } from '../src/createServer.js';
 
 const GRAPH = {
   nodes: [
-    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    // Constraint targets carry observed values so their normalisation ranges
+    // derive from real data (inferred_value tier), keeping the targets
+    // RELIABLE. Without them the user-unit thresholds (20000 / 5000) would be
+    // scaled against the made-up default [0,1] range, and item A producer
+    // honesty (CONSTRAINT_TARGET_UNRELIABLE) would rightly SUPPRESS the
+    // per-option probability fields this suite pins the mapping of — see
+    // tests/constraint-target-unreliable.fixture.test.ts for that contract.
+    { id: 'goal', kind: 'goal', label: 'Revenue', observed_state: { value: 15000 } },
     { id: 'factor-a', kind: 'factor', label: 'Market Size' },
-    { id: 'factor-b', kind: 'factor', label: 'Retention' },
+    { id: 'factor-b', kind: 'factor', label: 'Retention', observed_state: { value: 4000 } },
   ],
   edges: [
     { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
@@ -196,11 +203,15 @@ describe('CIL C1: Constraint Results Passthrough', () => {
   });
 
   it('passes through constraint_results with correct field mapping when ISL returns constraint_analysis', async () => {
-    // ISL returns constraint_analysis per-option (canonical "value" field)
+    // ISL returns constraint_analysis per-option (canonical "value" field).
+    // failure_margin_median is in NORMALISED units on the ISL wire (the
+    // constraints were normalised before forwarding); PLoT denormalises by
+    // range width — goal: [0, 30000] (inferred from observed 15000) → 0.04 ×
+    // 30000 = 1200; factor-b: [0, 8000] → 0.05 × 8000 = 400.
     mockConstraintAnalysis = {
       constraints: [
-        { node_id: 'goal', operator: '>=', value: 20000, prob_satisfied: 0.85, failure_margin_median: 1200, near_miss_fraction: 0.12, binding: true },
-        { node_id: 'factor-b', operator: '<=', value: 5000, prob_satisfied: 0.92, failure_margin_median: 400, near_miss_fraction: 0.05, binding: false },
+        { node_id: 'goal', operator: '>=', value: 20000, prob_satisfied: 0.85, failure_margin_median: 0.04, near_miss_fraction: 0.12, binding: true },
+        { node_id: 'factor-b', operator: '<=', value: 5000, prob_satisfied: 0.92, failure_margin_median: 0.05, near_miss_fraction: 0.05, binding: false },
       ],
       joint_probability: 0.78,
       conditional_probabilities: [

--- a/tests/constraint-reliability.unit.test.ts
+++ b/tests/constraint-reliability.unit.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for src/lib/constraint-reliability.ts (lane PLoT-H item A).
+ *
+ * Route-level behaviour (suppression + CONSTRAINT_TARGET_UNRELIABLE emission)
+ * is pinned in tests/constraint-target-unreliable.fixture.test.ts; these tests
+ * pin the detection semantics in isolation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectUnreliableConstraintTargets,
+  buildConstraintTargetUnreliableMessage,
+} from '../src/lib/constraint-reliability.js';
+import type { NormalisationRange } from '../src/lib/intervention-normaliser.js';
+
+const gc = (id: string, nodeId: string) => ({
+  constraint_id: id,
+  node_id: nodeId,
+  operator: '>=' as const,
+  value: 20,
+});
+
+const range = (source: NormalisationRange['source']): NormalisationRange => ({
+  min: 0,
+  max: 1,
+  source,
+});
+
+describe('detectUnreliableConstraintTargets', () => {
+  it('returns [] for no constraints / undefined inputs', () => {
+    expect(detectUnreliableConstraintTargets(undefined, undefined, undefined)).toEqual([]);
+    expect(detectUnreliableConstraintTargets([], new Map(), {})).toEqual([]);
+  });
+
+  it("flags a constraint whose normalisation range source is 'default'", () => {
+    const ranges = new Map([['c1', range('default')]]);
+    const out = detectUnreliableConstraintTargets([gc('c1', 'out_x')], ranges, {});
+    expect(out).toEqual([
+      { constraint_id: 'c1', node_id: 'out_x', reasons: ['threshold_normalisation_defaulted'] },
+    ]);
+  });
+
+  it('does NOT flag derivable range sources (explicit/inferred tiers)', () => {
+    for (const src of ['explicit_cap', 'explicit', 'extracted', 'inferred_spread', 'inferred_baseline', 'inferred_value'] as const) {
+      const ranges = new Map([['c1', range(src)]]);
+      expect(detectUnreliableConstraintTargets([gc('c1', 'out_x')], ranges, {})).toEqual([]);
+    }
+  });
+
+  it('flags a target named by the ISL CONSTRAINT_NODE_DEFAULT_BASE inference warning (nested detail shape)', () => {
+    const islResult = {
+      inference_warnings: [{
+        code: 'CONSTRAINT_NODE_DEFAULT_BASE',
+        field: 'nodes[out_x].base',
+        detail: { node_id: 'out_x', defaulted_to: 0.0, reason: 'no_parameter_uncertainty', message: 'm' },
+      }],
+    };
+    const out = detectUnreliableConstraintTargets([gc('c1', 'out_x')], undefined, islResult);
+    expect(out).toEqual([
+      { constraint_id: 'c1', node_id: 'out_x', reasons: ['target_base_defaulted'] },
+    ]);
+  });
+
+  it('flags a target named via the ISL critiques channel (affected_node_ids)', () => {
+    const islResult = {
+      critiques: [{ code: 'CONSTRAINT_NODE_DEFAULT_BASE', affected_node_ids: ['out_x'] }],
+    };
+    const out = detectUnreliableConstraintTargets([gc('c1', 'out_x')], undefined, islResult);
+    expect(out).toEqual([
+      { constraint_id: 'c1', node_id: 'out_x', reasons: ['target_base_defaulted'] },
+    ]);
+  });
+
+  it('combines both reasons on the full live chain', () => {
+    const ranges = new Map([['c1', range('default')]]);
+    const islResult = {
+      inference_warnings: [{
+        code: 'CONSTRAINT_NODE_DEFAULT_BASE',
+        detail: { node_id: 'out_x' },
+      }],
+    };
+    const out = detectUnreliableConstraintTargets([gc('c1', 'out_x')], ranges, islResult);
+    expect(out).toEqual([
+      {
+        constraint_id: 'c1',
+        node_id: 'out_x',
+        reasons: ['threshold_normalisation_defaulted', 'target_base_defaulted'],
+      },
+    ]);
+  });
+
+  it('only flags the affected constraint, not reliable siblings', () => {
+    const ranges = new Map([
+      ['c1', range('default')],
+      ['c2', range('inferred_value')],
+    ]);
+    const out = detectUnreliableConstraintTargets(
+      [gc('c1', 'out_x'), gc('c2', 'out_y')],
+      ranges,
+      {},
+    );
+    expect(out.map((t) => t.constraint_id)).toEqual(['c1']);
+  });
+
+  it('ignores unrelated warning codes and unrelated node ids', () => {
+    const islResult = {
+      inference_warnings: [
+        { code: 'ROOT_NODE_DEFAULT_VALUE', detail: { node_id: 'out_x' } },
+        { code: 'CONSTRAINT_NODE_DEFAULT_BASE', detail: { node_id: 'other_node' } },
+      ],
+    };
+    expect(detectUnreliableConstraintTargets([gc('c1', 'out_x')], undefined, islResult)).toEqual([]);
+  });
+});
+
+describe('buildConstraintTargetUnreliableMessage (provisional_doctrine_v0 wording)', () => {
+  it('names the node, states withholding, and gives the user action', () => {
+    const msg = buildConstraintTargetUnreliableMessage('Campaign effectiveness', ['target_base_defaulted']);
+    expect(msg).toContain('Campaign effectiveness');
+    expect(msg).toContain('withheld');
+    expect(msg).toContain('Set a value or range for "Campaign effectiveness"');
+  });
+
+  it('normalisation-only reason gets the scaling explanation', () => {
+    const msg = buildConstraintTargetUnreliableMessage('X', ['threshold_normalisation_defaulted']);
+    expect(msg).toContain('could not be scaled');
+  });
+
+  it('never contains the raw suppressed numbers or the strings EVPI / expected value', () => {
+    const msg = buildConstraintTargetUnreliableMessage('X', [
+      'threshold_normalisation_defaulted',
+      'target_base_defaulted',
+    ]);
+    expect(msg).not.toMatch(/\bEVPI\b/i);
+    expect(msg).not.toMatch(/expected value/i);
+    expect(msg).not.toMatch(/0(\.0+)?%/);
+  });
+});

--- a/tests/constraint-target-unreliable.fixture.test.ts
+++ b/tests/constraint-target-unreliable.fixture.test.ts
@@ -1,0 +1,300 @@
+/**
+ * CONSTRAINT_TARGET_UNRELIABLE fixture test (lane PLoT-H item A).
+ *
+ * Reproduces the live defect chain from scenario 327bc417 (2026-07-07):
+ * the user set a success target of "20" (unit "%") on
+ * `out_campaign_effectiveness` — a node with NO observed value. The pipeline
+ * then:
+ *   1. logged `plot.constraint_out_of_domain` (threshold 20 outside [0,1] on
+ *      a probability-domain node, non-temporal unit → forwarded);
+ *   2. normalised the threshold against the DEFAULT [0,1] fallback range
+ *      (`range_source: "default"`) → 20 clamped to 1 = "≥ domain max";
+ *   3. ISL defaulted the target node's base to 0.0
+ *      (CONSTRAINT_NODE_DEFAULT_BASE, reason no_parameter_uncertainty);
+ *   4. emitted probability_of_joint_goal = 0 for EVERY option — a meaningless
+ *      "0% goal fit everywhere".
+ *
+ * Producer-honesty contract under test (RED before the fix):
+ *   - probability_of_joint_goal and constraint_probabilities are SUPPRESSED
+ *     (absent) for the run;
+ *   - a WARNING-severity CONSTRAINT_TARGET_UNRELIABLE inference warning names
+ *     the node and the user action;
+ *   - coaching does not fabricate GOAL_FEASIBILITY_LOW from the placeholder 0;
+ *   - CONTROL: a reliable constraint target keeps both fields (suppression is
+ *     conditional, not blanket).
+ *
+ * The ISL request/ISL service are NOT changed — the mock returns exactly what
+ * live ISL returned for this chain.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Mutable mock state (per-request ISL behaviour)
+// ---------------------------------------------------------------------------
+
+/** When true, the ISL mock emits the CONSTRAINT_NODE_DEFAULT_BASE warning. */
+let emitDefaultBaseWarning = false;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    const goalConstraints = body.goal_constraints || [];
+
+    const constraintAnalysis = goalConstraints.length > 0
+      ? {
+          constraint_analysis: {
+            // Live shape: base defaulted to 0.0 → joint probability 0 for
+            // every option when the warning fires; a plausible non-zero
+            // probability otherwise (control).
+            joint_probability: emitDefaultBaseWarning ? 0 : 0.55,
+            constraints: goalConstraints.map((c: any) => ({
+              node_id: c.node_id,
+              operator: c.operator,
+              threshold: c.threshold ?? c.value,
+              prob_satisfied: emitDefaultBaseWarning ? 0 : 0.55,
+            })),
+          },
+        }
+      : {};
+
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+          win_probability: idx === 0 ? 0.6 : 0.4,
+          rank: idx + 1,
+          ...constraintAnalysis,
+        })),
+        factor_sensitivity: [],
+        robustness: { label: 'moderate', score: 0.6, fragile_edges: [], robust_edges: [] },
+        // Live ISL wire shape for the defaulted-base signal (see ISL
+        // robustness_analyzer_v2.py — InferenceWarning with nested detail):
+        inference_warnings: emitDefaultBaseWarning
+          ? [{
+              code: 'CONSTRAINT_NODE_DEFAULT_BASE',
+              field: 'nodes[out_campaign_effectiveness].base',
+              detail: {
+                node_id: 'out_campaign_effectiveness',
+                defaulted_to: 0.0,
+                reason: 'no_parameter_uncertainty',
+                message: "Node 'out_campaign_effectiveness' has no ParameterUncertainty — defaulted to base=0.0, constraint probability may be unreliable",
+              },
+            }]
+          : [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Paul's chain: outcome node with NO observed value, target 20 unit "%". */
+const GRAPH_VALUELESS_TARGET = {
+  nodes: [
+    { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
+    // The constraint target: outcome node with NO observed_state at all →
+    // deriveRange() bottoms out at the default [0,1] range.
+    { id: 'out_campaign_effectiveness', kind: 'outcome', label: 'Campaign effectiveness' },
+    { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_budget', to: 'out_campaign_effectiveness', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_campaign_effectiveness', to: 'goal_growth', strength: { mean: 0.6, std: 0.1 } },
+  ],
+};
+
+/** Control: same shape but the target node HAS an observed value (range derivable). */
+const GRAPH_VALUED_TARGET = {
+  nodes: [
+    { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
+    // observed value 50 → deriveRange() infers [0, 100] (inferred_value tier),
+    // NOT the default fallback.
+    { id: 'out_campaign_effectiveness', kind: 'outcome', label: 'Campaign effectiveness', observed_state: { value: 50 } },
+    { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_budget', to: 'out_campaign_effectiveness', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_campaign_effectiveness', to: 'goal_growth', strength: { mean: 0.6, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt_a', label: 'Push campaign', interventions: { fac_budget: 0.8 } },
+  { id: 'opt_b', label: 'Hold steady', interventions: { fac_budget: 0.4 } },
+];
+
+/** The exact user input from the live session: 20, unit '%'. */
+const SUCCESS_TARGET_20_PCT = {
+  constraint_id: 'success_target',
+  node_id: 'out_campaign_effectiveness',
+  operator: '>=',
+  value: 20,
+  unit: '%',
+  label: 'Effectiveness at least 20%',
+};
+
+describe('CONSTRAINT_TARGET_UNRELIABLE (item A — Paul\'s 20/% valueless-node chain)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    emitDefaultBaseWarning = false;
+  });
+
+  async function run(graph: any, constraint: any) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({
+        graph,
+        options: OPTIONS,
+        goal_node_id: 'goal_growth',
+        seed: 'constraint-honesty',
+        goal_constraints: [constraint],
+      }),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  it('suppresses probability_of_joint_goal and constraint_probabilities on the full live chain', async () => {
+    emitDefaultBaseWarning = true;
+    try {
+      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+
+      expect(body.analysis_status).not.toBe('blocked');
+      expect(Array.isArray(body.option_comparison)).toBe(true);
+      expect(body.option_comparison.length).toBe(2);
+
+      // The mirror-of-98%-fabrication defect: before the fix every option
+      // carried probability_of_joint_goal: 0. Absence is the honest contract.
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+      }
+    } finally {
+      emitDefaultBaseWarning = false;
+    }
+  });
+
+  it('emits a WARNING-severity CONSTRAINT_TARGET_UNRELIABLE naming the node and the user action', async () => {
+    emitDefaultBaseWarning = true;
+    try {
+      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+
+      const warnings = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+      );
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].severity).toBe('warning');
+      // Names the node (label, not internal id) …
+      expect(warnings[0].message).toContain('Campaign effectiveness');
+      // … says the numbers were withheld …
+      expect(warnings[0].message).toContain('withheld');
+      // … and tells the user what to do about it.
+      expect(warnings[0].message).toContain('Set a value or range');
+      // The raw suppressed numbers are never quoted in the warning.
+      expect(warnings[0].message).not.toContain('0%');
+    } finally {
+      emitDefaultBaseWarning = false;
+    }
+  });
+
+  it('suppresses on the normalisation-default leg ALONE (no ISL default-base warning)', async () => {
+    // Even if ISL does not flag the base (e.g. older ISL build), scaling a
+    // user-unit threshold against the made-up default [0,1] range is already
+    // not decision-grade.
+    emitDefaultBaseWarning = false;
+    const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+
+    for (const opt of body.option_comparison) {
+      expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+      expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+    }
+    const warnings = (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].severity).toBe('warning');
+  });
+
+  it('does not fabricate GOAL_FEASIBILITY_LOW coaching from the placeholder joint probability', async () => {
+    emitDefaultBaseWarning = true;
+    try {
+      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+      // The joint-prob readiness gate is skipped for unreliable targets: no
+      // "may not achieve the target" claim derived from a placeholder 0.
+      expect(JSON.stringify(body.m1_coaching ?? {})).not.toContain('GOAL_FEASIBILITY_LOW');
+    } finally {
+      emitDefaultBaseWarning = false;
+    }
+  });
+
+  it('CONTROL: reliable target (derivable range, no default base) keeps both probability fields', async () => {
+    emitDefaultBaseWarning = false;
+    const body = await run(GRAPH_VALUED_TARGET, SUCCESS_TARGET_20_PCT);
+
+    for (const opt of body.option_comparison) {
+      expect(opt.probability_of_joint_goal, opt.option_id).toBe(0.55);
+      expect(opt.constraint_probabilities, opt.option_id).toEqual({ success_target: 0.55 });
+    }
+    const warnings = (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('raw computed values stay available in diagnostics logs (not the wire): suppression event exists', async () => {
+    // The suppression path logs `constraint_probability_suppressed` with the
+    // raw values (see run.ts). Assert via a captured logger is heavyweight in
+    // route context; the wire-level absence above is the binding contract.
+    // Here we pin the complementary invariant: the top-level constraint block
+    // still discloses status honestly instead of disappearing silently.
+    emitDefaultBaseWarning = true;
+    try {
+      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+      expect(body.constraints_status).toBeDefined();
+    } finally {
+      emitDefaultBaseWarning = false;
+    }
+  });
+});

--- a/tests/isl-v2-envelope.unit.test.ts
+++ b/tests/isl-v2-envelope.unit.test.ts
@@ -155,7 +155,7 @@ describe('getIslComputedAt', () => {
   });
 });
 
-describe('mapIslFactorEvpi (guarded internal mapping — P-5 pending, NOT user-facing)', () => {
+describe('mapIslFactorEvpi (sanitising mapping — P-5 promoted behind ISL_FACTOR_EVPI_INTERNAL, provisional_doctrine_v0)', () => {
   it('proves the live wire delivers factor_evpi: 4 sanitised entries from capture A', () => {
     const { entries, dropped_invalid } = mapIslFactorEvpi(captureA);
     expect(entries).toHaveLength(4);
@@ -210,6 +210,36 @@ describe('mapIslFactorEvpi (guarded internal mapping — P-5 pending, NOT user-f
     });
     expect(garbage.entries).toHaveLength(1);
     expect(garbage.dropped_invalid).toBe(3);
+  });
+
+  it("honours ISL's evpi_status='below_resolution' even when the raw value clears PLoT's threshold", () => {
+    const { entries } = mapIslFactorEvpi({
+      factor_evpi: [
+        {
+          factor_id: 'fac_x', evpi: 0.02, evpi_percentage_points: 2.0,
+          current_metric: 0.5, perfect_metric: 0.52, metric_type: 'p_win_recommended',
+          n_evpi_samples: 500, evpi_status: 'below_resolution',
+        },
+      ] as any,
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].below_resolution).toBe(true);
+    expect(entries[0].emit_pp).toBeUndefined(); // producer's own label wins
+  });
+
+  it("does NOT let evpi_status='ok' override PLoT's threshold for sub-resolution raws", () => {
+    const { entries } = mapIslFactorEvpi({
+      factor_evpi: [
+        {
+          factor_id: 'fac_y', evpi: -0.0001, evpi_percentage_points: -0.01,
+          current_metric: 0.5, perfect_metric: 0.4999, metric_type: 'p_win_recommended',
+          n_evpi_samples: 500, evpi_status: 'ok',
+        },
+      ] as any,
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].below_resolution).toBe(true); // local threshold still applies
+    expect(entries[0].emit_pp).toBeUndefined();
   });
 });
 

--- a/tests/isl-v2-liveness.fixture.test.ts
+++ b/tests/isl-v2-liveness.fixture.test.ts
@@ -142,7 +142,10 @@ describe('ISL V2 science-channel liveness (live capture, build f3f5d92)', () => 
     process.env.CEE_ORCHESTRATOR_ENABLED = '0';
     process.env.DECISION_REVIEW_ENABLE = '0';
     process.env.ENABLE_REVIEW_PASS = '0';
-    // Flag hygiene under test: the internal factor_evpi mapping stays OFF
+    // P-5 promoted (lane PLoT-H item C): with no explicit env override the
+    // flag now DEFAULTS ON under NODE_ENV=test (and staging), so this run
+    // exercises the promoted ISL-counterfactual EVPI path. Prod default stays
+    // OFF (covered by the flag-off describe block below).
     delete process.env.ISL_FACTOR_EVPI_INTERNAL;
     app = await createServer();
     await app.ready();
@@ -181,6 +184,24 @@ describe('ISL V2 science-channel liveness (live capture, build f3f5d92)', () => 
     expect(body.robustness.is_robust).toBe(false);
     expect(body.robustness.level).toBe('low');
     expect(typeof body.robustness.confidence).toBe('number');
+  });
+
+  // -------------------------------------------------------------------------
+  // Item B (lane PLoT-H): recommendation_stability is a relabel of the
+  // leader's win_probability — never emitted.
+  // -------------------------------------------------------------------------
+
+  it('recommendation_stability is NOT emitted (byte-identical to leader win_probability on the wire)', () => {
+    // Evidence in this very capture: the wire value equals the leader's
+    // win_probability EXACTLY (ISL computes option_wins[winner]/n_samples).
+    const wireStability = captureA.robustness.recommendation_stability;
+    const leaderWinProb = Math.max(
+      ...captureA.options.map((o: any) => o.win_probability as number),
+    );
+    expect(wireStability).toBe(leaderWinProb); // 0.59025 === 0.59025
+    // Zero independent information → PLoT omits the key (absence is honest;
+    // the UI printed it as a fabricated "N% stability" and has an absence path).
+    expect(body.robustness).not.toHaveProperty('recommendation_stability');
   });
 
   it("analysis_types 'sensitivity' (factor-level) → factor_sensitivity non-empty and drivers computed", () => {
@@ -257,12 +278,13 @@ describe('ISL V2 science-channel liveness (live capture, build f3f5d92)', () => 
     }
   });
 
-  it('raw factor_evpi never leaks into the public response (flag off — P-5 pending)', () => {
+  it('raw factor_evpi never leaks into the public response (promotion ON — sanitised mapping only)', () => {
     expect(collectFields(body, (k) => k === 'factor_evpi')).toHaveLength(0);
     // The raw negative wire EVPI values must not appear under any EVPI/VOI
-    // key anywhere in the payload. (NOTE: a plain substring check would
-    // false-positive — the graph legitimately carries an edge mean of -0.15;
-    // the leak check must be structural, keyed to EVPI/VOI fields.)
+    // key anywhere in the payload — WITH the promotion active. (NOTE: a plain
+    // substring check would false-positive — the graph legitimately carries an
+    // edge mean of -0.15; the leak check must be structural, keyed to EVPI/VOI
+    // fields.)
     const evpiFields = collectFields(body, (k) =>
       k === 'evpi' || k === 'evpi_percentage_points' || k === 'value_of_information' ||
       k === 'raw_evpi' || k === 'raw_evpi_percentage_points',
@@ -270,6 +292,69 @@ describe('ISL V2 science-channel liveness (live capture, build f3f5d92)', () => 
     for (const [path, value] of evpiFields) {
       expect(value, `${path} must not carry the raw wire negatives`).not.toBe(-0.0015);
       expect(value, `${path} must not carry the raw wire negatives`).not.toBe(-0.15);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Item C (lane PLoT-H, P-5 promoted, provisional_doctrine_v0): ISL
+  // counterfactual factor_evpi feeds the factor_sensitivity EVPI surface IN
+  // PLACE of the heuristic (flag default ON under NODE_ENV=test).
+  // -------------------------------------------------------------------------
+
+  it('ISL factor_evpi maps to evpi_percentage_points with evpi_method counterfactual', () => {
+    const byId = new Map(
+      body.factor_sensitivity.map((f: any) => [f.factor_id, f]),
+    );
+    // Positive wire estimates → emitted, rounded to 0.1pp, method disclosed as
+    // counterfactual — EXCEPT option-pinned levers (zero_reason
+    // 'intervention_override'), which never carry EVPI in any form (P0a). In
+    // this capture fac_dev_headcount (1.85pp) and fac_tech_lead (0.85pp) are
+    // levers; fac_team_maturity (1.45pp) is the tunable positive.
+    for (const wire of captureA.factor_evpi as any[]) {
+      const f: any = byId.get(wire.factor_id);
+      if (!f) continue; // factors not in the public array carry nothing
+      if (f.zero_reason === 'intervention_override') {
+        // P0a: levers carry NO EVPI fields even when ISL supplies an estimate
+        expect(f, wire.factor_id).not.toHaveProperty('evpi_percentage_points');
+        expect(f, wire.factor_id).not.toHaveProperty('evpi_method');
+        expect(f, wire.factor_id).not.toHaveProperty('evpi_status');
+        continue;
+      }
+      if (wire.evpi_percentage_points >= 0.05) {
+        expect(f.evpi_method, wire.factor_id).toBe('counterfactual');
+        expect(f.evpi_percentage_points, wire.factor_id).toBeGreaterThan(0);
+        expect(f.evpi_percentage_points, wire.factor_id).toBeCloseTo(
+          Math.round(wire.evpi_percentage_points * 10) / 10,
+          10,
+        );
+        expect(f).not.toHaveProperty('evpi_status');
+      }
+    }
+    // At least one factor actually took the counterfactual path
+    const counterfactualCount = body.factor_sensitivity.filter(
+      (f: any) => f.evpi_method === 'counterfactual',
+    ).length;
+    expect(counterfactualCount).toBeGreaterThan(0);
+    // And NO factor took the heuristic path on this run (in-place, not mixed)
+    expect(
+      body.factor_sensitivity.some((f: any) => f.evpi_method === 'heuristic'),
+    ).toBe(false);
+  });
+
+  it('below-resolution wire estimate (fac_hiring_cost -0.15pp) → labelled, never 0, never negative', () => {
+    const hiringCost = body.factor_sensitivity.find(
+      (f: any) => f.factor_id === 'fac_hiring_cost',
+    );
+    // The capture carries a raw NEGATIVE estimate for this factor. It must be
+    // labelled below-resolution with the value ABSENT — a clamped 0 would
+    // falsely claim "measured as exactly worthless".
+    if (hiringCost) {
+      expect(hiringCost.evpi_status).toBe('below_resolution');
+      expect(hiringCost).not.toHaveProperty('evpi_percentage_points');
+      expect(hiringCost).not.toHaveProperty('evpi_method');
+    } else {
+      // If the factor is not on the public surface at all, absence is honest.
+      expect(hiringCost).toBeUndefined();
     }
   });
 
@@ -364,6 +449,54 @@ describe('CONSTRAINT_SAMPLES_UNNOISED warning tolerance', () => {
       expect(forwarded[0].severity).toBe('info');
     } finally {
       injectWarning = null;
+    }
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Item C prod posture: flag explicitly OFF → no counterfactual EVPI anywhere
+// (heuristic fallback semantics byte-identical to the pre-promotion build).
+// ---------------------------------------------------------------------------
+
+describe('factor_evpi promotion flag OFF (prod posture)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    process.env.ISL_FACTOR_EVPI_INTERNAL = '0'; // explicit prod-default override
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    delete process.env.ISL_FACTOR_EVPI_INTERNAL;
+  });
+
+  it('never emits evpi_method counterfactual or evpi_status when the flag is off', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: buildPlotBody(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    for (const f of body.factor_sensitivity as any[]) {
+      expect(f.evpi_method, f.factor_id).not.toBe('counterfactual');
+      expect(f, f.factor_id).not.toHaveProperty('evpi_status');
+    }
+    // Raw wire negatives still never leak
+    const evpiFields = collectFields(body, (k) =>
+      k === 'evpi' || k === 'evpi_percentage_points' || k === 'value_of_information',
+    );
+    for (const [path, value] of evpiFields) {
+      if (typeof value === 'number') {
+        expect(value, `${path} must never be negative`).toBeGreaterThanOrEqual(0);
+      }
     }
   }, 60_000);
 });

--- a/tests/robustness-enrichment.test.ts
+++ b/tests/robustness-enrichment.test.ts
@@ -325,6 +325,19 @@ describe('buildRobustnessDataForCee', () => {
     expect(result).toBeNull();
   });
 
+  it('returns null when ONLY recommendation_stability is present (item B: no longer meaningful data)', () => {
+    // recommendation_stability is the leader's win_probability relabelled —
+    // it neither counts as meaningful robustness data nor gets forwarded.
+    const result = buildRobustnessDataForCee(
+      { recommendation_stability: 0.87 },
+      [],
+      undefined,
+      TEST_GRAPH,
+      TEST_OPTIONS
+    );
+    expect(result).toBeNull();
+  });
+
   it('builds complete robustness data with all fields', () => {
     const islRobustness = {
       recommendation_stability: 0.87,
@@ -359,7 +372,10 @@ describe('buildRobustnessDataForCee', () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result!.recommendation_stability).toBe(0.87);
+    // Item B (producer honesty): recommendation_stability is NO LONGER
+    // forwarded — ISL derives it as option_wins[winner]/n_samples (the
+    // leader's win_probability relabelled), zero independent information.
+    expect(result!.recommendation_stability).toBeUndefined();
     expect(result!.recommended_option).toEqual({
       id: 'opt_premium',
       label: 'Premium Pricing',


### PR DESCRIPTION
# Lane PLoT-H — producer honesty: constraint chain (A) · stability relabel (B) · real EVPI (C)

All three defects evidenced in this morning's live test (scenario `327bc417`). Full evidence report with RED→GREEN proofs, traces, claim register and residuals: `docs/lanes/LANE6-producer-honesty-2026-07-07.md`.

## A — out-of-domain constraint chain (NEW P1)

Target `20` unit `%` on a valueless node → threshold normalised against the made-up default `[0,1]` range (→ "≥ domain max") → ISL defaults the base to `0.0` → `probability_of_joint_goal: 0` for ALL options. The user sees a meaningless 0% goal fit everywhere — the mirror image of the old 98% fabrication.

**Fix:** new `src/lib/constraint-reliability.ts` detects unreliable targets (`range_source: 'default'` normalisation fallback AND/OR ISL `CONSTRAINT_NODE_DEFAULT_BASE` naming the node). When any fire: `probability_of_joint_goal` + `constraint_probabilities` are **suppressed for the run** (absence is honest; the UI gates goal-fit on absence), a WARNING-severity **`CONSTRAINT_TARGET_UNRELIABLE`** inference warning names the node + the fix ("set a value or range for <node>…", `provisional_doctrine_v0`), raw computed values stay in the `constraint_probability_suppressed` diagnostics log only, and the coaching joint-prob gate is skipped (no fabricated `GOAL_FEASIBILITY_LOW`). ISL request and ISL untouched.

**RED→GREEN:** `tests/constraint-target-unreliable.fixture.test.ts` reproduces the exact chain — 4 failures on pristine `origin/staging` @ `04434eb`, 6/6 green here, incl. a CONTROL proving suppression is conditional.

## B — recommendation_stability relabel

`robustness.recommendation_stability` was **byte-identical** to the leader's `win_probability` in both manual tests (0.59025, 0.8541875) — ISL computes it as `option_wins[winner]/n_samples` (verified in ISL source + the live capture fixture). Zero independent information; the UI printed it as "N% stability". No genuinely distinct stability signal exists on the V2 wire (wire `confidence` is derived from the same value).

**Fix:** stop emitting it — omitted from the `/v2/run` robustness object and from `buildRobustnessDataForCee` (value-level omission of an optional field; types kept for inbound tolerance, marked deprecated; contract docs updated). Liveness test pins both the wire byte-identity and the non-emission (RED on staging).

**Residual (recorded, not changed):** the M2 decision-review request still sends `recommendation_stability ?? 0` as validator grounding — removing it is a non-additive PLoT→CEE boundary change (rule 6) → follow-up.

## C — VOI over-zeroing → real EVPI (P-5, provisional_doctrine_v0)

All 5 factors had `value_of_information: 0` (heuristic `|sens|×(1−conf)×max(marginal)` flattens when `marginal_switch_probability` is uniformly 0 — known).

**Fix:** `ISL_FACTOR_EVPI_INTERNAL` default flips **ON for test/staging, OFF for prod** (env overrides both ways). When on and the wire carries `factor_evpi[]`, the sanitised ISL counterfactual EVPI feeds `factor_sensitivity[].evpi_percentage_points` (`evpi_method: 'counterfactual'`) **in place of** the heuristic for the "worth checking next" ranking; heuristic stays as fallback when `factor_evpi` is absent. Hygiene: negatives never emitted; below-resolution labelled via new additive `evpi_status: 'below_resolution'` (never a clamped 0); ISL's new `evpi_status` wire field honoured where present; levers (`intervention_override`) still carry no EVPI (P0a). No user-facing string contains "EVPI"/"expected value" on this surface.

**Golden pricing-canary:** no `factor_evpi` in its fixture → fallback path → byte-identical (all golden suites green, goldens untouched).

## Verification

- `npx tsc --noEmit` clean.
- Full `npm test` in the lane worktree: the 3 pre-existing-style failures found were all in `tests/cil-constraint-passthrough.test.ts` pinning the OLD dishonest passthrough on default-range targets — fixture updated to reliable targets (see commit message); suite re-verified green in a **fresh detached worktree at the branch head** (result posted below/in report).
- RED proofs run in a pristine detached worktree at `origin/staging` @ `04434eb`.
- Known pre-existing CI reds (unrelated, per repo CLAUDE.md): `audit` + `gates (windows-latest)`.

## Wire-contract discipline

Value-level omissions of optional fields (A, B) + additive optional field / open-vocabulary warning code (A, C). No non-additive boundary change. Hand-authored OpenAPI + JSON-schema contracts updated in the same commits.

## provisional_doctrine_v0 register

1. `constraint-reliability.ts` warning wording (A).
2. `run.ts` CONSTRAINT_TARGET_UNRELIABLE emission site (A).
3. P-5 promotion decision + flag docs (C) — prod flip stays Paul-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
