### PR TITLE
Lane PLoT-R3: decision brief claim-safe surfaces (2.7) + diligence evidence capture (2.13)

### DIFF
--- a/docs/lanes/LANE10-brief-and-evidence-2026-07-07.md
+++ b/docs/lanes/LANE10-brief-and-evidence-2026-07-07.md
@@ -1,0 +1,172 @@
+# Lane PLoT-R3 — decision brief emission (2.7) + diligence evidence capture (2.13)
+
+- **Branch:** `claude-lane10/brief-and-evidence` (fresh worktree from `origin/staging` @ `1823e07`)
+- **Date:** 2026-07-07
+- **Scope discipline:** ONE repo (plot-lite-service); cross-repo reads only
+  (DecisionGuideAI UI-SEM inventory, read-only, to pin UI-SEM-060 semantics).
+  All wire changes ADDITIVE (new optional fields only). No goldens modified.
+  All new wording surfaces tagged `provisional_doctrine_v0`.
+
+---
+
+## Chronicle correction (trace of current state)
+
+The lane brief said "assembleBrief() exists — chronicle says stubbed near
+run.ts:1364 era; trace current state". Traced state on `origin/staging`
+(1823e07): **not stubbed** —
+
+- `src/assembly/decision-brief.ts:162` — full deterministic assembly
+  (headline via M2→M1→fallback chain, ranked options, A1b-filtered
+  top_drivers, evidence-gap key_assumptions, A1c-filtered
+  what_would_change, level-mapped robustness, deduped warnings, lineage);
+- `src/routes/v2/run.ts` — `decision_brief` ALREADY emitted on every
+  /v2/run response (null when analysis failed or option_comparison /
+  robustness absent), plus `_meta.decision_brief_assembled` diagnostic.
+
+So Feature A landed as the **claim-safe surface extension** of the live
+brief, not a from-scratch emission. What was missing vs the 2.7 spec:
+banded leader wording (UI-SEM-060 producer leg), value_defaulted
+assumption disclosures, an honest robustness caveat, and the
+warning-code echo. All added additively.
+
+---
+
+## Feature A — decision_brief claim-safe surfaces (roadmap 2.7, G.2)
+
+New optional fields on `DecisionBriefV1` (`src/types/decision-brief.ts`),
+built in `src/assembly/decision-brief.ts`, all `provisional_doctrine_v0`:
+
+| Field | Semantics | Claim-safety rule enforced |
+|---|---|---|
+| `headline_banded` | Leader claim banded by win-probability gap: `text`, `band`, leader/runner ids+labels, `win_probability_gap`, `robustness_gated`, `doctrine` | Bands EXACTLY 'very close' / 'slightly ahead' / 'clearly ahead'. gap < 0.10 (shared `NEAR_TIE_THRESHOLD` from `src/trust/result-coherence.ts`, so brief and `robustness.near_tie` can never disagree) → very_close; gap ≥ 0.25 (`CLEARLY_AHEAD_GAP_THRESHOLD`, provisional_doctrine_v0) AND robustness established → clearly_ahead; else slightly_ahead. **'clearly ahead' never emitted without established robustness** (`is_robust === true`, or `level === 'high'` with no explicit `is_robust === false`); downgrades carry `robustness_gated: true`. Absent when < 2 ranked options — no comparative claim without a comparison. |
+| `defaulted_assumptions` | value_defaulted factors + DEFAULT-coded inference-warning echoes | Intervention-pinned levers EXCLUDED via the shared A1b predicate (`filterInterventionOverrides`) — a pinned lever never appears in "check this input" framing. Run-level disclosures echo the producer-owned warning message verbatim, deduped by code. Max 10, deterministic order. |
+| `robustness_caveat` | `{ text, basis, doctrine }` | Wording derived STRICTLY from `is_robust` / `level`; when neither present, `basis: 'absent'` and the text says robustness was **not assessed** — absence stated, never implied stability. Explicit `is_robust: false` is never softened. |
+| `warning_codes` | Warning-severity inference-warning codes | Codes only (no numbers, no prose), deduped, bytewise-sorted, capped 20. Info-severity NOT echoed. |
+
+Forbidden-wording tripwire test: serialised brief contains no `EVPI`,
+no `expected value`, no `sensitive to` (case-insensitive) —
+`tests/decision-brief.claim-safety.test.ts`.
+
+UI-SEM-060 alignment (read-only trace of
+`DecisionGuideAI .claude/worktrees/*/CLAUDE.md` UI-SEM inventory row 060):
+the UI's debt note is "Remove when PLoT provides a leader-confidence
+band / close-call signal" — `headline_banded` is exactly that signal.
+The UI retirement is **next-round wiring** (cross-lane sequencing rule:
+consumption is not wired this round).
+
+### Golden byte-identity
+
+- Wire-capture goldens (`tests/golden/pricing-canary/*`): untouched;
+  those tests assert field-level passthrough/semantics, not full-shape
+  byte equality — unaffected by additive fields.
+- Brief unit goldens (`src/fixtures/decision-brief/*.json`, compared via
+  deep-equal in `tests/decision-brief.test.ts`): WOULD have broken.
+  Per the lane rules, emission is gated behind **default-ON**
+  `BRIEF_CLAIM_SAFE_SURFACES_ENABLE` (`src/config/flags.ts`; only
+  explicit '0'/'false' disables), and the golden-fixtures describe block
+  pins it '0'. **Fixture JSONs are byte-identical to staging.** The flag
+  exists for no other reason and is ON in every deployed environment.
+- Determinism replay (run-vs-run): new brief fields are pure functions
+  of response data → identical across same-seed runs; suite passes
+  unchanged (no new brief ignore entries).
+
+---
+
+## Feature B — diligence-grade evidence capture (roadmap 2.13)
+
+Gap traced: the UI debug bundle reported `plot: null / isl: null`
+because the full ISL payload mirror (`_meta.payloads`/`_meta.builds`)
+is gated behind `UI_CANONICAL_META` (`src/routes/v2/run.ts:170`,
+env-off in staging). Nothing on the default wire evidenced the ISL
+exchange.
+
+Added — ALWAYS present, additive `_meta.evidence`
+(`EvidenceCaptureV1` in `src/types/engine-v3.ts`):
+
+- `isl_request_digest` / `isl_response_digest` (`PayloadDigestV3`):
+  sha256 over the **exact wire bytes**, UTF-8 byte length, sorted
+  top-level key manifest. NOT full bodies. `src/integrations/isl/client.ts`
+  now sends the pre-serialised request text and reads `response.text()`
+  before parsing, so digests cover the true bytes, not a
+  re-serialisation. Recorded on success, HTTP-error and network-failure
+  paths (additive `DownstreamCall.requestDigest/responseDigest`,
+  `src/util/downstream-tracker.ts`). Primary exchange = first
+  `/robustness/analyze` call; flip probes remain in `downstream_calls`.
+- `plot_build`: deployed SHA from the existing `BUILD_ID`/`GITHUB_SHA`
+  build constant (same source as `_meta.plot_build`).
+- `isl_build`: passthrough of the ISL response `build` field
+  (string-typed check); `null` when ISL didn't run or didn't report —
+  never invented.
+
+Honest-null contract: all four keys always present; digests are `null`
+(not absent) when the ISL HTTP client was not exercised
+(route-level test proves this with the module-mocked ISL service).
+
+Determinism note (recorded in-code and in
+`tests/determinism-replay.test.ts`): the ISL request body carries
+`request_id`, so the two digest fields are per-request volatile — they
+are ignore-listed there with rationale (same class as the already
+ignored `downstream_calls`); `evidence.plot_build` / `evidence.isl_build`
+remain compared.
+
+---
+
+## Boundary audit (ADDITIVE-only check)
+
+- `decision_brief` existing fields: unchanged semantics, unchanged
+  emission condition. New fields optional.
+- `_meta`: new optional `evidence` key; existing keys unchanged.
+- `downstream_calls[*]`: new optional `request_digest`/`response_digest`.
+- Request schema: untouched. `response_hash`: computed from request
+  inputs only (`hashRequest`) — unaffected by all of the above.
+- No non-additive change was needed; nothing was stopped/blocked.
+- OpenAPI (hand-authored) updated additively:
+  `DecisionBriefV1`, `PayloadDigestV1`, `EvidenceCaptureV1`,
+  `decision_brief` + `_meta` on `V2RunResponse`. YAML parse verified.
+
+## Consumer-skew note (system map hazard 1)
+
+New fields are additive JSON on the wire. UI pins an older
+`@talchain/schemas` and its Zod parsing may strip unknown keys — the
+UI debug bundle reads the raw response, and consumption of
+`headline_banded` / `evidence` is next-round work per the cross-lane
+sequencing rule. No consumer is broken by absence or presence.
+
+## Tests
+
+- `tests/decision-brief.claim-safety.test.ts` (22): band wording matrix
+  incl. exact 0.10/0.25 boundaries (float-exact values), robustness
+  downgrade cases, pinned-lever exclusion from defaulted_assumptions /
+  top_drivers / what_would_change, DEFAULT-code disclosure echo + dedup,
+  honest robustness-caveat matrix incl. 'absent', warning-severity-only
+  echo, EVPI/expected-value/sensitive-to tripwire, flag-gate both ways.
+- `tests/evidence-capture.test.ts` (9): digest unit tests (exact bytes,
+  multibyte length, sorted manifest, non-object payloads), ISLClient
+  digest recording on success (whitespace-preserving exact-byte proof) /
+  HTTP-error / network paths, route-level always-present + honest-null
+  contract, end-to-end brief surfaces on /v2/run.
+- Updated: `tests/decision-brief.test.ts` (flag pin for golden fixtures),
+  `tests/request-id-chain.test.ts` (fetch stubs gained `text()` for the
+  new exact-byte read), `tests/determinism-replay.test.ts` (digest
+  ignore entries with rationale).
+
+## Gates
+
+- `npx tsc --noEmit`: clean.
+- Targeted suites (brief, evidence, request-id-chain, determinism,
+  golden/, report contract, meta/tier2/internal-field): all pass.
+- Full `npm test` (build + vitest + fixture replay + OpenAPI + loadcheck):
+  see PR checks / pre-push output. Known pre-existing CI reds unrelated
+  to this lane: `audit` (fast-uri/fastify advisories) and
+  `gates (windows-latest)` (invalid path `tools/sdk-smoke:python.mjs`).
+
+## Follow-ups (not this round)
+
+1. UI: consume `headline_banded` and retire UI-SEM-060 (+ 006/070
+   closeness debt where applicable) — next-round wiring.
+2. UI debug bundle: read `_meta.evidence` to close the "plot/isl
+   unavailable" panel gap — next-round wiring.
+3. Consider echoing digests for flip-probe ISL calls (currently primary
+   call only; probes visible in `downstream_calls` when captured).
+4. `CLEARLY_AHEAD_GAP_THRESHOLD` (0.25) is provisional_doctrine_v0 —
+   ratify or adjust when doctrine v1 lands.

