### PR TITLE
fix(constraints): abstain instead of fabricating goal-fit on suspect auto-threshold direction

### DIFF
--- a/src/lib/constraint-reliability.ts
+++ b/src/lib/constraint-reliability.ts
@@ -258,3 +258,58 @@ export function buildConstraintTargetUnreliableMessage(
     `Set a value or range for "${nodeLabel}" to make this target computable.`
   );
 }
+
+/**
+ * Defensive sign-check for the auto-constraint fallback (Phase 1c+, run.ts
+ * ~line 3696): when goal_constraints is empty but a bare `goal_threshold`
+ * exists, PLoT synthesises a single `>= threshold` constraint because it has
+ * no visibility into the goal-framing text CEE extracted the number from —
+ * a target phrased as a maximum ("keep churn under X") would need `<=`, not
+ * `>=`, and PLoT cannot tell the two apart from the number alone.
+ *
+ * Guessing wrong is usually harmless-looking (a plausible-but-wrong
+ * probability), which is exactly what makes it dangerous. This function
+ * catches the one case PLoT CAN detect on its own evidence, with no NLP:
+ * the guessed threshold is positive, and the modelled outcome distribution
+ * for that SAME target node never gets there even at its most favourable
+ * sampled percentile (p90 < 0). In that case `>= positive_threshold` is
+ * structurally unsatisfiable — every option is guaranteed a ~0% joint-goal
+ * probability by construction, not because the graph says the goal is hard.
+ * That ~0% is indistinguishable on the wire from a real "this option won't
+ * reach the target" signal, so emitting it would be a fabrication dressed
+ * up as a computation. Abstain instead (see run.ts call site).
+ *
+ * Deliberately conservative: absent/non-finite inputs, a non-positive
+ * threshold, or an outcome that reaches non-negative territory anywhere in
+ * its sampled range all return false — normal (satisfiable-looking) runs are
+ * completely untouched.
+ */
+export function isAutoConstraintDirectionSuspect(
+  autoConstraintValue: number | undefined,
+  outcomeP90: number | undefined,
+): boolean {
+  if (typeof autoConstraintValue !== 'number' || !Number.isFinite(autoConstraintValue)) return false;
+  if (autoConstraintValue <= 0) return false;
+  if (typeof outcomeP90 !== 'number' || !Number.isFinite(outcomeP90)) return false;
+  return outcomeP90 < 0;
+}
+
+/**
+ * Build the user-facing CONSTRAINT_DIRECTION_SUSPECT warning message.
+ *
+ * provisional_doctrine_v0 — wording surface. Names the node, states what
+ * PLoT observed (not an intent judgement — PLoT cannot see the goal framing
+ * text), says probabilities were withheld rather than fabricated, and
+ * suggests the concrete fix. Never quotes a suppressed number.
+ */
+export function buildConstraintDirectionSuspectMessage(nodeLabel: string): string {
+  return (
+    `The auto-generated success target for "${nodeLabel}" assumes higher is better, but the ` +
+    `modelled outcome for "${nodeLabel}" stays negative for every option even in the most ` +
+    `favourable modelled scenario — the target and the modelled direction don't line up. ` +
+    `Goal-fit probabilities were withheld for this run rather than showing a near-zero number ` +
+    `that the direction mismatch — not the graph — would produce. If "${nodeLabel}" is meant ` +
+    `to be minimised (e.g. a cost or a rate you want low), add an explicit goal constraint with ` +
+    `the correct operator instead of relying on the plain threshold.`
+  );
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -138,6 +138,8 @@ import {
   partitionConstraintTargets,
   buildConstraintTargetUnreliableMessage,
   buildConstraintGoalFitModelledMessage,
+  isAutoConstraintDirectionSuspect,
+  buildConstraintDirectionSuspectMessage,
   GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME,
   type UnreliableConstraintTarget,
 } from '../../lib/constraint-reliability.js';
@@ -1806,6 +1808,18 @@ function buildResponse(
     ...new Set(modelledBasisConstraintTargets.map((t) => t.node_id)),
   ].sort();
 
+  // Defensive sign-check (lane PLoT-goal-fit-sign-defense) on the Phase 1c+
+  // auto-constraint fallback: at most one constraint ever carries this
+  // provenance (synthesis only fires when zero constraints were compiled —
+  // see run.ts ~3696), so find it once here rather than per-option below.
+  const autoDirectionConstraint = goalConstraints?.find(
+    (c) => (c as any)._internal?.source === 'auto_from_goal_threshold',
+  );
+  // Node ids where the sign-mismatch fired for at least one option — used to
+  // emit exactly one CONSTRAINT_DIRECTION_SUSPECT warning below, mirroring
+  // the unreliable-constraint-target dedup-by-node pattern above.
+  const directionSuspectNodeIds = new Set<string>();
+
   // Map ISL results to response format
   // ISL V2 uses 'options' field; V1 uses 'results'. Check both for compatibility.
   const islOptionData = islResult?.options ?? islResult?.results;
@@ -1925,7 +1939,31 @@ function buildResponse(
         }
       }
 
