### PR TITLE
fix(constraints): honour producer-declared goal-target scales — '%' unit, goal_threshold_cap, CEE goal_threshold (P0-C1)

### DIFF
--- a/docs/lanes/LANE23-goal-threshold-normalisation-2026-07-07.md
+++ b/docs/lanes/LANE23-goal-threshold-normalisation-2026-07-07.md
@@ -1,0 +1,212 @@
+# Lane P0-C1 — goal-threshold normalisation (silent nullification of the user's success target)
+
+- **Branch:** `claude-lane23/goal-threshold-normalisation` (fresh worktree from `origin/staging` @ `38d589cd`)
+- **Date:** 2026-07-07
+- **Live evidence source:** 2026-07-07 live run — the user's "at least 20%" goal
+  constraint was clamped to 1.0 on a default [0,1] range; every option's goal
+  probability came back ~0 and was suppressed as unreliable. The displayed
+  results silently ignored his registered target.
+- **Scope discipline:** additive only. No ISL request-shape change, no schema
+  change, no change to the `target_base_defaulted` suppression leg (that is
+  the pending doctrine decision **P0-C2**, not this lane).
+
+---
+
+## The verified live mechanism (code @ 38d589cd + live logs)
+
+The correct value was on the wire the whole time and was never used:
+
+1. CEE sends the explicit goal constraint `{ value: 20, unit: '%' }` on node
+   `goal_productivity` — **and** stamps the goal node itself with the
+   correctly-normalised `goal_threshold: 0.2` plus `goal_threshold_cap: 100`
+   for exactly this normalisation.
+2. PLoT's constraint normaliser ignores BOTH signals:
+   - `normaliseGoalConstraints()` (`src/lib/intervention-normaliser.ts`,
+     pre-fix ~876–946) calls `deriveRange(node)` which reads only
+     `observed_state.cap` / `state_space.range` / hints / baselines. The goal
+     node has none of these → **default [0,1] range**.
+   - The constraint's `'%'` unit never reaches the normaliser at all: the
+     temporal filter (`src/normalisation/constraint-filter.ts`) strips `unit`
+     at the ISL boundary *before* Phase 4b normalisation runs.
+   - The node's `goal_threshold`/`goal_threshold_cap` never reach it either:
+     the graph normaliser (`src/normalisation/graph-normaliser.ts`,
+     `normaliseNode`) rebuilds nodes into canonical `EngineNodeV3`, which does
+     not carry those fields.
+3. Threshold 20 normalised against [0,1] → **clamped to 1.0** ("≥ domain
+   max"); PLoT logged `plot.constraint_out_of_domain` (warn) and the repair
+   `normalised range=[0,1] source=default (clamped)`.
+4. The lane-6 producer-honesty layer then (correctly, given its inputs)
+   flagged `threshold_normalisation_defaulted` and suppressed
+   `probability_of_joint_goal` / `constraint_probabilities` —
+   so the emitted results silently ignored the target.
+5. The one path that WOULD have used the node's already-normalised
+   `goal_threshold` (`auto_constraint_from_threshold`, `src/routes/v2/run.ts`
+   Phase 1c+) is skipped whenever an explicit constraint travels
+   (`action: 'skipped', reason: 'constraints_present'`).
+
+---
+
+## Fix (additive, three touch points)
+
+### 1. `src/lib/intervention-normaliser.ts` — producer-declared constraint scales
+
+`normaliseGoalConstraints(constraints, nodes, extras?)` gains an optional
+`ConstraintNormalisationExtras`:
+
+- `unitsByConstraintId` — the constraint units captured before the
+  ISL-boundary strip;
+- `goalThresholdMetaByNodeId` — `{ goal_threshold?, goal_threshold_cap? }`
+  captured from the RAW upstream nodes.
+
+Range derivation for a constraint, in priority order:
+
+| Priority | Source               | Rule                                                            |
+|----------|----------------------|-----------------------------------------------------------------|
+| 0        | `goal_threshold_cap` | node's CEE-stamped cap (> 0, finite) → range [0, cap]           |
+| 1        | `unit_percent`       | constraint unit is '%' (or percent/pct/percentage) → [0, 100] — house doctrine: '%' always normalises against 100 |
+| 2+       | existing chain       | `deriveRange(node)`: explicit_cap → explicit → … → default      |
+
+**Documented design choice (deliverable 2c):** when the node also carries a
+CEE-stamped, already-normalised finite `goal_threshold` in [0,1] that
+*corresponds to the same target* (|value/cap − goal_threshold| ≤ 1e-3 on the
+normalised scale, under a producer-declared cap), the stamp is **preferred**
+over re-normalising the raw client value. Rationale: CEE produced both
+numbers from the same user input, so its normalisation is authoritative and
+free of re-derivation drift; the correspondence check means a **stale** stamp
+(user changed the target to 25%, node still says 0.2) is ignored rather than
+silently overriding the newer constraint. The tolerance (1e-3) absorbs
+producer rounding to 4 dp but cannot bridge two genuinely different targets.
+
+New `RangeSource` members `'goal_threshold_cap'` and `'unit_percent'` are
+counted as **non-heuristic** (producer-declared) in `used_heuristic`, and the
+repair record / diagnostics carry the provenance
+(`source=goal_threshold_cap`, `used_node_goal_threshold: true`,
+`(node goal_threshold preferred)`).
+
+### 2. `src/normalisation/constraint-filter.ts` — out-of-domain gate honours declared scales
+
+A threshold outside [0,1] that normalises INTO [0,1] under a declared scale
+(node `goal_threshold_cap`, else 100 for a '%' unit) is **in-domain**: the
+gate now logs `plot.constraint_scale_resolved` (info) instead of
+`plot.constraint_out_of_domain` (warn) and emits no warning record (so no
+`CONSTRAINT_OUT_OF_DOMAIN` critique). Values **beyond** the declared cap
+(e.g. 150 '%') and negative values still warn exactly as before. Constraints
+with no declared scale are untouched.
+
+### 3. `src/routes/v2/run.ts` — capture the signals before they disappear
+
+Immediately after constraint compilation (before the temporal filter strips
+`unit` and after the graph normaliser has already dropped the raw node
+fields), the route builds:
+
+- `goalThresholdMetaByNodeId` via new `collectGoalThresholdNodeMeta(body.graph?.nodes)`
+  (direct or `data.`-nested fields, finite numbers only — same raw-node-read
+  pattern as the existing Phase 1c+ auto-constraint fallback);
+- `constraintUnitsByConstraintId` from the compiled `RawGoalConstraint[]`.
+
+Both are passed to `filterTemporalConstraints(...)` (new optional 4th param)
+and to `normaliseGoalConstraints(...)` (new optional 3rd param).
+
+---
+
+## Suppression boundary kept honest (deliverable 3 — P0-C2 unaffected)
+
+`detectUnreliableConstraintTargets` (`src/lib/constraint-reliability.ts`) is
+**unchanged**. After this fix, for a '%'-or-capped goal target the
+`threshold_normalisation_defaulted` reason can no longer fire (the range
+source is a declared scale, not `'default'`), so goal-fit suppression on this
+path depends ONLY on the remaining `target_base_defaulted` leg — ISL's
+`CONSTRAINT_NODE_DEFAULT_BASE` for the goal node's missing value channel.
+That leg is the pending doctrine decision **P0-C2** and fires exactly as
+before (pinned by the fixture test "PIN: suppression still fires on
+target_base_defaulted ALONE").
+
+---
+
+## RED → GREEN evidence
+
+New fixture `tests/goal-threshold-normalisation.fixture.test.ts` reproduces
+the live chain against a mocked ISL that captures the forwarded request
+(goal node stamped `goal_threshold 0.2` / `goal_threshold_cap 100`,
+constraint `{value: 20, unit: '%'}`, plus a no-stamps '%-only' variant):
+
+- **RED on origin/staging @ 38d589cd** (commit `3c6f6aa`, run before the fix):
+  **5 failed / 2 passed** —
+  - ISL received `value: 1` (clamped), expected 0.2;
+  - `CONSTRAINT_OUT_OF_DOMAIN` critique present, expected none;
+  - `probability_of_joint_goal` suppressed (undefined), expected 0.55;
+  - the 2 passes are the regression controls (non-'%' unit still defaults +
+    explicit-range node still normalises as before — pinning that the legacy
+    paths were already correct and must not change).
+- **GREEN on this branch:** 7/7, plus
+  `tests/goal-threshold-normalisation.unit.test.ts` 16/16 (unit pins for the
+  scale precedence, the stamp preference + stale-stamp rejection, cap-validity
+  guards, and the filter gate), and the surrounding constraint suite set:
+  **19 test files / 326 tests passed** (auto-constraint-fallback,
+  cil-constraint-*, constraint-*-*, constraints*, multi-constraint,
+  normaliser-constraint-passthrough, temporal-constraint-filter,
+  internal-field-preservation, gates/constraint-scale-correctness,
+  intervention-normaliser, constraint-target-unreliable).
+
+### Deliberately-changed test expectations (both are '%'-semantics, i.e. inside this fix's intended blast radius)
+
+1. `tests/temporal-constraint-filter.test.ts` **T5** pinned the old behaviour
+   that `1.1` with unit `'%'` warns out-of-domain. Under the house doctrine
+   `1.1%` is in-domain (= 0.011). Split into **T5a** (within the declared
+   scale → no warning, `plot.constraint_scale_resolved` logged) and **T5b**
+   (150 '%' → still warns), preserving the gate's original intent.
+2. `tests/constraint-target-unreliable.fixture.test.ts` — the lane-6 case
+   "suppresses on the normalisation-default leg ALONE" used the 20/'%'
+   constraint, which no longer hits the default range (it is now FIXED, not
+   suppressed). The case now uses a scale-less unit (`'points'`) on the same
+   valueless node so the default-range suppression leg itself stays pinned.
+   All other lane-6 cases (target_base_defaulted suppression, warning wording,
+   coaching gate, control) pass unchanged.
+
+---
+
+## Regression surface (deliverable 4)
+
+Pinned unchanged (unit + fixture tests):
+
+- constraints with **units other than '%'** (`USD`, `months`, `points`) — the
+  node-derived chain, out-of-domain warning, and default-range suppression
+  behave byte-identically;
+- constraints on nodes with **explicit `state_space.range`** — still
+  normalised against the explicit range (`source: 'explicit'`);
+- temporal drop rules (deadline_metadata, temporal units) — untouched;
+- no-extras calls to `normaliseGoalConstraints` — identical output including
+  repair strings (`source=default (clamped)`).
+
+Intentional behaviour change beyond the headline fix (documented, doctrine-
+consistent): a '%'-united constraint now ALWAYS normalises against 100, even
+on a node with an explicit range — a percent target reads as a fraction of
+the node's normalised domain (50% → 0.5), not as 50 raw range-units. Pinned
+in the unit tests.
+
+---
+
+## What remains (not this lane)
+
+- **`target_base_defaulted` leg = P0-C2 (doctrine decision, Paul-gated).**
+  With the mechanical bug fixed, the live scenario still suppresses goal-fit
+  whenever ISL defaults the goal node's base to 0.0 (no observed value /
+  parameter uncertainty on the goal node — the missing value channel). That
+  suppression is correct producer-honesty today; whether/how to give
+  objectives a value channel is the pending doctrine decision.
+- `constraintsNeedNormalisation` gate is value-based (any value outside
+  [0,1] triggers normalisation of ALL constraints). A '%'-united constraint
+  with value ≤ 1 (e.g. "0.5%") is NOT normalised — pre-existing semantics,
+  out of scope here; would need CEE input-shape doctrine first.
+- The auto_constraint_from_threshold path (no explicit constraint) already
+  used the node's goal_threshold and is unchanged; if CEE ever stamps a RAW
+  (unnormalised) goal_threshold there, the new cap tier now also covers that
+  case at normalisation time.
+- CEE-side: nothing in this lane changes what CEE sends. The stamp-preference
+  logic tolerates but does not fix stale `goal_threshold` stamps — staleness
+  is a CEE persistence concern.
+
+## Known pre-existing CI reds (not chased, per repo doctrine)
+
+`audit` (fast-uri/fastify advisories) and `gates (windows-latest)` (invalid
+path `tools/sdk-smoke:python.mjs`) fail on every PR, unrelated to this change.

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -21,9 +21,15 @@ import type { EngineNodeV3, OptionV3, InterventionValueV3, OutcomeStatsV3, Repai
 
 /**
  * Range source for normalisation.
- * Priority order: explicit_cap > explicit > extracted > inferred_spread > inferred_baseline > inferred_value > default
+ * Priority order (interventions): explicit_cap > explicit > extracted > inferred_spread > inferred_baseline > inferred_value > default
+ *
+ * Constraint-only sources (P0-C1, producer-declared scales — see
+ * normaliseGoalConstraints):
+ * - 'goal_threshold_cap': the node's CEE-stamped goal_threshold_cap
+ * - 'unit_percent': the constraint's '%' unit (house doctrine: '%' always
+ *   normalises against 100)
  */
-export type RangeSource = 'explicit_cap' | 'explicit' | 'extracted' | 'inferred_spread' | 'inferred_baseline' | 'inferred_value' | 'default';
+export type RangeSource = 'explicit_cap' | 'explicit' | 'extracted' | 'inferred_spread' | 'inferred_baseline' | 'inferred_value' | 'default' | 'goal_threshold_cap' | 'unit_percent';
 
 /**
  * Range for normalisation.
@@ -845,6 +851,54 @@ export interface NormalisedGoalConstraint extends GoalConstraint {
 }
 
 /**
+ * Node-level goal-threshold metadata (P0-C1).
+ *
+ * CEE stamps these on the RAW upstream node (`goal_threshold` already
+ * normalised to [0,1], `goal_threshold_cap` = the scale it was normalised
+ * against, e.g. 100 for '%'). The canonical EngineNodeV3 does not carry them,
+ * so the route captures them from `body.graph.nodes` and passes them in here.
+ */
+export interface GoalThresholdNodeMeta {
+  /** Already-normalised threshold in [0,1], stamped by CEE */
+  goal_threshold?: number;
+  /** Scale cap the raw user threshold was normalised against (e.g. 100 for '%') */
+  goal_threshold_cap?: number;
+}
+
+/**
+ * Producer-declared scale signals for constraint normalisation (P0-C1).
+ * Both are additive/optional — omitting them reproduces the legacy behaviour.
+ */
+export interface ConstraintNormalisationExtras {
+  /**
+   * Unit per constraint_id, captured from the raw client/compiled constraints
+   * BEFORE the ISL-boundary strip (the temporal filter removes `unit`).
+   */
+  unitsByConstraintId?: Map<string, string>;
+  /** Raw-node goal-threshold metadata per node_id */
+  goalThresholdMetaByNodeId?: Map<string, GoalThresholdNodeMeta>;
+}
+
+/**
+ * True when a constraint unit means "percent" (house doctrine: '%' always
+ * normalises against 100).
+ */
+export function isPercentUnit(unit: string | undefined): boolean {
+  if (typeof unit !== 'string') return false;
+  const u = unit.trim().toLowerCase();
+  return u === '%' || u === 'percent' || u === 'pct' || u === 'percentage';
+}
+
+/**
+ * Tolerance (on the normalised [0,1] scale) for treating the node's
+ * CEE-stamped goal_threshold as "the same target" as the re-normalised raw
+ * constraint value. Wide enough to absorb producer rounding (4 dp), narrow
+ * enough that a genuinely changed target (e.g. 25% vs a stale 0.2 stamp) is
+ * NOT silently overridden by the stale stamp.
+ */
+const GOAL_THRESHOLD_CORRESPONDENCE_TOLERANCE = 1e-3;
+
+/**
  * Result of constraint normalisation.
  */
 export interface ConstraintNormalisationResult {
@@ -860,22 +914,44 @@ export interface ConstraintNormalisationResult {
     normalised_value: number;
     range: NormalisationRange;
     used_heuristic: boolean;
+    /** True when the node's CEE-stamped goal_threshold was preferred (P0-C1) */
+    used_node_goal_threshold?: boolean;
   }>;
 }
 
 /**
  * Normalise goal constraint values to [0,1] space.
  *
- * Uses the same deriveRange() function as interventions.
+ * Uses the same deriveRange() function as interventions, extended with two
+ * producer-declared constraint scales (P0-C1) that outrank the node-derived
+ * chain:
+ *
+ * | Priority | Source               | Rule                                            |
+ * |----------|----------------------|-------------------------------------------------|
+ * | 0        | `goal_threshold_cap` | Node's CEE-stamped cap. Range [0, cap].         |
+ * | 1        | `unit_percent`       | Constraint unit is '%'. Range [0, 100] (house   |
+ * |          |                      | doctrine: '%' always normalises against 100).   |
+ * | 2+       | deriveRange(node)    | Existing chain (explicit_cap → … → default).    |
+ *
+ * Additionally, when the node carries a CEE-stamped, already-normalised
+ * finite `goal_threshold` in [0,1] that corresponds to the same target
+ * (|value/cap − goal_threshold| ≤ 1e-3 under a producer-declared cap), the
+ * stamp is PREFERRED over re-normalising the raw client value — CEE is the
+ * producer of both numbers, so its normalisation is authoritative and free of
+ * re-derivation drift. A stamp that does NOT correspond (e.g. stale after the
+ * user changed the target) is ignored.
+ *
  * Preserves original user-unit value for response denormalisation.
  *
  * @param constraints Goal constraints to normalise
  * @param nodes Graph nodes (for range derivation)
+ * @param extras Producer-declared scale signals (units, node goal-threshold metadata)
  * @returns Normalised constraints with original values preserved
  */
 export function normaliseGoalConstraints(
   constraints: GoalConstraint[],
-  nodes: EngineNodeV3[]
+  nodes: EngineNodeV3[],
+  extras?: ConstraintNormalisationExtras
 ): ConstraintNormalisationResult {
   const repairs: RepairRecord[] = [];
   const diagnostics: ConstraintNormalisationResult['diagnostics'] = [];
@@ -893,18 +969,50 @@ export function normaliseGoalConstraints(
     // Find target node
     const targetNode = nodeMap.get(node_id);
 
-    // Derive range for the target node.
-    // deriveRange() handles observed_state.cap as priority 0 (explicit_cap), then
-    // state_space.range → heuristics → [0,1]. If node not found, use default [0,1].
-    const range: NormalisationRange = targetNode
-      ? deriveRange(targetNode)
-      : { min: 0, max: 1, source: 'default' };
+    // Producer-declared scale signals (P0-C1)
+    const nodeMeta = extras?.goalThresholdMetaByNodeId?.get(node_id);
+    const unit = extras?.unitsByConstraintId?.get(constraint_id);
+    const nodeCap = nodeMeta?.goal_threshold_cap;
+
+    // Derive range. Producer-declared constraint scales outrank the
+    // node-derived chain; deriveRange() handles observed_state.cap as
+    // priority 0 (explicit_cap), then state_space.range → heuristics → [0,1].
+    // If node not found and no declared scale, use default [0,1].
+    let range: NormalisationRange;
+    if (typeof nodeCap === 'number' && Number.isFinite(nodeCap) && nodeCap > 0) {
+      range = { min: 0, max: nodeCap, source: 'goal_threshold_cap' };
+    } else if (isPercentUnit(unit)) {
+      range = { min: 0, max: 100, source: 'unit_percent' };
+    } else {
+      range = targetNode
+        ? deriveRange(targetNode)
+        : { min: 0, max: 1, source: 'default' };
+    }
 
     // Normalise value
-    const { normalised, clamped } = normaliseValue(value, range);
+    let { normalised, clamped } = normaliseValue(value, range);
 
-    // Track if we used a heuristic (non-explicit range)
-    const usedHeuristic = range.source !== 'explicit' && range.source !== 'explicit_cap';
+    // Prefer the node's CEE-stamped, already-normalised goal_threshold when it
+    // corresponds to the same target under a producer-declared cap.
+    let usedNodeGoalThreshold = false;
+    const nodeGoalThreshold = nodeMeta?.goal_threshold;
+    if (
+      (range.source === 'goal_threshold_cap' || range.source === 'unit_percent') &&
+      typeof nodeGoalThreshold === 'number' &&
+      Number.isFinite(nodeGoalThreshold) &&
+      nodeGoalThreshold >= 0 && nodeGoalThreshold <= 1 &&
+      Math.abs(normalised - nodeGoalThreshold) <= GOAL_THRESHOLD_CORRESPONDENCE_TOLERANCE
+    ) {
+      normalised = nodeGoalThreshold;
+      clamped = false;
+      usedNodeGoalThreshold = true;
+    }
+
+    // Track if we used a heuristic (non-producer-declared range)
+    const NON_HEURISTIC_SOURCES: ReadonlySet<RangeSource> = new Set<RangeSource>([
+      'explicit', 'explicit_cap', 'goal_threshold_cap', 'unit_percent',
+    ]);
+    const usedHeuristic = !NON_HEURISTIC_SOURCES.has(range.source);
 
     // Create normalised constraint
     const normalisedConstraint: NormalisedGoalConstraint = {
@@ -924,7 +1032,7 @@ export function normaliseGoalConstraints(
       action: 'normalised',
       from_value: value,
       to_value: normalised,
-      reason: `normalised range=[${range.min},${range.max}] source=${range.source}${clamped ? ' (clamped)' : ''}`,
+      reason: `normalised range=[${range.min},${range.max}] source=${range.source}${clamped ? ' (clamped)' : ''}${usedNodeGoalThreshold ? ' (node goal_threshold preferred)' : ''}`,
     });
 
     // Add diagnostic
@@ -935,6 +1043,7 @@ export function normaliseGoalConstraints(
       normalised_value: normalised,
       range,
       used_heuristic: usedHeuristic,
+      ...(usedNodeGoalThreshold && { used_node_goal_threshold: true }),
     });
 
     // Heuristic use is captured in diagnostics[].used_heuristic and repair records.

--- a/src/normalisation/constraint-filter.ts
+++ b/src/normalisation/constraint-filter.ts
@@ -25,6 +25,7 @@ import type {
   EngineNodeV3,
   FilteredConstraintRecord,
 } from '../types/engine-v3.js';
+import { isPercentUnit, type GoalThresholdNodeMeta } from '../lib/intervention-normaliser.js';
 
 // Node kinds whose scores are in probability domain (expected [0,1] range).
 // Constraints with large values + temporal units on these nodes are non-evaluable.
@@ -64,11 +65,16 @@ interface Logger {
  * @param constraints  Raw constraints (may carry CEE-specific fields like deadline_metadata, unit)
  * @param nodes        Graph nodes (for node-kind lookup)
  * @param logger       Optional structured logger (req.log compatible)
+ * @param goalThresholdMetaByNodeId  Raw-node goal-threshold metadata (P0-C1) —
+ *   a threshold that normalises into [0,1] under a producer-declared scale
+ *   (node goal_threshold_cap, or 100 for a '%' unit) is IN-domain, so the
+ *   out-of-domain safety gate must not fire for it
  */
 export function filterTemporalConstraints(
   constraints: RawGoalConstraint[],
   nodes: EngineNodeV3[],
-  logger?: Logger
+  logger?: Logger,
+  goalThresholdMetaByNodeId?: Map<string, GoalThresholdNodeMeta>
 ): ConstraintFilterResult {
   const nodeMap = new Map<string, EngineNodeV3>();
   for (const node of nodes) {
@@ -134,22 +140,52 @@ export function filterTemporalConstraints(
     // Constraint targets a probability-domain node with value outside [0,1],
     // but the unit is NOT temporal. This may be legitimate (e.g., NRR above 110%)
     // or a data issue. Log a warning but still forward to ISL.
+    //
+    // P0-C1 exception: a raw threshold that normalises INTO [0,1] under a
+    // producer-declared scale — the node's CEE-stamped goal_threshold_cap, or
+    // 100 for a '%' unit — is in-domain (e.g. "at least 20%" = 0.2). The
+    // normaliser will scale it against that same cap; warning here would flag
+    // the user's own valid target as a data issue.
     if (isProbabilityNode && (value < 0 || value > 1) && !isTemporalUnit) {
-      warnings.push({
-        constraint_id,
-        node_id,
-        threshold: value,
-        node_kind: nodeKind,
-        message: `Constraint ${constraint_id} targets ${nodeKind} node "${node_id}" with threshold ${value} outside [0,1] range`,
-      });
-      logger?.warn({
-        event: 'plot.constraint_out_of_domain',
-        constraint_id,
-        node_id,
-        threshold: value,
-        node_kind: nodeKind,
-        unit: unit ?? null,
-      });
+      const nodeMeta = goalThresholdMetaByNodeId?.get(node_id);
+      const declaredCap =
+        typeof nodeMeta?.goal_threshold_cap === 'number' &&
+        Number.isFinite(nodeMeta.goal_threshold_cap) &&
+        nodeMeta.goal_threshold_cap > 0
+          ? nodeMeta.goal_threshold_cap
+          : isPercentUnit(unit)
+            ? 100
+            : undefined;
+      const scalableIntoDomain =
+        declaredCap !== undefined && value >= 0 && value <= declaredCap;
+
+      if (scalableIntoDomain) {
+        logger?.info({
+          event: 'plot.constraint_scale_resolved',
+          constraint_id,
+          node_id,
+          threshold: value,
+          node_kind: nodeKind,
+          unit: unit ?? null,
+          declared_cap: declaredCap,
+        });
+      } else {
+        warnings.push({
+          constraint_id,
+          node_id,
+          threshold: value,
+          node_kind: nodeKind,
+          message: `Constraint ${constraint_id} targets ${nodeKind} node "${node_id}" with threshold ${value} outside [0,1] range`,
+        });
+        logger?.warn({
+          event: 'plot.constraint_out_of_domain',
+          constraint_id,
+          node_id,
+          threshold: value,
+          node_kind: nodeKind,
+          unit: unit ?? null,
+        });
+      }
     }
 
     // Strip CEE-specific fields, keep only GoalConstraint fields for ISL.

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -152,6 +152,7 @@ import {
   type NormalisationContext,
   type NormalisationDiagnostic,
   type NormalisationRange,
+  type GoalThresholdNodeMeta,
 } from '../../lib/intervention-normaliser.js';
 import { assembleBrief } from '../../assembly/decision-brief.js';
 import { buildEvidencePriorityCard, type FactorInput } from '../../review-pass/evidence-priority.js';
@@ -1407,6 +1408,39 @@ export function deriveRecommendedOption(
  * We use the first option's constraint_analysis as the canonical source for top-level
  * constraint metadata (diagnostics and conditional probabilities are per-graph, not per-option).
  */
+/**
+ * Collect CEE-stamped goal-threshold metadata from the RAW upstream nodes (P0-C1).
+ *
+ * CEE stamps `goal_threshold` (already normalised to [0,1]) and
+ * `goal_threshold_cap` (the scale the raw user target was normalised against,
+ * e.g. 100 for '%') on the goal node. The graph normaliser rebuilds nodes into
+ * canonical EngineNodeV3 and DROPS these fields, so they must be captured from
+ * `body.graph.nodes` before normalisation — same pattern as the
+ * auto_constraint_from_threshold fallback, which reads the raw goal node
+ * directly. Supports the same direct/data.-nested locations as normaliseNode.
+ */
+function collectGoalThresholdNodeMeta(
+  rawNodes: unknown
+): Map<string, GoalThresholdNodeMeta> {
+  const meta = new Map<string, GoalThresholdNodeMeta>();
+  if (!Array.isArray(rawNodes)) return meta;
+
+  const finiteOrUndefined = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+
+  for (const node of rawNodes as any[]) {
+    if (!node || typeof node.id !== 'string' || node.id.length === 0) continue;
+    const goalThreshold = finiteOrUndefined(node.goal_threshold ?? node.data?.goal_threshold);
+    const goalThresholdCap = finiteOrUndefined(node.goal_threshold_cap ?? node.data?.goal_threshold_cap);
+    if (goalThreshold === undefined && goalThresholdCap === undefined) continue;
+    meta.set(node.id, {
+      ...(goalThreshold !== undefined && { goal_threshold: goalThreshold }),
+      ...(goalThresholdCap !== undefined && { goal_threshold_cap: goalThresholdCap }),
+    });
+  }
+  return meta;
+}
+
 function buildConstraintFields(
   goalConstraints: GoalConstraint[] | undefined,
   islResult: any,
@@ -3567,6 +3601,26 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         );
 
         // =================================================================
+        // P0-C1: capture producer-declared constraint scales BEFORE they
+        // disappear from the pipeline.
+        // =================================================================
+        // - CEE stamps goal_threshold (already normalised) + goal_threshold_cap
+        //   on the RAW upstream node; the canonical EngineNodeV3 drops them.
+        // - The temporal filter strips the constraint's `unit` at the ISL
+        //   boundary.
+        // Both signals feed the out-of-domain gate below and the Phase 4b
+        // constraint normaliser — without them a raw "20 (%)" target falls to
+        // the default [0,1] range and is clamped to 1.0 (the live 2026-07-07
+        // silent-nullification defect).
+        const goalThresholdMetaByNodeId = collectGoalThresholdNodeMeta(body.graph?.nodes);
+        const constraintUnitsByConstraintId = new Map<string, string>();
+        for (const c of constraintCompilation.constraints as RawGoalConstraint[]) {
+          if (typeof c.unit === 'string' && c.unit.length > 0) {
+            constraintUnitsByConstraintId.set(c.constraint_id, c.unit);
+          }
+        }
+
+        // =================================================================
         // Phase 1c++: Temporal Constraint Filter
         // =================================================================
         // Drop non-evaluable temporal constraints before ISL.
@@ -3576,7 +3630,8 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         const temporalFilterResult = filterTemporalConstraints(
           constraintCompilation.constraints as RawGoalConstraint[],
           filteredGraph.nodes,
-          req.log
+          req.log,
+          goalThresholdMetaByNodeId
         );
 
         // Replace constraint list with filtered set
@@ -3956,7 +4011,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           if (constraintsNeedNormalisation(activeGoalConstraints)) {
             const constraintNormResult = normaliseGoalConstraints(
               activeGoalConstraints,
-              filteredGraph.nodes
+              filteredGraph.nodes,
+              // P0-C1: producer-declared scales (constraint '%' unit, node
+              // goal_threshold_cap / goal_threshold) captured before the
+              // temporal filter stripped them — see Phase 1c++ above.
+              {
+                unitsByConstraintId: constraintUnitsByConstraintId,
+                goalThresholdMetaByNodeId,
+              }
             );
             constraintsForISL = constraintNormResult.constraints;
 

--- a/tests/constraint-target-unreliable.fixture.test.ts
+++ b/tests/constraint-target-unreliable.fixture.test.ts
@@ -243,8 +243,19 @@ describe('CONSTRAINT_TARGET_UNRELIABLE (item A — Paul\'s 20/% valueless-node c
     // Even if ISL does not flag the base (e.g. older ISL build), scaling a
     // user-unit threshold against the made-up default [0,1] range is already
     // not decision-grade.
+    //
+    // P0-C1 update (lane 23): a '%' unit is now a producer-declared scale
+    // (normalises against 100), so the original 20/'%' constraint no longer
+    // hits the default range — that path is FIXED, not suppressed (see
+    // tests/goal-threshold-normalisation.fixture.test.ts). To keep THIS leg
+    // pinned, use a unit with no declared scale on the same valueless node:
+    // normalisation still falls to default [0,1] and must still suppress.
     emitDefaultBaseWarning = false;
-    const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+    const body = await run(GRAPH_VALUELESS_TARGET, {
+      ...SUCCESS_TARGET_20_PCT,
+      unit: 'points',
+      label: 'Effectiveness at least 20 points',
+    });
 
     for (const opt of body.option_comparison) {
       expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');

--- a/tests/goal-threshold-normalisation.fixture.test.ts
+++ b/tests/goal-threshold-normalisation.fixture.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Goal-threshold normalisation fixture (lane P0-C1).
+ *
+ * Live defect (2026-07-07): the user registered a success target of
+ * "at least 20%" ({ value: 20, unit: '%' }) on his goal node. CEE stamped the
+ * goal node with the correctly-normalised `goal_threshold: 0.2` and a
+ * `goal_threshold_cap: 100` for exactly this purpose — but PLoT's constraint
+ * normaliser ignored BOTH the constraint's '%' unit AND the node's
+ * goal_threshold_cap: `deriveRange()` reads only observed_state.cap /
+ * state_space / hints, so the goal node (no observed value) fell to the
+ * default [0,1] range, threshold 20 was clamped to 1.0, PLoT emitted
+ * `plot.constraint_out_of_domain` + `threshold_normalisation_defaulted`, and
+ * every option's goal probability came back ~0 and was suppressed as
+ * unreliable — the displayed results silently ignored the user's target.
+ *
+ * Contract under test (RED on origin/staging 38d589cd):
+ *   1. ISL receives the constraint with normalised value 0.2 (not 1.0);
+ *   2. NO CONSTRAINT_OUT_OF_DOMAIN critique — the threshold IS in-domain once
+ *      its producer-declared scale ('%' → 100, goal_threshold_cap) is honored;
+ *   3. NO threshold_normalisation_defaulted suppression — goal-fit
+ *      probabilities are emitted;
+ *   4. PIN (P0-C2 boundary): the target_base_defaulted suppression leg (ISL
+ *      CONSTRAINT_NODE_DEFAULT_BASE — the goal node's missing value channel,
+ *      a pending doctrine decision) is UNAFFECTED: suppression still fires on
+ *      that reason alone;
+ *   5. Regression: non-'%' units and explicit-range nodes behave exactly as
+ *      before.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Mutable mock state (per-request ISL behaviour)
+// ---------------------------------------------------------------------------
+
+/** When true, the ISL mock emits the CONSTRAINT_NODE_DEFAULT_BASE warning. */
+let emitDefaultBaseWarning = false;
+
+/** Captures the last analysis request body forwarded to ISL. */
+let lastISLRequestBody: any = null;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    lastISLRequestBody = body;
+    const options = body.options || [];
+    const goalConstraints = body.goal_constraints || [];
+
+    const constraintAnalysis = goalConstraints.length > 0
+      ? {
+          constraint_analysis: {
+            joint_probability: emitDefaultBaseWarning ? 0 : 0.55,
+            constraints: goalConstraints.map((c: any) => ({
+              node_id: c.node_id,
+              operator: c.operator,
+              threshold: c.threshold ?? c.value,
+              prob_satisfied: emitDefaultBaseWarning ? 0 : 0.55,
+            })),
+          },
+        }
+      : {};
+
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+          win_probability: idx === 0 ? 0.6 : 0.4,
+          rank: idx + 1,
+          ...constraintAnalysis,
+        })),
+        factor_sensitivity: [],
+        robustness: { label: 'moderate', score: 0.6, fragile_edges: [], robust_edges: [] },
+        inference_warnings: emitDefaultBaseWarning
+          ? [{
+              code: 'CONSTRAINT_NODE_DEFAULT_BASE',
+              field: 'nodes[goal_productivity].base',
+              detail: {
+                node_id: 'goal_productivity',
+                defaulted_to: 0.0,
+                reason: 'no_parameter_uncertainty',
+                message: "Node 'goal_productivity' has no ParameterUncertainty — defaulted to base=0.0, constraint probability may be unreliable",
+              },
+            }]
+          : [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * The live shape: goal node with NO observed value, but CEE-stamped
+ * goal_threshold (already normalised) + goal_threshold_cap.
+ */
+const GRAPH_GOAL_WITH_THRESHOLD_CAP = {
+  nodes: [
+    {
+      id: 'goal_productivity', kind: 'goal', label: 'Improve productivity',
+      // CEE stamps these on the goal node for exactly this normalisation:
+      goal_threshold: 0.2,
+      goal_threshold_cap: 100,
+    },
+    { id: 'out_focus', kind: 'outcome', label: 'Focus time' },
+    { id: 'fac_training', kind: 'factor', label: 'Training investment', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_training', to: 'out_focus', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_focus', to: 'goal_productivity', strength: { mean: 0.6, std: 0.1 } },
+  ],
+};
+
+/** Same graph but WITHOUT the CEE stamps — only the constraint's '%' unit travels. */
+const GRAPH_GOAL_NO_STAMPS = {
+  nodes: [
+    { id: 'goal_productivity', kind: 'goal', label: 'Improve productivity' },
+    { id: 'out_focus', kind: 'outcome', label: 'Focus time' },
+    { id: 'fac_training', kind: 'factor', label: 'Training investment', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_training', to: 'out_focus', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_focus', to: 'goal_productivity', strength: { mean: 0.6, std: 0.1 } },
+  ],
+};
+
+/** Regression control: target node with an explicit user-confirmed range. */
+const GRAPH_EXPLICIT_RANGE_TARGET = {
+  nodes: [
+    { id: 'goal_productivity', kind: 'goal', label: 'Improve productivity' },
+    {
+      id: 'out_focus', kind: 'outcome', label: 'Focus time',
+      state_space: { range: { min: 0, max: 200 } },
+    },
+    { id: 'fac_training', kind: 'factor', label: 'Training investment', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_training', to: 'out_focus', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_focus', to: 'goal_productivity', strength: { mean: 0.6, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt_a', label: 'Invest in training', interventions: { fac_training: 0.8 } },
+  { id: 'opt_b', label: 'Hold steady', interventions: { fac_training: 0.4 } },
+];
+
+/** The exact live user input: "at least 20%" on the goal node. */
+const AT_LEAST_20_PCT = {
+  constraint_id: 'success_target',
+  node_id: 'goal_productivity',
+  operator: '>=',
+  value: 20,
+  unit: '%',
+  label: 'Productivity at least 20%',
+};
+
+describe('goal-threshold normalisation (P0-C1 — "at least 20%" silently nullified)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    emitDefaultBaseWarning = false;
+  });
+
+  async function run(graph: any, constraint: any) {
+    lastISLRequestBody = null;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({
+        graph,
+        options: OPTIONS,
+        goal_node_id: 'goal_productivity',
+        seed: 'goal-threshold-normalisation',
+        goal_constraints: [constraint],
+      }),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  function outOfDomainCritiques(body: any): any[] {
+    return (body.critiques ?? []).filter((c: any) => c.code === 'CONSTRAINT_OUT_OF_DOMAIN');
+  }
+
+  function unreliableWarnings(body: any): any[] {
+    return (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // RED core: the live chain, fixed
+  // -------------------------------------------------------------------------
+
+  it('forwards the constraint to ISL with normalised value 0.2 (not clamped to 1.0)', async () => {
+    emitDefaultBaseWarning = false;
+    await run(GRAPH_GOAL_WITH_THRESHOLD_CAP, AT_LEAST_20_PCT);
+
+    expect(lastISLRequestBody).toBeTruthy();
+    expect(Array.isArray(lastISLRequestBody.goal_constraints)).toBe(true);
+    expect(lastISLRequestBody.goal_constraints).toHaveLength(1);
+    expect(lastISLRequestBody.goal_constraints[0].value).toBeCloseTo(0.2, 9);
+  });
+
+  it('emits NO CONSTRAINT_OUT_OF_DOMAIN critique — 20 on a %-scale is in-domain', async () => {
+    emitDefaultBaseWarning = false;
+    const body = await run(GRAPH_GOAL_WITH_THRESHOLD_CAP, AT_LEAST_20_PCT);
+    expect(outOfDomainCritiques(body)).toHaveLength(0);
+  });
+
+  it('does NOT suppress goal-fit via threshold_normalisation_defaulted — probabilities are emitted', async () => {
+    emitDefaultBaseWarning = false;
+    const body = await run(GRAPH_GOAL_WITH_THRESHOLD_CAP, AT_LEAST_20_PCT);
+
+    // No suppression: goal-fit probabilities present on every option.
+    for (const opt of body.option_comparison) {
+      expect(opt.probability_of_joint_goal, opt.option_id).toBe(0.55);
+      expect(opt.constraint_probabilities, opt.option_id).toEqual({ success_target: 0.55 });
+    }
+    expect(unreliableWarnings(body)).toHaveLength(0);
+
+    // The normalisation repair records a producer-declared scale, not the
+    // made-up default [0,1] range.
+    const constraintRepairs = (body._meta?.repairs_applied ?? []).filter(
+      (r: any) => r.field === 'constraint.value.success_target',
+    );
+    for (const r of constraintRepairs) {
+      expect(r.reason).not.toContain('source=default');
+    }
+  });
+
+  it("honors the constraint's '%' unit alone (no CEE node stamps): 20% -> 0.2", async () => {
+    emitDefaultBaseWarning = false;
+    const body = await run(GRAPH_GOAL_NO_STAMPS, AT_LEAST_20_PCT);
+
+    expect(lastISLRequestBody.goal_constraints[0].value).toBeCloseTo(0.2, 9);
+    expect(outOfDomainCritiques(body)).toHaveLength(0);
+    for (const opt of body.option_comparison) {
+      expect(opt.probability_of_joint_goal, opt.option_id).toBe(0.55);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // PIN (deliverable 3): target_base_defaulted leg is UNAFFECTED (P0-C2)
+  // -------------------------------------------------------------------------
+
+  it('PIN: suppression still fires on target_base_defaulted ALONE (missing value channel = P0-C2 doctrine)', async () => {
+    emitDefaultBaseWarning = true;
+    try {
+      const body = await run(GRAPH_GOAL_WITH_THRESHOLD_CAP, AT_LEAST_20_PCT);
+
+      // Threshold normalisation succeeded (0.2 went to ISL)…
+      expect(lastISLRequestBody.goal_constraints[0].value).toBeCloseTo(0.2, 9);
+      // …but ISL defaulted the goal node's base → suppression depends ONLY on
+      // that remaining reason.
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+      }
+      const warnings = unreliableWarnings(body);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].severity).toBe('warning');
+      // The target_base_defaulted wording variant (missing value channel).
+      expect(warnings[0].message).toContain('no observed value');
+    } finally {
+      emitDefaultBaseWarning = false;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression (deliverable 4): non-'%' units and explicit ranges unchanged
+  // -------------------------------------------------------------------------
+
+  it('regression: a non-percent unit on a rangeless node still defaults and still suppresses', async () => {
+    emitDefaultBaseWarning = false;
+    const body = await run(GRAPH_GOAL_NO_STAMPS, {
+      constraint_id: 'success_target',
+      node_id: 'goal_productivity',
+      operator: '>=',
+      value: 20,
+      unit: 'points',
+      label: 'Productivity at least 20 points',
+    });
+
+    // No producer-declared scale → the pre-existing chain is unchanged:
+    // out-of-domain critique + default-range suppression.
+    expect(outOfDomainCritiques(body)).toHaveLength(1);
+    for (const opt of body.option_comparison) {
+      expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+      expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+    }
+    expect(unreliableWarnings(body)).toHaveLength(1);
+  });
+
+  it('regression: an explicit state_space.range still normalises a unit-less constraint as before', async () => {
+    emitDefaultBaseWarning = false;
+    const body = await run(GRAPH_EXPLICIT_RANGE_TARGET, {
+      constraint_id: 'focus_floor',
+      node_id: 'out_focus',
+      operator: '>=',
+      value: 50,
+      label: 'Focus time at least 50',
+    });
+
+    // 50 against explicit [0, 200] → 0.25, exactly as before the fix.
+    expect(lastISLRequestBody.goal_constraints[0].value).toBeCloseTo(0.25, 9);
+    expect(unreliableWarnings(body)).toHaveLength(0);
+    for (const opt of body.option_comparison) {
+      expect(opt.probability_of_joint_goal, opt.option_id).toBe(0.55);
+    }
+  });
+});

--- a/tests/goal-threshold-normalisation.unit.test.ts
+++ b/tests/goal-threshold-normalisation.unit.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit pins for the P0-C1 goal-threshold normalisation fix.
+ *
+ * normaliseGoalConstraints() gains two producer-declared constraint scales
+ * that outrank the node-derived deriveRange() chain:
+ *   0. node goal_threshold_cap (CEE-stamped)      → range [0, cap]
+ *   1. constraint unit '%' (house doctrine)       → range [0, 100]
+ * and, when the node also carries a CEE-stamped already-normalised
+ * goal_threshold that corresponds to the same target, that stamp is PREFERRED
+ * over re-normalising the raw client value.
+ *
+ * filterTemporalConstraints() out-of-domain safety gate: a threshold that
+ * normalises INTO [0,1] under one of those declared scales is in-domain and
+ * must not be flagged.
+ *
+ * Legacy behaviour (no declared scale) is pinned unchanged.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  normaliseGoalConstraints,
+  isPercentUnit,
+  type GoalThresholdNodeMeta,
+} from '../src/lib/intervention-normaliser.js';
+import { filterTemporalConstraints } from '../src/normalisation/constraint-filter.js';
+import type { GoalConstraint, EngineNodeV3, RawGoalConstraint } from '../src/types/engine-v3.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALUELESS_GOAL = [{ id: 'goal', kind: 'goal', label: 'Goal' }] as unknown as EngineNodeV3[];
+
+function constraint(value: number, overrides: Partial<GoalConstraint> = {}): GoalConstraint {
+  return { constraint_id: 'c1', node_id: 'goal', operator: '>=', value, ...overrides };
+}
+
+function extras(opts: {
+  unit?: string;
+  meta?: GoalThresholdNodeMeta;
+  nodeId?: string;
+  constraintId?: string;
+}) {
+  return {
+    ...(opts.unit !== undefined && {
+      unitsByConstraintId: new Map([[opts.constraintId ?? 'c1', opts.unit]]),
+    }),
+    ...(opts.meta !== undefined && {
+      goalThresholdMetaByNodeId: new Map([[opts.nodeId ?? 'goal', opts.meta]]),
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isPercentUnit
+// ---------------------------------------------------------------------------
+
+describe('isPercentUnit', () => {
+  it('recognises percent spellings, rejects everything else', () => {
+    for (const u of ['%', 'percent', 'PCT', ' Percentage ']) {
+      expect(isPercentUnit(u), u).toBe(true);
+    }
+    for (const u of ['months', 'USD', 'points', '', undefined]) {
+      expect(isPercentUnit(u as any), String(u)).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normaliseGoalConstraints — producer-declared scales
+// ---------------------------------------------------------------------------
+
+describe('normaliseGoalConstraints · producer-declared scales (P0-C1)', () => {
+  it("'%' unit normalises against 100 (house doctrine), even on a valueless node", () => {
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [constraint(20)],
+      VALUELESS_GOAL,
+      extras({ unit: '%' })
+    );
+    expect(constraints[0].value).toBeCloseTo(0.2, 12);
+    expect(constraints[0].original_value).toBe(20);
+    expect(diagnostics[0].range).toMatchObject({ min: 0, max: 100, source: 'unit_percent' });
+    // Producer-declared scale is NOT a heuristic.
+    expect(diagnostics[0].used_heuristic).toBe(false);
+  });
+
+  it('node goal_threshold_cap normalises against the cap, and outranks the unit', () => {
+    // cap 50 beats '%' → 10/50 = 0.2, not 10/100 = 0.1.
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [constraint(10)],
+      VALUELESS_GOAL,
+      extras({ unit: '%', meta: { goal_threshold_cap: 50 } })
+    );
+    expect(constraints[0].value).toBeCloseTo(0.2, 12);
+    expect(diagnostics[0].range).toMatchObject({ min: 0, max: 50, source: 'goal_threshold_cap' });
+    expect(diagnostics[0].used_heuristic).toBe(false);
+  });
+
+  it("PREFERS the node's CEE-stamped goal_threshold when it corresponds to the same target", () => {
+    const { constraints, diagnostics, repairs } = normaliseGoalConstraints(
+      [constraint(20)],
+      VALUELESS_GOAL,
+      extras({ unit: '%', meta: { goal_threshold: 0.2, goal_threshold_cap: 100 } })
+    );
+    // Exactly the stamp — no re-derivation drift.
+    expect(constraints[0].value).toBe(0.2);
+    expect(diagnostics[0].used_node_goal_threshold).toBe(true);
+    expect(repairs[0].reason).toContain('node goal_threshold preferred');
+  });
+
+  it('ignores a STALE goal_threshold stamp that does not correspond (user changed the target)', () => {
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [constraint(25)],
+      VALUELESS_GOAL,
+      extras({ unit: '%', meta: { goal_threshold: 0.2, goal_threshold_cap: 100 } })
+    );
+    // 25% re-normalised against the cap, NOT overridden by the stale 0.2.
+    expect(constraints[0].value).toBeCloseTo(0.25, 12);
+    expect(diagnostics[0].used_node_goal_threshold).toBeUndefined();
+  });
+
+  it('ignores a goal_threshold stamp outside [0,1] (raw, not normalised)', () => {
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [constraint(20)],
+      VALUELESS_GOAL,
+      extras({ meta: { goal_threshold: 20, goal_threshold_cap: 100 } })
+    );
+    expect(constraints[0].value).toBeCloseTo(0.2, 12);
+    expect(diagnostics[0].used_node_goal_threshold).toBeUndefined();
+  });
+
+  it("'%' outranks node-derived ranges: 50% means 0.5 of the domain, not 50-of-range-units", () => {
+    // House doctrine: '%' always normalises against 100. A percent target is a
+    // fraction of the node's (normalised) domain, not a raw user-unit value.
+    const rangedNode = [
+      { id: 'goal', kind: 'goal', label: 'Goal', state_space: { range: { min: 0, max: 200 } } },
+    ] as unknown as EngineNodeV3[];
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [constraint(50)],
+      rangedNode,
+      extras({ unit: '%' })
+    );
+    expect(constraints[0].value).toBeCloseTo(0.5, 12);
+    expect(diagnostics[0].range.source).toBe('unit_percent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normaliseGoalConstraints — legacy behaviour unchanged (regression)
+// ---------------------------------------------------------------------------
+
+describe('normaliseGoalConstraints · legacy behaviour unchanged', () => {
+  it('no extras → identical to before: valueless node falls to default [0,1] and clamps', () => {
+    const { constraints, diagnostics, repairs } = normaliseGoalConstraints(
+      [constraint(20)],
+      VALUELESS_GOAL
+    );
+    expect(constraints[0].value).toBe(1); // clamped — the pre-fix defect shape
+    expect(diagnostics[0].range).toMatchObject({ min: 0, max: 1, source: 'default' });
+    expect(diagnostics[0].used_heuristic).toBe(true);
+    expect(repairs[0].reason).toContain('source=default');
+    expect(repairs[0].reason).toContain('(clamped)');
+  });
+
+  it('a non-percent unit does not declare a scale: explicit state_space.range still wins', () => {
+    const rangedNode = [
+      { id: 'goal', kind: 'goal', label: 'Goal', state_space: { range: { min: 0, max: 40000 } } },
+    ] as unknown as EngineNodeV3[];
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [constraint(20000)],
+      rangedNode,
+      extras({ unit: 'USD' })
+    );
+    expect(constraints[0].value).toBeCloseTo(0.5, 12);
+    expect(diagnostics[0].range.source).toBe('explicit');
+  });
+
+  it('a non-positive or non-finite goal_threshold_cap is ignored', () => {
+    for (const cap of [0, -100, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const { diagnostics } = normaliseGoalConstraints(
+        [constraint(20)],
+        VALUELESS_GOAL,
+        extras({ meta: { goal_threshold_cap: cap } })
+      );
+      expect(diagnostics[0].range.source, `cap=${cap}`).toBe('default');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterTemporalConstraints — out-of-domain gate honours declared scales
+// ---------------------------------------------------------------------------
+
+describe('filterTemporalConstraints · out-of-domain gate (P0-C1)', () => {
+  const NODES = [{ id: 'goal', kind: 'goal', label: 'Goal' }] as unknown as EngineNodeV3[];
+
+  function raw(value: number, unit?: string): RawGoalConstraint {
+    return {
+      constraint_id: 'c1', node_id: 'goal', operator: '>=', value,
+      ...(unit !== undefined && { unit }),
+    } as RawGoalConstraint;
+  }
+
+  it("does NOT warn for a '%' threshold within [0,100] — it is in-domain under the declared scale", () => {
+    const result = filterTemporalConstraints([raw(20, '%')], NODES);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.passed).toHaveLength(1); // still forwarded
+  });
+
+  it('does NOT warn when the node carries a covering goal_threshold_cap', () => {
+    const meta = new Map([['goal', { goal_threshold_cap: 100 }]]);
+    const result = filterTemporalConstraints([raw(20, 'points')], NODES, undefined, meta);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.passed).toHaveLength(1);
+  });
+
+  it("STILL warns when the value exceeds the declared cap (150 '%')", () => {
+    const result = filterTemporalConstraints([raw(150, '%')], NODES);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.passed).toHaveLength(1); // warn-and-forward, unchanged
+  });
+
+  it('STILL warns when no scale is declared (legacy behaviour)', () => {
+    const result = filterTemporalConstraints([raw(20, 'points')], NODES);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].threshold).toBe(20);
+    expect(result.passed).toHaveLength(1);
+  });
+
+  it('STILL warns for negative thresholds even with a declared scale', () => {
+    const result = filterTemporalConstraints([raw(-5, '%')], NODES);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('temporal drop rules are untouched: deadline_metadata still drops', () => {
+    const c = { ...raw(12, 'months'), deadline_metadata: { horizon_months: 12 } } as RawGoalConstraint;
+    const result = filterTemporalConstraints([c], NODES);
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].reason).toBe('temporal_deadline');
+    expect(result.passed).toHaveLength(0);
+  });
+});

--- a/tests/temporal-constraint-filter.test.ts
+++ b/tests/temporal-constraint-filter.test.ts
@@ -10,7 +10,8 @@
  * - T2: temporal unit on goal node with value > 1 → filtered
  * - T3: legitimate goal constraint (no temporal markers) → NOT filtered
  * - T4: factor constraint → NOT filtered (not probability-domain node)
- * - T5: NRR-style constraint (value > 1, unit = "%") → NOT filtered + warning
+ * - T5a/T5b: '%'-united constraints (P0-C1) — within [0,100] = in-domain
+ *   (scale resolved, no warning); beyond the cap → still warns
  * - T6: mixed array → correct split
  * - T7: empty array → no-op
  * - T8: unknown node_id → passed through (let validation catch it)
@@ -153,8 +154,12 @@ describe('filterTemporalConstraints', () => {
     expect(result.passed[0].constraint_id).toBe('c4');
   });
 
-  // T5: NRR-style constraint (value > 1, unit = "%") → NOT filtered + out-of-domain warning
-  it('T5: does NOT filter NRR-style constraint (value 1.1, unit "%"), emits warning', () => {
+  // T5 (updated for P0-C1): a '%' unit is a producer-declared scale (house
+  // doctrine: '%' normalises against 100), so a '%' value within [0,100] is
+  // IN-domain — the gate resolves the scale instead of warning. The original
+  // intent (flag values that cannot be scaled into the domain) is preserved:
+  // a '%' value beyond the cap still warns.
+  it("T5a: does NOT warn for a '%' value within the declared scale (1.1% is in-domain)", () => {
     const constraints: RawGoalConstraint[] = [{
       constraint_id: 'c5',
       node_id: 'goal_mid_market_success',
@@ -167,18 +172,43 @@ describe('filterTemporalConstraints', () => {
 
     expect(result.passed).toHaveLength(1);
     expect(result.filtered).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'plot.constraint_scale_resolved',
+        constraint_id: 'c5',
+        threshold: 1.1,
+        declared_cap: 100,
+      })
+    );
+  });
+
+  it("T5b: STILL warns for a '%' value beyond the declared cap (150%)", () => {
+    const constraints: RawGoalConstraint[] = [{
+      constraint_id: 'c5',
+      node_id: 'goal_mid_market_success',
+      operator: '>=',
+      value: 150,
+      unit: '%',
+    }];
+    const logger = mockLogger();
+    const result = filterTemporalConstraints(constraints, ALL_NODES, logger);
+
+    expect(result.passed).toHaveLength(1);
+    expect(result.filtered).toHaveLength(0);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toEqual(expect.objectContaining({
       constraint_id: 'c5',
       node_id: 'goal_mid_market_success',
-      threshold: 1.1,
+      threshold: 150,
       node_kind: 'goal',
     }));
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         event: 'plot.constraint_out_of_domain',
         constraint_id: 'c5',
-        threshold: 1.1,
+        threshold: 150,
       })
     );
   });


### PR DESCRIPTION
## What
Fixes the mechanical half of the goal-fit dead-end (P0-C1, program board): a user's registered success target (e.g. "at least 20%") was silently nullified because the constraint normaliser ignored both the constraint's `%` unit and the `goal_threshold_cap` CEE stamps for exactly this purpose — the threshold fell to the default [0,1] range, clamped to 1.0, fired `constraint_out_of_domain` + `threshold_normalisation_defaulted`, and every option's goal probability came back ~0 then got suppressed as unreliable. Verified live in the product owner's 2026-07-07 staging session.

## How
- `normaliseGoalConstraints` gains producer-declared scale sources that outrank the node-derived chain: `goal_threshold_cap` (node stamp) → `unit_percent` ('%' normalises against 100, house doctrine) → existing `deriveRange` chain.
- When the node carries a CEE-stamped, already-normalised `goal_threshold` corresponding to the same target (±1e-3), the stamp is preferred over re-normalisation (CEE is the producer of both numbers); a stale non-corresponding stamp is ignored.
- Constraint `unit` is captured before the ISL-boundary strip; run.ts wires the extras through.
- Additive: omitting the new signals reproduces legacy behaviour. `target_base_defaulted` suppression (the P0-C2 doctrine leg, decided option B, implementation queued) is deliberately unaffected — pinned by test.

## Proof
- RED→GREEN fixture: `tests/goal-threshold-normalisation.fixture.test.ts` ("at least 20%" → 0.2, no out-of-domain, no normalisation-defaulted) + unit suite; 41/41 across the four touched test files; `tsc --noEmit` clean; repo pre-push validation 6/6 PASS (full suite included).
- Two deliberate updates to pre-existing tests are documented in-line (each preserves the original intent: valueless-node suppression re-pinned via a unit with no declared scale; '%' beyond cap still warns).
- Evidence: `docs/lanes/LANE23-goal-threshold-normalisation-2026-07-07.md`.

## Notes
- Known pre-existing CI reds on every PR (`audit`, `gates (windows-latest)`) are unrelated.
- Lane executed by an implementation agent; agent hit the account session limit after committing — orchestrator verified (typecheck + targeted suites + pre-push gate), pushed, and opened this PR from the lane worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)