--- a/openapi/openapi-plot-lite-v1.yaml
+++ b/openapi/openapi-plot-lite-v1.yaml
@@ -938,6 +938,32 @@ components:
           description: Deterministic hash of semantic response fields
         processing_time_ms:
           type: number
+        decision_brief:
+          oneOf:
+            - $ref: '#/components/schemas/DecisionBriefV1'
+            - type: 'null'
+          description: >
+            Shareable decision brief assembled deterministically from the
+            analysis results (no LLM call). null when analysis failed or
+            required source data (option_comparison, robustness) is absent.
+            Contains non-deterministic fields (brief_id, created_at);
+            excluded from response_hash.
+        _meta:
+          type: object
+          description: >
+            Response-only diagnostic metadata (excluded from response_hash).
+            Base fields are always present; extended debug payloads are gated
+            behind the UI_CANONICAL_META flag. Additive lane PLoT-R3 field:
+            `evidence` — diligence-grade capture of the ISL exchange
+            (sha256/byte-length/key-manifest digests, never full bodies) plus
+            plot_build and isl_build. See CanonicalMeta in
+            src/types/engine-v3.ts.
+          properties:
+            source_path: { type: string, enum: [isl, graph_fallback] }
+            request_id: { type: string }
+            plot_build: { type: string }
+            evidence:
+              $ref: '#/components/schemas/EvidenceCaptureV1'
         meta:
           type: object
           description: Processing metadata
@@ -1191,3 +1217,166 @@ components:
             negatives). evpi_percentage_points is deliberately absent in that case —
             labelled, never a clamped 0 and never a negative.
       required: [factor_id]
+    # =========================================================================
+    # Decision brief (lane PLoT-R3, roadmap 2.7 producer leg)
+    # =========================================================================
+    DecisionBriefV1:
+      type: object
+      description: >
+        Deterministically assembled decision brief. Claim-safe surfaces
+        (headline_banded, defaulted_assumptions, robustness_caveat,
+        warning_codes) are ADDITIVE, provisional_doctrine_v0-worded, and
+        gated behind the default-ON BRIEF_CLAIM_SAFE_SURFACES_ENABLE flag.
+      properties:
+        brief_id: { type: string, description: Deterministic SHA-256-derived UUID }
+        version: { type: string, enum: ['1'] }
+        graph_hash: { type: string }
+        seed: { type: number }
+        created_at: { type: string, format: date-time }
+        headline:
+          type: string
+          description: Narrative summary (M2 review → M1 coaching → 'Analysis complete' fallback chain).
+        options:
+          type: array
+          description: Options ranked by win_probability descending.
+          items:
+            type: object
+            properties:
+              option_id: { type: string }
+              label: { type: string }
+              win_probability: { type: number, minimum: 0, maximum: 1 }
+              rank: { type: integer, minimum: 1 }
+            required: [option_id, label, win_probability, rank]
+        top_drivers:
+          type: array
+          description: >
+            Top factors by absolute elasticity (influence-based, max 5).
+            Intervention-pinned levers are excluded — a pinned lever is not an
+            independently tunable driver and never appears in "check this"
+            framing.
+          items:
+            type: object
+            properties:
+              factor_label: { type: string }
+              sensitivity: { type: number }
+              direction: { type: string, enum: [positive, negative] }
+            required: [factor_label, sensitivity, direction]
+        key_assumptions:
+          type: array
+          items: { type: string }
+        what_would_change:
+          type: array
+          items: { type: string }
+        robustness:
+          type: string
+          enum: [robust, moderate, fragile]
+        warnings:
+          type: array
+          items:
+            type: object
+            properties:
+              code: { type: string }
+              message: { type: string }
+              severity: { type: string, enum: [info, warning, error] }
+            required: [code, message, severity]
+        lineage:
+          type: object
+          properties:
+            config_version: { type: string }
+            response_hash: { type: string }
+            n_samples: { type: integer }
+          required: [config_version, response_hash]
+        headline_banded:
+          type: object
+          description: >
+            ADDITIVE (lane PLoT-R3, provisional_doctrine_v0): deterministic
+            leader claim banded by win-probability gap — the producer leg of
+            the UI's UI-SEM-060 leader-claim banding. Bands: gap < 0.10 →
+            very_close; gap >= 0.25 AND robustness established →
+            clearly_ahead; otherwise slightly_ahead. 'clearly ahead' wording
+            is NEVER emitted without established robustness. Absent when
+            fewer than two ranked options exist.
+          properties:
+            text: { type: string, description: provisional_doctrine_v0 wording }
+            band: { type: string, enum: [very_close, slightly_ahead, clearly_ahead] }
+            leader_option_id: { type: string }
+            leader_label: { type: string }
+            runner_up_option_id: { type: [string, 'null'] }
+            runner_up_label: { type: [string, 'null'] }
+            win_probability_gap: { type: number, minimum: 0, maximum: 1 }
+            robustness_gated:
+              type: boolean
+              description: True when a clearly_ahead-sized gap was downgraded because robustness was not established.
+            doctrine: { type: string, enum: [provisional_doctrine_v0] }
+          required: [text, band, leader_option_id, leader_label, win_probability_gap, robustness_gated, doctrine]
+        defaulted_assumptions:
+          type: array
+          description: >
+            ADDITIVE (lane PLoT-R3): defaulted-input disclosures —
+            value_defaulted factors (pinned levers excluded) plus
+            DEFAULT-coded inference-warning echoes. Max 10.
+          items:
+            type: object
+            properties:
+              factor_label: { type: [string, 'null'] }
+              note: { type: string }
+              source: { type: string, enum: [value_defaulted, default_disclosure] }
+              code: { type: string }
+              doctrine: { type: string, enum: [provisional_doctrine_v0] }
+            required: [factor_label, note, source, doctrine]
+        robustness_caveat:
+          type: object
+          description: >
+            ADDITIVE (lane PLoT-R3): honest robustness wording derived
+            strictly from is_robust / level; when neither is present the text
+            states robustness was not assessed.
+          properties:
+            text: { type: string }
+            basis: { type: string, enum: [is_robust, level, absent] }
+            doctrine: { type: string, enum: [provisional_doctrine_v0] }
+          required: [text, basis, doctrine]
+        warning_codes:
+          type: array
+          description: >
+            ADDITIVE (lane PLoT-R3): echo of warning-severity
+            inference-warning codes (codes only). Sorted, deduplicated.
+          items: { type: string }
+      required: [brief_id, version, graph_hash, seed, created_at, headline, options, top_drivers, key_assumptions, what_would_change, robustness, warnings, lineage]
+    # =========================================================================
+    # Diligence-grade evidence capture (lane PLoT-R3, roadmap 2.13)
+    # =========================================================================
+    PayloadDigestV1:
+      type: object
+      description: >
+        Content digest of an exact wire payload: sha256 over the exact bytes
+        sent/received, byte length, and the sorted top-level key manifest.
+        Full bodies are NOT carried on the wire — the digest lets an auditor
+        verify a separately captured payload matches what PLoT exchanged.
+      properties:
+        sha256: { type: string, description: Hex SHA-256 of the exact payload bytes }
+        bytes: { type: integer, minimum: 0, description: Payload length in bytes (UTF-8) }
+        key_manifest:
+          type: array
+          description: Sorted top-level JSON keys of the payload ([] for non-object payloads).
+          items: { type: string }
+      required: [sha256, bytes, key_manifest]
+    EvidenceCaptureV1:
+      type: object
+      description: >
+        ADDITIVE (lane PLoT-R3, roadmap 2.13): always-present diligence
+        evidence for the primary ISL exchange. Closes the debug-bundle
+        "plot: null / isl: null" gap without shipping full payloads.
+      properties:
+        plot_build: { type: string, description: Deployed PLoT build SHA (BUILD_ID / GITHUB_SHA / git fallback) }
+        isl_build:
+          type: [string, 'null']
+          description: ISL build identifier from the ISL response 'build' field; null when ISL was not called or did not report one.
+        isl_request_digest:
+          oneOf:
+            - $ref: '#/components/schemas/PayloadDigestV1'
+            - type: 'null'
+        isl_response_digest:
+          oneOf:
+            - $ref: '#/components/schemas/PayloadDigestV1'
+            - type: 'null'
+      required: [plot_build, isl_build, isl_request_digest, isl_response_digest]

--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -28,10 +28,17 @@ import type {
   BriefDriver,
   BriefWarning,
   BriefLineage,
+  BriefBandedHeadline,
+  BriefDefaultedAssumption,
+  BriefRobustnessCaveat,
 } from '../types/decision-brief.js';
 import { DECISION_BRIEF_VERSION } from '../types/decision-brief.js';
 import type { RunResponseV3 } from '../types/engine-v3.js';
 import { STANDARD_N_SAMPLES_DEFAULT } from '../config/sampling.js';
+import { FLAGS } from '../config/flags.js';
+// Lane PLoT-R3: 'very close' band shares the near-tie threshold (0.10) with
+// computeNearTie so the brief and robustness.near_tie can never disagree.
+import { NEAR_TIE_THRESHOLD } from '../trust/result-coherence.js';
 // A1b: intervention-controlled levers are not independently tunable; exclude them
 // from the |elasticity|-ranked tunability surfaces (top_drivers, what_would_change).
 import { filterInterventionOverrides, interventionOverrideFactorIds, filterLeverSourcedFragileEdges } from '../lib/intervention-override.js';
@@ -44,6 +51,17 @@ const MAX_TOP_DRIVERS = 5;
 const MAX_WARNINGS = 10;
 const MAX_KEY_ASSUMPTIONS = 10;
 const MAX_WHAT_WOULD_CHANGE = 10;