-      if (suppressConstraintProbabilities) {
+      // Defensive sign-check (lane PLoT-goal-fit-sign-defense): the auto-
+      // constraint fallback guessed '>=' with no visibility into goal-framing
+      // text. If the guessed positive threshold can never be reached — this
+      // option's modelled outcome for the SAME target node stays negative
+      // even at its most favourable sampled percentile (p90) — the ~0% ISL
+      // just computed is a mechanical certainty of the sign mismatch, not a
+      // signal about the graph. Abstain rather than emit it. Checked BEFORE
+      // suppressConstraintProbabilities/modelled-basis so it takes priority
+      // over both (this is a stronger, option-specific defect than either).
+      const directionSuspect =
+        autoDirectionConstraint !== undefined &&
+        isAutoConstraintDirectionSuspect(autoDirectionConstraint.value, outcome?.p90);
+
+      if (directionSuspect) {
+        directionSuspectNodeIds.add(autoDirectionConstraint!.node_id);
+        logger?.warn({
+          event: 'constraint_direction_suspect',
+          option_id: optionId,
+          node_id: autoDirectionConstraint!.node_id,
+          auto_threshold: autoDirectionConstraint!.value,
+          outcome_p90: outcome?.p90,
+          raw_probability_of_joint_goal: constraintAnalysis.joint_probability,
+          raw_constraint_probabilities: constraintProbs,
+        });
+      } else if (suppressConstraintProbabilities) {
         // Producer honesty (item A): the computed values are structurally
         // meaningless (default-range threshold and/or defaulted base). Emit
         // NEITHER field — absence is honest — and keep the raw values in
@@ -2260,6 +2298,22 @@ function buildResponse(
         severity: 'info',
       });
     }
+  }
+
+  // Defensive sign-check (lane PLoT-goal-fit-sign-defense): one WARNING per
+  // affected auto-constraint target node when the fallback's guessed '>='
+  // direction was structurally unsatisfiable for at least one option (see
+  // the per-option check above, next to suppressConstraintProbabilities).
+  // Independent of the if/else-if above — it fires alongside whichever of
+  // those applies, since it is a stronger, option-specific defect.
+  for (const nodeId of directionSuspectNodeIds) {
+    const nodeLabel = graph?.nodes?.find((n) => n.id === nodeId)?.label ?? nodeId;
+    inferenceWarnings.push({
+      code: INFERENCE_WARNING_CODES.CONSTRAINT_DIRECTION_SUSPECT,
+      // provisional_doctrine_v0 — wording surface (see constraint-reliability.ts)
+      message: buildConstraintDirectionSuspectMessage(nodeLabel),
+      severity: 'warning',
+    });
   }
 
   // Merge ISL-originated inference_warnings into the PLoT array.

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1999,6 +1999,22 @@ export const INFERENCE_WARNING_CODES = {
    * @see src/lib/constraint-reliability.ts
    */
   CONSTRAINT_GOALFIT_MODELLED_BASIS: 'CONSTRAINT_GOALFIT_MODELLED_BASIS',
+  /**
+   * Defensive sign-check on the auto-constraint fallback (Phase 1c+, run.ts
+   * ~line 3696): goal_constraints was empty so PLoT synthesised a single
+   * `>= goal_threshold` constraint from a bare number, with no visibility
+   * into the goal-framing text CEE extracted it from — the fallback cannot
+   * tell "at least X" from "at most X". When the guessed threshold is
+   * positive AND the modelled outcome distribution for that same target node
+   * never reaches non-negative territory even at its most favourable sampled
+   * percentile (p90 < 0), the constraint is structurally unsatisfiable: every
+   * option is guaranteed a ~0% `probability_of_joint_goal` by construction of
+   * the sign mismatch, not by the graph. That fabricated-looking near-zero is
+   * SUPPRESSED for the affected option(s) (absence is honest) in favour of
+   * this warning. Severity: warning.
+   * @see src/lib/constraint-reliability.ts
+   */
+  CONSTRAINT_DIRECTION_SUSPECT: 'CONSTRAINT_DIRECTION_SUSPECT',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];

