### PR TITLE
feat(run): display-safe robustness.display_verdict + reason (PLoT-W5)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -5892,6 +5892,34 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/critiqueV3'
+        robustness:
+          type: object
+          description: >-
+            Empty robustness object maintained on blocked/failed responses
+            (CIL 0.2 contract). ADDITIVE (lane PLoT-W5): also carries
+            display_verdict 'not_assessed' + display_verdict_reason — a
+            blocked/failed run never computed robustness, so the
+            display-safe verdict is always 'not_assessed' here.
+          properties:
+            fragile_edges:
+              type: array
+              description: Always [] on blocked/failed responses.
+              items:
+                type: object
+            robust_edges:
+              type: array
+              description: Always [] on blocked/failed responses.
+              items:
+                type: object
+            display_verdict:
+              type: string
+              enum: [not_assessed]
+              description: Always 'not_assessed' on blocked/failed responses.
+            display_verdict_reason:
+              type: string
+              description: >-
+                Producer-owned claim-safe phrase (wording
+                provisional_doctrine_v0, no numbers).
 
     runResponseV3:
       type: object
@@ -6335,6 +6363,29 @@ components:
                     description: Probability that this edge's existence would flip
             explanation:
               type: string
+            display_verdict:
+              type: string
+              enum: [robust, moderate, fragile, not_assessed]
+              description: >-
+                ADDITIVE (lane PLoT-W5, roadmap Tier 1.6): display-safe
+                robustness verdict, derived by PLoT honestly and ONLY from
+                the producer facts is_robust/level (confidence is never an
+                input and can never upgrade a verdict). Mapping
+                (provisional_doctrine_v0): is_robust true AND level high →
+                robust; level medium (wire vocabulary) or moderate →
+                moderate; is_robust false OR level low/very_low → fragile
+                (explicit is_robust false always wins, never softened);
+                robustness absent/failed/facts-missing → not_assessed. Never
+                a determinate-looking verdict without computed robustness.
+                The UI renders this verbatim and must not re-derive meaning
+                from is_robust/level/confidence.
+            display_verdict_reason:
+              type: string
+              description: >-
+                ADDITIVE (lane PLoT-W5): producer-owned claim-safe phrase
+                matching display_verdict (wording provisional_doctrine_v0,
+                no numbers), e.g. fragile → 'small changes could flip this
+                result'.
         meta:
           type: object
           required: [seed_used, n_samples, detail_level, latency_ms]

