### PR TITLE
feat(constraints): goal-fit doctrine B — deliver modelled goal-fit instead of suppressing (P0-C2)

### DIFF
--- a/docs/lanes/LANE25-goalfit-doctrine-b-2026-07-07.md
+++ b/docs/lanes/LANE25-goalfit-doctrine-b-2026-07-07.md
@@ -1,0 +1,201 @@
+# LANE 25 — Goal-fit doctrine B: deliver modelled goal-fit instead of suppressing (P0-C2)
+
+Date: 2026-07-07
+Branch: `claude-lane25/goalfit-doctrine-b` (base `origin/staging` ff423310 — includes PR #203)
+Doctrine reference: product-owner decision, 2026-07-07, **"option B"** — goal-fit is
+scored from the goal node's forward-propagated outcome distribution vs the normalised
+threshold, instead of being suppressed because the goal node has no observed value
+channel.
+
+## 1. Problem (verified current behaviour on base)
+
+On the live goal-target run (goal node with CEE-stamped `goal_threshold: 0.2` /
+`goal_threshold_cap: 100`, explicit `'%'` goal constraint, no observed value on the
+goal node):
+
+- ISL computes differentiated per-option goal probabilities from the exact goal
+  outcome-sample series, and flags `CONSTRAINT_NODE_DEFAULT_BASE` (base defaulted to
+  0.0) via `inference_warnings`.
+- Post-#203 the threshold normalisation leg is sound (producer-declared scale), so
+  the ONLY remaining unreliability reason is `target_base_defaulted`.
+- PLoT (`src/lib/constraint-reliability.ts` + `buildResponse` in
+  `src/routes/v2/run.ts`) still SUPPRESSED `probability_of_joint_goal` /
+  `constraint_probabilities` for the whole run and emitted the WARNING-severity
+  `CONSTRAINT_TARGET_UNRELIABLE` — the user's ratified target produced no goal-fit at
+  all.
+
+RED evidence: `tests/goalfit-doctrine-b.fixture.test.ts` on base ff423310 — the three
+doctrine tests fail (probabilities absent / warning present); the suppression PINs and
+regression controls pass (i.e. the fixture isolates exactly the doctrine surface).
+
+## 2. Mechanism implemented
+
+### Classification (`src/lib/constraint-reliability.ts`)
+
+- `detectUnreliableConstraintTargets` is unchanged (detection semantics identical).
+- NEW `partitionConstraintTargets(targets, graph)` splits detected targets:
+  - **`modelledBasis`** (doctrine B delivery): reason set is exactly
+    `{target_base_defaulted}` AND the target node has ≥1 **directed** incoming edge
+    in the graph PLoT sent to ISL (bidirected edges excluded — the ISL translator
+    strips them from the forward model, `translator-v3.ts:414`).
+  - **`suppressed`**: everything else (default-range normalisation, mixed reason
+    sets, root-node targets, absent graph). Conservative on absent inputs.
+- NEW `GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME = 'modelled_outcome_distribution'` and
+  `buildConstraintGoalFitModelledMessage(nodeLabel)` (claim-safe info-note wording,
+  `provisional_doctrine_v0` surface; never quotes the delivered numbers).
+
+### Emission (`src/routes/v2/run.ts`, buildResponse)
+
+- Run-level suppression now keys on `partition.suppressed.length > 0`. When ANY
+  target suppresses, the whole run suppresses **exactly as today** (mixed
+  multi-constraint runs included), with the same WARNING-severity
+  `CONSTRAINT_TARGET_UNRELIABLE` per affected node and the same
+  `constraint_probability_suppressed` diagnostics log.
+- When nothing suppresses and `modelledBasis` targets exist, per-option
+  `probability_of_joint_goal` / `constraint_probabilities` are DELIVERED unchanged,
+  plus an **additive** annotation on each delivering option:
+
+  ```json
+  "goal_fit_basis": {
+    "scored_from": "modelled_outcome_distribution",
+    "node_ids": ["goal_productivity"]
+  }
+  ```
+
+  and one info-severity `CONSTRAINT_GOALFIT_MODELLED_BASIS` inference warning per
+  affected node (new code in `INFERENCE_WARNING_CODES`, `src/types/engine-v3.ts`).
+  A `constraint_probability_modelled_basis` info log marks each delivery.
+- The decision brief's `warning_codes` echoes **warning-severity** codes only
+  (`buildWarningCodes`), so the info note does not enter the brief — no brief drift.
+- Coaching (`generateM1Coaching` call site): DELIBERATELY left stricter than the
+  wire — the GOAL_FEASIBILITY_LOW joint-prob gate still skips for base-defaulted
+  targets. A feasibility claim derived from a modelled-baseline number needs its own
+  caveated wording; silence stays the claim-safe default until that wording is
+  ratified. Pinned by the existing "does not fabricate GOAL_FEASIBILITY_LOW" test.
+- Boundary contract doc updated: `src/contracts/isl-to-ui.contract.ts` (filtered
+  section now records the doctrine-B exception).
+- OpenAPI: the hand-authored spec (`openapi-plot-lite-v1.yaml`) covers V1 only and
+  never documented `probability_of_joint_goal`/`option_comparison`; no spec change
+  required for this V2-only additive field (verified by grep — 0 hits).
+
+## 3. Semantic-coherence check (deliverable 3 — ISL read-only)
+
+Question: are the goal node's sampled values and the normalised threshold (0.2)
+apples-to-apples on the same [0,1]/cap scale, given the defaulted base=0.0?
+
+Verified from ISL code (`Inference-Service-Layer/src/services/robustness_analyzer_v2.py`,
+read-only):
+
+1. **Same series as the outcome distribution.** Constraint-target samples are
+   captured by `evaluate_multi` inside the same Monte Carlo pass that produces the
+   outcome distribution (`_run_monte_carlo`, lines ~1032-1064; `evaluate_multi`
+   lines 528-601 duplicates `evaluate`'s structural equation). For a constraint on
+   the goal node, `constraint_node_values[option][goal]` is the **identical**
+   forward-propagated series used for `outcome.mean/p10/p50/p90`.
+2. **What base=0.0 means.** Node value per sample =
+   `base + intercept + Σ(parent_value × sampled_strength)` (lines 596, 516). The
+   defaulted base (line 583, non-root node without factor sample/observed value)
+   makes the goal samples the modelled level attributable to upstream propagation
+   from a zero baseline — a real distribution (differentiated across options via
+   interventions and sampled strengths), NOT a constant placeholder.
+3. **Same scale as the threshold.** `_check_constraint_satisfied` (lines 3076-3097)
+   compares each sample against `constraint.threshold` — the value PLoT normalised
+   to the goal node's [0,1]/cap scale (0.2 = 20% of `goal_threshold_cap` 100,
+   `normaliseGoalConstraints`, `src/lib/intervention-normaliser.ts:951-1047`). The
+   samples are on the same normalised scale: PLoT normalises interventions to [0,1]
+   (Phase 4a), CEE-drafted node values are [0,1], and edge strengths are unitless
+   multipliers in the linear SCM — so `Σ(parent∈[0,1] × strength)` is the goal
+   node's modelled normalised level.
+4. **The decisive apples-to-apples argument:** ISL's already-delivered,
+   never-suppressed `probability_of_goal` is computed as
+   `mean(outcome_samples >= request.goal_threshold)` (lines 1242-1245) — the SAME
+   samples against the SAME PLoT-normalised threshold. Doctrine-B delivery of
+   `prob_satisfied` for a goal-node constraint is computationally the same
+   comparison; suppressing one while shipping the other was incoherent.
+
+**Conclusion: no scale mismatch; no PLoT-side comparison change needed.** The honest
+residual caveat is the zero baseline (samples measure modelled change from a zero
+base, not from an observed level) — exactly what the `goal_fit_basis` annotation and
+the info note disclose.
+
+Guard rail derived from this analysis: ISL emits `CONSTRAINT_NODE_DEFAULT_BASE` only
+for **non-root** nodes (line 741, `if not is_root and …`), so the marker itself
+implies forward propagation; PLoT's incoming-edge check in
+`partitionConstraintTargets` is defensive against ISL semantics drift, and a
+root-node target (constant-placeholder samples) keeps suppressing.
+
+## 4. Fixture diff (deliverable 1)
+
+New: `tests/goalfit-doctrine-b.fixture.test.ts` (8 tests) — the live goal-target
+request shape (goal node `goal_threshold: 0.2` / `goal_threshold_cap: 100`, explicit
+`'%'` constraint) with an ISL response fixture carrying **differentiated** per-option
+goal probabilities (0.62 / 0.38) + the live-shape `CONSTRAINT_NODE_DEFAULT_BASE`
+warning:
+
+- RED→GREEN: delivery of differentiated probabilities; `goal_fit_basis` annotation;
+  info-severity `CONSTRAINT_GOALFIT_MODELLED_BASIS` (naming the node, "modelled",
+  never quoting the numbers) with NO `CONSTRAINT_TARGET_UNRELIABLE`.
+- PINs (passed on base AND after): default-range normalisation suppresses; mixed
+  multi-constraint run suppresses the whole run; root-node base-defaulted target
+  suppresses.
+- Regressions (passed on base AND after): reliable-target run delivers WITHOUT
+  annotation/note; no-goal-constraints run untouched.
+
+Updated pins (all were explicitly awaiting the P0-C2 doctrine decision):
+
+- `tests/goal-threshold-normalisation.fixture.test.ts` — the P0-C2 boundary PIN
+  ("suppression still fires on target_base_defaulted ALONE") re-pinned to the
+  ratified doctrine: delivery + annotation + info note.
+- `tests/constraint-target-unreliable.fixture.test.ts` — the two suppression pins
+  moved from `'%'` (now a doctrine-B delivery case post-#203) to `'points'` (no
+  declared scale → default-range leg still fires); coaching-conservatism test kept
+  on `'%'` deliberately.
+- `tests/constraint-reliability.unit.test.ts` — +9 unit tests for
+  `partitionConstraintTargets` (root/bidirected/absent-graph conservatism, mixed
+  sets) and the new message builder.
+
+## 5. Regression pinning (deliverable 5)
+
+- Non-goal constraints on reliable targets: `tests/cil-constraint-passthrough.test.ts`
+  (7 tests) — byte-identical path (annotation only attaches when a modelledBasis
+  target exists).
+- Multi-reason suppression: pinned in the new fixture + re-pinned item-A fixture.
+- Runs without goal constraints: pinned in the new fixture (no constraint fields, no
+  annotation, no note).
+- Brief claim-safety: `tests/decision-brief.claim-safety.test.ts` (22 tests) —
+  unchanged (info notes are not echoed into `warning_codes`).
+
+## 6. Test results
+
+- `npx tsc --noEmit` — clean.
+- Affected suites: 6 files, 70 tests — all pass.
+- `npx vitest run --changed` (after `npm run build`; the spawn-server suites need
+  `dist/`): **171 files, 1464 passed, 5 skipped, 0 failed**.
+
+## 7. What remains for ISL (follow-up lane; ISL repo occupied, not touched)
+
+1. **Warning reclassification (cosmetic, low priority):**
+   `CONSTRAINT_NODE_DEFAULT_BASE`'s message text ("… constraint probability may be
+   unreliable") is forwarded verbatim by PLoT's ISL-warning merge (info severity).
+   Under doctrine B the sentence is stale for the forward-propagated goal-node case
+   — the probability is now the ratified scoring basis. Suggested ISL change:
+   distinguish "non-root defaulted base (modelled distribution; scored per doctrine
+   B)" from any future root-ish degenerate case in the message, or drop the
+   "may be unreliable" clause for non-root targets. No structural change needed:
+   PLoT already classifies correctly from the existing `detail.node_id` payload.
+2. **No semantic change required** — the sample/threshold comparison was verified
+   coherent (§3). Nothing in ISL blocks doctrine B.
+
+## 8. Residual risks / deliberate stops
+
+- **Coaching stays conservative** (GOAL_FEASIBILITY_LOW still skipped for
+  base-defaulted targets even when the wire delivers). Deliberate; needs a ratified
+  caveated wording before coaching may consume modelled goal-fit.
+- **Top-level `constraint_results[].probability` (buildConstraintFields) was never
+  gated by the item-A suppression** (pre-existing seam, unchanged by this lane): it
+  carries the first option's `prob_satisfied` regardless of target reliability. Out
+  of scope here; flagged for a follow-up honesty pass.
+- The `goal_fit_basis` field is additive and undocumented in `@talchain/schemas`;
+  consumers on older schema pins will silently drop it (platform-known hazard). The
+  UI gates goal-fit on field absence, so delivery itself is consumed; only the
+  provenance annotation is at drop risk until the schema package adds it.