+const MAX_DEFAULTED_ASSUMPTIONS = 10;
+const MAX_WARNING_CODES = 20;
+
+/**
+ * provisional_doctrine_v0 — gap at/above which the leader MAY be called
+ * 'clearly ahead' (still requires established robustness; see
+ * buildBandedHeadline). Below it (and at/above NEAR_TIE_THRESHOLD) the claim
+ * is 'slightly ahead'. Deliberately far above the UI's UI-SEM-006/060
+ * GAP_THRESHOLD (0.10) so the strongest wording needs a decisive gap.
+ */
+export const CLEARLY_AHEAD_GAP_THRESHOLD = 0.25;
 
 /**
  * Deterministic brief_id: SHA-256 of `graph_hash:seed:config_version`,
@@ -105,6 +123,12 @@ export type BriefAssemblyInput = Pick<RunResponseV3, 'analysis_status' | 'critiq
   robustness?: RunResponseV3['robustness'];
   m1_coaching?: RunResponseV3['m1_coaching'];
   m1_review?: RunResponseV3['m1_review'];
+  /**
+   * Lane PLoT-R3 (additive, optional): the run's inference_warnings, used for
+   * warning_codes (warning-severity echo) and defaulted_assumptions
+   * (DEFAULT-coded disclosures). Absent → both surfaces treat as none.
+   */
+  inference_warnings?: RunResponseV3['inference_warnings'];
   response_hash?: string;
   meta: {
     seed_used: string;
@@ -203,6 +227,21 @@ export function assembleBrief(input: BriefAssemblyInput): DecisionBriefV1 | null
   const seed = Number(input.meta.seed_used);
   const briefId = computeBriefId(graphHash, seed, lineage.config_version);
 
+  // --- Lane PLoT-R3 claim-safe surfaces (provisional_doctrine_v0) ---
+  // Gated default-ON; the flag exists ONLY so pre-R3 golden fixtures stay
+  // byte-identical (see FLAGS.BRIEF_CLAIM_SAFE_SURFACES_ENABLE).
+  const claimSafeSurfaces = FLAGS.BRIEF_CLAIM_SAFE_SURFACES_ENABLE
+    ? {
+        ...(() => {
+          const banded = buildBandedHeadline(options, input);
+          return banded ? { headline_banded: banded } : {};
+        })(),
+        defaulted_assumptions: buildDefaultedAssumptions(input),
+        robustness_caveat: buildRobustnessCaveat(input),
+        warning_codes: buildWarningCodes(input),
+      }
+    : {};
+
   return {
     brief_id: briefId,
     version: DECISION_BRIEF_VERSION,
@@ -217,6 +256,7 @@ export function assembleBrief(input: BriefAssemblyInput): DecisionBriefV1 | null
     robustness,
     warnings,
     lineage,
+    ...claimSafeSurfaces,
   };
 }
 
@@ -417,4 +457,182 @@ function buildLineage(input: BriefAssemblyInput): BriefLineage {
     // briefs (and fixtures without a depth) keep their existing lineage shape.
     ...(nSamples !== undefined ? { n_samples: nSamples } : {}),
   };