--- a/docs/lanes/LANE18-robustness-display-verdict-2026-07-07.md
+++ b/docs/lanes/LANE18-robustness-display-verdict-2026-07-07.md
@@ -1,0 +1,154 @@
+# Lane PLoT-W5 (lane 18) evidence report — display-safe robustness verdict on /v2/run
+
+- Date: 2026-07-07
+- Branch: `claude-lane18/robustness-display-verdict` (fresh worktree; base `origin/staging` @ `14dd31a`)
+- Roadmap: Tier 1.6, **producer side** — ends the "Robustness unknown" era. The UI
+  hardcodes `robustnessVerdict = undefined` because no display-safe field exists on the
+  /v2/run wire: it carries `robustness.is_robust` / `level` / `confidence`, but the UI is
+  forbidden to re-derive meaning from raw producer facts (claim-safety doctrine: meaning
+  is producer-owned). The UI consumer leg is a separate lane.
+- Contract status: **ADDITIVE ONLY** — two new optional fields on the existing
+  `robustness` object (`display_verdict`, `display_verdict_reason`). No boundary field
+  renamed, retyped, removed, or made required. No request-shape change. Nothing
+  non-additive was needed — no blocker raised.
+- Doctrine: the verdict **mapping** and every **reason phrase** are tagged
+  `provisional_doctrine_v0` (module doc, type JSDoc, both OpenAPI specs, contract file).
+
+## RED inheritance
+
+A previous session on this lane was killed by an account usage limit mid-implementation
+after committing the RED route-level fixture test as a checkpoint
+(`3a8ea15`, `tests/robustness-display-verdict.fixture.test.ts`). This session resumed
+from that branch tip and **re-confirmed RED against the pristine baseline first**:
+10/10 tests failing (every `display_verdict` expectation received `undefined`) before
+any implementation code was written. After implementation: 10/10 GREEN, plus 13 new
+unit mapping-table tests (`tests/robustness-display-verdict.unit.test.ts`).
+
+## What is emitted (commit `0964db6`)
+
+`robustness.display_verdict` — enum `'robust' | 'moderate' | 'fragile' | 'not_assessed'`
+and `robustness.display_verdict_reason` — one short producer-owned phrase per verdict.
+
+Derivation module: `src/routes/v2/robustness-display-verdict.ts` (pure function, single
+source of truth). Mapping table (**provisional_doctrine_v0**, evaluated strictly in
+order):
+
+| # | Producer facts | Verdict |
+|---|---|---|
+| 1 | robustness not computed (absent / failed / blocked — `robustness_status !== 'computed'`) | `not_assessed` |
+| 2 | `is_robust === false` (explicit negative always wins — never softened by level/confidence) | `fragile` |
+| 3 | `level === 'low' \| 'very_low'` | `fragile` |
+| 4 | `level === 'medium'` (ISL wire vocabulary) `\| 'moderate'` (UI-vocabulary tolerance) | `moderate` |
+| 5 | `is_robust === true` **AND** `level === 'high'` (both facts required — level alone never upgrades) | `robust` |
+| 6 | verdict-bearing facts missing or unrecognised | `not_assessed` |
+
+Reason phrases (**provisional_doctrine_v0**, claim-safe, no numbers — the UI renders
+them verbatim):
+
+- `robust` → "this result held up under the changes we tested"
+- `moderate` → "this result mostly held up, but could shift under some changes"
+- `fragile` → "small changes could flip this result"
+- `not_assessed` → "robustness was not assessed for this run"
+
+### Honesty invariants (each pinned by a test)
+
+- **Never a determinate-looking verdict when robustness wasn't computed** — rule 1 gates
+  on `robustness_status === 'computed'`; blocked (422) and failed error shapes always
+  carry `not_assessed`; a computed robustness whose verdict-bearing facts are missing is
+  also `not_assessed` (rule 6).
+- **Confidence can never upgrade a verdict** — it is not an input: the derivation
+  function signature does not accept it (pinned live: `confidence: 0.99` on the fragile
+  capture still yields `fragile`).
+- Unrecognised external values (ISL is external input) degrade to `not_assessed` —
+  never a crash, never a fabricated verdict.
+
+### Emission sites (all /v2/run response shapes)
+
+- `buildResponse` (`src/routes/v2/run.ts`) — success / partial / failed 200 shapes,
+  derived from the **assembled** `robustness.is_robust`/`level` after the CIL Phase-0
+  fallback, gated on `robustnessStatus === 'computed'`. Covers both call sites (main ISL
+  path and the `graph_fallback` ISL-not-enabled path — the latter passes
+  `robustnessStatus: 'unavailable'` → `not_assessed`).
+- `buildV2RunError` — blocked (422) and failed error shapes: the CIL 0.2 empty
+  robustness object now also carries `display_verdict: 'not_assessed'` + reason.
+
+Not touched: the PLoT→CEE enrichment payload (`buildRobustnessDataForCee`),
+`decision_brief.robustness_caveat` (lane PLoT-R3 surface), `fact_objects` lineage.
+
+## Fixture derivation (live capture sets, as mandated)
+
+Route-level tests mock only the ISL transport and replay the **committed live
+captures**:
+
+- `tests/fixtures/isl-v2-live-20260706` (ISL build `f3f5d92`): the live **fragile**
+  case — `is_robust: false`, `level: 'low'` → `display_verdict: 'fragile'`, with
+  producer facts asserted unchanged on the wire (additive proof).
+- `tests/fixtures/isl-v2-live-20260707` (ISL build `9a22a1a`, see its `PROVENANCE.md`):
+  same verdict facts on the newer deployed build → `'fragile'`.
+- **Absent-robustness case**: the 20260706 capture with the `robustness` key deleted →
+  `robustness_status !== 'computed'`, CIL fallback object carries `'not_assessed'`.
+- Synthetic mapping-table edits clone a capture and edit **only** the verdict-bearing
+  facts (`is_robust`/`level`): robust, moderate, is_robust-false-beats-level-high,
+  confidence-cannot-upgrade, facts-missing.
+- **Blocked path**: preflight-blocked request (missing goal node) → 422 with
+  `'not_assessed'` on the CIL empty robustness object.
+- Claim-safety: every emitted reason asserted digit-free (`not.toMatch(/\d/)`).
+
+## Contract surfaces (commit `4bfc01d` — all additive)
+
+- `src/types/engine-v3.ts` — `RobustnessAssessmentV3.display_verdict?` +
+  `display_verdict_reason?` (optional on the type for inbound tolerance of old
+  payloads; emitted on every /v2/run response by current builds).
+- `openapi/openapi-plot-lite-v1.yaml` (hand-authored, updated manually per repo rule):
+  `V2RunResponse.robustness` gains the two properties (enum documented);
+  `V2RunError.robustness` documents the always-`not_assessed` verdict.
+- `contracts/openapi.yaml` (the spectral-linted spec): same additions on
+  `runResponseV3.robustness` + `v2RunError.robustness`. Spectral: 0 errors (the
+  `MarginSensitivity` unused-component warning is pre-existing on `origin/staging`).
+- `src/contracts/isl-to-ui.contract.ts` — `robustness.display_verdict` +
+  `robustness.display_verdict_reason` declared in `enriched` (fields PLoT adds that ISL
+  does not provide).
+
+## Goldens: byte-identical, no flag needed
+
+The lane-10 escape hatch (default-ON flag pinned `'0'` in the golden describe block) was
+**not needed**: no golden/fixture test byte-compares a stored /v2/run response
+containing the `robustness` object. Verified by (a) the full suite passing with the
+fields emitted unconditionally — including `tests/golden/*` (engine + near-tie +
+canonical-route), `tests/decision-brief.test.ts` golden fixtures (assembled from
+analysis inputs, not the response robustness object — fixture JSONs untouched), and
+`tests/v2-determinism.test.ts` (response_hash canonicalises the REQUEST, so an additive
+response field cannot drift it); and (b) grep review of `toEqual`/`Object.keys` pins on
+`robustness` — all are sub-array or field-level assertions, none pin the key set.
+Because emission is unconditional, staging behaviour needs no env/flag coordination.
+
+## Verification (fresh worktree, authoritative gates)
+
+- Tier 1: `npx tsc --noEmit` — clean.
+- Targeted suites (this change + nearest neighbours): fixture 10/10, unit 13/13,
+  `boundary-isl-to-ui.contract` 24/24, `cil-phase02-blocked-robustness` 2/2,
+  `v2-determinism` 27/27.
+- Full authoritative gate `bash scripts/pre-push-validate.sh`, run 1 (honest
+  attribution): **2 failures, both understood** —
+  1. spectral `array-items` errors on the two array stubs I had added to
+     `v2RunError.robustness` — **mine**, fixed by adding `items` (folded into
+     `4bfc01d`);
+  2. `tests/error.taxonomy.test.ts` "RATE_LIMIT → 429" — **unrelated flake**: the test
+     spawns its own server on fixed port 4343 inside the fully parallel suite; passes
+     12/12 in isolation; no robustness/verdict code is anywhere near it.
+  Everything else: 5292 passed / 1 failed / 25 skipped across 493 files.
+- Full gate, run 2 (after the spectral fix): spectral **PASS** (0 errors; the
+  `MarginSensitivity` warning is pre-existing on staging). Test step: 5291 passed /
+  **2 flaked** — `error.taxonomy` 429 again, plus `option-compare` include_debug
+  (`503` from its spawned server under full parallel load). Both pass 17/17 when run
+  in isolation immediately afterwards. The flake set DIFFERS between the two runs
+  (run 1: error.taxonomy only; run 2: error.taxonomy + option-compare) — the
+  signature of load-sensitive spawned-server tests, not of a deterministic
+  regression; neither test touches any surface in this diff (draft-flows
+  rate-limiting and /v1/run option-compare debug).
+- **Pristine-baseline attribution**: full `npm test` on a fresh worktree at
+  `origin/staging` @ `14dd31a` (identical environment, cloned node_modules):
+  BASELINE_RESULT_PLACEHOLDER.
+- Known pre-existing CI reds (per repo `CLAUDE.md`, not chased): `audit`
+  (fast-uri/fastify advisories) and `gates (windows-latest)` (invalid path
+  `tools/sdk-smoke:python.mjs`).