--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -42,6 +42,14 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
    * threshold normalisation and/or ISL CONSTRAINT_NODE_DEFAULT_BASE on the
    * target node). Marked by the WARNING-severity CONSTRAINT_TARGET_UNRELIABLE
    * inference warning; raw values stay in diagnostics logs only.
+   *
+   * Doctrine B exception (lane P0-C2, ratified 2026-07-07): when the ONLY
+   * unreliability reason is the defaulted base AND the target node is
+   * forward-propagated (≥1 directed incoming edge), the fields are DELIVERED
+   * with an additive per-option `goal_fit_basis` provenance annotation
+   * ({ scored_from: 'modelled_outcome_distribution', node_ids }) and an
+   * info-severity CONSTRAINT_GOALFIT_MODELLED_BASIS note instead of the
+   * warning.
    * @see src/lib/constraint-reliability.ts
    */
   filtered: [

--- a/src/lib/constraint-reliability.ts
+++ b/src/lib/constraint-reliability.ts
@@ -23,8 +23,28 @@
  * tell the user what to do. Raw computed values stay in diagnostics (logs)
  * only.
  *
- * This module is detection only — suppression happens at the emission sites in
- * `src/routes/v2/run.ts` (buildResponse). No ISL request change; no ISL change.
+ * DOCTRINE B EXCEPTION (lane P0-C2, ratified by the product owner 2026-07-07):
+ * when the ONLY reason is `target_base_defaulted` AND the target node has
+ * forward-propagated inputs (≥1 directed incoming edge), the probabilities are
+ * DELIVERED, not suppressed. Rationale: post PR #203 the threshold
+ * normalisation is sound (producer-declared scale), and ISL scores the
+ * constraint from the target node's forward-propagated outcome-sample series
+ * (robustness_analyzer_v2.py — evaluate_multi shares the outcome code path;
+ * prob_satisfied compares the SAME normalised samples the already-delivered
+ * `probability_of_goal` uses). The defaulted base=0.0 means those samples are
+ * the modelled level driven by upstream factors from a zero baseline — a
+ * meaningful modelled distribution, not a constant placeholder. Delivery
+ * carries an additive `goal_fit_basis` provenance annotation and an
+ * info-severity CONSTRAINT_GOALFIT_MODELLED_BASIS note instead of the
+ * warning. A defaulted-base target WITHOUT forward-propagated inputs (root
+ * node) keeps suppressing: its samples would be a constant placeholder.
+ * (ISL only emits CONSTRAINT_NODE_DEFAULT_BASE for non-root nodes today —
+ * robustness_analyzer_v2.py `if not is_root and …` — the PLoT-side edge check
+ * is defensive against ISL semantics drift.)
+ *
+ * This module is detection + classification only — suppression/delivery
+ * happens at the emission sites in `src/routes/v2/run.ts` (buildResponse).
+ * No ISL request change; no ISL change.
  */
 
 import type { GoalConstraint } from '../types/engine-v3.js';
@@ -128,6 +148,94 @@ function collectDefaultedBaseNodeIds(islResult: unknown): Set<string> {
   }
 
   return ids;
+}
+
+/**
+ * Wire value for the goal-fit provenance annotation (doctrine B): the
+ * delivered probabilities are scored from the target node's
+ * forward-propagated Monte Carlo outcome distribution against the normalised
+ * threshold — not measured against an observed baseline for that node.
+ */
+export const GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME = 'modelled_outcome_distribution' as const;
+
+/** Partition of unreliable targets into suppression vs doctrine-B delivery. */
+export interface ConstraintTargetPartition {
+  /** Targets that keep run-level suppression (any reason set other than the doctrine-B case). */
+  suppressed: UnreliableConstraintTarget[];
+  /**
+   * Doctrine-B targets: reason set exactly {target_base_defaulted} AND the
+   * node has forward-propagated inputs. Probabilities are delivered with a
+   * `goal_fit_basis` annotation + info-severity disclosure.
+   */
+  modelledBasis: UnreliableConstraintTarget[];
+}
+
+/**
+ * Classify detected unreliable targets under doctrine B (P0-C2).
+ *
+ * A target qualifies for modelled-basis DELIVERY only when:
+ *  - its reason set is exactly {target_base_defaulted} — i.e. threshold
+ *    normalisation used a real, producer-declared or node-derived scale
+ *    (post-#203); AND
+ *  - the target node has at least one DIRECTED incoming edge in the graph
+ *    PLoT sent to ISL, so its sample series is a forward-propagated modelled
+ *    distribution, not a constant defaulted placeholder. Bidirected edges are
+ *    excluded — the ISL translator strips them from the forward model
+ *    (translator-v3.ts), so they contribute no propagation.
+ *
+ * Conservative on absent inputs: no graph (or no edges) → nothing qualifies,
+ * every target keeps suppressing exactly as before doctrine B.
+ */
+export function partitionConstraintTargets(
+  targets: UnreliableConstraintTarget[],
+  graph: { edges?: Array<{ from?: string; to?: string; edge_type?: string }> } | undefined,
+): ConstraintTargetPartition {
+  const suppressed: UnreliableConstraintTarget[] = [];
+  const modelledBasis: UnreliableConstraintTarget[] = [];
+
+  // Node ids with ≥1 directed (non-bidirected) incoming edge — mirrors the
+  // ISL translator's directed-edge filter (edge_type !== 'bidirected').
+  const forwardPropagatedNodeIds = new Set<string>();
+  if (Array.isArray(graph?.edges)) {
+    for (const edge of graph.edges) {
+      if (edge?.edge_type === 'bidirected') continue;
+      if (typeof edge?.to === 'string' && edge.to.length > 0) {
+        forwardPropagatedNodeIds.add(edge.to);
+      }
+    }
+  }
+
+  for (const target of targets) {
+    const baseDefaultedOnly =
+      target.reasons.length === 1 && target.reasons[0] === 'target_base_defaulted';
+    if (baseDefaultedOnly && forwardPropagatedNodeIds.has(target.node_id)) {
+      modelledBasis.push(target);
+    } else {
+      suppressed.push(target);
+    }
+  }
+
+  return { suppressed, modelledBasis };
+}
+
+/**
+ * Build the user-facing CONSTRAINT_GOALFIT_MODELLED_BASIS info note
+ * (doctrine B delivery disclosure).
+ *
+ * provisional_doctrine_v0 — wording surface. Claim-safe: says what the
+ * numbers ARE (modelled from the forward-propagated outcome distribution
+ * against the target) and what they are NOT (anchored to an observed
+ * baseline), names the node and the concrete user action, and never quotes
+ * the delivered probabilities.
+ */
+export function buildConstraintGoalFitModelledMessage(nodeLabel: string): string {
+  return (
+    `Goal-fit for "${nodeLabel}" is modelled: "${nodeLabel}" has no observed baseline value, ` +
+    `so each option's probability is scored from the modelled outcome distribution for ` +
+    `"${nodeLabel}" against your target — it reflects modelled change driven by upstream ` +
+    `factors, not distance from a measured starting point. ` +
+    `Set a value for "${nodeLabel}" to anchor these probabilities to an observed baseline.`
+  );
 }
 
 /**

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -134,7 +134,10 @@ import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagM
 import { sanitiseIslVoi, computeEvpiPercentagePoints } from '../../lib/evpi-emission.js';
 import {
   detectUnreliableConstraintTargets,
+  partitionConstraintTargets,
   buildConstraintTargetUnreliableMessage,
+  buildConstraintGoalFitModelledMessage,
+  GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME,
 } from '../../lib/constraint-reliability.js';
 import { NEAR_TIE_THRESHOLD } from '../../trust/result-coherence.js';
 import { assessGraphIdentifiability, toIdentifiabilityResponse, detectUnmeasuredConfounding } from '../../trust/identifiability-v2.js';
@@ -1724,12 +1727,34 @@ function buildResponse(
   // the UI gates goal-fit on absence) and a WARNING-severity
   // CONSTRAINT_TARGET_UNRELIABLE inference warning names the node + the fix.
   // Raw computed values are logged (diagnostics) but never emitted.
+  //
+  // Doctrine B (lane P0-C2, ratified 2026-07-07): a target whose ONLY reason
+  // is target_base_defaulted AND whose samples are forward-propagated (≥1
+  // directed incoming edge) is DELIVERED instead — scored from the modelled
+  // outcome distribution — with an additive per-option `goal_fit_basis`
+  // annotation and an info-severity CONSTRAINT_GOALFIT_MODELLED_BASIS note.
+  // Any other reason combination (default-range normalisation, root-node
+  // targets, mixed multi-constraint runs) keeps suppressing exactly as
+  // before. See src/lib/constraint-reliability.ts for the classification.
   const unreliableConstraintTargets = detectUnreliableConstraintTargets(
     goalConstraints,
     constraintNormRanges,
     islResult,
   );
-  const suppressConstraintProbabilities = unreliableConstraintTargets.length > 0;
+  const constraintTargetPartition = partitionConstraintTargets(
+    unreliableConstraintTargets,
+    graph,
+  );
+  const suppressConstraintProbabilities = constraintTargetPartition.suppressed.length > 0;
+  // Modelled-basis delivery is only active when NOTHING suppresses: on a
+  // mixed run the run-level suppression wins (exactly today's behaviour).
+  const modelledBasisConstraintTargets = suppressConstraintProbabilities
+    ? []
+    : constraintTargetPartition.modelledBasis;
+  // Sorted + deduplicated node ids for the per-option annotation.
+  const modelledBasisNodeIds = [
+    ...new Set(modelledBasisConstraintTargets.map((t) => t.node_id)),
+  ].sort();
 
   // Map ISL results to response format
   // ISL V2 uses 'options' field; V1 uses 'results'. Check both for compatibility.
@@ -1870,6 +1895,24 @@ function buildResponse(
         if (constraintProbs !== undefined) {
           result.constraint_probabilities = constraintProbs;
           logger?.info({ event: 'constraint_probs_mapped', option_id: optionId, count: Object.keys(constraintProbs).length });
+        }
+        // Doctrine B (P0-C2): honest provenance for delivered goal-fit scored
+        // from the modelled outcome distribution (target base defaulted, no
+        // observed baseline). Additive — absent on fully-reliable runs, and
+        // only attached when the option actually carries a delivered value.
+        if (
+          modelledBasisNodeIds.length > 0 &&
+          (jointProb !== undefined || constraintProbs !== undefined)
+        ) {
+          result.goal_fit_basis = {
+            scored_from: GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME,
+            node_ids: modelledBasisNodeIds,
+          };
+          logger?.info({
+            event: 'constraint_probability_modelled_basis',
+            option_id: optionId,
+            node_ids: modelledBasisNodeIds,
+          });
         }
       }
     }
@@ -2123,6 +2166,24 @@ function buildResponse(
         // provisional_doctrine_v0 — wording surface (see constraint-reliability.ts)
         message: buildConstraintTargetUnreliableMessage(nodeLabel, target.reasons),
         severity: 'warning',
+      });
+    }
+  } else if (modelledBasisConstraintTargets.length > 0) {
+    // Doctrine B (P0-C2): goal-fit was DELIVERED, scored from the modelled
+    // outcome distribution. The honesty signal is downgraded to an
+    // info-severity note — one per affected node — pairing with the
+    // per-option `goal_fit_basis` annotation emitted above. Raw numbers are
+    // never quoted in the note.
+    const notedNodeIds = new Set<string>();
+    for (const target of modelledBasisConstraintTargets) {
+      if (notedNodeIds.has(target.node_id)) continue;
+      notedNodeIds.add(target.node_id);
+      const nodeLabel = graph?.nodes?.find((n) => n.id === target.node_id)?.label ?? target.node_id;
+      inferenceWarnings.push({
+        code: INFERENCE_WARNING_CODES.CONSTRAINT_GOALFIT_MODELLED_BASIS,
+        // provisional_doctrine_v0 — wording surface (see constraint-reliability.ts)
+        message: buildConstraintGoalFitModelledMessage(nodeLabel),
+        severity: 'info',
       });
     }
   }
@@ -4959,6 +5020,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           // coaching joint-probability gate never reads placeholder-derived
           // joint probabilities (same inputs → same verdict as the public
           // suppression).
+          //
+          // Doctrine B (P0-C2) note — DELIBERATELY stricter than the wire:
+          // even when the base-defaulted-only case now DELIVERS goal-fit
+          // probabilities (with a modelled-basis disclosure), coaching keeps
+          // skipping the GOAL_FEASIBILITY_LOW gate for them. A feasibility
+          // claim ("may not achieve the target") derived from a
+          // modelled-baseline number would need its own caveated wording;
+          // silence is the claim-safe default until that wording is ratified.
           const coachingConstraintTargetsUnreliable = detectUnreliableConstraintTargets(
             activeGoalConstraints,
             constraintNormalisationRanges,

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1426,6 +1426,10 @@ export interface OptionComparisonResultV3 {
    * SUPPRESSED (absent) when any constraint target is unreliable
    * (CONSTRAINT_TARGET_UNRELIABLE inference warning present) — the raw
    * computed value would be meaningless and lives in diagnostics logs only.
+   * Doctrine B (P0-C2): a target whose ONLY unreliability reason is a
+   * defaulted base (no observed value) but whose samples are
+   * forward-propagated is DELIVERED with a `goal_fit_basis` annotation
+   * instead of suppressed — see src/lib/constraint-reliability.ts.
    */
   probability_of_joint_goal?: number;
 