--- a/tests/goal-fit-direction-defense.fixture.test.ts
+++ b/tests/goal-fit-direction-defense.fixture.test.ts
@@ -1,0 +1,257 @@
+/**
+ * CONSTRAINT_DIRECTION_SUSPECT fixture test (lane PLoT-goal-fit-sign-defense).
+ *
+ * Third blind spot on the Phase 1c+ auto-constraint fallback (run.ts
+ * ~line 3696): when `goal_constraints` is empty but a bare `goal_threshold`
+ * exists, PLoT synthesises a single `>= goal_threshold` constraint. PLoT has
+ * no visibility into the goal-framing text CEE extracted the number from —
+ * a target phrased as a maximum ("keep churn under X") needs `<=`, not the
+ * hardcoded `>=`. Guessing wrong usually just produces a plausible-but-wrong
+ * probability (invisible on the wire). This test pins the one sub-case PLoT
+ * CAN detect on its own evidence, with no NLP: the guessed threshold is
+ * positive, but the modelled outcome for the SAME target node never reaches
+ * non-negative territory even at its most favourable sampled percentile
+ * (p90 < 0). `>= positive_threshold` is then structurally unsatisfiable —
+ * ISL's ~0% joint probability is a mechanical certainty of the sign
+ * mismatch, not a computed signal about the graph. The fix must:
+ *   - SUPPRESS probability_of_joint_goal / constraint_probabilities for the
+ *     affected option (absence is honest — same contract as
+ *     CONSTRAINT_TARGET_UNRELIABLE);
+ *   - emit exactly one WARNING-severity CONSTRAINT_DIRECTION_SUSPECT naming
+ *     the node, via the existing code-keyed inference_warnings channel;
+ *   - leave the normal (non-suspect, e.g. positive-outcome) auto-constraint
+ *     path byte-for-byte unchanged — this is a narrow abstention, not a
+ *     behaviour change to the fallback itself;
+ *   - never fire for explicit user-supplied constraints (PLoT only guesses
+ *     direction for its OWN synthesis — a user who wrote `>=` explicitly
+ *     meant it).
+ *
+ * The ISL request/ISL service shape is not changed — only the constraint
+ * fallback + response-assembly honesty layer in run.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Mutable mock state (per-request ISL behaviour)
+// ---------------------------------------------------------------------------
+
+/**
+ * 'negative': every option's modelled outcome stays negative even at p90
+ * (structurally can never satisfy '>= positive_threshold').
+ * 'positive': normal satisfiable-looking outcome (control / regression case).
+ */
+let outcomeMode: 'negative' | 'positive' = 'positive';
+
+function buildOutcome(idx: number) {
+  if (outcomeMode === 'negative') {
+    // Every percentile strictly negative — the whole modelled distribution
+    // sits below zero, so a '>= positive' threshold can never be reached.
+    return { mean: -0.4, std: 0.1, p10: -0.6, p50: -0.4, p90: -0.1, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 };
+  }
+  return { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 };
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    const goalConstraints = body.goal_constraints || [];
+
+    // ISL evaluates the (near-)guaranteed-unsatisfiable case exactly like any
+    // other: a real Monte Carlo joint probability that happens to round to
+    // ~0 because the sampled distribution never crosses the threshold. This
+    // mirrors the live "fake ~0%" shape — ISL is not at fault; it computed
+    // honestly against what it was sent.
+    const constraintAnalysis = goalConstraints.length > 0
+      ? {
+          constraint_analysis: {
+            joint_probability: outcomeMode === 'negative' ? 0.001 : 0.72,
+            constraints: goalConstraints.map((c: any) => ({
+              node_id: c.node_id,
+              operator: c.operator,
+              threshold: c.threshold ?? c.value,
+              prob_satisfied: outcomeMode === 'negative' ? 0.001 : 0.72,
+            })),
+          },
+        }
+      : {};
+
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: buildOutcome(idx),
+          win_probability: idx === 0 ? 0.6 : 0.4,
+          rank: idx + 1,
+          ...constraintAnalysis,
+        })),
+        factor_sensitivity: [],
+        robustness: { label: 'moderate', score: 0.6, fragile_edges: [], robust_edges: [] },
+        inference_warnings: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const GRAPH = {
+  nodes: [
+    // The goal node is the auto-constraint's implicit target (Phase 1c+
+    // synthesises node_id: goal_node_id).
+    { id: 'goal_cost_reduction', kind: 'goal', label: 'Net cost change' },
+    { id: 'fac_spend', kind: 'factor', label: 'Marketing spend', observed_state: { value: 0.5 } },
+  ],
+  edges: [
+    { from: 'fac_spend', to: 'goal_cost_reduction', strength: { mean: 0.5, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt_a', label: 'Increase spend', interventions: { fac_spend: 0.8 } },
+  { id: 'opt_b', label: 'Hold steady', interventions: { fac_spend: 0.4 } },
+];
+
+async function run(app: FastifyInstance, goalThreshold: number, explicitConstraint?: any) {
+  const payload: Record<string, unknown> = {
+    graph: GRAPH,
+    options: OPTIONS,
+    goal_node_id: 'goal_cost_reduction',
+    seed: 'goal-fit-direction-defense',
+    goal_threshold: goalThreshold,
+  };
+  if (explicitConstraint) {
+    payload.goal_constraints = [explicitConstraint];
+  }
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v2/run',
+    headers: { 'Content-Type': 'application/json' },
+    payload: JSON.stringify(payload),
+  });
+  expect(res.statusCode).toBe(200);
+  return JSON.parse(res.body);
+}
+
+describe('CONSTRAINT_DIRECTION_SUSPECT (auto-constraint sign defense)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    outcomeMode = 'positive';
+  });
+
+  it('RED: strictly-negative modelled outcome + positive auto-threshold → suppressed fields + CONSTRAINT_DIRECTION_SUSPECT', async () => {
+    outcomeMode = 'negative';
+    try {
+      const body = await run(app, 0.5);
+
+      expect(body.analysis_status).not.toBe('blocked');
+      expect(Array.isArray(body.option_comparison)).toBe(true);
+      expect(body.option_comparison.length).toBe(2);
+
+      // Abstention, not fabrication: no fake ~0% on the wire.
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+      }
+
+      const warnings = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_DIRECTION_SUSPECT',
+      );
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].severity).toBe('warning');
+      expect(warnings[0].message).toContain('Net cost change');
+      // Raw fabricated-looking number never quoted.
+      expect(warnings[0].message).not.toContain('0.001');
+      expect(warnings[0].message).not.toContain('0%');
+    } finally {
+      outcomeMode = 'positive';
+    }
+  });
+
+  it('CONTROL: positive/satisfiable modelled outcome — auto-constraint path byte-unchanged (no suppression, no new warning)', async () => {
+    outcomeMode = 'positive';
+    const body = await run(app, 0.5);
+
+    for (const opt of body.option_comparison) {
+      expect(opt.probability_of_joint_goal, opt.option_id).toBe(0.72);
+      expect(opt.constraint_probabilities, opt.option_id).toEqual({ auto_goal_threshold: 0.72 });
+    }
+
+    const warnings = (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'CONSTRAINT_DIRECTION_SUSPECT',
+    );
+    expect(warnings).toHaveLength(0);
+
+    // Auto-synthesis repair still fires exactly as before (unrelated to this defence).
+    const autoRepair = (body._meta?.repairs_applied ?? []).find(
+      (r: any) => r.field === 'goal_constraints' && r.action === 'derived',
+    );
+    expect(autoRepair).toBeDefined();
+  });
+
+  it('does NOT fire for an explicit user-supplied constraint (PLoT only guesses direction for its OWN synthesis)', async () => {
+    outcomeMode = 'negative';
+    try {
+      const body = await run(app, undefined as unknown as number, {
+        constraint_id: 'user_target',
+        node_id: 'goal_cost_reduction',
+        operator: '>=',
+        value: 0.5,
+      });
+
+      // No auto-synthesis (explicit constraint present) → the defensive
+      // sign-check is scoped to _internal.source === 'auto_from_goal_threshold'
+      // only, so it must not fire here even though the outcome is negative.
+      const warnings = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_DIRECTION_SUSPECT',
+      );
+      expect(warnings).toHaveLength(0);
+
+      // The user explicitly asked for this comparison — ISL's honestly-
+      // computed near-zero is delivered, not suppressed by this lane.
+      for (const opt of body.option_comparison) {
+        expect(opt.probability_of_joint_goal, opt.option_id).toBe(0.001);
+      }
+    } finally {
+      outcomeMode = 'positive';
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Defensive sign-check on the Phase 1c+ auto-constraint fallback (`src/routes/v2/run.ts` ~line 3696): when `goal_constraints` is empty but a bare `goal_threshold` exists, PLoT synthesises a single `>= threshold` constraint. PLoT has no visibility into the goal-framing text CEE extracted the number from — a target phrased as a maximum ("keep churn under X") needs `<=`, not the hardcoded `>=`. Guessing wrong usually just produces an invisible plausible-but-wrong probability.

This fixes the one sub-case PLoT **can** detect from its own evidence, with no NLP: the guessed threshold is positive, but the modelled outcome distribution for that same target node never reaches non-negative territory even at its most favourable sampled percentile (`p90 < 0`). `>= positive_threshold` is then structurally unsatisfiable — ISL's ~0% joint probability is a mechanical certainty of the sign mismatch, not a computed signal about the graph, and is indistinguishable on the wire from a real "this option won't reach the target" result.

**Doctrine (disclose or abstain, never guess intent — the real fix is CEE-side and in flight):**
- Suppress `probability_of_joint_goal` / `constraint_probabilities` for the affected option (absence is honest — same contract as the existing `CONSTRAINT_TARGET_UNRELIABLE` producer-honesty lane).
- Emit exactly one WARNING-severity `CONSTRAINT_DIRECTION_SUSPECT` inference warning naming the node, on the existing code-keyed `inference_warnings` channel (consumers key off `code`, no wording pins).
- Scoped to PLoT's **own** synthesis only (`_internal.source === 'auto_from_goal_threshold'`) — explicit user-supplied constraints are never touched, even with the same negative-outcome shape.
- Normal/satisfiable auto-constraint runs are byte-for-byte unchanged.

## Changes

- `src/lib/constraint-reliability.ts`: `isAutoConstraintDirectionSuspect()` detection + `buildConstraintDirectionSuspectMessage()` (mirrors the existing `detectUnreliableConstraintTargets` / `CONSTRAINT_TARGET_UNRELIABLE` pattern).
- `src/types/engine-v3.ts`: new `INFERENCE_WARNING_CODES.CONSTRAINT_DIRECTION_SUSPECT`.
- `src/routes/v2/run.ts`: per-option check inside `buildResponse`'s option-comparison loop, ahead of (and taking priority over) the existing suppression/modelled-basis branches; one warning emitted per affected node after the loop.
- `tests/goal-fit-direction-defense.fixture.test.ts` (new): RED-first fixture — verified failing pre-fix (fake `0.001` on the wire), passing post-fix. Covers: (1) negative-outcome + positive auto-threshold → suppression + warning, (2) positive/satisfiable auto-threshold control → unchanged, (3) explicit user-supplied constraint with the same negative-outcome shape → does NOT fire.

## Evidence

RED-first, verified in a scratch `git stash` of the fix:
```
✓ CONTROL: positive/satisfiable modelled outcome — byte-unchanged                         (passed pre- and post-fix)
✓ does NOT fire for an explicit user-supplied constraint                                  (passed pre- and post-fix)
✗ RED: strictly-negative modelled outcome + positive auto-threshold → …                    (FAILED pre-fix: opt_a had probability_of_joint_goal: 0.001 — the fake ~0%)
```
After the fix, all 3 pass. `npx tsc --noEmit` clean. Full targeted suite (`auto-constraint-fallback`, `constraint-reliability.unit`, `constraint-target-unreliable.fixture`, `goalfit-doctrine-b.fixture`, `cil-constraint-passthrough`, new fixture) — 63/71 pass; the 8 failures are `tests/auto-constraint-fallback.test.ts` T6 subprocess-`spawnServer` tests that time out identically on `origin/staging` HEAD with no changes applied (pre-existing sandbox limitation, not a regression — confirmed via `git stash`).

Pre-push gate (`scripts/pre-push-validate.sh`) passed in full, including `npm test` (5399 passed / 25 skipped) and OpenAPI spectral lint. No known pre-existing CI reds expected other than the tolerated `audit` (fast-uri/fastify advisories) and `gates (windows-latest)` (unrelated path bug).

## Test plan

- [x] RED-first: new fixture fails on pre-fix code, passes post-fix
- [x] `npx tsc --noEmit` clean
- [x] Targeted vitest run: 63/71 pass (8 pre-existing unrelated T6 failures reproduced on unmodified `origin/staging`)
- [x] `scripts/pre-push-validate.sh` full gate passed (typecheck, `npm test`, stale-.js check, dep policy, OpenAPI lint)
- [ ] CI: only pre-existing `audit` + `gates (windows-latest)` reds tolerated

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>