+}
+
+// =============================================================================
+// Lane PLoT-R3 claim-safe surface builders (provisional_doctrine_v0)
+//
+// Wording rules enforced here:
+//   - band vocabulary is EXACTLY 'very close' / 'slightly ahead' /
+//     'clearly ahead' — and 'clearly ahead' only when robustness is
+//     established (UI-SEM-060 producer leg);
+//   - no 'EVPI', no 'expected value', no 'sensitive to <factor>' phrasing;
+//   - intervention-pinned levers never appear in "check this" framing
+//     (value_defaulted disclosures filter them like top_drivers does);
+//   - nothing is invented: every sentence is derived from a present upstream
+//     signal, and absence is stated as absence (robustness_caveat 'absent').
+// =============================================================================
+
+/**
+ * Robustness is "established" only on a positive signal: an explicit
+ * `is_robust === true`, or `level === 'high'` without an explicit
+ * `is_robust === false` contradicting it. Missing signals never count.
+ */
+function isRobustnessEstablished(robustness: BriefAssemblyInput['robustness']): boolean {
+  if (!robustness) return false;
+  if (robustness.is_robust === true) return true;
+  if (robustness.is_robust === false) return false;
+  return robustness.level === 'high';
+}
+
+/**
+ * Leader claim banded by win-probability gap (provisional_doctrine_v0):
+ *   gap <  NEAR_TIE_THRESHOLD (0.10)        → 'very_close'
+ *   gap >= CLEARLY_AHEAD_GAP_THRESHOLD (0.25)
+ *     AND robustness established            → 'clearly_ahead'
+ *   otherwise                               → 'slightly_ahead'
+ *     (robustness_gated: true when only the missing robustness kept the
+ *      claim out of 'clearly_ahead')
+ *
+ * Returns null when fewer than two ranked options exist — no comparative
+ * claim without a comparison.
+ */
+function buildBandedHeadline(
+  options: BriefOption[],
+  input: BriefAssemblyInput,
+): BriefBandedHeadline | null {
+  if (options.length < 2) return null;
+
+  const leader = options[0];
+  const runnerUp = options[1];
+  const gap = leader.win_probability - runnerUp.win_probability;
+  const robust = isRobustnessEstablished(input.robustness);
+
+  let band: BriefBandedHeadline['band'];
+  let robustnessGated = false;
+  let text: string;
+
+  if (gap < NEAR_TIE_THRESHOLD) {
+    band = 'very_close';
+    // provisional_doctrine_v0
+    text = `${leader.label} leads, but the top options are very close.`;
+  } else if (gap >= CLEARLY_AHEAD_GAP_THRESHOLD && robust) {
+    band = 'clearly_ahead';
+    // provisional_doctrine_v0 — strongest claim requires decisive gap AND robustness
+    text = `${leader.label} is clearly ahead.`;
+  } else {
+    band = 'slightly_ahead';
+    robustnessGated = gap >= CLEARLY_AHEAD_GAP_THRESHOLD && !robust;
+    // provisional_doctrine_v0
+    text = `${leader.label} is slightly ahead.`;
+  }
+
+  return {
+    text,
+    band,
+    leader_option_id: leader.option_id,
+    leader_label: leader.label,
+    runner_up_option_id: runnerUp.option_id,
+    runner_up_label: runnerUp.label,
+    win_probability_gap: gap,
+    robustness_gated: robustnessGated,
+    doctrine: 'provisional_doctrine_v0',
+  };
+}
+
+/**
+ * Defaulted-input disclosures:
+ *   1. factor_sensitivity entries with value_defaulted === true —
+ *      intervention-pinned levers EXCLUDED (a pinned lever must never appear
+ *      in "check this input" framing; same A1b predicate as top_drivers).
+ *      Sorted by factor_id bytewise for determinism.
+ *   2. inference warnings whose code contains 'DEFAULT'
+ *      (e.g. ROOT_NODE_DEFAULT_VALUE) — run-level disclosures echoed
+ *      verbatim (message is producer-owned wording), sorted by code.
+ * Capped at MAX_DEFAULTED_ASSUMPTIONS, factor-scoped entries first.
+ */
+function buildDefaultedAssumptions(input: BriefAssemblyInput): BriefDefaultedAssumption[] {
+  const out: BriefDefaultedAssumption[] = [];
+
+  const factors = filterInterventionOverrides(input.factor_sensitivity ?? [])
+    .filter((f) => f.value_defaulted === true)
+    .sort((a, b) => (a.factor_id < b.factor_id ? -1 : a.factor_id > b.factor_id ? 1 : 0));
+  for (const f of factors) {
+    const label = f.factor_label?.trim() || f.factor_id;
+    out.push({
+      factor_label: label,
+      // provisional_doctrine_v0
+      note: `No starting value was provided for "${label}" — the analysis used a default. Setting a real value or range would make this result more trustworthy.`,
+      source: 'value_defaulted',
+      doctrine: 'provisional_doctrine_v0',
+    });
+  }
+
+  const seenCodes = new Set<string>();
+  const defaultWarnings = (input.inference_warnings ?? [])
+    .filter((w) => typeof w.code === 'string' && w.code.includes('DEFAULT'))
+    .sort((a, b) => (a.code < b.code ? -1 : a.code > b.code ? 1 : 0));
+  for (const w of defaultWarnings) {
+    if (seenCodes.has(w.code)) continue;
+    seenCodes.add(w.code);
+    out.push({
+      factor_label: null,
+      note: w.message,
+      source: 'default_disclosure',
+      code: w.code,
+      doctrine: 'provisional_doctrine_v0',
+    });
+  }
+
+  return out.slice(0, MAX_DEFAULTED_ASSUMPTIONS);
+}
+
+/**
+ * Honest robustness caveat (provisional_doctrine_v0). Wording is derived
+ * strictly from upstream signals; when neither is_robust nor level is
+ * present the caveat SAYS robustness was not assessed instead of implying
+ * stability.
+ */
+function buildRobustnessCaveat(input: BriefAssemblyInput): BriefRobustnessCaveat {
+  const robustness = input.robustness;
+  const isRobust = robustness?.is_robust;
+  const level = robustness?.level as string | undefined;
+
+  const basis: BriefRobustnessCaveat['basis'] =
+    isRobust !== undefined ? 'is_robust' : level !== undefined ? 'level' : 'absent';
+
+  // provisional_doctrine_v0 wording matrix
+  let text: string;
+  if (basis === 'absent') {
+    text = 'Robustness was not assessed for this run — treat the ranking as unverified against perturbations.';
+  } else if (isRobust === true || (isRobust === undefined && level === 'high')) {
+    text = 'This ranking held up under the perturbations tested. That is not a guarantee — defaulted or uncertain inputs can still change the result.';
+  } else if (isRobust === false && level === undefined) {
+    text = 'This ranking did not pass the robustness checks — small changes to assumptions could change which option leads.';
+  } else if (level === 'medium' || level === 'moderate') {
+    text = 'This ranking was only moderately stable under the perturbations tested — treat the lead as provisional.';
+  } else if (level === 'low' || level === 'very_low') {
+    text = 'This ranking was fragile under the perturbations tested — small changes to assumptions could change which option leads.';
+  } else {
+    // is_robust === false with a level that is not low/very_low, or an
+    // unrecognised level value — state the weaker of the two signals.
+    text = 'This ranking did not pass the robustness checks — small changes to assumptions could change which option leads.';
+  }
+
+  return { text, basis, doctrine: 'provisional_doctrine_v0' };
+}
+
+/**
+ * Echo of warning-severity inference-warning codes (codes only — no values,
+ * no prose). Deduplicated, bytewise-sorted, capped. Info-severity warnings
+ * are NOT echoed (they are diagnostics, not caveats).
+ */
+function buildWarningCodes(input: BriefAssemblyInput): string[] {
+  const codes = new Set<string>();
+  for (const w of input.inference_warnings ?? []) {
+    if (w.severity === 'warning' && typeof w.code === 'string' && w.code.length > 0) {
+      codes.add(w.code);
+    }
+  }
+  return [...codes].sort().slice(0, MAX_WARNING_CODES);
 }

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -53,6 +53,8 @@ export const KNOWN_FEATURE_FLAGS = [
   'ENABLE_REVIEW_PASS',
   // Track A: Validate-patch endpoint
   'ENABLE_VALIDATE_PATCH',
+  // Lane PLoT-R3: decision_brief claim-safe surfaces (default ON; golden-fixture byte-identity gate)
+  'BRIEF_CLAIM_SAFE_SURFACES_ENABLE',
 ] as const;
 
 export function validateFeatureFlags(logger?: any): void {

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -104,6 +104,23 @@ export const FLAGS = {
     return process.env.NODE_ENV === 'test' || process.env.RENDER_SERVICE_NAME?.includes('staging') === true;
   },
 
+  // Lane PLoT-R3 (roadmap 2.7): decision_brief claim-safe surfaces
+  /**
+   * Gates the ADDITIVE claim-safe surfaces on `decision_brief`
+   * (headline_banded, defaulted_assumptions, robustness_caveat,
+   * warning_codes — all wording provisional_doctrine_v0).
+   *
+   * Default: ON in every environment. The ONLY reason this flag exists is
+   * byte-identity of the pre-existing decision-brief golden fixtures
+   * (tests/decision-brief.test.ts "golden fixtures" describe pins it '0'
+   * so src/fixtures/decision-brief/*.json stay byte-identical). Explicit
+   * '0'/'false' disables; anything else (including unset) enables.
+   */
+  get BRIEF_CLAIM_SAFE_SURFACES_ENABLE() {
+    const raw = process.env.BRIEF_CLAIM_SAFE_SURFACES_ENABLE;
+    return raw !== '0' && raw !== 'false';
+  },
+
   // ISL V2 science channel: per-factor counterfactual EVPI (factor_evpi wire field)
   /**
    * P-5 promotion gate (provisional_doctrine_v0, lane PLoT-H item C,

--- a/src/integrations/isl/client.ts
+++ b/src/integrations/isl/client.ts
@@ -10,7 +10,7 @@
 
 import { ISLHttpError, ISLTimeoutError, ISLNetworkError, isRetryableError, type ISLError422 } from './errors.js';
 import { computeOlumiHash } from '../../util/canonical.js';
-import { recordDownstreamCall, sanitizePayloadForDebug } from '../../util/downstream-tracker.js';
+import { recordDownstreamCall, sanitizePayloadForDebug, computePayloadDigest } from '../../util/downstream-tracker.js';
 import { ISL_TIMEOUT_MS, ISL_HEALTH_CHECK_TIMEOUT_MS } from '../../config/timeouts.js';
 
 /**
@@ -99,6 +99,12 @@ export class ISLClient {
     // P1: Compute payload hash outside loop for catch block access
     const payloadHash = computeOlumiHash(body);
 
+    // Lane PLoT-R3 (2.13): diligence-grade digest of the EXACT request bytes
+    // sent to ISL (same serialisation as the fetch body below). sha256 + byte
+    // length + sorted top-level key manifest — full bodies never ride the wire.
+    const requestBodyText = JSON.stringify(body);
+    const requestDigest = computePayloadDigest(requestBodyText, body);
+
     for (let attempt = 1; attempt <= this.config.maxRetries; attempt++) {
       // Track start time outside try block for catch access
       const startTime = Date.now();
@@ -120,7 +126,9 @@ export class ISLClient {
             // P0-PLOT-2: Request ISL V2 responses
             'X-ISL-Response-Version': '2',
           },
-          body: JSON.stringify(body),
+          // Lane PLoT-R3 (2.13): send the pre-serialised text so requestDigest
+          // is a digest of the EXACT bytes on the wire.
+          body: requestBodyText,
           signal: controller.signal,
         });
 
@@ -152,6 +160,9 @@ export class ISLClient {
             requestId,
             requestPayload: sanitizePayloadForDebug(body),
             responsePayload: sanitizePayloadForDebug(tryParseJson(errorBody)),
+            // Lane PLoT-R3 (2.13): digests of the exact bytes exchanged
+            requestDigest,
+            responseDigest: computePayloadDigest(errorBody, tryParseJson(errorBody)),
           });
 
           // P0-PLOT-3: Parse ISL 422 as structured result
@@ -176,8 +187,11 @@ export class ISLClient {
           throw err;
         }
 
-        // Parse response and record successful downstream call with payloads for debug
-        const responseData = (await response.json()) as T;
+        // Parse response and record successful downstream call with payloads for debug.
+        // Lane PLoT-R3 (2.13): read the raw text first so responseDigest covers
+        // the EXACT bytes received, then parse (same JSON, same errors as .json()).
+        const responseText = await response.text();
+        const responseData = JSON.parse(responseText) as T;
         const islEchoedRequestId = response.headers.get('x-request-id') ?? null;
         const responseHash = computeOlumiHash(responseData);
         recordDownstreamCall({
@@ -190,6 +204,9 @@ export class ISLClient {
           requestId,
           requestPayload: sanitizePayloadForDebug(body),
           responsePayload: sanitizePayloadForDebug(responseData),
+          // Lane PLoT-R3 (2.13): digests of the exact bytes exchanged
+          requestDigest,
+          responseDigest: computePayloadDigest(responseText, responseData),
         });
 
         return { data: responseData, islEchoedRequestId };
@@ -241,6 +258,8 @@ export class ISLClient {
               requestId,
               requestPayload: sanitizePayloadForDebug(body),
               // No response payload for network/timeout errors
+              // Lane PLoT-R3 (2.13): request digest still recorded (what was sent)
+              requestDigest,
             });
           }
           break;

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -2457,6 +2457,27 @@ function buildResponse(
         baseMeta.range_derivation_sources = meta.rangeDerivationSources;
       }
 
+      // Lane PLoT-R3 (roadmap 2.13): diligence-grade evidence capture — ALWAYS
+      // present (deliberately NOT gated behind UI_CANONICAL_META, which stays
+      // off in staging and left the UI debug bundle reporting plot/isl payloads
+      // unavailable). Digests of the primary ISL exchange (sha256 + byte
+      // length + key manifest — never full bodies) + deployed builds. The
+      // primary exchange is the first robustness/analyze call; flip probes and
+      // follow-ups remain visible in downstream_calls when captured.
+      baseMeta.evidence = (() => {
+        const calls = getDownstreamCallsForLog(requestId);
+        const primaryIslCall =
+          calls.find((c) => c.service === 'isl' && c.endpoint.includes('/robustness/analyze')) ??
+          calls.find((c) => c.service === 'isl');
+        return {
+          plot_build: meta.build ?? 'unknown',
+          // Passthrough of ISL's `build` response field; never invented.
+          isl_build: typeof islResult?.build === 'string' ? islResult.build : null,
+          isl_request_digest: primaryIslCall?.request_digest ?? null,
+          isl_response_digest: primaryIslCall?.response_digest ?? null,
+        };
+      })();
+
       // Diagnostic fields — lightweight metadata for debug panel / developer inspection.
       // NOT consumed by UI display logic. NOT included in response_hash.
       baseMeta.feature_flags_snapshot = getAllFeatureFlags();

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -2089,6 +2089,9 @@ function buildResponse(
     robustness,
     m1_coaching: m1Coaching,
     m1_review: m2DecisionReview?.m1_review ?? undefined,
+    // Lane PLoT-R3: warning_codes echo + DEFAULT-coded disclosures for the
+    // brief's claim-safe surfaces (provisional_doctrine_v0 wording).
+    inference_warnings: inferenceWarnings,
     response_hash: responseHash,
     // Track S: depth-aware brief lineage (config_version + lineage.n_samples).
     meta: { seed_used: meta.seedUsed, n_samples: meta.nSamples },

--- a/src/types/decision-brief.ts
+++ b/src/types/decision-brief.ts
@@ -68,6 +68,97 @@ export interface DecisionBriefV1 {
   // Provenance
   /** Lineage information for audit trail */
   lineage: BriefLineage;
+
+  // ===========================================================================
+  // Lane PLoT-R3 (roadmap 2.7 producer leg) — ADDITIVE claim-safe surfaces.
+  // All optional: absent on pre-R3 briefs and when
+  // BRIEF_CLAIM_SAFE_SURFACES_ENABLE is '0'/'false' (golden-fixture
+  // byte-identity gate). All wording is provisional_doctrine_v0.
+  // ===========================================================================
+
+  /**
+   * Deterministic leader claim banded by win-probability gap (the producer
+   * leg of the UI's UI-SEM-060 leader-claim banding debt — "Remove when PLoT
+   * provides a leader-confidence band / close-call signal").
+   * Absent when fewer than two ranked options exist (no comparative claim
+   * is made without a comparison).
+   */
+  headline_banded?: BriefBandedHeadline;
+
+  /**
+   * Defaulted-input disclosures: factors ISL substituted a default value for
+   * (`value_defaulted: true`, intervention-pinned levers excluded) plus
+   * run-level default disclosures echoed from DEFAULT-coded inference
+   * warnings. Max 10, deterministic order.
+   */
+  defaulted_assumptions?: BriefDefaultedAssumption[];
+
+  /** Honest robustness wording derived from is_robust / level (never invented). */
+  robustness_caveat?: BriefRobustnessCaveat;
+
+  /**
+   * Echo of warning-severity inference-warning codes from the run response
+   * (codes only — no numbers, no prose). Sorted, deduplicated. [] when the
+   * run carried no warning-severity inference warnings.
+   */
+  warning_codes?: string[];
+}
+
+// =============================================================================
+// Lane PLoT-R3 claim-safe surface types (all wording provisional_doctrine_v0)
+// =============================================================================
+
+/**
+ * Gap bands for the leader claim. 'clearly_ahead' is ONLY emitted when the
+ * run's robustness is established (is_robust === true, or level 'high' with
+ * no explicit is_robust === false) — a large gap without robustness is
+ * downgraded to 'slightly_ahead' with robustness_gated: true.
+ */
+export type BriefHeadlineBand = 'very_close' | 'slightly_ahead' | 'clearly_ahead';
+
+export interface BriefBandedHeadline {
+  /** provisional_doctrine_v0 wording — claim-safe leader sentence */
+  text: string;
+  band: BriefHeadlineBand;
+  leader_option_id: string;
+  leader_label: string;
+  runner_up_option_id: string | null;
+  runner_up_label: string | null;
+  /** win_probability(leader) − win_probability(runner-up), [0,1] */
+  win_probability_gap: number;
+  /**
+   * True when the gap alone qualified for 'clearly_ahead' but robustness was
+   * not established, so the claim was downgraded to 'slightly_ahead'.
+   */
+  robustness_gated: boolean;
+  doctrine: 'provisional_doctrine_v0';
+}
+
+export interface BriefDefaultedAssumption {
+  /** Factor label when the disclosure is factor-scoped; null for run-level disclosures */
+  factor_label: string | null;
+  /** provisional_doctrine_v0 wording (factor-scoped) or verbatim warning echo (run-level) */
+  note: string;
+  /**
+   * 'value_defaulted'     — factor_sensitivity[*].value_defaulted === true
+   * 'default_disclosure'  — inference warning whose code names a default
+   */
+  source: 'value_defaulted' | 'default_disclosure';
+  /** Inference-warning code for 'default_disclosure' entries */
+  code?: string;
+  doctrine: 'provisional_doctrine_v0';
+}
+
+export interface BriefRobustnessCaveat {
+  /** provisional_doctrine_v0 wording — honest, no invented certainty */
+  text: string;
+  /**
+   * Which upstream signal the wording was derived from:
+   * 'is_robust' — ISL boolean flag; 'level' — ISL robustness level;
+   * 'absent' — neither present (wording says robustness was not assessed).
+   */
+  basis: 'is_robust' | 'level' | 'absent';
+  doctrine: 'provisional_doctrine_v0';
 }
 
 export interface BriefOption {

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2217,6 +2217,42 @@ export interface CanonicalMeta {
   review_cards_count?: number;
   /** Whether the R.1 evidence_priority card was emitted (diagnostic only) */
   evidence_priority_card_present?: boolean;
+  /**
+   * Lane PLoT-R3 (roadmap 2.13): diligence-grade evidence capture — ALWAYS
+   * present (not gated behind UI_CANONICAL_META). Closes the debug-bundle
+   * "plot: null / isl: null" gap without shipping full ISL payloads:
+   * digests (sha256 + byte length + key manifest) of the primary ISL
+   * exchange plus the deployed PLoT and ISL builds. Diagnostic only;
+   * excluded from response_hash like all _meta fields.
+   */
+  evidence?: EvidenceCaptureV1;
+}
+
+/**
+ * Lane PLoT-R3 (2.13): content digest of an exact wire payload —
+ * sha256 over the exact bytes, UTF-8 byte length, sorted top-level key
+ * manifest ([] for non-object payloads). Never carries the body itself.
+ */
+export interface PayloadDigestV3 {
+  sha256: string;
+  bytes: number;
+  key_manifest: string[];
+}
+
+/**
+ * Lane PLoT-R3 (2.13): always-present diligence evidence for the primary
+ * ISL exchange (the first robustness/analyze call; flip probes and other
+ * follow-up calls remain visible in downstream_calls).
+ */
+export interface EvidenceCaptureV1 {
+  /** Deployed PLoT build SHA (BUILD_ID / GITHUB_SHA / git fallback) */
+  plot_build: string;
+  /** ISL build identifier from the ISL response `build` field; null when unavailable */
+  isl_build: string | null;
+  /** Digest of the exact request bytes PLoT sent to ISL; null when ISL was not called */
+  isl_request_digest: PayloadDigestV3 | null;
+  /** Digest of the exact response bytes ISL returned; null when unavailable */
+  isl_response_digest: PayloadDigestV3 | null;
 }
 
 /**
@@ -2243,6 +2279,10 @@ export interface DownstreamCallInfoV3 {
   response_payload?: unknown;
   /** Error response body for non-200 responses (truncated to 1000 chars) */
   error_body?: string;
+  /** Lane PLoT-R3 (2.13): digest of the exact request bytes sent (additive) */
+  request_digest?: PayloadDigestV3;
+  /** Lane PLoT-R3 (2.13): digest of the exact response bytes received (additive) */
+  response_digest?: PayloadDigestV3;
 }
 
 /**

--- a/src/util/downstream-tracker.ts
+++ b/src/util/downstream-tracker.ts
@@ -6,6 +6,40 @@
  * Each request gets its own isolated call log.
  */
 