@@ -1434,9 +1438,27 @@ export interface OptionComparisonResultV3 {
    * Map of constraint_id to probability [0, 1].
    * Only present when goal_constraints provided in request.
    * SUPPRESSED (absent) when any constraint target is unreliable
-   * (CONSTRAINT_TARGET_UNRELIABLE inference warning present).
+   * (CONSTRAINT_TARGET_UNRELIABLE inference warning present); delivered with
+   * `goal_fit_basis` under doctrine B (see probability_of_joint_goal).
    */
   constraint_probabilities?: Record<string, number>;
+
+  /**
+   * Provenance annotation for delivered goal-fit probabilities (doctrine B,
+   * P0-C2). Present ONLY when probability_of_joint_goal /
+   * constraint_probabilities were scored from the target node's
+   * forward-propagated Monte Carlo outcome distribution because the node has
+   * no observed baseline value (ISL defaulted its base to 0.0). Absent on
+   * fully-reliable runs — additive, never fabricated.
+   * Accompanied by the info-severity CONSTRAINT_GOALFIT_MODELLED_BASIS
+   * inference warning.
+   */
+  goal_fit_basis?: {
+    /** How the delivered probabilities were scored. */
+    scored_from: 'modelled_outcome_distribution';
+    /** Constraint-target node ids scored this way (sorted, deduplicated). */
+    node_ids: string[];
+  };
 }
 
 /**
@@ -1946,9 +1968,22 @@ export const INFERENCE_WARNING_CODES = {
    * uncertainty). `probability_of_joint_goal` and `constraint_probabilities`
    * are SUPPRESSED for the run (absence is honest; raw computed values stay
    * in diagnostics logs only). Severity: warning.
+   * Doctrine B (P0-C2): the base-defaulted-only forward-propagated case no
+   * longer suppresses — it emits CONSTRAINT_GOALFIT_MODELLED_BASIS instead.
    * @see src/lib/constraint-reliability.ts
    */
   CONSTRAINT_TARGET_UNRELIABLE: 'CONSTRAINT_TARGET_UNRELIABLE',