--- a/openapi/openapi-plot-lite-v1.yaml
+++ b/openapi/openapi-plot-lite-v1.yaml
@@ -923,7 +923,33 @@ components:
           description: Graph identifiability assessment
         robustness:
           type: object
-          description: Robustness assessment (sensitivity to edge removal)
+          description: >
+            Robustness assessment (sensitivity to edge removal). ADDITIVE
+            (lane PLoT-W5): display_verdict + display_verdict_reason — the
+            display-safe verdict, derived by PLoT honestly and ONLY from the
+            producer facts is_robust/level (confidence is never an input and
+            can never upgrade a verdict). 'not_assessed' whenever robustness
+            was not computed or the verdict-bearing facts are missing — never
+            a determinate-looking verdict without computed robustness. The UI
+            renders these verbatim and must not re-derive meaning from
+            is_robust/level/confidence.
+          properties:
+            display_verdict:
+              type: string
+              enum: [robust, moderate, fragile, not_assessed]
+              description: >
+                Display-safe robustness verdict (mapping
+                provisional_doctrine_v0): is_robust true AND level high →
+                robust; level medium (wire vocabulary) or moderate →
+                moderate; is_robust false OR level low/very_low → fragile
+                (explicit is_robust false always wins, never softened);
+                robustness absent/failed/facts-missing → not_assessed.
+            display_verdict_reason:
+              type: string
+              description: >
+                Producer-owned claim-safe phrase matching display_verdict
+                (wording provisional_doctrine_v0, no numbers), e.g. fragile →
+                'small changes could flip this result'.
         option_comparison_status:
           type: string
           enum: [computed, unavailable, skipped, error]
@@ -998,7 +1024,22 @@ components:
             $ref: '#/components/schemas/CritiqueV3'
         robustness:
           type: object
-          description: Empty robustness object (CIL 0.2 contract)
+          description: >
+            Empty robustness object (CIL 0.2 contract). ADDITIVE (lane
+            PLoT-W5): also carries display_verdict 'not_assessed' +
+            display_verdict_reason — a blocked/failed run never computed
+            robustness, so the display-safe verdict is always
+            'not_assessed' here.
+          properties:
+            display_verdict:
+              type: string
+              enum: [not_assessed]
+              description: Always 'not_assessed' on blocked/failed responses.
+            display_verdict_reason:
+              type: string
+              description: >
+                Producer-owned claim-safe phrase (wording
+                provisional_doctrine_v0, no numbers).
       required: [analysis_status, status_reason, critiques]
     CritiqueV3:
       type: object

--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -110,6 +110,15 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     'recommended_option_id',
     'recommended_option_label',
     'near_tie',
+    // Lane PLoT-W5 (roadmap Tier 1.6): display-safe robustness verdict — the
+    // producer-owned meaning of is_robust/level so the UI never re-derives it.
+    // Derived ONLY from is_robust + level (confidence is NEVER an input);
+    // 'not_assessed' whenever robustness was not computed or the
+    // verdict-bearing facts are missing. Emitted on success AND blocked/failed
+    // error shapes. Mapping + wording provisional_doctrine_v0 — see
+    // src/routes/v2/robustness-display-verdict.ts.
+    'robustness.display_verdict',        // enum: robust | moderate | fragile | not_assessed
+    'robustness.display_verdict_reason', // claim-safe producer phrase, no numbers (e.g. fragile → 'small changes could flip this result')
     'confidence_tier',                   // B1: derived from m1_coaching.readiness (ready→strong, close_call→fair, else→needs_work)
     'dominant_factor',                   // B1: detected from factor_sensitivity (influence >0.5 AND ratio >2:1)
     'factor_sensitivity[].evpi_percentage_points', // P-5: ISL factor_evpi[] counterfactual (sanitised, flag-gated staging/test) OR VOI×spread heuristic fallback; source disclosed via evpi_method