+import { createHash } from 'node:crypto';
+
+/**
+ * Lane PLoT-R3 (roadmap 2.13): diligence-grade content digest of an exact
+ * wire payload. Carries enough to verify a separately captured payload
+ * matches what PLoT actually exchanged — WITHOUT shipping the body:
+ *   - sha256 over the exact serialised bytes (request: the JSON.stringify'd
+ *     body sent; response: the raw response text received);
+ *   - byte length (UTF-8);
+ *   - sorted top-level key manifest ([] for non-object payloads).
+ */
+export interface PayloadDigest {
+  sha256: string;
+  bytes: number;
+  key_manifest: string[];
+}
+
+/**
+ * Compute a PayloadDigest from the exact serialised text of a payload.
+ * `parsed` provides the top-level key manifest (pass the object the text
+ * serialises to / parses from; non-objects yield an empty manifest).
+ */
+export function computePayloadDigest(text: string, parsed: unknown): PayloadDigest {
+  const keys =
+    parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? Object.keys(parsed as Record<string, unknown>).sort()
+      : [];
+  return {
+    sha256: createHash('sha256').update(text, 'utf8').digest('hex'),
+    bytes: Buffer.byteLength(text, 'utf8'),
+    key_manifest: keys,
+  };
+}
+
 /**
  * Represents a single downstream service call
  */