+  /**
+   * Doctrine B (P0-C2, ratified 2026-07-07): goal-fit probabilities WERE
+   * delivered, scored from the constraint-target node's forward-propagated
+   * Monte Carlo outcome distribution against the normalised threshold —
+   * because the node has no observed baseline value (ISL defaulted its base
+   * to 0.0), they reflect modelled change driven by upstream factors, not
+   * distance from a measured starting point. Pairs with the per-option
+   * `goal_fit_basis` annotation. Severity: info.
+   * @see src/lib/constraint-reliability.ts
+   */
+  CONSTRAINT_GOALFIT_MODELLED_BASIS: 'CONSTRAINT_GOALFIT_MODELLED_BASIS',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];

--- a/tests/constraint-reliability.unit.test.ts
+++ b/tests/constraint-reliability.unit.test.ts
@@ -9,7 +9,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   detectUnreliableConstraintTargets,
+  partitionConstraintTargets,
   buildConstraintTargetUnreliableMessage,
+  buildConstraintGoalFitModelledMessage,
+  GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME,
+  type UnreliableConstraintTarget,
 } from '../src/lib/constraint-reliability.js';
 import type { NormalisationRange } from '../src/lib/intervention-normaliser.js';
 
@@ -110,6 +114,94 @@ describe('detectUnreliableConstraintTargets', () => {
       ],
     };
     expect(detectUnreliableConstraintTargets([gc('c1', 'out_x')], undefined, islResult)).toEqual([]);