--- a/src/routes/v2/robustness-display-verdict.ts
+++ b/src/routes/v2/robustness-display-verdict.ts
@@ -1,0 +1,117 @@
+/**
+ * Display-safe robustness verdict (lane PLoT-W5, roadmap Tier 1.6 — producer side).
+ *
+ * WHY: the UI hardcodes robustnessVerdict = undefined ("Robustness unknown")
+ * because no display-safe field exists on the /v2/run wire. The wire carries
+ * the raw producer facts (robustness.is_robust / level / confidence) but the
+ * UI is forbidden to re-derive meaning from raw facts (claim-safety doctrine:
+ * meaning is producer-owned). This module derives the ADDITIVE
+ * `robustness.display_verdict` + `robustness.display_verdict_reason` fields
+ * honestly and ONLY from producer facts.
+ *
+ * Mapping table (provisional_doctrine_v0 — evaluated strictly in order):
+ *
+ *   1. robustness not computed (absent / failed / blocked)  → 'not_assessed'
+ *   2. is_robust === false                                  → 'fragile'
+ *      (an explicit negative always wins — NEVER softened by level/confidence)
+ *   3. level === 'low' | 'very_low'                         → 'fragile'
+ *   4. level === 'medium' | 'moderate'                      → 'moderate'
+ *      (ISL V2 wire sends 'medium'; 'moderate' accepted for vocabulary
+ *      tolerance — same normalisation the UI applies)
+ *   5. is_robust === true AND level === 'high'              → 'robust'
+ *      (BOTH facts required — level alone never upgrades to 'robust')
+ *   6. anything else (verdict-bearing facts missing or
+ *      unrecognised)                                        → 'not_assessed'
+ *
+ * Honesty invariants:
+ *  - NEVER a determinate-looking verdict ('robust'/'moderate'/'fragile') when
+ *    robustness was not actually computed.
+ *  - `confidence` is NEVER an input — the function signature does not accept
+ *    it, so confidence alone can never upgrade (or create) a verdict.
+ *  - The reason phrases are producer-owned, claim-safe, and carry no numbers.
+ */
+
+/** The four display-safe verdict values. Additive /v2/run wire enum. */
+export type RobustnessDisplayVerdict =
+  | 'robust'
+  | 'moderate'
+  | 'fragile'
+  | 'not_assessed';
+
+/**
+ * Producer-owned display reason per verdict (provisional_doctrine_v0 wording).
+ * Claim-safe: one short phrase, no numbers, no re-derivable statistics.
+ * Single source of truth — the route emits these verbatim.
+ */
+export const ROBUSTNESS_DISPLAY_VERDICT_REASONS: Record<
+  RobustnessDisplayVerdict,
+  string
+> = {
+  robust: 'this result held up under the changes we tested',
+  moderate: 'this result mostly held up, but could shift under some changes',
+  fragile: 'small changes could flip this result',
+  not_assessed: 'robustness was not assessed for this run',
+};
+
+/**
+ * The verdict-bearing producer facts. `unknown`-typed on purpose: the ISL
+ * payload is external input — unrecognised values must degrade to
+ * 'not_assessed', never crash or fabricate a determinate verdict.
+ *
+ * NOTE deliberately absent: `confidence`. It is not a verdict input
+ * (invariant: confidence alone can never upgrade a verdict).
+ */
+export interface RobustnessVerdictFacts {
+  is_robust?: unknown;
+  level?: unknown;
+}
+
+/**
+ * Derive the display-safe verdict + reason from producer facts.
+ *
+ * @param facts               is_robust / level as assembled from the ISL
+ *                            response (undefined when ISL returned no
+ *                            robustness object).
+ * @param robustnessComputed  true ONLY when the response's
+ *                            robustness_status is 'computed' — any other
+ *                            status (unavailable / skipped / error, or a
+ *                            blocked run that never reached ISL) must yield
+ *                            'not_assessed'.
+ */
+export function deriveRobustnessDisplayVerdict(
+  facts: RobustnessVerdictFacts | undefined,
+  robustnessComputed: boolean,
+): { display_verdict: RobustnessDisplayVerdict; display_verdict_reason: string } {
+  const display_verdict = deriveVerdict(facts, robustnessComputed);
+  return {
+    display_verdict,
+    display_verdict_reason: ROBUSTNESS_DISPLAY_VERDICT_REASONS[display_verdict],
+  };
+}
+
+function deriveVerdict(
+  facts: RobustnessVerdictFacts | undefined,
+  robustnessComputed: boolean,
+): RobustnessDisplayVerdict {
+  // Rule 1: no computed robustness → never a determinate-looking verdict.
+  if (!robustnessComputed || facts === undefined) return 'not_assessed';
+
+  const isRobust =
+    typeof facts.is_robust === 'boolean' ? facts.is_robust : undefined;
+  const level = typeof facts.level === 'string' ? facts.level : undefined;
+
+  // Rule 2: explicit negative always wins — never softened.
+  if (isRobust === false) return 'fragile';
+
+  // Rule 3
+  if (level === 'low' || level === 'very_low') return 'fragile';
+
+  // Rule 4 (ISL wire vocabulary 'medium'; 'moderate' tolerated)
+  if (level === 'medium' || level === 'moderate') return 'moderate';
+
+  // Rule 5: BOTH facts required for the strongest claim.
+  if (isRobust === true && level === 'high') return 'robust';
+
+  // Rule 6: verdict-bearing facts missing or unrecognised.
+  return 'not_assessed';
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -94,6 +94,7 @@ import {
   normalizeFragileEdges,
   normalizeRobustEdges,
 } from '../../integrations/isl/adapters/robustness-analysis.js';
+import { deriveRobustnessDisplayVerdict } from './robustness-display-verdict.js';
 import type { RobustnessDataForCee, NormalizedEdgeInfo } from '../../integrations/isl/types/plot-types.js';
 import type { ISLConstraintResult, ISLEdgeEValue, ISLConditionalWinner } from '../../integrations/isl/types/isl-types.js';
 import { getIslEdgeEValues, getIslEdgeSensitivity, getIslComputedAt, mapIslFactorEvpi } from '../../integrations/isl/v2-envelope.js';
@@ -1203,10 +1204,14 @@ function buildV2RunError({
     analysis_status: analysisStatus,
     status_reason: statusReason,
     critiques,
-    // CIL 0.2: maintain robustness contract on error responses
+    // CIL 0.2: maintain robustness contract on error responses.
+    // Lane PLoT-W5 (additive): blocked/failed runs never computed robustness,
+    // so the display-safe verdict is 'not_assessed' — never a
+    // determinate-looking verdict without computed robustness.
     robustness: {
       fragile_edges: [],
       robust_edges: [],
+      ...deriveRobustnessDisplayVerdict(undefined, false),
     },
     retryable,
     meta: {
@@ -2009,6 +2014,20 @@ function buildResponse(
   if (nearTie) {
     robustness.near_tie = nearTie;
   }
+
+  // Display-safe robustness verdict (lane PLoT-W5, roadmap Tier 1.6 —
+  // additive). Derived honestly and ONLY from the producer facts
+  // is_robust/level as assembled above (confidence is NEVER an input);
+  // 'not_assessed' whenever robustness_status is not 'computed' or the
+  // verdict-bearing facts are missing — never a determinate-looking verdict
+  // without computed robustness. Mapping + wording provisional_doctrine_v0 —
+  // see src/routes/v2/robustness-display-verdict.ts.
+  const displayVerdictFields = deriveRobustnessDisplayVerdict(
+    { is_robust: robustness.is_robust, level: robustness.level },
+    robustnessStatus === 'computed',
+  );
+  robustness.display_verdict = displayVerdictFields.display_verdict;
+  robustness.display_verdict_reason = displayVerdictFields.display_verdict_reason;
 
   // Extract factor_enrichments from sensitivityData (if present)
   const factorEnrichments = sensitivityData?.factorEnrichments;

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2071,6 +2071,26 @@ export interface RobustnessAssessmentV3 {
    * Present when option_comparison is computed with valid win_probability values.
    */
   near_tie?: NearTieInfoV3;
+  /**
+   * ADDITIVE (lane PLoT-W5, roadmap Tier 1.6): display-safe robustness verdict,
+   * derived by PLoT honestly and ONLY from the producer facts is_robust/level
+   * (confidence is NEVER an input — it can never upgrade a verdict). Mapping
+   * is provisional_doctrine_v0 — see src/routes/v2/robustness-display-verdict.ts.
+   * 'not_assessed' whenever robustness was not computed (absent/failed/blocked)
+   * or the verdict-bearing facts are missing — NEVER a determinate-looking
+   * verdict without computed robustness. Emitted on every /v2/run response
+   * (success shapes via buildResponse, blocked/failed shapes via
+   * buildV2RunError); optional on the type for inbound tolerance of payloads
+   * from older builds.
+   */
+  display_verdict?: 'robust' | 'moderate' | 'fragile' | 'not_assessed';
+  /**
+   * ADDITIVE (lane PLoT-W5): producer-owned claim-safe phrase matching
+   * display_verdict (e.g. fragile → 'small changes could flip this result').
+   * No numbers, wording provisional_doctrine_v0 — the UI renders it verbatim
+   * and must not re-derive meaning.
+   */
+  display_verdict_reason?: string;
 }
 
 /**

--- a/tests/robustness-display-verdict.fixture.test.ts
+++ b/tests/robustness-display-verdict.fixture.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Display-safe robustness verdict — route-level fixture tests (lane PLoT-W5,
+ * roadmap Tier 1.6 producer side).
+ *
+ * The UI hardcodes robustnessVerdict = undefined ("Robustness unknown")
+ * because no display-safe field exists on the /v2/run wire: it carries
+ * is_robust / level / confidence but the UI is forbidden to re-derive
+ * meaning from raw producer facts. These tests pin the ADDITIVE producer
+ * fields `robustness.display_verdict` + `robustness.display_verdict_reason`.
+ *
+ * Fixture derivation (live capture sets):
+ *  - tests/fixtures/isl-v2-live-20260706 (ISL build f3f5d92): the FRAGILE
+ *    case — robustness.is_robust === false, level === 'low' → 'fragile'.
+ *  - tests/fixtures/isl-v2-live-20260707 (see PROVENANCE.md): same verdict
+ *    facts on a later build → 'fragile'.
+ *  - absent-robustness case: the 20260706 capture with the robustness key
+ *    DELETED (simulates an ISL response that never computed robustness) →
+ *    'not_assessed' on the CIL Phase-0 fallback object.
+ *  - synthetic robust / moderate / confidence-cannot-upgrade cases: capture
+ *    clones with only the verdict-bearing facts (is_robust / level) edited.
+ *
+ * Honesty invariants pinned here:
+ *  - NEVER a determinate-looking verdict when robustness wasn't computed.
+ *  - confidence alone can never upgrade a verdict (it is not an input).
+ *  - display_verdict_reason is claim-safe: no digits, producer-owned phrase.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURES_ROOT = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+const capture20260706 = JSON.parse(
+  readFileSync(join(FIXTURES_ROOT, 'isl-v2-live-20260706', 'isl-staging-capture.json'), 'utf8'),
+);
+const request20260706 = JSON.parse(
+  readFileSync(join(FIXTURES_ROOT, 'isl-v2-live-20260706', 'isl-v2-request.json'), 'utf8'),
+);
+const capture20260707 = JSON.parse(
+  readFileSync(join(FIXTURES_ROOT, 'isl-v2-live-20260707', 'isl-staging-capture.json'), 'utf8'),
+);
+const request20260707 = JSON.parse(
+  readFileSync(join(FIXTURES_ROOT, 'isl-v2-live-20260707', 'isl-v2-request.json'), 'utf8'),
+);
+
+// The ISL payload the mock returns for the NEXT /v2/run call. Reassigned per
+// test; always deep-cloned so the raw captures stay untouched.
+let currentIslPayload: any = null;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(): Promise<{ data: T | null; error: string | null }> {
+    return { data: JSON.parse(JSON.stringify(currentIslPayload)) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+/** Map a captured ISL request back to PLoT /v2/run body shape. */
+function buildPlotBody(islRequest: any) {
+  return {
+    graph: {
+      nodes: islRequest.graph.nodes.map((n: any) => ({
+        id: n.id,
+        kind: n.kind,
+        label: n.label,
+        ...(n.observed_state?.value !== undefined && n.observed_state?.value !== null
+          ? { observed_state: { value: n.observed_state.value } }
+          : {}),
+      })),
+      edges: islRequest.graph.edges.map((e: any) => ({
+        from: e.from,
+        to: e.to,
+        exists_probability: e.exists_probability,
+        strength: { mean: e.strength.mean, std: e.strength.std },
+      })),
+    },
+    options: islRequest.options.map((o: any) => ({
+      id: o.id,
+      label: o.label,
+      interventions: Object.fromEntries(
+        Object.entries(o.interventions).map(([nodeId, value]) => [
+          nodeId,
+          { value, source: 'user_specified' },
+        ]),
+      ),
+    })),
+    goal_node_id: islRequest.goal_node_id,
+    seed: String(islRequest.seed),
+  };
+}
+
+async function runV2(app: FastifyInstance, payload: any) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v2/run',
+    headers: { 'Content-Type': 'application/json' },
+    payload,
+  });
+  return { statusCode: res.statusCode, body: JSON.parse(res.body) };
+}
+
+const VERDICT_ENUM = ['robust', 'moderate', 'fragile', 'not_assessed'];
+
+describe('robustness.display_verdict — /v2/run (live-capture derived)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Live fragile case — 20260706 capture (is_robust=false, level='low')
+  // -------------------------------------------------------------------------
+
+  it("20260706 live capture (is_robust=false, level='low') → 'fragile' + claim-safe reason", async () => {
+    currentIslPayload = capture20260706;
+    const { statusCode, body } = await runV2(app, buildPlotBody(request20260706));
+    expect(statusCode).toBe(200);
+
+    // Producer facts unchanged (additive change only)
+    expect(body.robustness.is_robust).toBe(false);
+    expect(body.robustness.level).toBe('low');
+    expect(body.robustness_status).toBe('computed');
+
+    expect(body.robustness.display_verdict).toBe('fragile');
+    expect(typeof body.robustness.display_verdict_reason).toBe('string');
+    expect(body.robustness.display_verdict_reason.length).toBeGreaterThan(0);
+    // Claim-safe: producer-owned phrase, no numbers.
+    expect(body.robustness.display_verdict_reason).not.toMatch(/\d/);
+  });
+
+  it("20260707 live capture (is_robust=false, level='low') → 'fragile'", async () => {
+    currentIslPayload = capture20260707;
+    const { statusCode, body } = await runV2(app, buildPlotBody(request20260707));
+    expect(statusCode).toBe(200);
+    expect(body.robustness.is_robust).toBe(false);
+    expect(body.robustness.level).toBe('low');
+    expect(body.robustness.display_verdict).toBe('fragile');
+    expect(body.robustness.display_verdict_reason).not.toMatch(/\d/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Absent robustness — ISL response without the robustness key
+  // -------------------------------------------------------------------------
+
+  it("robustness ABSENT from ISL response → 'not_assessed' on the CIL fallback object", async () => {
+    const noRobustness = JSON.parse(JSON.stringify(capture20260706));
+    delete noRobustness.robustness;
+    currentIslPayload = noRobustness;
+
+    const { statusCode, body } = await runV2(app, buildPlotBody(request20260706));
+    expect(statusCode).toBe(200);
+
+    // CIL Phase 0 guarantee: robustness object still present with empty arrays
+    expect(body.robustness).toBeDefined();
+    expect(body.robustness.fragile_edges).toEqual([]);
+    expect(body.robustness.robust_edges).toEqual([]);
+    expect(body.robustness_status).not.toBe('computed');
+
+    expect(body.robustness.display_verdict).toBe('not_assessed');
+    expect(typeof body.robustness.display_verdict_reason).toBe('string');
+    expect(body.robustness.display_verdict_reason).not.toMatch(/\d/);
+    // NEVER a determinate-looking verdict when robustness wasn't computed
+    expect(['robust', 'moderate', 'fragile']).not.toContain(body.robustness.display_verdict);
+  });
+
+  // -------------------------------------------------------------------------
+  // Synthetic verdict-fact edits on the live capture (mapping table)
+  // -------------------------------------------------------------------------
+
+  it("is_robust=true + level='high' → 'robust'", async () => {
+    const edited = JSON.parse(JSON.stringify(capture20260706));
+    edited.robustness.is_robust = true;
+    edited.robustness.level = 'high';
+    currentIslPayload = edited;
+
+    const { body } = await runV2(app, buildPlotBody(request20260706));
+    expect(body.robustness.display_verdict).toBe('robust');
+    expect(body.robustness.display_verdict_reason).not.toMatch(/\d/);
+  });
+
+  it("level='medium' → 'moderate' (is_robust true does not inflate to robust)", async () => {
+    const edited = JSON.parse(JSON.stringify(capture20260706));
+    edited.robustness.is_robust = true;
+    edited.robustness.level = 'medium';
+    currentIslPayload = edited;
+
+    const { body } = await runV2(app, buildPlotBody(request20260706));
+    expect(body.robustness.display_verdict).toBe('moderate');
+  });
+
+  it("explicit is_robust=false wins over level='high' → 'fragile' (never softened)", async () => {
+    const edited = JSON.parse(JSON.stringify(capture20260706));
+    edited.robustness.is_robust = false;
+    edited.robustness.level = 'high';
+    currentIslPayload = edited;
+
+    const { body } = await runV2(app, buildPlotBody(request20260706));
+    expect(body.robustness.display_verdict).toBe('fragile');
+  });
+
+  it('high confidence alone NEVER upgrades the verdict (is_robust=false, level=low, confidence=0.99)', async () => {
+    const edited = JSON.parse(JSON.stringify(capture20260706));
+    edited.robustness.confidence = 0.99;
+    currentIslPayload = edited;
+
+    const { body } = await runV2(app, buildPlotBody(request20260706));
+    expect(body.robustness.display_verdict).toBe('fragile');
+  });
+
+  it("verdict-bearing facts missing (no is_robust, no level) on a computed robustness → 'not_assessed'", async () => {
+    const edited = JSON.parse(JSON.stringify(capture20260706));
+    delete edited.robustness.is_robust;
+    delete edited.robustness.level;
+    currentIslPayload = edited;
+
+    const { body } = await runV2(app, buildPlotBody(request20260706));
+    // fragile_edges/confidence survive, but no determinate verdict without
+    // the verdict-bearing facts.
+    expect(body.robustness.display_verdict).toBe('not_assessed');
+  });
+
+  // -------------------------------------------------------------------------
+  // Blocked path (422) — robustness never computed
+  // -------------------------------------------------------------------------
+
+  it("blocked run (422) carries display_verdict 'not_assessed' on the CIL empty robustness object", async () => {
+    currentIslPayload = capture20260706; // never reached — preflight blocks first
+    const blockedBody = buildPlotBody(request20260706);
+    blockedBody.goal_node_id = 'missing-goal-node';
+
+    const { statusCode, body } = await runV2(app, blockedBody);
+    expect(statusCode).toBe(422);
+    expect(body.analysis_status).toBe('blocked');
+    expect(body.robustness.fragile_edges).toEqual([]);
+    expect(body.robustness.robust_edges).toEqual([]);
+    expect(body.robustness.display_verdict).toBe('not_assessed');
+    expect(typeof body.robustness.display_verdict_reason).toBe('string');
+  });
+
+  // -------------------------------------------------------------------------
+  // Wire hygiene
+  // -------------------------------------------------------------------------
+
+  it('display_verdict is always one of the four enum values whenever present', async () => {
+    currentIslPayload = capture20260706;
+    const { body } = await runV2(app, buildPlotBody(request20260706));
+    expect(VERDICT_ENUM).toContain(body.robustness.display_verdict);
+  });
+});

--- a/tests/robustness-display-verdict.unit.test.ts
+++ b/tests/robustness-display-verdict.unit.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit mapping-table tests for the display-safe robustness verdict
+ * derivation (lane PLoT-W5). Route-level behaviour (live-capture fixtures,
+ * blocked path, CIL fallback) is pinned separately in
+ * tests/robustness-display-verdict.fixture.test.ts — this file pins the pure
+ * function's mapping table and its honesty invariants exhaustively.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveRobustnessDisplayVerdict,
+  ROBUSTNESS_DISPLAY_VERDICT_REASONS,
+  type RobustnessDisplayVerdict,
+} from '../src/routes/v2/robustness-display-verdict.js';
+
+const derive = (facts: { is_robust?: unknown; level?: unknown } | undefined, computed: boolean) =>
+  deriveRobustnessDisplayVerdict(facts, computed).display_verdict;
+
+describe('deriveRobustnessDisplayVerdict — mapping table (provisional_doctrine_v0)', () => {
+  it("is_robust=true + level='high' → 'robust'", () => {
+    expect(derive({ is_robust: true, level: 'high' }, true)).toBe('robust');
+  });
+
+  it("level='medium' → 'moderate' (regardless of is_robust=true)", () => {
+    expect(derive({ is_robust: true, level: 'medium' }, true)).toBe('moderate');
+    expect(derive({ is_robust: undefined, level: 'medium' }, true)).toBe('moderate');
+  });
+
+  it("level='moderate' tolerated as 'moderate' (UI vocabulary variant)", () => {
+    expect(derive({ is_robust: true, level: 'moderate' }, true)).toBe('moderate');
+  });
+
+  it("is_robust=false → 'fragile' regardless of level (explicit negative never softened)", () => {
+    expect(derive({ is_robust: false, level: 'high' }, true)).toBe('fragile');
+    expect(derive({ is_robust: false, level: 'medium' }, true)).toBe('fragile');
+    expect(derive({ is_robust: false, level: 'low' }, true)).toBe('fragile');
+    expect(derive({ is_robust: false, level: undefined }, true)).toBe('fragile');
+  });
+
+  it("level='low' | 'very_low' → 'fragile' even without is_robust", () => {
+    expect(derive({ level: 'low' }, true)).toBe('fragile');
+    expect(derive({ level: 'very_low' }, true)).toBe('fragile');
+  });
+
+  it("level='high' WITHOUT is_robust=true never upgrades to 'robust'", () => {
+    expect(derive({ level: 'high' }, true)).toBe('not_assessed');
+    expect(derive({ is_robust: undefined, level: 'high' }, true)).toBe('not_assessed');
+  });
+
+  it("is_robust=true WITHOUT a level is not a determinate verdict", () => {
+    expect(derive({ is_robust: true }, true)).toBe('not_assessed');
+  });
+
+  it("verdict-bearing facts missing entirely → 'not_assessed'", () => {
+    expect(derive({}, true)).toBe('not_assessed');
+    expect(derive(undefined, true)).toBe('not_assessed');
+  });
+
+  it("robustness not computed → 'not_assessed' even when facts LOOK determinate", () => {
+    expect(derive({ is_robust: true, level: 'high' }, false)).toBe('not_assessed');
+    expect(derive({ is_robust: false, level: 'low' }, false)).toBe('not_assessed');
+    expect(derive(undefined, false)).toBe('not_assessed');
+  });
+
+  it('unrecognised external values degrade honestly, never crash or fabricate', () => {
+    expect(derive({ is_robust: 'yes', level: 'HIGH' }, true)).toBe('not_assessed');
+    expect(derive({ is_robust: 1, level: 42 }, true)).toBe('not_assessed');
+    expect(derive({ is_robust: null, level: null }, true)).toBe('not_assessed');
+    // Unrecognised level with a valid explicit negative still reads the negative
+    expect(derive({ is_robust: false, level: 'garbage' }, true)).toBe('fragile');
+  });
+});
+
+describe('display_verdict_reason — claim safety', () => {
+  const VERDICTS: RobustnessDisplayVerdict[] = ['robust', 'moderate', 'fragile', 'not_assessed'];
+
+  it('every verdict has a non-empty producer-owned reason with no numbers', () => {
+    for (const verdict of VERDICTS) {
+      const reason = ROBUSTNESS_DISPLAY_VERDICT_REASONS[verdict];
+      expect(reason.length).toBeGreaterThan(0);
+      expect(reason).not.toMatch(/\d/);
+    }
+  });
+
+  it('the emitted reason always matches the emitted verdict (single source of truth)', () => {
+    const cases: Array<[{ is_robust?: unknown; level?: unknown } | undefined, boolean]> = [
+      [{ is_robust: true, level: 'high' }, true],
+      [{ is_robust: true, level: 'medium' }, true],
+      [{ is_robust: false, level: 'low' }, true],
+      [undefined, false],
+    ];
+    for (const [facts, computed] of cases) {
+      const { display_verdict, display_verdict_reason } = deriveRobustnessDisplayVerdict(facts, computed);
+      expect(display_verdict_reason).toBe(ROBUSTNESS_DISPLAY_VERDICT_REASONS[display_verdict]);
+    }
+  });
+
+  it("fragile reason carries the doctrine phrase 'small changes could flip this result'", () => {
+    expect(ROBUSTNESS_DISPLAY_VERDICT_REASONS.fragile).toBe('small changes could flip this result');
+  });
+});


### PR DESCRIPTION
Producer-side display-safe robustness verdict (robust|moderate|fragile|not_assessed) + display_verdict_reason, additive on /v2/run. RED fixture from checkpoint 3a8ea15; 10/10 green; contract declarations in both OpenAPI specs + isl-to-ui contract. Lane report lost to a subagent failure — evidence report in docs/lanes/LANE18-robustness-display-verdict-2026-07-07.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)