@@ -30,6 +64,10 @@ export interface DownstreamCall {
   responsePayload?: unknown;
   /** Error response body for non-200 responses (truncated to 1000 chars) */
   errorBody?: string;
+  /** Lane PLoT-R3 (2.13): digest of the exact request bytes sent downstream */
+  requestDigest?: PayloadDigest;
+  /** Lane PLoT-R3 (2.13): digest of the exact response bytes received */
+  responseDigest?: PayloadDigest;
 }
 
 /**
@@ -147,6 +185,8 @@ export function getDownstreamCallsForLog(requestId: string): Array<{
   request_payload?: unknown;
   response_payload?: unknown;
   error_body?: string;
+  request_digest?: PayloadDigest;
+  response_digest?: PayloadDigest;
 }> {
   return getDownstreamCalls(requestId).map((call) => ({
     service: call.service,
@@ -159,6 +199,9 @@ export function getDownstreamCallsForLog(requestId: string): Array<{
     request_payload: call.requestPayload,
     response_payload: call.responsePayload,
     ...(call.errorBody && { error_body: call.errorBody }),
+    // Lane PLoT-R3 (2.13): additive digest passthrough for _meta.evidence
+    ...(call.requestDigest && { request_digest: call.requestDigest }),
+    ...(call.responseDigest && { response_digest: call.responseDigest }),
   }));
 }
 

--- a/tests/decision-brief.claim-safety.test.ts
+++ b/tests/decision-brief.claim-safety.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Decision Brief claim-safe surfaces (Lane PLoT-R3, roadmap 2.7 producer leg)
+ *
+ * Covers the ADDITIVE provisional_doctrine_v0 surfaces on DecisionBriefV1:
+ *   - headline_banded: UI-SEM-060 gap-band wording matrix
+ *     ('very close' / 'slightly ahead' / 'clearly ahead' — the strongest
+ *     claim ONLY when robustness is established);
+ *   - defaulted_assumptions: value_defaulted factors (pinned levers
+ *     excluded) + DEFAULT-coded inference-warning disclosures;
+ *   - robustness_caveat: honest is_robust/level wording (absence stated);
+ *   - warning_codes: warning-severity echo;
+ *   - forbidden-wording tripwire: no 'EVPI' / 'expected value' anywhere in
+ *     an assembled brief;
+ *   - flag gate: '0' suppresses every new surface (golden byte-identity).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { assembleBrief, type BriefAssemblyInput } from '../src/assembly/decision-brief.js';
+
+afterEach(() => {
+  delete process.env.BRIEF_CLAIM_SAFE_SURFACES_ENABLE;
+});
+
+/** Two-option input with a configurable gap and robustness signal. */
+function makeInput(overrides: {
+  topWin?: number;
+  secondWin?: number;
+  robustness?: Record<string, unknown>;
+  factor_sensitivity?: unknown[];
+  inference_warnings?: Array<{ code: string; message: string; severity: 'info' | 'warning' }>;
+  option_comparison?: unknown[];
+} = {}): BriefAssemblyInput {
+  const topWin = overrides.topWin ?? 0.6;
+  const secondWin = overrides.secondWin ?? 0.4;
+  return {
+    analysis_status: 'computed',
+    critiques: [],
+    option_comparison: (overrides.option_comparison ?? [
+      { option_id: 'opt_a', option_label: 'Keep price', id: 'opt_a', label: 'Keep price', win_probability: topWin },
+      { option_id: 'opt_b', option_label: 'Raise price', id: 'opt_b', label: 'Raise price', win_probability: secondWin },
+    ]) as any[],
+    robustness: (overrides.robustness ?? { level: 'moderate', fragile_edges: [], robust_edges: [] }) as any,
+    factor_sensitivity: overrides.factor_sensitivity as any,
+    inference_warnings: overrides.inference_warnings as any,
+    meta: { seed_used: '42' },
+  };
+}
+
+// =============================================================================
+// Band wording matrix (UI-SEM-060 gap bands, provisional_doctrine_v0)
+// =============================================================================
+
+describe('headline_banded — band matrix', () => {
+  it('gap < 0.10 → very_close (never a lead claim)', () => {
+    const brief = assembleBrief(makeInput({ topWin: 0.52, secondWin: 0.48 }))!;
+    expect(brief.headline_banded).toBeDefined();
+    expect(brief.headline_banded!.band).toBe('very_close');
+    expect(brief.headline_banded!.text).toContain('very close');
+    expect(brief.headline_banded!.text).not.toContain('clearly ahead');
+    expect(brief.headline_banded!.text).not.toContain('slightly ahead');
+    expect(brief.headline_banded!.win_probability_gap).toBeCloseTo(0.04, 10);
+    expect(brief.headline_banded!.doctrine).toBe('provisional_doctrine_v0');
+  });
+
+  it('0.10 <= gap < 0.25 → slightly_ahead regardless of robustness', () => {
+    const brief = assembleBrief(makeInput({
+      topWin: 0.575, secondWin: 0.425,
+      robustness: { is_robust: true, level: 'high', fragile_edges: [], robust_edges: [] },
+    }))!;
+    expect(brief.headline_banded!.band).toBe('slightly_ahead');
+    expect(brief.headline_banded!.text).toContain('slightly ahead');
+    expect(brief.headline_banded!.robustness_gated).toBe(false);
+  });
+
+  it('gap >= 0.25 AND is_robust true → clearly_ahead', () => {
+    const brief = assembleBrief(makeInput({
+      topWin: 0.65, secondWin: 0.35,
+      robustness: { is_robust: true, fragile_edges: [], robust_edges: [] },
+    }))!;
+    expect(brief.headline_banded!.band).toBe('clearly_ahead');
+    expect(brief.headline_banded!.text).toBe('Keep price is clearly ahead.');
+    expect(brief.headline_banded!.robustness_gated).toBe(false);
+  });
+
+  it('gap >= 0.25 AND level high (no explicit is_robust) → clearly_ahead', () => {
+    const brief = assembleBrief(makeInput({
+      topWin: 0.65, secondWin: 0.35,
+      robustness: { level: 'high', fragile_edges: [], robust_edges: [] },
+    }))!;
+    expect(brief.headline_banded!.band).toBe('clearly_ahead');
+  });
+
+  it('CLAIM SAFETY: gap >= 0.25 but robustness NOT established → downgraded to slightly_ahead with robustness_gated', () => {
+    const cases: Array<Record<string, unknown>> = [
+      { level: 'medium', fragile_edges: [], robust_edges: [] },
+      { level: 'low', fragile_edges: [], robust_edges: [] },
+      { is_robust: false, level: 'high', fragile_edges: [], robust_edges: [] }, // explicit false beats level
+      { fragile_edges: [], robust_edges: [] },                                  // no signal at all
+    ];
+    for (const robustness of cases) {
+      const brief = assembleBrief(makeInput({ topWin: 0.7, secondWin: 0.3, robustness }))!;
+      expect(brief.headline_banded!.band).toBe('slightly_ahead');
+      expect(brief.headline_banded!.robustness_gated).toBe(true);
+      expect(brief.headline_banded!.text).not.toContain('clearly ahead');
+    }
+  });
+
+  it('single ranked option → no headline_banded (no comparative claim without a comparison)', () => {
+    const brief = assembleBrief(makeInput({
+      option_comparison: [
+        { option_id: 'opt_a', option_label: 'Only option', id: 'opt_a', label: 'Only option', win_probability: 0.9 },
+      ],
+    }))!;
+    expect(brief.headline_banded).toBeUndefined();
+  });
+
+  it('band boundaries: gap exactly 0.10 → slightly_ahead; exactly 0.25 + robust → clearly_ahead', () => {
+    // 0.2 − 0.1 === 0.1 exactly in IEEE-754 doubles (0.55 − 0.45 is NOT),
+    // so this pins the >= boundary without float drift.
+    const atNearTie = assembleBrief(makeInput({ topWin: 0.2, secondWin: 0.1 }))!;
+    expect(atNearTie.headline_banded!.band).toBe('slightly_ahead');
+
+    const atClear = assembleBrief(makeInput({
+      topWin: 0.625, secondWin: 0.375,
+      robustness: { is_robust: true, fragile_edges: [], robust_edges: [] },
+    }))!;
+    expect(atClear.headline_banded!.band).toBe('clearly_ahead');
+  });
+});
+
+// =============================================================================
+// Defaulted assumptions (value_defaulted + DEFAULT disclosures)
+// =============================================================================
+
+describe('defaulted_assumptions', () => {
+  it('includes value_defaulted factors with claim-safe wording', () => {
+    const brief = assembleBrief(makeInput({
+      factor_sensitivity: [
+        { factor_id: 'f1', factor_label: 'Market Size', elasticity: 0.5, value_defaulted: true },
+        { factor_id: 'f2', factor_label: 'Churn', elasticity: 0.3 }, // absent value_defaulted → excluded
+        { factor_id: 'f3', factor_label: 'Costs', elasticity: 0.2, value_defaulted: false },
+      ],
+    }))!;
+    expect(brief.defaulted_assumptions).toHaveLength(1);
+    expect(brief.defaulted_assumptions![0]).toMatchObject({
+      factor_label: 'Market Size',
+      source: 'value_defaulted',
+      doctrine: 'provisional_doctrine_v0',
+    });
+    expect(brief.defaulted_assumptions![0].note).toContain('Market Size');
+    expect(brief.defaulted_assumptions![0].note).toContain('default');
+  });
+
+  it('CLAIM SAFETY: intervention-pinned levers NEVER appear in defaulted_assumptions', () => {
+    const brief = assembleBrief(makeInput({
+      factor_sensitivity: [
+        { factor_id: 'lever', factor_label: 'Price', elasticity: 0.9, value_defaulted: true, zero_reason: 'intervention_override' },
+        { factor_id: 'f1', factor_label: 'Market Size', elasticity: 0.5, value_defaulted: true },
+      ],
+    }))!;
+    const labels = brief.defaulted_assumptions!.map((a) => a.factor_label);
+    expect(labels).toEqual(['Market Size']);
+    expect(JSON.stringify(brief.defaulted_assumptions)).not.toContain('Price');
+  });
+
+  it('echoes DEFAULT-coded inference warnings as run-level disclosures (deduped by code)', () => {
+    const brief = assembleBrief(makeInput({
+      inference_warnings: [
+        { code: 'ROOT_NODE_DEFAULT_VALUE', message: 'Root node used a default value', severity: 'info' },
+        { code: 'ROOT_NODE_DEFAULT_VALUE', message: 'Root node used a default value (dup)', severity: 'info' },
+        { code: 'EDGE_SENSITIVITY_UNAVAILABLE', message: 'Not default-related', severity: 'info' },
+      ],
+    }))!;
+    const disclosures = brief.defaulted_assumptions!.filter((a) => a.source === 'default_disclosure');
+    expect(disclosures).toHaveLength(1);
+    expect(disclosures[0]).toMatchObject({
+      factor_label: null,
+      code: 'ROOT_NODE_DEFAULT_VALUE',
+      note: 'Root node used a default value',
+    });
+  });
+
+  it('is [] when nothing was defaulted', () => {
+    const brief = assembleBrief(makeInput({}))!;
+    expect(brief.defaulted_assumptions).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Robustness caveat (honest wording, absence stated)
+// =============================================================================
+
+describe('robustness_caveat', () => {
+  it('is_robust true → held-up wording with no-guarantee qualifier (basis is_robust)', () => {
+    const brief = assembleBrief(makeInput({
+      robustness: { is_robust: true, fragile_edges: [], robust_edges: [] },
+    }))!;
+    expect(brief.robustness_caveat!.basis).toBe('is_robust');
+    expect(brief.robustness_caveat!.text).toContain('held up');
+    expect(brief.robustness_caveat!.text).toContain('not a guarantee');
+  });
+
+  it('is_robust false → did-not-pass wording (never softened)', () => {
+    const brief = assembleBrief(makeInput({
+      robustness: { is_robust: false, fragile_edges: [], robust_edges: [] },
+    }))!;
+    expect(brief.robustness_caveat!.basis).toBe('is_robust');
+    expect(brief.robustness_caveat!.text).toContain('did not pass');
+  });
+
+  it('level medium → moderately-stable wording (basis level)', () => {
+    const brief = assembleBrief(makeInput({
+      robustness: { level: 'medium', fragile_edges: [], robust_edges: [] },
+    }))!;
+    expect(brief.robustness_caveat!.basis).toBe('level');
+    expect(brief.robustness_caveat!.text).toContain('moderately stable');
+  });
+
+  it('level low / very_low → fragile wording', () => {
+    for (const level of ['low', 'very_low']) {
+      const brief = assembleBrief(makeInput({
+        robustness: { level, fragile_edges: [], robust_edges: [] },
+      }))!;
+      expect(brief.robustness_caveat!.text).toContain('fragile');
+    }
+  });
+
+  it('HONESTY: no is_robust and no level → says robustness was not assessed (basis absent)', () => {
+    const brief = assembleBrief(makeInput({
+      robustness: { fragile_edges: [], robust_edges: [] },
+    }))!;
+    expect(brief.robustness_caveat!.basis).toBe('absent');
+    expect(brief.robustness_caveat!.text).toContain('not assessed');
+  });
+});
+
+// =============================================================================
+// Warning codes echo
+// =============================================================================
+
+describe('warning_codes', () => {
+  it('echoes only warning-severity codes, deduped and sorted', () => {
+    const brief = assembleBrief(makeInput({
+      inference_warnings: [
+        { code: 'CONSTRAINT_TARGET_UNRELIABLE', message: 'x', severity: 'warning' },
+        { code: 'AUTO_NOISE_APPLIED', message: 'y', severity: 'warning' },
+        { code: 'AUTO_NOISE_APPLIED', message: 'y2', severity: 'warning' },
+        { code: 'EDGE_SENSITIVITY_UNAVAILABLE', message: 'z', severity: 'info' },
+      ],
+    }))!;
+    expect(brief.warning_codes).toEqual(['AUTO_NOISE_APPLIED', 'CONSTRAINT_TARGET_UNRELIABLE']);
+  });
+
+  it('is [] when the run carried no warning-severity warnings', () => {
+    const brief = assembleBrief(makeInput({}))!;
+    expect(brief.warning_codes).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Forbidden-wording tripwire + existing claim-safety invariants
+// =============================================================================
+
+describe('claim-safety wording invariants', () => {
+  it('an assembled brief NEVER contains EVPI or expected-value wording', () => {
+    const brief = assembleBrief(makeInput({
+      topWin: 0.7, secondWin: 0.3,
+      robustness: { is_robust: true, level: 'high', fragile_edges: [], robust_edges: [] },
+      factor_sensitivity: [
+        { factor_id: 'f1', factor_label: 'Market Size', elasticity: 0.5, value_defaulted: true },
+      ],
+      inference_warnings: [
+        { code: 'ROOT_NODE_DEFAULT_VALUE', message: 'Root node used a default value', severity: 'warning' },
+      ],
+    }))!;
+    const serialised = JSON.stringify(brief);
+    expect(serialised).not.toMatch(/EVPI/i);
+    expect(serialised).not.toMatch(/expected value/i);
+    expect(serialised).not.toMatch(/sensitive to/i);
+  });
+
+  it('CLAIM SAFETY: pinned levers stay out of top_drivers and what_would_change with the new surfaces active', () => {
+    const brief = assembleBrief(makeInput({
+      factor_sensitivity: [
+        { factor_id: 'lever', factor_label: 'Price', elasticity: 0.9, zero_reason: 'intervention_override' },
+        { factor_id: 'f1', factor_label: 'Market Size', elasticity: 0.5 },
+      ],
+    }))!;
+    expect(brief.top_drivers.map((d) => d.factor_label)).toEqual(['Market Size']);
+    expect(brief.what_would_change).toEqual(['Market Size']);
+  });
+});
+
+// =============================================================================
+// Flag gate (golden byte-identity guarantee)
+// =============================================================================
+
+describe('BRIEF_CLAIM_SAFE_SURFACES_ENABLE gate', () => {
+  it("flag '0' suppresses every claim-safe surface (pre-R3 brief shape)", () => {
+    process.env.BRIEF_CLAIM_SAFE_SURFACES_ENABLE = '0';
+    const brief = assembleBrief(makeInput({
+      factor_sensitivity: [
+        { factor_id: 'f1', factor_label: 'Market Size', elasticity: 0.5, value_defaulted: true },
+      ],
+      inference_warnings: [
+        { code: 'CONSTRAINT_TARGET_UNRELIABLE', message: 'x', severity: 'warning' },
+      ],
+    }))!;
+    expect(brief.headline_banded).toBeUndefined();
+    expect(brief.defaulted_assumptions).toBeUndefined();
+    expect(brief.robustness_caveat).toBeUndefined();
+    expect(brief.warning_codes).toBeUndefined();
+    expect(Object.keys(brief)).not.toContain('headline_banded');
+    expect(Object.keys(brief)).not.toContain('defaulted_assumptions');
+    expect(Object.keys(brief)).not.toContain('robustness_caveat');
+    expect(Object.keys(brief)).not.toContain('warning_codes');
+  });
+
+  it('unset flag (default) emits the surfaces', () => {
+    delete process.env.BRIEF_CLAIM_SAFE_SURFACES_ENABLE;
+    const brief = assembleBrief(makeInput({}))!;
+    expect(brief.headline_banded).toBeDefined();
+    expect(brief.robustness_caveat).toBeDefined();
+    expect(brief.defaulted_assumptions).toEqual([]);
+    expect(brief.warning_codes).toEqual([]);
+  });
+});

--- a/tests/decision-brief.test.ts
+++ b/tests/decision-brief.test.ts
@@ -5,7 +5,7 @@
  * from existing run_bundle response data.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -47,6 +47,19 @@ const MINIMAL_OPTIONS = [
 // =============================================================================
 
 describe('assembleBrief — golden fixtures', () => {
+  // Lane PLoT-R3: the golden fixtures pre-date the claim-safe surfaces
+  // (headline_banded, defaulted_assumptions, robustness_caveat,
+  // warning_codes). Emission is gated behind the default-ON
+  // BRIEF_CLAIM_SAFE_SURFACES_ENABLE flag and pinned OFF here so the
+  // fixture JSONs stay byte-identical. The new surfaces are covered in
+  // tests/decision-brief.claim-safety.test.ts.
+  beforeAll(() => {
+    process.env.BRIEF_CLAIM_SAFE_SURFACES_ENABLE = '0';
+  });
+  afterAll(() => {
+    delete process.env.BRIEF_CLAIM_SAFE_SURFACES_ENABLE;
+  });
+
   it('assembles correctly from normal response (happy path)', () => {
     const { input, expected } = loadFixture('normal.json');
     const result = assembleBrief(input);

--- a/tests/determinism-replay.test.ts
+++ b/tests/determinism-replay.test.ts
@@ -138,6 +138,12 @@ const IGNORE_FIELDS = [
   'brief_id',            // decision_brief: deterministic SHA-256-derived UUID (excluded for backwards compat with existing snapshots)
   'created_at',          // decision_brief: timestamp per assembly
   'fact_objects',        // F.7: fact_objects contain per-request IDs (fact_id, isl_request_id, content_hash); tested separately
+  // Lane PLoT-R3 (2.13): _meta.evidence digests cover the EXACT ISL wire bytes,
+  // which include the per-request request_id — legitimately volatile per run
+  // (same class as downstream_calls / request_id, already ignored above).
+  // evidence.plot_build and evidence.isl_build remain compared.
+  'isl_request_digest',
+  'isl_response_digest',
 ];
 
 /** Sort arrays by their natural key so element order doesn't cause false mismatches. */

--- a/tests/evidence-capture.test.ts
+++ b/tests/evidence-capture.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Diligence-grade evidence capture (Lane PLoT-R3, roadmap 2.13)
+ *
+ * The UI debug bundle reported "plot: null / isl: null" because the full
+ * payload mirror is gated behind UI_CANONICAL_META (off in staging). These
+ * tests cover the always-on additive `_meta.evidence` surface:
+ *   - computePayloadDigest: sha256 over EXACT bytes + UTF-8 byte length +
+ *     sorted top-level key manifest (never the body itself);
+ *   - ISLClient: digests recorded for the exact request bytes sent and the
+ *     exact response bytes received (success, HTTP-error and network paths);
+ *   - /v2/run: _meta.evidence always present with honest nulls when the ISL
+ *     HTTP client was not exercised.
+ */
+
+import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import {
+  computePayloadDigest,
+  initDownstreamTracking,
+  getDownstreamCallsForLog,
+  clearDownstreamTracking,
+} from '../src/util/downstream-tracker.js';
+import { ISLClient } from '../src/integrations/isl/client.js';
+
+const sha256 = (text: string) => createHash('sha256').update(text, 'utf8').digest('hex');
+
+// =============================================================================
+// computePayloadDigest — unit
+// =============================================================================
+
+describe('computePayloadDigest', () => {
+  it('digests the exact text bytes (sha256 + UTF-8 length)', () => {
+    const text = '{"a":1,"b":"£"}'; // £ is 2 bytes in UTF-8
+    const digest = computePayloadDigest(text, JSON.parse(text));
+    expect(digest.sha256).toBe(sha256(text));
+    expect(digest.bytes).toBe(Buffer.byteLength(text, 'utf8'));
+    expect(digest.bytes).toBe(text.length + 1); // multibyte proof
+  });
+
+  it('key_manifest is the sorted top-level keys', () => {
+    const digest = computePayloadDigest('{"zeta":1,"alpha":2,"mid":3}', { zeta: 1, alpha: 2, mid: 3 });
+    expect(digest.key_manifest).toEqual(['alpha', 'mid', 'zeta']);
+  });
+
+  it('key_manifest is [] for arrays and primitives', () => {
+    expect(computePayloadDigest('[1,2]', [1, 2]).key_manifest).toEqual([]);
+    expect(computePayloadDigest('"x"', 'x').key_manifest).toEqual([]);
+    expect(computePayloadDigest('null', null).key_manifest).toEqual([]);
+  });
+
+  it('is a pure content digest: same bytes → same digest, different bytes → different digest', () => {
+    const a1 = computePayloadDigest('{"a":1}', { a: 1 });
+    const a2 = computePayloadDigest('{"a":1}', { a: 1 });
+    const b = computePayloadDigest('{"a":2}', { a: 2 });
+    expect(a1).toEqual(a2);
+    expect(a1.sha256).not.toBe(b.sha256);
+  });
+});
+
+// =============================================================================
+// ISLClient — digest recording over exact wire bytes
+// =============================================================================
+
+describe('ISLClient — evidence digests', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function makeClient() {
+    return new ISLClient({
+      baseUrl: 'https://isl.test.example.com',
+      apiKey: 'test-key',
+      timeoutMs: 5000,
+      maxRetries: 1,
+    });
+  }
+
+  it('records request/response digests of the EXACT bytes exchanged', async () => {
+    const requestId = 'evidence-digest-success';
+    initDownstreamTracking(requestId);
+
+    // Response text with non-canonical whitespace + unsorted keys: the digest
+    // must cover these exact bytes, not a re-serialisation.
+    const responseText = '{ "zeta": 1,\n  "alpha": { "nested": true } }';
+    let sentBody: string | undefined;
+
+    globalThis.fetch = vi.fn(async (_url: any, init: any) => {
+      sentBody = init?.body as string;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: async () => responseText,
+      };
+    }) as unknown as typeof fetch;
+
+    const client = makeClient();
+    await client.request({ endpoint: '/api/v1/robustness/analyze/v2', body: { graph: { nodes: [] }, seed: '42' }, requestId });
+
+    const calls = getDownstreamCallsForLog(requestId);
+    clearDownstreamTracking(requestId);
+    expect(calls).toHaveLength(1);
+
+    const call = calls[0];
+    // Request digest covers exactly what went over the wire
+    expect(sentBody).toBeDefined();
+    expect(call.request_digest!.sha256).toBe(sha256(sentBody!));
+    expect(call.request_digest!.bytes).toBe(Buffer.byteLength(sentBody!, 'utf8'));
+    expect(call.request_digest!.key_manifest).toEqual(['graph', 'seed']);
+
+    // Response digest covers the exact received text (whitespace included),
+    // with the manifest from the parsed object (sorted)
+    expect(call.response_digest!.sha256).toBe(sha256(responseText));
+    expect(call.response_digest!.bytes).toBe(Buffer.byteLength(responseText, 'utf8'));
+    expect(call.response_digest!.key_manifest).toEqual(['alpha', 'zeta']);
+  });
+
+  it('records digests on HTTP error responses (non-retryable 4xx)', async () => {
+    const requestId = 'evidence-digest-http-error';
+    initDownstreamTracking(requestId);
+
+    const errorText = '{"detail":"unprocessable"}';
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => errorText,
+    })) as unknown as typeof fetch;
+
+    const client = makeClient();
+    await expect(
+      client.request({ endpoint: '/api/v1/robustness/analyze/v2', body: { graph: {} }, requestId }),
+    ).rejects.toThrow();
+
+    const calls = getDownstreamCallsForLog(requestId);
+    clearDownstreamTracking(requestId);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].request_digest).toBeDefined();
+    expect(calls[0].response_digest!.sha256).toBe(sha256(errorText));
+    expect(calls[0].response_digest!.key_manifest).toEqual(['detail']);
+  });
+
+  it('records the request digest (no response digest) on network failure', async () => {
+    const requestId = 'evidence-digest-network';
+    initDownstreamTracking(requestId);
+
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    }) as unknown as typeof fetch;
+
+    const client = makeClient();
+    await expect(
+      client.request({ endpoint: '/api/v1/robustness/analyze/v2', body: { graph: {} }, requestId }),
+    ).rejects.toThrow();
+
+    const calls = getDownstreamCallsForLog(requestId);
+    clearDownstreamTracking(requestId);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].request_digest).toBeDefined();
+    expect(calls[0].request_digest!.key_manifest).toEqual(['graph']);
+    expect(calls[0].response_digest).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// /v2/run — _meta.evidence always present (honest nulls)
+// =============================================================================
+
+// Mock the ISL service MODULE (same pattern as determinism-replay.test.ts):
+// the mocked callAnalysisEndpoint bypasses the HTTP client, so no downstream
+// call (and no digest) is recorded — evidence must then report honest nulls.
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock validation', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.65 + idx * 0.12, std: 0.08, p10: 0.45, p50: 0.65, p90: 0.85, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+          rank: idx + 1,
+        })),
+        edges: [],
+        factors: [],
+        value_of_information: [],
+        overall_robustness: 'robust', robustness_score: 0.82,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+describe('/v2/run — _meta.evidence', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  it('is always present: plot_build populated, honest nulls when the ISL HTTP client was not exercised', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      payload: {
+        graph: {
+          nodes: [
+            { id: 'goal', kind: 'goal', label: 'Revenue' },
+            { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+          ],
+          edges: [
+            { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+          ],
+        },
+        options: [
+          { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 0.8 } },
+          { id: 'opt2', label: 'Hold Marketing', interventions: { 'factor-a': 0.6 } },
+        ],
+        goal_node_id: 'goal',
+        seed: '4242',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body._meta).toBeDefined();
+    const evidence = body._meta.evidence;
+    expect(evidence).toBeDefined();
+    expect(typeof evidence.plot_build).toBe('string');
+    expect(evidence.plot_build.length).toBeGreaterThan(0);
+    // Module-level ISL mock bypasses the HTTP client: no digest was recorded
+    // and the mock response carries no `build` — nulls must be explicit
+    // (field present), never absent.
+    expect(evidence).toHaveProperty('isl_build', null);
+    expect(evidence).toHaveProperty('isl_request_digest', null);
+    expect(evidence).toHaveProperty('isl_response_digest', null);
+  });
+
+  it('decision_brief carries the claim-safe surfaces end-to-end (flag default ON)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      payload: {
+        graph: {
+          nodes: [
+            { id: 'goal', kind: 'goal', label: 'Revenue' },
+            { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+          ],
+          edges: [
+            { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+          ],
+        },
+        options: [
+          { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 0.8 } },
+          { id: 'opt2', label: 'Hold Marketing', interventions: { 'factor-a': 0.6 } },
+        ],
+        goal_node_id: 'goal',
+        seed: '4242',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.decision_brief).toBeTruthy();
+    expect(body.decision_brief.robustness_caveat).toBeDefined();
+    expect(body.decision_brief.robustness_caveat.doctrine).toBe('provisional_doctrine_v0');
+    expect(Array.isArray(body.decision_brief.warning_codes)).toBe(true);
+    expect(Array.isArray(body.decision_brief.defaulted_assumptions)).toBe(true);
+    if (body.decision_brief.headline_banded) {
+      expect(['very_close', 'slightly_ahead', 'clearly_ahead']).toContain(body.decision_brief.headline_banded.band);
+      expect(body.decision_brief.headline_banded.text).not.toMatch(/EVPI|expected value/i);
+    }
+  });
+});

--- a/tests/request-id-chain.test.ts
+++ b/tests/request-id-chain.test.ts
@@ -582,6 +582,8 @@ describe('ISL Client — request ID echo capture', () => {
         'x-request-id': requestId,
       }),
       json: async () => ({ status: 'ok' }),
+      // Lane PLoT-R3: client now reads raw text (for exact-byte digests) and parses it
+      text: async () => JSON.stringify({ status: 'ok' }),
     })) as unknown as typeof fetch;
 
     const client = new ISLClient({
@@ -607,6 +609,8 @@ describe('ISL Client — request ID echo capture', () => {
       status: 200,
       headers: new Headers({ 'content-type': 'application/json' }),
       json: async () => ({ status: 'ok' }),
+      // Lane PLoT-R3: client now reads raw text (for exact-byte digests) and parses it
+      text: async () => JSON.stringify({ status: 'ok' }),
     })) as unknown as typeof fetch;
 
     const client = new ISLClient({


### PR DESCRIPTION
## Lane PLoT-R3 — decision brief emission (2.7) + diligence evidence capture (2.13)

Fresh worktree from `origin/staging` @ `1823e07`. All wire changes **additive** (new optional fields only). All new wording surfaces tagged `provisional_doctrine_v0`. Evidence report: `docs/lanes/LANE10-brief-and-evidence-2026-07-07.md`.

### Chronicle correction
`assembleBrief()` was **already live** (not stubbed): full deterministic assembly in `src/assembly/decision-brief.ts` and `decision_brief` already emitted on `/v2/run`. Feature A therefore lands as the claim-safe surface extension the 2.7 spec asks for, not a from-scratch emission.

### A — decision_brief claim-safe surfaces (roadmap 2.7 / G.2)
New optional fields on `DecisionBriefV1`, all `provisional_doctrine_v0`:

- **`headline_banded`** — deterministic leader claim banded by win-probability gap (the producer leg of the UI's UI-SEM-060 debt: "Remove when PLoT provides a leader-confidence band / close-call signal"). Bands are exactly **'very close'** (gap < 0.10, shared `NEAR_TIE_THRESHOLD`), **'slightly ahead'**, **'clearly ahead'** (gap >= 0.25 `CLEARLY_AHEAD_GAP_THRESHOLD` **and** robustness established — `is_robust === true`, or `level === 'high'` with no explicit false). A clearly-ahead-sized gap without robustness is downgraded with `robustness_gated: true`. Absent when < 2 ranked options — no comparative claim without a comparison.
- **`defaulted_assumptions`** — `value_defaulted` factors (**intervention-pinned levers excluded** via the shared A1b predicate — never in "check this" framing) + DEFAULT-coded inference-warning disclosures (echoed verbatim, deduped).
- **`robustness_caveat`** — honest wording strictly from `is_robust`/`level`; absence is stated as "not assessed", never implied stability.
- **`warning_codes`** — warning-severity inference-warning code echo (codes only, sorted, deduped).

No `EVPI` / `expected value` / `sensitive to` wording anywhere (tripwire test).

**Goldens:** wire-capture goldens untouched (field-level assertions, unaffected by additive fields). The brief unit-test golden fixtures (`src/fixtures/decision-brief/*.json`, deep-equal compared) would have broken → per lane rules, emission is gated behind **default-ON** `BRIEF_CLAIM_SAFE_SURFACES_ENABLE`, pinned `'0'` only in that golden-fixtures describe block. Fixture JSONs byte-identical; flag is ON in every deployed environment.

### B — diligence-grade evidence capture (roadmap 2.13)
The UI debug bundle reported `plot: null / isl: null` because the full payload mirror is gated behind `UI_CANONICAL_META` (off in staging). Adds always-present, additive **`_meta.evidence`**:

- `isl_request_digest` / `isl_response_digest` — sha256 over the **exact wire bytes** (client now sends pre-serialised text and reads `response.text()` before parsing), UTF-8 byte length, sorted top-level key manifest. Never full bodies. Recorded on success / HTTP-error / network paths; primary exchange = first `/robustness/analyze` call.
- `plot_build` — deployed SHA (existing `BUILD_ID`/`GITHUB_SHA` source).
- `isl_build` — passthrough of ISL's `build` response field; `null` when not reported, never invented.

Honest-null contract: all four keys always present; digests `null` when the ISL HTTP client wasn't exercised. Determinism replay: the two digest keys are per-request volatile (ISL body carries `request_id`) and ignore-listed with rationale; `plot_build`/`isl_build` remain compared.

### Tests
- `tests/decision-brief.claim-safety.test.ts` (22) — band matrix incl. float-exact 0.10/0.25 boundaries, robustness downgrades, pinned-lever exclusion, disclosure echo/dedup, caveat matrix, forbidden-wording tripwire, flag gate both ways.
- `tests/evidence-capture.test.ts` (9) — digest units (exact bytes, multibyte, manifest), ISLClient recording on all three paths, route-level always-present/honest-null, end-to-end brief surfaces.
- Updated: brief golden flag pin, request-id-chain fetch stubs (`text()`), determinism ignore entries.

### Gates
- Pre-push validation PASSED locally: tsc clean; full suite **5247 passed | 25 skipped**; no stale .js; file-dep policy OK; spectral lint OK.
- Known pre-existing CI reds unrelated to this lane: `audit` (fast-uri/fastify advisories) and `gates (windows-latest)` (invalid path `tools/sdk-smoke:python.mjs`).

### Cross-lane sequencing
UI consumption of `headline_banded` (retiring UI-SEM-060) and of `_meta.evidence` (debug bundle) is **next-round wiring** — nothing here consumes fields other lanes are adding this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