+  });
+});
+
+describe('partitionConstraintTargets (P0-C2 doctrine B classification)', () => {
+  const target = (
+    nodeId: string,
+    reasons: UnreliableConstraintTarget['reasons'],
+  ): UnreliableConstraintTarget => ({
+    constraint_id: `c_${nodeId}`,
+    node_id: nodeId,
+    reasons,
+  });
+
+  const graph = {
+    edges: [
+      { from: 'fac_a', to: 'out_x' },
+      { from: 'out_x', to: 'goal_g' },
+    ],
+  };
+
+  it('classifies base-defaulted-only targets with forward-propagated inputs as modelledBasis', () => {
+    const out = partitionConstraintTargets([target('goal_g', ['target_base_defaulted'])], graph);
+    expect(out.modelledBasis.map((t) => t.node_id)).toEqual(['goal_g']);
+    expect(out.suppressed).toEqual([]);
+  });
+
+  it('keeps suppressing a base-defaulted target with NO incoming edges (root: constant placeholder, not a distribution)', () => {
+    const out = partitionConstraintTargets([target('fac_a', ['target_base_defaulted'])], graph);
+    expect(out.suppressed.map((t) => t.node_id)).toEqual(['fac_a']);
+    expect(out.modelledBasis).toEqual([]);
+  });
+
+  it('keeps suppressing when the reason set includes threshold_normalisation_defaulted', () => {
+    for (const reasons of [
+      ['threshold_normalisation_defaulted'],
+      ['threshold_normalisation_defaulted', 'target_base_defaulted'],
+    ] as const) {
+      const out = partitionConstraintTargets([target('goal_g', [...reasons])], graph);
+      expect(out.suppressed, reasons.join('+')).toHaveLength(1);
+      expect(out.modelledBasis, reasons.join('+')).toEqual([]);
+    }
+  });
+
+  it('ignores bidirected edges when deciding forward propagation (ISL strips them from the forward model)', () => {
+    const bidirectedOnly = { edges: [{ from: 'fac_a', to: 'goal_g', edge_type: 'bidirected' }] };
+    const out = partitionConstraintTargets([target('goal_g', ['target_base_defaulted'])], bidirectedOnly);
+    expect(out.suppressed).toHaveLength(1);
+    expect(out.modelledBasis).toEqual([]);
+  });
+
+  it('is conservative on absent graph/edges: everything keeps suppressing', () => {
+    for (const g of [undefined, {}, { edges: [] }] as const) {
+      const out = partitionConstraintTargets([target('goal_g', ['target_base_defaulted'])], g);
+      expect(out.suppressed).toHaveLength(1);
+      expect(out.modelledBasis).toEqual([]);
+    }
+  });
+
+  it('partitions a mixed set target-by-target', () => {
+    const out = partitionConstraintTargets(
+      [
+        target('goal_g', ['target_base_defaulted']),
+        target('out_x', ['threshold_normalisation_defaulted']),
+      ],
+      graph,
+    );
+    expect(out.modelledBasis.map((t) => t.node_id)).toEqual(['goal_g']);
+    expect(out.suppressed.map((t) => t.node_id)).toEqual(['out_x']);
+  });
+});
+
+describe('buildConstraintGoalFitModelledMessage (provisional_doctrine_v0 wording)', () => {
+  it('names the node, states the modelled basis, and gives the anchoring action', () => {
+    const msg = buildConstraintGoalFitModelledMessage('Improve productivity');
+    expect(msg).toContain('Improve productivity');
+    expect(msg.toLowerCase()).toContain('modelled');
+    expect(msg).toContain('no observed baseline value');
+    expect(msg).toContain('Set a value for "Improve productivity"');
+  });
+
+  it('never quotes probabilities or percentage figures', () => {
+    const msg = buildConstraintGoalFitModelledMessage('X');
+    expect(msg).not.toMatch(/\d+(\.\d+)?%/);
+    expect(msg).not.toMatch(/0\.\d+/);
+  });
+
+  it('exports the wire value used by the goal_fit_basis annotation', () => {
+    expect(GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME).toBe('modelled_outcome_distribution');
   });
 });
 

--- a/tests/constraint-target-unreliable.fixture.test.ts
+++ b/tests/constraint-target-unreliable.fixture.test.ts
@@ -25,6 +25,16 @@
  *
  * The ISL request/ISL service are NOT changed — the mock returns exactly what
  * live ISL returned for this chain.
+ *
+ * POST-HISTORY UPDATES to the original chain:
+ *   - P0-C1 (PR #203): '%' is now a producer-declared scale (normalises
+ *     against 100), so the ORIGINAL 20/'%' constraint no longer trips the
+ *     default-range leg. The suppression pins below use unit 'points' (no
+ *     declared scale) to keep the default-range chain exercised.
+ *   - P0-C2 doctrine B (ratified 2026-07-07): target_base_defaulted ALONE on
+ *     a forward-propagated node now DELIVERS with a modelled-basis
+ *     disclosure — see tests/goalfit-doctrine-b.fixture.test.ts. Every
+ *     OTHER reason combination (as pinned here) suppresses exactly as before.
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
@@ -162,6 +172,17 @@ const SUCCESS_TARGET_20_PCT = {
   label: 'Effectiveness at least 20%',
 };
 
