### PR TITLE
fix(constraints): gate top-level constraint_results by target reliability (ROADMAP 1.26a)

### DIFF
--- a/docs/lanes/LANE27-constraint-results-top-level-gating-2026-07-08.md
+++ b/docs/lanes/LANE27-constraint-results-top-level-gating-2026-07-08.md
@@ -1,0 +1,160 @@
+# LANE 27 — Gate top-level constraint_results by target reliability (ROADMAP 1.26a)
+
+Date: 2026-07-08 (lane launched 2026-07-07)
+Branch: `claude-lane27/constraint-results-top-level-gating` (base `origin/staging` 9026304 — includes LANE25/PR #204)
+Follow-up to: `docs/lanes/LANE25-goalfit-doctrine-b-2026-07-07.md` §8, which filed this
+exact leak as a residual risk ("Top-level `constraint_results[].probability`
+(buildConstraintFields) was never gated by the item-A suppression").
+
+## 0. Scope note — deliberate narrowing
+
+A previously-planned wider scope for lane 27 included **ROADMAP 1.24** (V2-shaped ISL
+reads + an `isl_version` assertion). That work is **deliberately split out into a
+follow-up lane** and was NOT attempted here — this lane is the claim-integrity fix for
+the top-level constraint leak only. The narrowing is stated here so it is visible; 1.24
+remains open on the roadmap.
+
+## 1. Problem (verified on base 9026304)
+
+The producer-honesty suppression for unreliable constraint targets
+(`src/lib/constraint-reliability.ts` — `detectUnreliableConstraintTargets` +
+`partitionConstraintTargets`, applied in `buildResponse` of `src/routes/v2/run.ts`)
+gated ONLY the per-option fields `probability_of_joint_goal` and
+`constraint_probabilities`. The TOP-LEVEL constraint block built by
+`buildConstraintFields()` still emitted:
+
+- `constraint_results[].probability` = the first option's `prob_satisfied`,
+  REGARDLESS of target reliability — on a suppressed run the withheld probabilities
+  leaked straight back out via the top-level surface;
+- `constraints_status: 'computed'` — a fabricated decision-grade claim over numbers
+  the per-option doctrine had already ruled not decision-grade;
+- `constraint_diagnostics` and `conditional_probabilities` derived from the same
+  non-decision-grade evaluation.
+
+RED evidence (base 9026304, commit 917a3fc):
+`npx vitest run tests/constraint-results-top-level-gating.fixture.test.ts` →
+**3 failed | 3 passed**. The three LEAK tests each failed with
+`constraints_status: 'computed'` (expected `'unavailable'`) on (a) the full
+two-leg suppression chain, (b) the normalisation-default leg alone, and (c) a mixed
+run (one suppressed + one reliable target). The doctrine-B delivery pin, the
+reliable-run byte-identity pin, and the no-constraints pin passed on base.
+
+## 2. Mechanism implemented
+
+`src/routes/v2/run.ts` only; no ISL change; per-option suppression logic untouched —
+its classification is REUSED:
+
+- `buildConstraintFields` gains two optional parameters:
+  `suppressedConstraintTargets` (the `suppressed` half of the SAME
+  `partitionConstraintTargets` result the per-option suppression keys on) and a
+  `logger`.
+- Gate placement: AFTER the existing early returns (`'error'` for explicit ISL
+  option errors, `'unavailable'` for absent/empty/malformed/incomplete results) and
+  immediately BEFORE the `'computed'` return — so ISL error/unavailable outcomes
+  keep their more specific status, and only a would-be-`'computed'` block is
+  converted. When `suppressedConstraintTargets` is non-empty the function logs a
+  `constraint_results_suppressed` diagnostics event (raw constraint_results,
+  constraint_diagnostics, conditional_probabilities, and the unreliable-target
+  classification — logs only, never the wire) and returns
+  `{ constraints_status: 'unavailable' }`.
+- Call site (the response spread in `buildResponse`) passes
+  `constraintTargetPartition.suppressed` + `logger`.
+- Status vocabulary: `'unavailable'` is the existing `ConstraintFeatureStatus`
+  member for "constraints sent, no usable result" — consistent with LANE25's
+  per-option doctrine, where suppression = honest ABSENCE and the run-level
+  explanation is carried by the WARNING-severity `CONSTRAINT_TARGET_UNRELIABLE`
+  inference warning (already emitted by the per-option path; one per affected
+  node). No new status value, no schema change.
+- Doctrine-B `modelledBasis` targets are NOT passed to the gate (only the
+  `suppressed` partition is), so a modelled-basis run DELIVERS the top-level block
+  unchanged — consistent with the per-option delivery + `goal_fit_basis`
+  annotation + info-severity `CONSTRAINT_GOALFIT_MODELLED_BASIS` note.
+- Mixed runs: run-level doctrine preserved — ANY suppressed target withholds the
+  whole block (`partition.suppressed.length > 0`), exactly as it does per-option.
+- Boundary contract doc updated: `src/contracts/isl-to-ui.contract.ts` `filtered`
+  section records the top-level mirror.
+
+Byte-identity for reliable runs: the non-suppressed code path through
+`buildConstraintFields` is unchanged (the gate is a single length check before the
+final return), pinned by the regression test below.
+
+## 3. Fixture diff
+
+New: `tests/constraint-results-top-level-gating.fixture.test.ts` (6 tests) —
+mirrors the mocked-ISL harness and graph/constraint fixtures of
+`tests/constraint-target-unreliable.fixture.test.ts` (live wire shapes for the
+`CONSTRAINT_NODE_DEFAULT_BASE` signal), with a controllable `prob_satisfied`:
+
+- LEAK (RED→GREEN): full two-leg suppression run (`'points'` unit on a valueless
+  node + ISL default-base warning) → `constraints_status: 'unavailable'`, NO
+  `constraint_results` / `constraint_diagnostics` / `conditional_probabilities`;
+  per-option suppression sanity-checked in the same run.
+- LEAK (RED→GREEN): normalisation-default leg ALONE (no ISL warning) gates the top
+  level too.
+- LEAK (RED→GREEN): mixed run (one suppressed valueless target + one reliable
+  valued target) withholds the WHOLE top-level block.
+- PIN (green on base AND after): doctrine-B modelled-basis run (`'%'` declared
+  scale, base-defaulted forward-propagated node) DELIVERS the top-level block
+  (`constraints_status: 'computed'`, exact `constraint_results` row with the
+  modelled probability) with the info note and no warning.
+- REGRESSION PIN (green on base AND after): reliable run keeps the EXACT top-level
+  block — deep-equal on `constraint_results`, `conditional_probabilities: []`, no
+  `constraint_diagnostics`, no constraint-reliability warning codes.
+- REGRESSION PIN (green on base AND after): no goal constraints → no top-level
+  constraint fields at all.
+
+Updated: `tests/gates/constraint-scale-correctness.test.ts` — the WP1
+constraints_status gate suite's shared payload gains `observed_state: { value:
+40000 }` on the `goal` node. Its three positive controls ("computed" cases) used a
+valueless target whose 20000/50000 constraints normalised against the default
+[0,1] range — exactly the unreliable case the new gate withholds (on base, those
+runs' per-option probability fields were ALREADY suppressed; the suite just never
+read them). The suite's intent is the correspondence/validity mechanics of
+`buildConstraintFields`, so its target is made RELIABLE (`deriveRange` →
+`[0, 80000]`, source `inferred_value`); the reliability gating itself is pinned in
+the new fixture. All 14 regression/error-shape tests in that suite were unaffected
+(they exercise the early returns above the gate).
+
+## 4. Test results (exact commands)
+
+- RED (base 9026304): `npx vitest run tests/constraint-results-top-level-gating.fixture.test.ts`
+  → 3 failed | 3 passed (failures are the three LEAK tests, each on
+  `expected 'unavailable', received 'computed'`).
+- After fix: same command → **6 passed**.
+- `npm run typecheck` (`tsc -p tsconfig.json --noEmit`) → clean.
+- Constraint-adjacent sweep: `npx vitest run` over 12 files
+  (constraint-results-top-level-gating, constraint-target-unreliable,
+  goalfit-doctrine-b, goal-threshold-normalisation, constraint-reliability.unit,
+  gates/constraint-scale-correctness, cil-constraint-passthrough, multi-constraint,
+  boundary-isl-to-ui.contract, enrichment-emission-contract, cil-constraint-auto-pu,
+  golden/canonical-route-integration) → **12 files, 171 passed, 0 failed**.
+  (Note: `tests/multi-constraint.test.ts` spawn-server cases require `npm run
+  build` first — 11 `waitFor(server ready)` timeouts in a fresh worktree without
+  `dist/` are an environment artifact, reproduced and cleared by building.)
+- Full gate: `npm test` (build + engine fixtures + vitest + OpenAPI + loadcheck)
+  → exit 0.
+- `bash scripts/pre-push-validate.sh` → PASSED, 0 failures — branch guard,
+  TypeScript compilation, full test suite (**5340 passed | 25 skipped (5376), 0
+  failed**), no stale .js, file: dependency policy, OpenAPI spectral lint. The
+  same script also ran as the husky pre-push hook on the final push.
+
+## 5. Residual risks / deliberate stops
+
+- **ROADMAP 1.24 (V2-shaped ISL reads + `isl_version` assertion) deliberately not
+  attempted** — split to a follow-up lane (see §0).
+- `constraints_status: 'unavailable'` does not DISTINGUISH "ISL returned nothing
+  usable" from "computed but withheld for reliability" at the status level; the
+  distinction is carried by the WARNING-severity `CONSTRAINT_TARGET_UNRELIABLE`
+  inference warning (present only in the withheld case) and the
+  `constraint_results_suppressed` diagnostics log. Introducing a dedicated status
+  value would be a wire-vocabulary change across consumers — deliberately not done
+  in a claim-integrity lane.
+- The suppressed-run diagnostics log (`constraint_results_suppressed`) duplicates
+  raw values also logged per-option by `constraint_probability_suppressed` —
+  acceptable redundancy; both are log-only surfaces.
+- Consumers that previously read the leaked top-level `constraint_results` on
+  suppressed runs will now see the block absent with `'unavailable'`. This is the
+  intended honesty fix; the UI already gates constraint rendering on absence
+  (same doctrine as the per-option fields, LANE25 §2).
+- The known-open PLoT→CEE enrichment passthrough (`z.record`, untyped) is
+  unchanged by this lane — nothing new crosses that seam.

--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -50,11 +50,19 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
    * ({ scored_from: 'modelled_outcome_distribution', node_ids }) and an
    * info-severity CONSTRAINT_GOALFIT_MODELLED_BASIS note instead of the
    * warning.
+   *
+   * Top-level mirror (lane 27, ROADMAP 1.26a — the LANE25 §8 follow-up): the
+   * TOP-LEVEL block built by buildConstraintFields (constraint_results[]
+   * .probability, constraint_diagnostics, conditional_probabilities) is gated
+   * by the SAME partition — on a suppressed run the whole block is withheld
+   * and constraints_status reports 'unavailable' instead of a fabricated
+   * 'computed'; doctrine-B modelledBasis targets deliver it unchanged.
    * @see src/lib/constraint-reliability.ts
    */
   filtered: [
     'constraint_analysis.joint_probability (when CONSTRAINT_TARGET_UNRELIABLE)',
     'constraint_analysis.constraints[].prob_satisfied (when CONSTRAINT_TARGET_UNRELIABLE)',
+    'constraint_results[] / constraint_diagnostics[] / conditional_probabilities[] (top-level block, when CONSTRAINT_TARGET_UNRELIABLE — constraints_status: unavailable)',
   ],
 
   /** WHY renamed: UI schema uses different field names than ISL's response. */

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -138,6 +138,7 @@ import {
   buildConstraintTargetUnreliableMessage,
   buildConstraintGoalFitModelledMessage,
   GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME,
+  type UnreliableConstraintTarget,
 } from '../../lib/constraint-reliability.js';
 import { NEAR_TIE_THRESHOLD } from '../../trust/result-coherence.js';
 import { assessGraphIdentifiability, toIdentifiabilityResponse, detectUnmeasuredConfounding } from '../../trust/identifiability-v2.js';
@@ -1410,6 +1411,12 @@ export function deriveRecommendedOption(
  *
  * We use the first option's constraint_analysis as the canonical source for top-level
  * constraint metadata (diagnostics and conditional probabilities are per-graph, not per-option).
+ *
+ * Reliability gate (lane 27, ROADMAP 1.26a): when any constraint target is
+ * suppressed-unreliable (partitionConstraintTargets — the same classification
+ * behind the per-option probability suppression), the whole block returns
+ * { constraints_status: 'unavailable' } instead of 'computed' with leaked
+ * probabilities; raw values go to the constraint_results_suppressed log only.
  */
 /**
  * Collect CEE-stamped goal-threshold metadata from the RAW upstream nodes (P0-C1).
@@ -1447,7 +1454,14 @@ function collectGoalThresholdNodeMeta(
 function buildConstraintFields(
   goalConstraints: GoalConstraint[] | undefined,
   islResult: any,
-  constraintNormRanges?: Map<string, NormalisationRange>
+  constraintNormRanges?: Map<string, NormalisationRange>,
+  // Producer honesty (lane 27, ROADMAP 1.26a): the suppressed half of the
+  // constraint-target partition (partitionConstraintTargets — same
+  // classification the per-option suppression keys on). When non-empty, the
+  // top-level block is withheld too; doctrine-B modelledBasis targets are NOT
+  // passed here — they deliver (lane P0-C2).
+  suppressedConstraintTargets?: UnreliableConstraintTarget[],
+  logger?: { warn: (obj: object, msg?: string) => void }
 ): {
   constraints_status?: ConstraintFeatureStatus;
   constraint_results?: ConstraintResult[];
@@ -1635,6 +1649,33 @@ function buildConstraintFields(
       // or effective_sample_size is non-finite (would serialise to a fabricated `null`
       // on these required-number fields). Non-finite ROW filtering only.
       .filter((cp: ConditionalProbability) => Number.isFinite(cp.probability) && Number.isFinite(cp.effective_sample_size));
+  }
+
+  // Producer honesty (lane 27, ROADMAP 1.26a — the LANE25 §8 follow-up): the
+  // per-option suppression (item A + doctrine B, see buildResponse) withholds
+  // probability_of_joint_goal / constraint_probabilities when any constraint
+  // target is suppressed-unreliable, but this top-level block previously still
+  // emitted constraint_results[].probability (= the first option's
+  // prob_satisfied) under constraints_status: 'computed' — the withheld
+  // numbers leaked via the top-level surface. Gate it on the SAME partition:
+  // when any target suppresses, the whole block is withheld (absence is
+  // honest; the WARNING-severity CONSTRAINT_TARGET_UNRELIABLE explains why)
+  // and 'unavailable' replaces the fabricated 'computed'. The diagnostics and
+  // conditional probabilities derive from the same non-decision-grade
+  // evaluation, so they are withheld with it. Raw values stay in the
+  // diagnostics log below — never on the wire. Doctrine-B modelledBasis
+  // targets deliver unchanged (callers pass only the suppressed partition).
+  // Gated AFTER the early returns above so ISL 'error'/'unavailable'
+  // outcomes keep their more specific status.
+  if (suppressedConstraintTargets && suppressedConstraintTargets.length > 0) {
+    logger?.warn({
+      event: 'constraint_results_suppressed',
+      raw_constraint_results: constraintResults,
+      raw_constraint_diagnostics: constraintDiagnostics,
+      raw_conditional_probabilities: conditionalProbabilities,
+      unreliable_targets: suppressedConstraintTargets,
+    });
+    return { constraints_status: 'unavailable' };
   }
 
   return {
@@ -2353,8 +2394,18 @@ function buildResponse(
     robustness_status: robustnessStatus,
     drivers_status: driversStatus,
 
-    // CIL C1: Multi-constraint analysis fields
-    ...buildConstraintFields(goalConstraints, islResult, constraintNormRanges),
+    // CIL C1: Multi-constraint analysis fields.
+    // Lane 27 (ROADMAP 1.26a): gated by the SAME reliability partition as the
+    // per-option suppression above — suppressed targets withhold the whole
+    // top-level block ('unavailable'); doctrine-B modelledBasis targets and
+    // fully-reliable runs deliver it byte-identically.
+    ...buildConstraintFields(
+      goalConstraints,
+      islResult,
+      constraintNormRanges,
+      constraintTargetPartition.suppressed,
+      logger,
+    ),
 
     // Auto-noise disclosure (audit B3, P0). `auto_noise_applied` echoes
     // ISL's flag verbatim (or `null` when ISL's `_metadata` omits the

--- a/tests/constraint-results-top-level-gating.fixture.test.ts
+++ b/tests/constraint-results-top-level-gating.fixture.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Top-level constraint_results gating fixture (lane 27, ROADMAP 1.26a).
+ *
+ * LEAK under test (RED before the fix — filed as the follow-up in
+ * docs/lanes/LANE25-goalfit-doctrine-b-2026-07-07.md §8):
+ *
+ * The producer-honesty suppression for unreliable constraint targets
+ * (src/lib/constraint-reliability.ts, applied in buildResponse of
+ * src/routes/v2/run.ts) gates ONLY the per-option fields
+ * `probability_of_joint_goal` and `constraint_probabilities`. The TOP-LEVEL
+ * constraint block built by buildConstraintFields() still emits
+ * `constraint_results[].probability` (= the first option's prob_satisfied)
+ * REGARDLESS of target reliability — so on a suppressed run the withheld
+ * probabilities leak via the top-level surface, and `constraints_status:
+ * 'computed'` claims a decision-grade result that the per-option doctrine
+ * already ruled not decision-grade.
+ *
+ * Contract under test (mirrors the per-option doctrine, run-level):
+ *   - FULLY-SUPPRESSED run (any suppressed target): the top-level constraint
+ *     block is withheld — `constraints_status: 'unavailable'` (existing
+ *     vocabulary; the WARNING-severity CONSTRAINT_TARGET_UNRELIABLE emitted
+ *     by the per-option path explains WHY) and NO constraint_results /
+ *     constraint_diagnostics / conditional_probabilities. Absence is honest.
+ *   - MIXED run (one suppressed + one reliable target): run-level suppression
+ *     wins, exactly as it does per-option.
+ *   - DOCTRINE-B run (target_base_defaulted ALONE on a forward-propagated
+ *     node, lane P0-C2): the top-level block DELIVERS unchanged — the
+ *     modelled probability is the ratified scoring basis, disclosed by the
+ *     info-severity CONSTRAINT_GOALFIT_MODELLED_BASIS note + per-option
+ *     goal_fit_basis annotation.
+ *   - RELIABLE run: byte-identical top-level block (regression pin).
+ *
+ * The ISL request/ISL service are NOT changed — the mock mirrors
+ * tests/constraint-target-unreliable.fixture.test.ts (live wire shapes).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Mutable mock state (per-request ISL behaviour)
+// ---------------------------------------------------------------------------
+
+/** When true, the ISL mock emits the CONSTRAINT_NODE_DEFAULT_BASE warning. */
+let emitDefaultBaseWarning = false;
+/** prob_satisfied / joint_probability the ISL mock returns (distinguishable per test). */
+let mockProbSatisfied = 0.55;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    const goalConstraints = body.goal_constraints || [];
+
+    const constraintAnalysis = goalConstraints.length > 0
+      ? {
+          constraint_analysis: {
+            joint_probability: mockProbSatisfied,
+            constraints: goalConstraints.map((c: any) => ({
+              node_id: c.node_id,
+              operator: c.operator,
+              threshold: c.threshold ?? c.value,
+              prob_satisfied: mockProbSatisfied,
+            })),
+          },
+        }
+      : {};
+
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+          win_probability: idx === 0 ? 0.6 : 0.4,
+          rank: idx + 1,
+          ...constraintAnalysis,
+        })),
+        factor_sensitivity: [],
+        robustness: { label: 'moderate', score: 0.6, fragile_edges: [], robust_edges: [] },
+        // Live ISL wire shape for the defaulted-base signal (see ISL
+        // robustness_analyzer_v2.py — InferenceWarning with nested detail):
+        inference_warnings: emitDefaultBaseWarning
+          ? [{
+              code: 'CONSTRAINT_NODE_DEFAULT_BASE',
+              field: 'nodes[out_campaign_effectiveness].base',
+              detail: {
+                node_id: 'out_campaign_effectiveness',
+                defaulted_to: 0.0,
+                reason: 'no_parameter_uncertainty',
+                message: "Node 'out_campaign_effectiveness' has no ParameterUncertainty — defaulted to base=0.0, constraint probability may be unreliable",
+              },
+            }]
+          : [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirror tests/constraint-target-unreliable.fixture.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Constraint target: outcome node with NO observed value → default [0,1] range. */
+const GRAPH_VALUELESS_TARGET = {
+  nodes: [
+    { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
+    { id: 'out_campaign_effectiveness', kind: 'outcome', label: 'Campaign effectiveness' },
+    { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_budget', to: 'out_campaign_effectiveness', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_campaign_effectiveness', to: 'goal_growth', strength: { mean: 0.6, std: 0.1 } },
+  ],
+};
+
+/** Control: same shape but the target node HAS an observed value (range derivable). */
+const GRAPH_VALUED_TARGET = {
+  nodes: [
+    { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
+    // observed value 50 → deriveRange() infers [0, 100] (inferred_value tier).
+    { id: 'out_campaign_effectiveness', kind: 'outcome', label: 'Campaign effectiveness', observed_state: { value: 50 } },
+    { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_budget', to: 'out_campaign_effectiveness', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'out_campaign_effectiveness', to: 'goal_growth', strength: { mean: 0.6, std: 0.1 } },
+  ],
+};
+
+/** Mixed run: one valueless target (suppresses) + one valued target (reliable). */
+const GRAPH_MIXED_TARGETS = {
+  nodes: [
+    { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
+    { id: 'out_campaign_effectiveness', kind: 'outcome', label: 'Campaign effectiveness' },
+    { id: 'out_retention', kind: 'outcome', label: 'Customer retention', observed_state: { value: 50 } },
+    { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_budget', to: 'out_campaign_effectiveness', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'fac_budget', to: 'out_retention', strength: { mean: 0.4, std: 0.1 } },
+    { from: 'out_campaign_effectiveness', to: 'goal_growth', strength: { mean: 0.6, std: 0.1 } },
+    { from: 'out_retention', to: 'goal_growth', strength: { mean: 0.3, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt_a', label: 'Push campaign', interventions: { fac_budget: 0.8 } },
+  { id: 'opt_b', label: 'Hold steady', interventions: { fac_budget: 0.4 } },
+];
+
+/** Doctrine-B / control constraint: '%' is a producer-declared scale post-#203. */
+const SUCCESS_TARGET_20_PCT = {
+  constraint_id: 'success_target',
+  node_id: 'out_campaign_effectiveness',
+  operator: '>=',
+  value: 20,
+  unit: '%',
+  label: 'Effectiveness at least 20%',
+};
+
+/**
+ * Suppression variant: 'points' has no producer-declared scale, so the
+ * valueless node normalises against the default [0,1] range
+ * (threshold_normalisation_defaulted) — post-#203, '%' alone no longer does.
+ */
+const SUCCESS_TARGET_20_POINTS = {
+  ...SUCCESS_TARGET_20_PCT,
+  unit: 'points',
+  label: 'Effectiveness at least 20 points',
+};
+
+/** Reliable second constraint for the mixed run (valued node, declared '%' scale). */
+const RETENTION_TARGET_30_PCT = {
+  constraint_id: 'retention_floor',
+  node_id: 'out_retention',
+  operator: '>=',
+  value: 30,
+  unit: '%',
+  label: 'Retention at least 30%',
+};
+
+describe('top-level constraint_results gating by target reliability (lane 27, ROADMAP 1.26a)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    emitDefaultBaseWarning = false;
+    mockProbSatisfied = 0.55;
+  });
+
+  async function run(graph: any, constraints: any[]) {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({
+        graph,
+        options: OPTIONS,
+        goal_node_id: 'goal_growth',
+        seed: 'constraint-top-level-gating',
+        goal_constraints: constraints,
+      }),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  it('LEAK: fully-suppressed run (both legs) must not emit the top-level constraint block', async () => {
+    emitDefaultBaseWarning = true;
+    mockProbSatisfied = 0; // the live placeholder value the per-option path withholds
+    try {
+      const body = await run(GRAPH_VALUELESS_TARGET, [SUCCESS_TARGET_20_POINTS]);
+
+      // Sanity — the per-option suppression doctrine (lane PLoT-H item A)
+      // already holds on base; this test targets the top-level mirror.
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+      }
+      const warnings = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+      );
+      expect(warnings).toHaveLength(1);
+
+      // THE LEAK (RED on base): the withheld probability re-surfaces at the
+      // top level as constraint_results[0].probability = first option's
+      // prob_satisfied, under a fabricated constraints_status: 'computed'.
+      expect(body.constraints_status).toBe('unavailable');
+      expect(body).not.toHaveProperty('constraint_results');
+      expect(body).not.toHaveProperty('constraint_diagnostics');
+      expect(body).not.toHaveProperty('conditional_probabilities');
+    } finally {
+      emitDefaultBaseWarning = false;
+      mockProbSatisfied = 0.55;
+    }
+  });
+
+  it('LEAK: normalisation-default leg ALONE (no ISL warning) gates the top level too', async () => {
+    emitDefaultBaseWarning = false;
+    mockProbSatisfied = 0.55;
+    const body = await run(GRAPH_VALUELESS_TARGET, [SUCCESS_TARGET_20_POINTS]);
+
+    expect(body.constraints_status).toBe('unavailable');
+    expect(body).not.toHaveProperty('constraint_results');
+    expect(body).not.toHaveProperty('constraint_diagnostics');
+    expect(body).not.toHaveProperty('conditional_probabilities');
+  });
+
+  it('LEAK: mixed run (one suppressed + one reliable target) withholds the WHOLE top-level block', async () => {
+    // Run-level doctrine (lane P0-C2): when ANY target suppresses, the whole
+    // run suppresses — the reliable constraint's probability must not ship
+    // alongside a withheld one at either surface.
+    emitDefaultBaseWarning = false;
+    mockProbSatisfied = 0.55;
+    const body = await run(GRAPH_MIXED_TARGETS, [SUCCESS_TARGET_20_POINTS, RETENTION_TARGET_30_PCT]);
+
+    expect(body.constraints_status).toBe('unavailable');
+    expect(body).not.toHaveProperty('constraint_results');
+    expect(body).not.toHaveProperty('constraint_diagnostics');
+    expect(body).not.toHaveProperty('conditional_probabilities');
+  });
+
+  it('DOCTRINE B: modelled-basis run DELIVERS the top-level constraint block', async () => {
+    // '%' on the valueless node post-#203: threshold normalisation is sound,
+    // the ONLY reason is target_base_defaulted, and the node is
+    // forward-propagated → doctrine-B delivery (lane P0-C2), disclosed by the
+    // info-severity note. The top-level block must deliver consistently.
+    emitDefaultBaseWarning = true;
+    mockProbSatisfied = 0.62;
+    try {
+      const body = await run(GRAPH_VALUELESS_TARGET, [SUCCESS_TARGET_20_PCT]);
+
+      expect(body.constraints_status).toBe('computed');
+      expect(body.constraint_results).toEqual([
+        {
+          constraint_id: 'success_target',
+          node_id: 'out_campaign_effectiveness',
+          operator: '>=',
+          value: 20,
+          probability: 0.62,
+        },
+      ]);
+      expect(body.conditional_probabilities).toEqual([]);
+
+      const unreliable = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+      );
+      expect(unreliable).toHaveLength(0);
+      const modelled = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_GOALFIT_MODELLED_BASIS',
+      );
+      expect(modelled).toHaveLength(1);
+      expect(modelled[0].severity).toBe('info');
+    } finally {
+      emitDefaultBaseWarning = false;
+      mockProbSatisfied = 0.55;
+    }
+  });
+
+  it('REGRESSION PIN: reliable run keeps the exact top-level constraint block', async () => {
+    // Byte-identity pin for runs with NO unreliable targets: the block below
+    // is exactly what base emits today — the fix must not perturb it.
+    emitDefaultBaseWarning = false;
+    mockProbSatisfied = 0.55;
+    const body = await run(GRAPH_VALUED_TARGET, [SUCCESS_TARGET_20_PCT]);
+
+    expect(body.constraints_status).toBe('computed');
+    expect(body.constraint_results).toEqual([
+      {
+        constraint_id: 'success_target',
+        node_id: 'out_campaign_effectiveness',
+        operator: '>=',
+        value: 20,
+        probability: 0.55,
+      },
+    ]);
+    expect(body).not.toHaveProperty('constraint_diagnostics');
+    expect(body.conditional_probabilities).toEqual([]);
+
+    const constraintCodes = (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE' || w.code === 'CONSTRAINT_GOALFIT_MODELLED_BASIS',
+    );
+    expect(constraintCodes).toHaveLength(0);
+  });
+
+  it('REGRESSION PIN: no goal constraints → no top-level constraint fields', async () => {
+    emitDefaultBaseWarning = false;
+    mockProbSatisfied = 0.55;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({
+        graph: GRAPH_VALUED_TARGET,
+        options: OPTIONS,
+        goal_node_id: 'goal_growth',
+        seed: 'constraint-top-level-gating',
+      }),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+
+    expect(body).not.toHaveProperty('constraints_status');
+    expect(body).not.toHaveProperty('constraint_results');
+    expect(body).not.toHaveProperty('constraint_diagnostics');
+    expect(body).not.toHaveProperty('conditional_probabilities');
+  });
+});

--- a/tests/gates/constraint-scale-correctness.test.ts
+++ b/tests/gates/constraint-scale-correctness.test.ts
@@ -194,7 +194,15 @@ const { createServer } = await import('../../src/createServer.js');
 const BASE_PAYLOAD = {
   graph: {
     nodes: [
-      { id: 'goal', kind: 'goal', label: 'Revenue' },
+      // observed_state.value gives deriveRange() a real inferred range
+      // ([0, 80000], source 'inferred_value') for the 20000/50000 constraints
+      // below. Without it the threshold normalisation falls back to the
+      // default [0,1] range, which since lane 27 (ROADMAP 1.26a) honestly
+      // reports constraints_status: 'unavailable' (unreliable target) — this
+      // suite tests the buildConstraintFields correspondence/validity
+      // mechanics, so its target must be RELIABLE. Reliability suppression
+      // itself is pinned in tests/constraint-results-top-level-gating.fixture.test.ts.
+      { id: 'goal', kind: 'goal', label: 'Revenue', observed_state: { value: 40000 } },
       { id: 'factor-a', kind: 'factor', label: 'Market Size' },
     ],
     edges: [{ from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],


### PR DESCRIPTION
## Problem (claim-integrity leak, ROADMAP 1.26a)

The producer-honesty suppression for unreliable constraint targets (`src/lib/constraint-reliability.ts`, applied in `buildResponse` of `src/routes/v2/run.ts`) gated ONLY the per-option fields `probability_of_joint_goal` / `constraint_probabilities`. The TOP-LEVEL block built by `buildConstraintFields()` still emitted `constraint_results[].probability` (= the first option's `prob_satisfied`) under `constraints_status: 'computed'` regardless of target reliability — on a suppressed run the withheld probabilities leaked straight back out via the top-level surface. This is the residual leak filed in `docs/lanes/LANE25-goalfit-doctrine-b-2026-07-07.md` §8.

## Fix

`buildConstraintFields` now receives the `suppressed` half of the SAME `partitionConstraintTargets` classification the per-option suppression keys on (per-option logic untouched — classification reused):

- Any suppressed target → the whole top-level block (`constraint_results` / `constraint_diagnostics` / `conditional_probabilities`) is withheld and `constraints_status` reports `'unavailable'` (existing vocabulary; the WARNING-severity `CONSTRAINT_TARGET_UNRELIABLE` inference warning — already emitted by the per-option path — carries the explanation, matching LANE25's absence-is-honest doctrine). Raw values go to a `constraint_results_suppressed` diagnostics log only.
- Gate sits AFTER the existing early returns, so explicit ISL `'error'` / `'unavailable'` outcomes keep their more specific status.
- Doctrine-B modelled-basis targets (lane P0-C2) DELIVER the block unchanged (only the suppressed partition is passed).
- Mixed runs: run-level doctrine preserved — any suppressed target withholds the whole block, exactly as per-option.
- Reliable runs: code path unchanged → byte-identical output, pinned by a deep-equal regression test.
- Boundary contract doc (`src/contracts/isl-to-ui.contract.ts` `filtered`) updated. No ISL change; no schema/OpenAPI change (the hand-authored spec is V1-only and never documented these V2 fields — grep: 0 hits).

## RED-first evidence

New fixture `tests/constraint-results-top-level-gating.fixture.test.ts` (6 tests, mirrors the item-A fixture harness):

- On base 9026304 (commit 917a3fc): `npx vitest run tests/constraint-results-top-level-gating.fixture.test.ts` → **3 failed | 3 passed** — the 3 LEAK tests (full two-leg chain; normalisation-default leg alone; mixed run) each failed with `constraints_status: 'computed'` expected `'unavailable'`; the doctrine-B delivery pin, reliable-run byte-identity pin, and no-constraints pin passed.
- After the fix (commit 8133d6c): same command → **6 passed**.

## Fixture update

`tests/gates/constraint-scale-correctness.test.ts`: the WP1 constraints_status suite's shared payload gains `observed_state: { value: 40000 }` on the `goal` node. Its 3 positive controls used a valueless target whose 20000/50000 constraints normalised against the default [0,1] range — exactly the unreliable case the new gate withholds (those runs' per-option probability fields were ALREADY suppressed on base; the suite never read them). The suite tests correspondence/validity mechanics, so its target is made RELIABLE (`deriveRange` → `[0, 80000]`, source `inferred_value`). Its 14 regression/error-shape tests were unaffected (they exercise the early returns above the gate).

## Gates (exact commands + results)

- `npm run typecheck` (`tsc -p tsconfig.json --noEmit`) → clean.
- Constraint-adjacent sweep (12 files: constraint-results-top-level-gating, constraint-target-unreliable, goalfit-doctrine-b, goal-threshold-normalisation, constraint-reliability.unit, gates/constraint-scale-correctness, cil-constraint-passthrough, multi-constraint, boundary-isl-to-ui.contract, enrichment-emission-contract, cil-constraint-auto-pu, golden/canonical-route-integration) → **171 passed, 0 failed**.
- `npm test` (full: build + engine fixtures + vitest + OpenAPI + loadcheck) → **exit 0**.
- `bash scripts/pre-push-validate.sh` → **PASSED, 0 failures**: branch guard, TypeScript compilation, full test suite (**5340 passed | 25 skipped (5376), 0 failed**), no stale .js, file: dependency policy, OpenAPI spectral lint. The same script also ran as the husky pre-push hook on the final push.
- Known always-red CI checks `audit` and `gates (windows-latest)` fail on every PR (pre-existing, unrelated).

## Scope note

A previously-planned wider scope for lane 27 included ROADMAP 1.24 (V2-shaped ISL reads + an `isl_version` assertion). That is DELIBERATELY split out to a follow-up lane and not attempted here — see `docs/lanes/LANE27-constraint-results-top-level-gating-2026-07-08.md` §0.

## Residual risks

- `'unavailable'` does not distinguish "ISL returned nothing usable" from "computed but withheld for reliability" at the status level; the distinction is carried by the `CONSTRAINT_TARGET_UNRELIABLE` warning + diagnostics log. A dedicated status value would be a wire-vocabulary change across consumers — deliberately not done here.
- Consumers that previously read the leaked top-level `constraint_results` on suppressed runs now see the block absent with `'unavailable'` — the intended honesty fix (UI already gates constraint rendering on absence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