+/**
+ * Suppression-pin variant: 'points' has no producer-declared scale, so the
+ * valueless node still normalises against the default [0,1] range
+ * (threshold_normalisation_defaulted) — post-#203, '%' alone no longer does.
+ */
+const SUCCESS_TARGET_20_POINTS = {
+  ...SUCCESS_TARGET_20_PCT,
+  unit: 'points',
+  label: 'Effectiveness at least 20 points',
+};
+
 describe('CONSTRAINT_TARGET_UNRELIABLE (item A — Paul\'s 20/% valueless-node chain)', () => {
   let app: FastifyInstance;
 
@@ -199,7 +220,10 @@ describe('CONSTRAINT_TARGET_UNRELIABLE (item A — Paul\'s 20/% valueless-node c
   it('suppresses probability_of_joint_goal and constraint_probabilities on the full live chain', async () => {
     emitDefaultBaseWarning = true;
     try {
-      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+      // 'points' variant: keeps BOTH legs firing (default range + default
+      // base) post-#203 — the multi-reason set must suppress exactly as the
+      // original chain did (doctrine B only exempts base-defaulted ALONE).
+      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_POINTS);
 
       expect(body.analysis_status).not.toBe('blocked');
       expect(Array.isArray(body.option_comparison)).toBe(true);
@@ -219,7 +243,7 @@ describe('CONSTRAINT_TARGET_UNRELIABLE (item A — Paul\'s 20/% valueless-node c
   it('emits a WARNING-severity CONSTRAINT_TARGET_UNRELIABLE naming the node and the user action', async () => {
     emitDefaultBaseWarning = true;
     try {
-      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_POINTS);
 
       const warnings = (body.inference_warnings ?? []).filter(
         (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
@@ -271,6 +295,10 @@ describe('CONSTRAINT_TARGET_UNRELIABLE (item A — Paul\'s 20/% valueless-node c
   it('does not fabricate GOAL_FEASIBILITY_LOW coaching from the placeholder joint probability', async () => {
     emitDefaultBaseWarning = true;
     try {
+      // Deliberately the '%' (doctrine-B delivery) case: even though the
+      // modelled goal-fit is now DELIVERED on the wire, the coaching
+      // joint-prob gate stays conservative — no feasibility claim is derived
+      // from a modelled-baseline number (see run.ts coaching call site).
       const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
       // The joint-prob readiness gate is skipped for unreliable targets: no
       // "may not achieve the target" claim derived from a placeholder 0.
@@ -302,7 +330,7 @@ describe('CONSTRAINT_TARGET_UNRELIABLE (item A — Paul\'s 20/% valueless-node c
     // still discloses status honestly instead of disappearing silently.
     emitDefaultBaseWarning = true;
     try {
-      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_PCT);
+      const body = await run(GRAPH_VALUELESS_TARGET, SUCCESS_TARGET_20_POINTS);
       expect(body.constraints_status).toBeDefined();
     } finally {
       emitDefaultBaseWarning = false;

--- a/tests/goal-threshold-normalisation.fixture.test.ts
+++ b/tests/goal-threshold-normalisation.fixture.test.ts
@@ -19,10 +19,11 @@
  *      its producer-declared scale ('%' → 100, goal_threshold_cap) is honored;
  *   3. NO threshold_normalisation_defaulted suppression — goal-fit
  *      probabilities are emitted;
- *   4. PIN (P0-C2 boundary): the target_base_defaulted suppression leg (ISL
- *      CONSTRAINT_NODE_DEFAULT_BASE — the goal node's missing value channel,
- *      a pending doctrine decision) is UNAFFECTED: suppression still fires on
- *      that reason alone;
+ *   4. P0-C2 doctrine B (ratified 2026-07-07): the target_base_defaulted leg
+ *      ALONE no longer suppresses — goal-fit is DELIVERED, scored from the
+ *      forward-propagated outcome distribution, with a goal_fit_basis
+ *      annotation and an info-severity disclosure (see
+ *      tests/goalfit-doctrine-b.fixture.test.ts for the full contract);
  *   5. Regression: non-'%' units and explicit-range nodes behave exactly as
  *      before.
  */
@@ -279,27 +280,35 @@ describe('goal-threshold normalisation (P0-C1 — "at least 20%" silently nullif
   });
 
   // -------------------------------------------------------------------------
-  // PIN (deliverable 3): target_base_defaulted leg is UNAFFECTED (P0-C2)
+  // P0-C2 doctrine B (ratified 2026-07-07): target_base_defaulted ALONE
+  // delivers — scored from the modelled outcome distribution
   // -------------------------------------------------------------------------
 
-  it('PIN: suppression still fires on target_base_defaulted ALONE (missing value channel = P0-C2 doctrine)', async () => {
+  it('doctrine B: target_base_defaulted ALONE delivers goal-fit with a modelled-basis disclosure', async () => {
     emitDefaultBaseWarning = true;
     try {
       const body = await run(GRAPH_GOAL_WITH_THRESHOLD_CAP, AT_LEAST_20_PCT);
 
       // Threshold normalisation succeeded (0.2 went to ISL)…
       expect(lastISLRequestBody.goal_constraints[0].value).toBeCloseTo(0.2, 9);
-      // …but ISL defaulted the goal node's base → suppression depends ONLY on
-      // that remaining reason.
+      // …and although ISL defaulted the goal node's base, the goal node is
+      // forward-propagated, so the modelled probabilities are DELIVERED with
+      // honest provenance (doctrine B) instead of suppressed.
       for (const opt of body.option_comparison) {
-        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
-        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+        expect(opt.probability_of_joint_goal, opt.option_id).toBe(0);
+        expect(opt.constraint_probabilities, opt.option_id).toEqual({ success_target: 0 });
+        expect(opt.goal_fit_basis, opt.option_id).toEqual({
+          scored_from: 'modelled_outcome_distribution',
+          node_ids: ['goal_productivity'],
+        });
       }
-      const warnings = unreliableWarnings(body);
-      expect(warnings).toHaveLength(1);
-      expect(warnings[0].severity).toBe('warning');
-      // The target_base_defaulted wording variant (missing value channel).
-      expect(warnings[0].message).toContain('no observed value');
+      // The honesty signal is downgraded: no warning, one info note.
+      expect(unreliableWarnings(body)).toHaveLength(0);
+      const notes = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_GOALFIT_MODELLED_BASIS',
+      );
+      expect(notes).toHaveLength(1);
+      expect(notes[0].severity).toBe('info');
     } finally {
       emitDefaultBaseWarning = false;
     }

--- a/tests/goalfit-doctrine-b.fixture.test.ts
+++ b/tests/goalfit-doctrine-b.fixture.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Goal-fit doctrine B fixture (lane P0-C2, ratified 2026-07-07).
+ *
+ * Doctrine decision (product owner, 2026-07-07, "option B"): goal-fit is
+ * scored from the goal node's forward-propagated outcome distribution vs the
+ * normalised threshold — instead of being suppressed because the goal node
+ * has no observed value channel.
+ *
+ * Live shape this reproduces (post PR #203): the goal node carries a
+ * CEE-stamped goal_threshold 0.2 / goal_threshold_cap 100 and an explicit '%'
+ * goal constraint. Threshold normalisation now succeeds (producer-declared
+ * scale), so the ONLY remaining unreliability reason is target_base_defaulted
+ * (ISL CONSTRAINT_NODE_DEFAULT_BASE — the goal node has no observed value).
+ * ISL still computes differentiated per-option goal probabilities from the
+ * exact goal outcome-sample series (robustness_analyzer_v2.py — evaluate_multi
+ * shares the outcome code path; prob_satisfied compares the same samples the
+ * delivered probability_of_goal already uses).
+ *
+ * Contract under test (RED on origin/staging ff423310 — suppressed today):
+ *   1. probability_of_joint_goal / constraint_probabilities are DELIVERED,
+ *      differentiated per option;
+ *   2. each delivering option carries an honest provenance annotation
+ *      goal_fit_basis { scored_from: 'modelled_outcome_distribution' };
+ *   3. NO warning-severity CONSTRAINT_TARGET_UNRELIABLE — instead an
+ *      info-severity CONSTRAINT_GOALFIT_MODELLED_BASIS note names the node
+ *      and never quotes the probabilities;
+ *   4. PIN: any OTHER reason combination keeps suppressing exactly as today
+ *      (default-range normalisation, mixed multi-constraint runs);
+ *   5. PIN: a defaulted-base target WITHOUT forward-propagated inputs (root
+ *      node) still suppresses — its samples are a constant placeholder, not a
+ *      modelled distribution;
+ *   6. Regression: reliable-target runs and runs without goal constraints are
+ *      byte-identical to today (no annotation, no note).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Mutable mock state (per-request ISL behaviour)
+// ---------------------------------------------------------------------------
+
+/** Node id the ISL mock flags with CONSTRAINT_NODE_DEFAULT_BASE (null = no warning). */
+let defaultBaseNodeId: string | null = null;
+
+/** Captures the last analysis request body forwarded to ISL. */
+let lastISLRequestBody: any = null;
+
+/** Differentiated per-option goal probabilities (the post-#203 live shape). */
+const JOINT_PROB_BY_INDEX = [0.62, 0.38];
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    lastISLRequestBody = body;
+    const options = body.options || [];
+    const goalConstraints = body.goal_constraints || [];
+
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+          win_probability: idx === 0 ? 0.6 : 0.4,
+          rank: idx + 1,
+          ...(goalConstraints.length > 0
+            ? {
+                constraint_analysis: {
+                  joint_probability: JOINT_PROB_BY_INDEX[idx] ?? 0.5,
+                  constraints: goalConstraints.map((c: any) => ({
+                    node_id: c.node_id,
+                    operator: c.operator,
+                    threshold: c.threshold ?? c.value,
+                    prob_satisfied: JOINT_PROB_BY_INDEX[idx] ?? 0.5,
+                  })),
+                },
+              }
+            : {}),
+        })),
+        factor_sensitivity: [],
+        robustness: { label: 'moderate', score: 0.6, fragile_edges: [], robust_edges: [] },
+        // Live ISL wire shape for the defaulted-base signal (InferenceWarning
+        // with nested detail — see ISL robustness_analyzer_v2.py:742-757).
+        inference_warnings: defaultBaseNodeId
+          ? [{
+              code: 'CONSTRAINT_NODE_DEFAULT_BASE',
+              field: `nodes[${defaultBaseNodeId}].base`,
+              detail: {
+                node_id: defaultBaseNodeId,
+                defaulted_to: 0.0,
+                reason: 'no_parameter_uncertainty',
+                message: `Node '${defaultBaseNodeId}' has no ParameterUncertainty — defaulted to base=0.0, constraint probability may be unreliable`,
+              },
+            }]
+          : [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * The live goal-target shape: goal node with NO observed value, CEE-stamped
+ * goal_threshold 0.2 / goal_threshold_cap 100, fed by forward propagation.
+ */
+const GRAPH_GOAL_TARGET = {
+  nodes: [
+    {
+      id: 'goal_productivity', kind: 'goal', label: 'Improve productivity',
+      goal_threshold: 0.2,
+      goal_threshold_cap: 100,
+    },
+    { id: 'out_focus', kind: 'outcome', label: 'Focus time' },
+    { id: 'fac_training', kind: 'factor', label: 'Training investment', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_training', to: 'out_focus', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_focus', to: 'goal_productivity', strength: { mean: 0.6, std: 0.1 } },
+  ],
+};
+
+/**
+ * Root-target variant: fac_orphan has NO incoming edges and NO observed value.
+ * If ISL ever flagged it CONSTRAINT_NODE_DEFAULT_BASE, its "samples" would be
+ * a constant placeholder (no forward-propagated inputs) — not a modelled
+ * distribution. PLoT must keep suppressing defensively.
+ */
+const GRAPH_ROOT_TARGET = {
+  nodes: [
+    { id: 'goal_productivity', kind: 'goal', label: 'Improve productivity' },
+    { id: 'out_focus', kind: 'outcome', label: 'Focus time' },
+    { id: 'fac_training', kind: 'factor', label: 'Training investment', observed_state: { value: 0.6 } },
+    { id: 'fac_orphan', kind: 'factor', label: 'Untracked morale' },
+  ],
+  edges: [
+    { from: 'fac_training', to: 'out_focus', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_focus', to: 'goal_productivity', strength: { mean: 0.6, std: 0.1 } },
+    { from: 'fac_orphan', to: 'goal_productivity', strength: { mean: 0.4, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt_a', label: 'Invest in training', interventions: { fac_training: 0.8 } },
+  { id: 'opt_b', label: 'Hold steady', interventions: { fac_training: 0.4 } },
+];
+
+/** The exact live user input: "at least 20%" on the goal node. */
+const AT_LEAST_20_PCT = {
+  constraint_id: 'success_target',
+  node_id: 'goal_productivity',
+  operator: '>=',
+  value: 20,
+  unit: '%',
+  label: 'Productivity at least 20%',
+};
+
+describe('goal-fit doctrine B (P0-C2 — scored from the modelled outcome distribution)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    defaultBaseNodeId = null;
+  });
+
+  async function run(graph: any, constraints: any[] | undefined) {
+    lastISLRequestBody = null;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({
+        graph,
+        options: OPTIONS,
+        goal_node_id: 'goal_productivity',
+        seed: 'goalfit-doctrine-b',
+        ...(constraints ? { goal_constraints: constraints } : {}),
+      }),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  function warningsByCode(body: any, code: string): any[] {
+    return (body.inference_warnings ?? []).filter((w: any) => w.code === code);
+  }
+
+  // -------------------------------------------------------------------------
+  // RED core: doctrine B delivery
+  // -------------------------------------------------------------------------
+
+  it('DELIVERS differentiated per-option goal probabilities when the only reason is target_base_defaulted', async () => {
+    defaultBaseNodeId = 'goal_productivity';
+    try {
+      const body = await run(GRAPH_GOAL_TARGET, [AT_LEAST_20_PCT]);
+
+      // Threshold normalisation is sound post-#203 (0.2 went to ISL) …
+      expect(lastISLRequestBody.goal_constraints[0].value).toBeCloseTo(0.2, 9);
+
+      // … and the modelled goal probabilities are delivered, differentiated.
+      const byId = new Map(body.option_comparison.map((o: any) => [o.option_id, o]));
+      expect((byId.get('opt_a') as any).probability_of_joint_goal).toBe(0.62);
+      expect((byId.get('opt_b') as any).probability_of_joint_goal).toBe(0.38);
+      expect((byId.get('opt_a') as any).constraint_probabilities).toEqual({ success_target: 0.62 });
+      expect((byId.get('opt_b') as any).constraint_probabilities).toEqual({ success_target: 0.38 });
+    } finally {
+      defaultBaseNodeId = null;
+    }
+  });
+
+  it('annotates every delivering option with goal_fit_basis (honest provenance)', async () => {
+    defaultBaseNodeId = 'goal_productivity';
+    try {
+      const body = await run(GRAPH_GOAL_TARGET, [AT_LEAST_20_PCT]);
+
+      for (const opt of body.option_comparison) {
+        expect(opt.goal_fit_basis, opt.option_id).toEqual({
+          scored_from: 'modelled_outcome_distribution',
+          node_ids: ['goal_productivity'],
+        });
+      }
+    } finally {
+      defaultBaseNodeId = null;
+    }
+  });
+
+  it('downgrades the honesty signal: info-severity CONSTRAINT_GOALFIT_MODELLED_BASIS instead of the warning', async () => {
+    defaultBaseNodeId = 'goal_productivity';
+    try {
+      const body = await run(GRAPH_GOAL_TARGET, [AT_LEAST_20_PCT]);
+
+      // No suppression warning …
+      expect(warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE')).toHaveLength(0);
+
+      // … but an informational disclosure names the node and the basis.
+      const notes = warningsByCode(body, 'CONSTRAINT_GOALFIT_MODELLED_BASIS');
+      expect(notes).toHaveLength(1);
+      expect(notes[0].severity).toBe('info');
+      expect(notes[0].message).toContain('Improve productivity');
+      // Modelled, not observed — and the raw numbers are never quoted.
+      expect(notes[0].message.toLowerCase()).toContain('modelled');
+      expect(notes[0].message).not.toContain('0.62');
+      expect(notes[0].message).not.toContain('0.38');
+      expect(notes[0].message).not.toContain('62%');
+    } finally {
+      defaultBaseNodeId = null;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // PINs: every other reason combination keeps suppressing exactly as today
+  // -------------------------------------------------------------------------
+
+  it('PIN: default-range threshold normalisation still suppresses (with or without the base marker)', async () => {
+    defaultBaseNodeId = 'goal_productivity';
+    try {
+      // No producer-declared scale ('points') on a node with no derivable
+      // range → threshold_normalisation_defaulted + target_base_defaulted.
+      const body = await run(
+        {
+          ...GRAPH_GOAL_TARGET,
+          nodes: GRAPH_GOAL_TARGET.nodes.map((n) =>
+            n.id === 'goal_productivity' ? { id: n.id, kind: n.kind, label: n.label } : n,
+          ),
+        },
+        [{ ...AT_LEAST_20_PCT, unit: 'points', label: 'Productivity at least 20 points' }],
+      );
+
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+        expect(opt, opt.option_id).not.toHaveProperty('goal_fit_basis');
+      }
+      const warnings = warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].severity).toBe('warning');
+      expect(warningsByCode(body, 'CONSTRAINT_GOALFIT_MODELLED_BASIS')).toHaveLength(0);
+    } finally {
+      defaultBaseNodeId = null;
+    }
+  });
+
+  it('PIN: a mixed multi-constraint run (one doctrine-B-eligible, one default-range) suppresses the whole run', async () => {
+    defaultBaseNodeId = 'goal_productivity';
+    try {
+      const body = await run(GRAPH_GOAL_TARGET, [
+        AT_LEAST_20_PCT,
+        {
+          constraint_id: 'focus_floor',
+          node_id: 'out_focus', // valueless, no declared scale → default [0,1] range
+          operator: '>=',
+          value: 50,
+          unit: 'points',
+          label: 'Focus at least 50 points',
+        },
+      ]);
+
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+        expect(opt, opt.option_id).not.toHaveProperty('goal_fit_basis');
+      }
+      // Exactly today's multi-target behaviour: one warning per affected node.
+      const warnings = warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE');
+      expect(warnings.length).toBeGreaterThanOrEqual(1);
+      for (const w of warnings) expect(w.severity).toBe('warning');
+      expect(warningsByCode(body, 'CONSTRAINT_GOALFIT_MODELLED_BASIS')).toHaveLength(0);
+    } finally {
+      defaultBaseNodeId = null;
+    }
+  });
+
+  it('PIN: a defaulted-base target with NO forward-propagated inputs (root node) still suppresses', async () => {
+    defaultBaseNodeId = 'fac_orphan';
+    try {
+      const body = await run(GRAPH_ROOT_TARGET, [{
+        constraint_id: 'morale_floor',
+        node_id: 'fac_orphan',
+        operator: '>=',
+        value: 20,
+        unit: '%', // producer-declared scale → normalisation sound; base is the only reason
+        label: 'Morale at least 20%',
+      }]);
+
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+        expect(opt, opt.option_id).not.toHaveProperty('goal_fit_basis');
+      }
+      const warnings = warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].severity).toBe('warning');
+      expect(warningsByCode(body, 'CONSTRAINT_GOALFIT_MODELLED_BASIS')).toHaveLength(0);
+    } finally {
+      defaultBaseNodeId = null;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: unaffected runs are byte-identical
+  // -------------------------------------------------------------------------
+
+  it('regression: a reliable goal target (no base marker) delivers WITHOUT annotation or note', async () => {
+    defaultBaseNodeId = null;
+    const body = await run(GRAPH_GOAL_TARGET, [AT_LEAST_20_PCT]);
+
+    const byId = new Map(body.option_comparison.map((o: any) => [o.option_id, o]));
+    expect((byId.get('opt_a') as any).probability_of_joint_goal).toBe(0.62);
+    expect((byId.get('opt_b') as any).probability_of_joint_goal).toBe(0.38);
+    for (const opt of body.option_comparison) {
+      expect(opt, opt.option_id).not.toHaveProperty('goal_fit_basis');
+    }
+    expect(warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE')).toHaveLength(0);
+    expect(warningsByCode(body, 'CONSTRAINT_GOALFIT_MODELLED_BASIS')).toHaveLength(0);
+  });
+
+  it('regression: a run without goal constraints carries no constraint fields, annotation, or note', async () => {
+    defaultBaseNodeId = null;
+    // Unstamped goal node: a goal_threshold stamp would auto-generate a
+    // constraint (auto_constraint_from_threshold, pre-existing behaviour),
+    // which is not the "no goal constraints" case this test pins.
+    const body = await run(
+      {
+        ...GRAPH_GOAL_TARGET,
+        nodes: GRAPH_GOAL_TARGET.nodes.map((n) =>
+          n.id === 'goal_productivity' ? { id: n.id, kind: n.kind, label: n.label } : n,
+        ),
+      },
+      undefined,
+    );
+
+    for (const opt of body.option_comparison) {
+      expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+      expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+      expect(opt, opt.option_id).not.toHaveProperty('goal_fit_basis');
+    }
+    expect(warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE')).toHaveLength(0);
+    expect(warningsByCode(body, 'CONSTRAINT_GOALFIT_MODELLED_BASIS')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Doctrine

Implements the **ratified P0-C2 doctrine decision** (product owner, 2026-07-07, "option B"): goal-fit is scored from the goal node's forward-propagated outcome distribution vs the normalised threshold — instead of being suppressed because the goal node has no observed value channel.

Base includes PR #203 (goal-threshold normalisation), so on the live goal-target run the only remaining suppression reason was `target_base_defaulted`.

## What changes

- **`src/lib/constraint-reliability.ts`** — new `partitionConstraintTargets()`: a detected target whose reason set is exactly `{target_base_defaulted}` AND that has ≥1 directed incoming edge (bidirected excluded, mirroring the ISL translator's forward model) classifies as **modelled-basis delivery**; everything else keeps suppressing. Conservative on absent graph. New claim-safe info-note builder.
- **`src/routes/v2/run.ts` (buildResponse)** — deliver `probability_of_joint_goal` / `constraint_probabilities` for the doctrine-B case with an additive per-option annotation `goal_fit_basis: { scored_from: 'modelled_outcome_distribution', node_ids }` and one info-severity `CONSTRAINT_GOALFIT_MODELLED_BASIS` note per affected node, instead of the WARNING-severity `CONSTRAINT_TARGET_UNRELIABLE`. Any other reason combination suppresses byte-identically to before (pinned).
- **Coaching stays stricter than the wire** (deliberate): the `GOAL_FEASIBILITY_LOW` joint-prob gate still skips base-defaulted targets until caveated wording is ratified.
- Types + boundary-contract doc updated; OpenAPI unaffected (V1-only spec never documented these V2 fields — verified).

## Semantic coherence (verified against ISL, read-only)

ISL scores constraint `prob_satisfied` from the same forward-propagated Monte Carlo series as the outcome distribution (`evaluate_multi`), against the PLoT-normalised threshold — the **identical comparison** the already-delivered `probability_of_goal` ships (`robustness_analyzer_v2.py:1242-1245`). `base=0.0` means modelled-change-from-zero-baseline, which is exactly what the annotation and note disclose. No scale mismatch; **no ISL change needed**. ISL follow-up (cosmetic message reclassification for `CONSTRAINT_NODE_DEFAULT_BASE`) documented in the evidence file.

## RED→GREEN

`tests/goalfit-doctrine-b.fixture.test.ts` — RED on base `ff423310` (3 doctrine tests fail: delivery, annotation, downgraded disclosure; suppression PINs and regression controls pass), GREEN after. Re-pins updated: the P0-C2 boundary PIN in `goal-threshold-normalisation.fixture.test.ts` now asserts the ratified delivery; item-A suppression pins move from `'%'` (a doctrine-B case post-#203) to `'points'`.

## Evidence

`docs/lanes/LANE25-goalfit-doctrine-b-2026-07-07.md` — mechanism, fixture diff, full semantic-coherence analysis, ISL follow-up, residual risks (incl. the pre-existing ungated top-level `constraint_results[].probability` seam, out of scope).

## Verification

- `npx tsc --noEmit` clean; affected suites 70/70; `npx vitest run --changed`: **171 files, 1464 passed, 0 failed**.
- Pre-push hook ran the full validation suite on push (push not blocked).
- Known pre-existing CI reds (`audit`, `gates (windows-latest)`) are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)