### PR TITLE
feat(complexity): adaptive n_samples + honest refusal at the ISL complexity cap (ROADMAP 1.54)

### DIFF
--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -44,3 +44,131 @@ export const STANDARD_N_SAMPLES_DEFAULT = 4000;
 export function resolveStandardNSamples(): number {
   return resolveBoundedIntEnvOrWarn('STANDARD_N_SAMPLES', MIN_N_SAMPLES, MAX_N_SAMPLES) ?? STANDARD_N_SAMPLES_DEFAULT;
 }
+
+// ---------------------------------------------------------------------------
+// ROADMAP 1.54 — Adaptive depth vs the ISL complexity cap (density wall)
+// ---------------------------------------------------------------------------
+
+/**
+ * ISL's request-complexity budget: it rejects (422) any robustness request
+ * where `n_samples × nodes × edges` STRICTLY exceeds this
+ * (Inference-Service-Layer src/api/robustness.py, `complexity > max_complexity`,
+ * default 10,000,000, env `ISL_MAX_COMPUTE_COMPLEXITY`). At PLoT's standard
+ * depth of 4,000 that walled off every causal graph with nodes × edges > 2,500
+ * — real dense decision graphs hit a raw ISL 422 on the live path (verified:
+ * acceptance-evidence/dense-graph-test attempt 6, 43 × 70 causal = 12,040,000).
+ * PLoT mirrors the budget so it can adapt the depth BEFORE calling ISL.
+ */
+export const ISL_COMPLEXITY_BUDGET_DEFAULT = 10_000_000;
+
+/**
+ * The floor for ADAPTIVE reductions: PLoT never lowers a requested depth
+ * below 1,000 samples — below that, displayed probabilities are too unstable
+ * to present honestly (Track S seed-sweep evidence: 1,000 is already
+ * fragile on harder fixtures). A graph that cannot fit the budget even at
+ * this floor (nodes × edges > budget / 1,000) is refused with a structured
+ * GRAPH_TOO_COMPLEX blocker instead of silently degrading further.
+ * NOTE: this floor bounds reductions only — an EXPLICIT caller depth below
+ * 1,000 that already fits the budget is respected untouched.
+ */
+export const ADAPTIVE_N_SAMPLES_FLOOR = 1_000;
+
+/**
+ * Resolve the complexity budget PLoT enforces before calling ISL.
+ *
+ * Env `ISL_MAX_COMPUTE_COMPLEXITY` — the SAME variable name ISL reads — so
+ * ops can keep the two services in lock-step with one value. Strictly parsed
+ * (see env-int.ts); malformed or out-of-bounds values fall back to the
+ * default rather than silently widening/narrowing the gate. Read at call
+ * time so an override takes effect without a rebuild.
+ */
+export function resolveComplexityBudget(): number {
+  return (
+    resolveBoundedIntEnvOrWarn('ISL_MAX_COMPUTE_COMPLEXITY', 1_000, 1_000_000_000_000) ??
+    ISL_COMPLEXITY_BUDGET_DEFAULT
+  );
+}
+
+/** Outcome of applying the complexity budget to a resolved sample depth. */
+export type ComplexityBudgetDecision =
+  | {
+      /** Depth fits the budget as-is (or there is nothing to bound). */
+      kind: 'unchanged';
+      nSamples: number;
+      complexity: number;
+      budget: number;
+    }
+  | {
+      /** Depth was lowered to the largest value that fits the budget (≥ floor). */
+      kind: 'reduced';
+      nSamples: number;
+      originalNSamples: number;
+      /** complexity at the ORIGINAL depth (what would have been sent). */
+      complexity: number;
+      /** complexity at the REDUCED depth (what will be sent). */
+      reducedComplexity: number;
+      budget: number;
+    }
+  | {
+      /** Even ADAPTIVE_N_SAMPLES_FLOOR samples exceed the budget — refuse before ISL. */
+      kind: 'refused';
+      originalNSamples: number;
+      /** The largest depth that would fit (strictly below the floor here). */
+      fittingNSamples: number;
+      nodeEdgeProduct: number;
+      /** Largest nodes × edges product analysable at the floor depth. */
+      maxNodeEdgeProduct: number;
+      budget: number;
+    };
+
+/**
+ * Apply ISL's complexity budget to the resolved sample depth BEFORE the ISL
+ * call, using the node/edge counts of the request ISL will actually receive
+ * (causal graph: option/decision nodes filtered, bidirected edges dropped).
+ *
+ *  - complexity = nSamples × nodeCount × edgeCount; ≤ budget passes (ISL
+ *    blocks strictly above the limit);
+ *  - over budget → reduce to floor(budget / (nodes × edges)), never below
+ *    {@link ADAPTIVE_N_SAMPLES_FLOOR};
+ *  - if even the floor exceeds the budget → 'refused' (caller emits a
+ *    GRAPH_TOO_COMPLEX blocker instead of forwarding a doomed request).
+ *
+ * Applies identically to defaulted and explicit caller depths — an explicit
+ * depth is never silently overridden: the caller pairs every reduction with
+ * a SAMPLES_REDUCED_FOR_COMPLEXITY warning naming both depths.
+ */
+export function applyComplexityBudget(
+  nSamples: number,
+  nodeCount: number,
+  edgeCount: number,
+): ComplexityBudgetDecision {
+  const budget = resolveComplexityBudget();
+  const product = nodeCount * edgeCount;
+  const complexity = nSamples * product;
+
+  // Nothing to bound (degenerate graph) or already within budget.
+  if (product <= 0 || complexity <= budget) {
+    return { kind: 'unchanged', nSamples, complexity, budget };
+  }
+
+  const fittingNSamples = Math.floor(budget / product);
+  if (fittingNSamples < ADAPTIVE_N_SAMPLES_FLOOR) {
+    return {
+      kind: 'refused',
+      originalNSamples: nSamples,
+      fittingNSamples,
+      nodeEdgeProduct: product,
+      maxNodeEdgeProduct: Math.floor(budget / ADAPTIVE_N_SAMPLES_FLOOR),
+      budget,
+    };
+  }
+
+  return {
+    kind: 'reduced',
+    nSamples: fittingNSamples,
+    originalNSamples: nSamples,
+    complexity,
+    reducedComplexity: fittingNSamples * product,
+    budget,
+  };
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -123,7 +123,7 @@ import type { SeedSourceType } from '@talchain/schemas';
 import { factorReviewV2, type CEESchemaV2Config } from '../../cee/client.js';
 import { FLAGS } from '../../config/flags.js';
 import { getAllFeatureFlags } from '../../config/feature-flags.js';
-import { resolveStandardNSamples } from '../../config/sampling.js';
+import { resolveStandardNSamples, applyComplexityBudget, ADAPTIVE_N_SAMPLES_FLOOR } from '../../config/sampling.js';
 import { generateM1Coaching } from '../../coaching/m1-coaching.js';
 import { filterInterventionOverrides } from '../../coaching/sensitivity-filter.js';
 import type { M1Review } from '../../cee/validation/m1-review-types.js';
@@ -1143,6 +1143,13 @@ interface MetaParams {
   /** CIL Phase 1: Seed origin — type from @talchain/schemas SeedSource */
   seedSource: SeedSourceType;
   nSamples: number;
+  /**
+   * ROADMAP 1.54: the originally requested/default depth when nSamples was
+   * reduced to fit ISL's complexity budget. Present ONLY on reduced runs —
+   * its presence drives the SAMPLES_REDUCED_FOR_COMPLEXITY inference warning.
+   * nSamples itself is always the TRUE depth used.
+   */
+  originalNSamples?: number;
   /** Track S: sample depth used for flip probes (decoupled from nSamples). Omitted when no flip search ran. */
   flipProbeNSamples?: number;
   detailLevel: string;
@@ -2316,6 +2323,20 @@ function buildResponse(
     });
   }
 
+  // ROADMAP 1.54 (density wall): the sample depth was reduced before the ISL
+  // call so the request fits ISL's complexity budget — disclose it, naming
+  // BOTH depths. meta.n_samples (and brief/fact lineage) already report the
+  // TRUE reduced depth; this warning is what stops the reduction from being
+  // a silent override, including when the caller set n_samples explicitly.
+  if (meta.originalNSamples !== undefined && meta.originalNSamples !== meta.nSamples) {
+    inferenceWarnings.push({
+      code: INFERENCE_WARNING_CODES.SAMPLES_REDUCED_FOR_COMPLEXITY,
+      // provisional_doctrine_v0 — wording surface (diagnostic disclosure)
+      message: `Monte Carlo sample depth was reduced from ${meta.originalNSamples} to ${meta.nSamples} samples so this graph fits the analysis engine's complexity budget (sample depth × nodes × edges). All reported results were computed at ${meta.nSamples} samples; displayed probabilities may be slightly less stable than at the standard depth.`,
+      severity: 'warning',
+    });
+  }
+
   // Merge ISL-originated inference_warnings into the PLoT array.
   // ISL may return warnings like ROOT_NODE_DEFAULT_VALUE that PLoT forwards as-is.
   // Deduplicate by code to prevent equivalent warnings from both sources.
@@ -3290,7 +3311,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
       const providedSeed = body.seed;  // May be undefined - will resolve after normalization
       // Track S PR-E: standard base-analysis depth (default 4000, env-overridable
       // to 1000 via STANDARD_N_SAMPLES). An explicit request n_samples always wins.
-      const nSamples = body.n_samples ?? resolveStandardNSamples();
+      // ROADMAP 1.54: this is the REQUESTED depth — the depth actually used
+      // (`nSamples`) is finalised after preflight by applyComplexityBudget(),
+      // which may reduce it (never below ADAPTIVE_N_SAMPLES_FLOOR) so the ISL
+      // call fits ISL's complexity cap instead of drawing a raw 422.
+      const requestedNSamples = body.n_samples ?? resolveStandardNSamples();
       const detailLevel = body.detail_level ?? 'standard';
 
       // Normalize goal_threshold: null is treated as absent
@@ -3995,6 +4020,86 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         }
 
         // =================================================================
+        // Phase 2a+: Complexity budget — adaptive n_samples (ROADMAP 1.54)
+        // =================================================================
+        // ISL 422s any request whose n_samples × nodes × edges strictly
+        // exceeds its complexity cap (default 10,000,000). Fit the depth to
+        // the budget BEFORE calling ISL, using the causal counts ISL will
+        // receive: filteredGraph nodes (options/decision already filtered)
+        // and its directed edges (the translator drops bidirected edges —
+        // see toISLRobustnessRequest). Exact-duplicate edges may still be
+        // coalesced later (Phase 4b-adjacent), which only SHRINKS the edge
+        // count — so this bound is conservative, never permissive.
+        //
+        // Every later consumer of the depth — the base response hash, the
+        // ISL request, flip-probe depth resolution, meta.n_samples, and
+        // brief/fact lineage — sees the SAME post-budget value, so anything
+        // that reports n_samples reports the depth genuinely used.
+        const causalNodeCount = filteredGraph.nodes.length;
+        const causalDirectedEdgeCount = filteredGraph.edges.filter(
+          (e) => e.edge_type !== 'bidirected',
+        ).length;
+        const complexityDecision = applyComplexityBudget(
+          requestedNSamples,
+          causalNodeCount,
+          causalDirectedEdgeCount,
+        );
+
+        if (complexityDecision.kind === 'refused') {
+          // Honest structured refusal — never forward a request ISL is
+          // guaranteed to 422, and never pass that raw 422 through.
+          req.log.warn({
+            event: 'graph_too_complex_refused',
+            request_id: requestId,
+            node_count: causalNodeCount,
+            edge_count: causalDirectedEdgeCount,
+            node_edge_product: complexityDecision.nodeEdgeProduct,
+            max_node_edge_product: complexityDecision.maxNodeEdgeProduct,
+            requested_n_samples: complexityDecision.originalNSamples,
+            n_samples_floor: ADAPTIVE_N_SAMPLES_FLOOR,
+            complexity_budget: complexityDecision.budget,
+          });
+          return reply.status(422).send(buildBlockedResponse(
+            'Graph too complex to analyse',
+            [{
+              id: randomUUID(),
+              code: 'GRAPH_TOO_COMPLEX',
+              severity: 'blocker' as const,
+              message: `This graph is too complex to analyse: ${causalNodeCount} causal nodes × ${causalDirectedEdgeCount} causal edges = ${complexityDecision.nodeEdgeProduct}, above the maximum of ${complexityDecision.maxNodeEdgeProduct} the analysis engine can compute even at its minimum reliable sample depth (${ADAPTIVE_N_SAMPLES_FLOOR} samples, complexity budget ${complexityDecision.budget}). Reduce the number of nodes or edges — e.g. remove weaker or duplicate influences — and re-run.`,
+              source: 'validation' as const,
+              blocks_analysis: true,
+            }],
+            filteredGraph,
+            normalizedOptions,
+            requestId,
+            requestComputedAt,
+          ));
+        }
+
+        // Depth actually used everywhere below. When reduced, originalNSamples
+        // travels via meta so the response carries a SAMPLES_REDUCED_FOR_COMPLEXITY
+        // warning naming both depths (explicit caller depths are never silently
+        // overridden).
+        const nSamples = complexityDecision.nSamples;
+        const originalNSamples =
+          complexityDecision.kind === 'reduced' ? complexityDecision.originalNSamples : undefined;
+
+        if (complexityDecision.kind === 'reduced') {
+          req.log.info({
+            event: 'n_samples_reduced_for_complexity',
+            request_id: requestId,
+            node_count: causalNodeCount,
+            edge_count: causalDirectedEdgeCount,
+            original_n_samples: complexityDecision.originalNSamples,
+            reduced_n_samples: complexityDecision.nSamples,
+            original_complexity: complexityDecision.complexity,
+            reduced_complexity: complexityDecision.reducedComplexity,
+            complexity_budget: complexityDecision.budget,
+            n_samples_explicit: body.n_samples !== undefined,
+          });
+        }
+
+        // =================================================================
         // Phase 2b: Identifiability Assessment (B1.5)
         // =================================================================
         // WARNING only — never blocks. Silent degradation on error (returns undefined).
@@ -4100,6 +4205,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               seedUsed: plotSeedUsed,
               seedSource: providedSeed !== undefined ? 'client_generated' : 'server_generated',
               nSamples,
+              originalNSamples,
               detailLevel,
               latencyMs: totalMs,
               normalizationMs,
@@ -5633,6 +5739,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             seedUsed: plotSeedUsed,
             seedSource: providedSeed !== undefined ? 'client_generated' : 'server_generated',
             nSamples,
+            originalNSamples,
             flipProbeNSamples,
             detailLevel,
             latencyMs: finalTotalMs,

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2015,6 +2015,21 @@ export const INFERENCE_WARNING_CODES = {
    * @see src/lib/constraint-reliability.ts
    */
   CONSTRAINT_DIRECTION_SUSPECT: 'CONSTRAINT_DIRECTION_SUSPECT',
+  /**
+   * ROADMAP 1.54 (density wall): the Monte Carlo sample depth for this run
+   * was reduced before the ISL call so that the request fits ISL's
+   * complexity budget (`n_samples × nodes × edges ≤ ISL_MAX_COMPUTE_COMPLEXITY`,
+   * default 10,000,000) — previously such graphs failed outright with a raw
+   * ISL 422. The message names BOTH the originally requested/default depth
+   * and the reduced depth actually used; `meta.n_samples` (and brief/fact
+   * lineage) always report the TRUE reduced depth. Reductions never go below
+   * ADAPTIVE_N_SAMPLES_FLOOR (1,000) — graphs that cannot fit even at the
+   * floor are refused with a GRAPH_TOO_COMPLEX blocker instead (422, before
+   * ISL). Displayed probabilities may be less stable than at the standard
+   * depth (Track S ±3pp target was calibrated at 4,000). Severity: warning.
+   * @see src/config/sampling.ts applyComplexityBudget
+   */
+  SAMPLES_REDUCED_FOR_COMPLEXITY: 'SAMPLES_REDUCED_FOR_COMPLEXITY',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];

--- a/tests/adaptive-n-samples-complexity.test.ts
+++ b/tests/adaptive-n-samples-complexity.test.ts
@@ -168,12 +168,17 @@ vi.mock('../src/integrations/isl/index.ts', async () => {
 import { createServer } from '../src/createServer.js';
 
 /**
- * Build a fully-connected star graph: `factorCount` factors, each with a
- * directed edge into a single goal node. Causal size seen by ISL:
- * (factorCount + 1) nodes × factorCount edges.
- * Small strength means keep the inbound-strength-sum warning quiet.
+ * Build a dense DAG within PLoT's own graph limits (50 nodes / 100 edges,
+ * @talchain/schemas LIMITS — preflight blocks anything larger with
+ * GRAPH_TOO_LARGE before this lane's guard runs): `factorCount` factors,
+ * each with a directed edge into a single goal node, plus a factor chain
+ * factor-i → factor-(i+1). Causal size seen by ISL:
+ * (factorCount + 1) nodes × (2 × factorCount − 1) edges.
+ * denseGraph(43) → 44 × 85 = 3,740 — the same density regime as the
+ * verified live failure (43 × 70 causal, attempt 6). Small strength means
+ * keep the inbound-strength-sum warning quiet.
  */
-function starGraph(factorCount: number) {
+function denseGraph(factorCount: number) {
   const factors = Array.from({ length: factorCount }, (_, i) => ({
     id: `factor-${i}`,
     kind: 'factor',
@@ -181,12 +186,20 @@ function starGraph(factorCount: number) {
     observed_state: { value: 0.5 },
   }));
   const goal = { id: 'goal', kind: 'goal', label: 'Goal' };
-  const edges = factors.map((f) => ({
-    from: f.id,
-    to: 'goal',
-    exists_probability: 0.8,
-    strength: { mean: 0.005, std: 0.01 },
-  }));
+  const edges = [
+    ...factors.map((f) => ({
+      from: f.id,
+      to: 'goal',
+      exists_probability: 0.8,
+      strength: { mean: 0.005, std: 0.01 },
+    })),
+    ...factors.slice(0, -1).map((f, i) => ({
+      from: f.id,
+      to: `factor-${i + 1}`,
+      exists_probability: 0.8,
+      strength: { mean: 0.005, std: 0.01 },
+    })),
+  ];
   return { nodes: [...factors, goal], edges };
 }
 
@@ -221,13 +234,13 @@ describe('adaptive n_samples via /v2/run', () => {
 
   it('dense graph: reduces n_samples before calling ISL and attaches SAMPLES_REDUCED_FOR_COMPLEXITY naming original and reduced depths', async () => {
     islCalls = [];
-    // 51 factors + goal = 52 nodes, 51 edges → 4000 × 2652 = 10,608,000 > 10M
+    // 43 factors + goal = 44 nodes, 85 edges → 4000 × 3,740 = 14,960,000 > 10M
     const res = await app.inject({
       method: 'POST',
       url: '/v2/run',
       headers: { 'Content-Type': 'application/json' },
       payload: {
-        graph: starGraph(51),
+        graph: denseGraph(43),
         options: OPTIONS,
         goal_node_id: 'goal',
         seed: '42',
@@ -236,11 +249,11 @@ describe('adaptive n_samples via /v2/run', () => {
 
     expect(res.statusCode).toBe(200);
 
-    // ISL received the reduced depth — floor(10,000,000 / (52 × 51)) = 3,770
+    // ISL received the reduced depth — floor(10,000,000 / (44 × 85)) = 2,673
     expect(islCalls.length).toBeGreaterThan(0);
-    expect(islCalls[0].graph.nodes).toHaveLength(52);
-    expect(islCalls[0].graph.edges).toHaveLength(51);
-    expect(islCalls[0].n_samples).toBe(3770);
+    expect(islCalls[0].graph.nodes).toHaveLength(44);
+    expect(islCalls[0].graph.edges).toHaveLength(85);
+    expect(islCalls[0].n_samples).toBe(2673);
     // No ISL call of any kind (base or probe) may breach the budget.
     for (const call of islCalls) {
       expect(call.n_samples * call.graph.nodes.length * call.graph.edges.length)
@@ -249,7 +262,7 @@ describe('adaptive n_samples via /v2/run', () => {
 
     const body = JSON.parse(res.body);
     // The response reports the TRUE depth used, not the requested default.
-    expect(body.meta?.n_samples).toBe(3770);
+    expect(body.meta?.n_samples).toBe(2673);
 
     // Exactly one warning, carried on the inference_warnings surface
     // (the CONSTRAINT_DIRECTION_SUSPECT pattern), naming both depths.
@@ -257,38 +270,51 @@ describe('adaptive n_samples via /v2/run', () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0].severity).toBe('warning');
     expect(warnings[0].message).toContain('4000');
-    expect(warnings[0].message).toContain('3770');
+    expect(warnings[0].message).toContain('2673');
   });
 
-  it('ultra-dense graph: refuses with GRAPH_TOO_COMPLEX before calling ISL — never a raw ISL 422 passthrough', async () => {
+  it('graph too complex even at the floor: refuses with GRAPH_TOO_COMPLEX before calling ISL — never a raw ISL 422 passthrough', async () => {
+    // At the DEFAULT budget the refusal arm needs nodes × edges > 10,000,
+    // which PLoT's own 50-node/100-edge graph limits keep out of reach
+    // (max product 5,000) — preflight GRAPH_TOO_LARGE fires first. The arm
+    // is live protection for a lowered ISL_MAX_COMPUTE_COMPLEXITY (the env
+    // both services read) and for future graph-limit raises, so exercise it
+    // here the way it would really fire: same env, lower budget. The
+    // >10,000-at-default arithmetic is covered by the unit tests above.
     islCalls = [];
-    // 101 factors + goal = 102 nodes, 101 edges → 10,302 > 10,000: even
-    // 1,000 samples would breach the budget (1,000 × 10,302 = 10,302,000).
-    const res = await app.inject({
-      method: 'POST',
-      url: '/v2/run',
-      headers: { 'Content-Type': 'application/json' },
-      payload: {
-        graph: starGraph(101),
-        options: OPTIONS,
-        goal_node_id: 'goal',
-        seed: '42',
-      },
-    });
+    const prev = process.env.ISL_MAX_COMPUTE_COMPLEXITY;
+    try {
+      // 44 × 85 = 3,740; fitting depth floor(1,000,000 / 3,740) = 267 < 1,000.
+      process.env.ISL_MAX_COMPUTE_COMPLEXITY = '1000000';
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v2/run',
+        headers: { 'Content-Type': 'application/json' },
+        payload: {
+          graph: denseGraph(43),
+          options: OPTIONS,
+          goal_node_id: 'goal',
+          seed: '42',
+        },
+      });
 
-    expect(res.statusCode).toBe(422);
-    const body = JSON.parse(res.body);
-    expect(body.analysis_status).toBe('blocked');
-    const critique = (body.critiques ?? []).find((c: any) => c.code === 'GRAPH_TOO_COMPLEX');
-    expect(critique).toBeDefined();
-    expect(critique.severity).toBe('blocker');
-    expect(critique.blocks_analysis).toBe(true);
-    // Actionable: names the causal size and the budget so the caller can act.
-    expect(critique.message).toMatch(/102/);
-    expect(critique.message).toMatch(/101/);
+      expect(res.statusCode).toBe(422);
+      const body = JSON.parse(res.body);
+      expect(body.analysis_status).toBe('blocked');
+      const critique = (body.critiques ?? []).find((c: any) => c.code === 'GRAPH_TOO_COMPLEX');
+      expect(critique).toBeDefined();
+      expect(critique.severity).toBe('blocker');
+      expect(critique.blocks_analysis).toBe(true);
+      // Actionable: names the causal size and the budget so the caller can act.
+      expect(critique.message).toMatch(/44/);
+      expect(critique.message).toMatch(/85/);
 
-    // ISL was NEVER called — the refusal is PLoT-originated, not a passthrough.
-    expect(islCalls).toHaveLength(0);
+      // ISL was NEVER called — the refusal is PLoT-originated, not a passthrough.
+      expect(islCalls).toHaveLength(0);
+    } finally {
+      if (prev === undefined) delete process.env.ISL_MAX_COMPUTE_COMPLEXITY;
+      else process.env.ISL_MAX_COMPUTE_COMPLEXITY = prev;
+    }
   });
 
   it('normal graph: default depth passes through untouched with no reduction warning', async () => {
@@ -298,7 +324,7 @@ describe('adaptive n_samples via /v2/run', () => {
       url: '/v2/run',
       headers: { 'Content-Type': 'application/json' },
       payload: {
-        graph: starGraph(2), // 3 nodes × 2 edges → 4000 × 6 = 24,000
+        graph: denseGraph(2), // 3 nodes × 3 edges → 4000 × 9 = 36,000
         options: OPTIONS,
         goal_node_id: 'goal',
         seed: '42',
@@ -319,7 +345,7 @@ describe('adaptive n_samples via /v2/run', () => {
       url: '/v2/run',
       headers: { 'Content-Type': 'application/json' },
       payload: {
-        graph: starGraph(51), // 52 × 51 = 2,652 → floor(10M / 2,652) = 3,770
+        graph: denseGraph(43), // 44 × 85 = 3,740 → floor(10M / 3,740) = 2,673
         options: OPTIONS,
         goal_node_id: 'goal',
         seed: '42',
@@ -328,13 +354,13 @@ describe('adaptive n_samples via /v2/run', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(islCalls[0].n_samples).toBe(3770);
+    expect(islCalls[0].n_samples).toBe(2673);
     const body = JSON.parse(res.body);
-    expect(body.meta?.n_samples).toBe(3770);
+    expect(body.meta?.n_samples).toBe(2673);
     const warnings = findSamplesReducedWarnings(body);
     expect(warnings).toHaveLength(1);
     expect(warnings[0].message).toContain('8000');
-    expect(warnings[0].message).toContain('3770');
+    expect(warnings[0].message).toContain('2673');
   });
 
   it('explicit caller n_samples within budget is respected exactly, with no warning', async () => {
@@ -344,7 +370,7 @@ describe('adaptive n_samples via /v2/run', () => {
       url: '/v2/run',
       headers: { 'Content-Type': 'application/json' },
       payload: {
-        graph: starGraph(2),
+        graph: denseGraph(2),
         options: OPTIONS,
         goal_node_id: 'goal',
         seed: '42',

--- a/tests/adaptive-n-samples-complexity.test.ts
+++ b/tests/adaptive-n-samples-complexity.test.ts
@@ -1,0 +1,361 @@
+/**
+ * ROADMAP 1.54 — Adaptive n_samples vs the ISL complexity cap (density wall).
+ *
+ * ISL enforces `n_samples × nodes × edges ≤ ISL_MAX_COMPUTE_COMPLEXITY`
+ * (default 10,000,000) and returns a raw 422 when exceeded
+ * (Inference-Service-Layer src/api/robustness.py — strict `>` comparison on
+ * the request's node/edge array lengths). PLoT's standard depth is 4,000, so
+ * any causal graph with nodes × edges > 2,500 hit the wall on the live path
+ * (verified: acceptance-evidence/dense-graph-test attempt 6, 43×70 causal =
+ * 12,040,000 > 10,000,000).
+ *
+ * The fix (binding design):
+ *  1. ADAPTIVE: before calling ISL, if n_samples × nodes × edges exceeds the
+ *     budget, reduce n_samples to floor(budget / (nodes × edges)).
+ *  2. WARN: attach SAMPLES_REDUCED_FOR_COMPLEXITY (inference_warnings, the
+ *     CONSTRAINT_DIRECTION_SUSPECT carrier pattern) naming original and
+ *     reduced depths.
+ *  3. FLOOR + REFUSE: never send below 1,000 samples. If even 1,000 exceeds
+ *     the budget (nodes × edges > 10,000) refuse BEFORE calling ISL with a
+ *     GRAPH_TOO_COMPLEX blocker (422) — never a raw ISL 422 passthrough.
+ *  4. Explicit caller n_samples gets the same treatment (reduce + warn, or
+ *     refuse) — never silently overridden without the warning.
+ *  5. Anywhere the response reports n_samples, it reports the TRUE depth used.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import {
+  applyComplexityBudget,
+  resolveComplexityBudget,
+  ISL_COMPLEXITY_BUDGET_DEFAULT,
+  ADAPTIVE_N_SAMPLES_FLOOR,
+} from '../src/config/sampling.js';
+
+// ---------------------------------------------------------------------------
+// Unit tests — applyComplexityBudget
+// ---------------------------------------------------------------------------
+
+describe('applyComplexityBudget (unit)', () => {
+  it('leaves depth unchanged when complexity is within the ISL budget', () => {
+    // 4000 × 3 × 2 = 24,000 ≪ 10,000,000
+    const d = applyComplexityBudget(4000, 3, 2);
+    expect(d.kind).toBe('unchanged');
+    if (d.kind === 'unchanged') expect(d.nSamples).toBe(4000);
+  });
+
+  it('allows complexity exactly at the budget (ISL blocks only strictly above the limit)', () => {
+    // 1000 × 100 × 100 = 10,000,000 == budget → allowed, unchanged
+    const d = applyComplexityBudget(1000, 100, 100);
+    expect(d.kind).toBe('unchanged');
+  });
+
+  it('reduces depth to floor(budget / (nodes × edges)) when over budget', () => {
+    // 4000 × 52 × 51 = 10,608,000 > 10,000,000
+    // floor(10,000,000 / 2,652) = 3,770 → 3,770 × 2,652 = 9,998,040 ≤ budget
+    const d = applyComplexityBudget(4000, 52, 51);
+    expect(d.kind).toBe('reduced');
+    if (d.kind === 'reduced') {
+      expect(d.nSamples).toBe(3770);
+      expect(d.originalNSamples).toBe(4000);
+      expect(d.nSamples * 52 * 51).toBeLessThanOrEqual(ISL_COMPLEXITY_BUDGET_DEFAULT);
+      // One more sample would breach the budget — maximal honest depth.
+      expect((d.nSamples + 1) * 52 * 51).toBeGreaterThan(ISL_COMPLEXITY_BUDGET_DEFAULT);
+    }
+  });
+
+  it('reduces to exactly the 1,000-sample floor when that is what fits', () => {
+    // nodes × edges = 10,000 → floor(10,000,000 / 10,000) = 1,000 == floor
+    const d = applyComplexityBudget(4000, 100, 100);
+    expect(d.kind).toBe('reduced');
+    if (d.kind === 'reduced') expect(d.nSamples).toBe(ADAPTIVE_N_SAMPLES_FLOOR);
+  });
+
+  it('refuses when even the 1,000-sample floor exceeds the budget', () => {
+    // nodes × edges = 10,302 → floor(10,000,000 / 10,302) = 970 < 1,000
+    const d = applyComplexityBudget(4000, 102, 101);
+    expect(d.kind).toBe('refused');
+  });
+
+  it('respects an explicit low depth that already fits (no raise, no reduction)', () => {
+    // 500 × 100 × 150 = 7,500,000 ≤ budget — even though nodes × edges > 10,000
+    // would refuse AT the floor, the caller's smaller explicit depth fits as-is.
+    const d = applyComplexityBudget(500, 100, 150);
+    expect(d.kind).toBe('unchanged');
+    if (d.kind === 'unchanged') expect(d.nSamples).toBe(500);
+  });
+
+  it('refuses an explicit depth whose graph cannot fit even at the floor', () => {
+    // 1500 × 102 × 101 = 15,453,000 > budget; fitting depth 970 < floor → refuse
+    const d = applyComplexityBudget(1500, 102, 101);
+    expect(d.kind).toBe('refused');
+  });
+
+  it('treats a zero node/edge product as unchanged (nothing to bound)', () => {
+    const d = applyComplexityBudget(4000, 5, 0);
+    expect(d.kind).toBe('unchanged');
+  });
+
+  it('honours the ISL_MAX_COMPUTE_COMPLEXITY env override at call time', () => {
+    const prev = process.env.ISL_MAX_COMPUTE_COMPLEXITY;
+    try {
+      process.env.ISL_MAX_COMPUTE_COMPLEXITY = '20000000';
+      expect(resolveComplexityBudget()).toBe(20_000_000);
+      // 4000 × 52 × 51 = 10,608,000 ≤ 20,000,000 → unchanged under the raised budget
+      expect(applyComplexityBudget(4000, 52, 51).kind).toBe('unchanged');
+    } finally {
+      if (prev === undefined) delete process.env.ISL_MAX_COMPUTE_COMPLEXITY;
+      else process.env.ISL_MAX_COMPUTE_COMPLEXITY = prev;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route-level tests: /v2/run with a mocked ISL service
+// (harness mirrors tests/duplicate-edge-preflight.test.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Every ISL call body, in order. The BASE analysis call is always first;
+ * flip-threshold probes (their own decoupled depth) follow it — so base-call
+ * assertions must read islCalls[0], never the last call.
+ */
+let islCalls: any[] = [];
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    islCalls.push(body);
+    const options = body.options || [];
+    return {
+      data: {
+        analysis_status: 'computed',
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.6 + idx * 0.1, std: 0.05, p10: 0.4, p50: 0.6, p90: 0.8, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+          win_probability: idx === 0 ? 0.7 : 0.3,
+          status: 'computed',
+        })),
+        factor_sensitivity: [],
+        robustness: { confidence: 0.8, level: 'high', is_robust: true, fragile_edges: [], robust_edges: [] },
+        inference_warnings: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+/**
+ * Build a fully-connected star graph: `factorCount` factors, each with a
+ * directed edge into a single goal node. Causal size seen by ISL:
+ * (factorCount + 1) nodes × factorCount edges.
+ * Small strength means keep the inbound-strength-sum warning quiet.
+ */
+function starGraph(factorCount: number) {
+  const factors = Array.from({ length: factorCount }, (_, i) => ({
+    id: `factor-${i}`,
+    kind: 'factor',
+    label: `Factor ${i}`,
+    observed_state: { value: 0.5 },
+  }));
+  const goal = { id: 'goal', kind: 'goal', label: 'Goal' };
+  const edges = factors.map((f) => ({
+    from: f.id,
+    to: 'goal',
+    exists_probability: 0.8,
+    strength: { mean: 0.005, std: 0.01 },
+  }));
+  return { nodes: [...factors, goal], edges };
+}
+
+const OPTIONS = [
+  { id: 'opt-a', label: 'Option A', interventions: { 'factor-0': { value: 0.8, source: 'user_specified' } } },
+  { id: 'opt-b', label: 'Option B', interventions: { 'factor-1': { value: 0.7, source: 'user_specified' } } },
+];
+
+function findSamplesReducedWarnings(body: any): any[] {
+  return (body.inference_warnings ?? []).filter(
+    (w: any) => w.code === 'SAMPLES_REDUCED_FOR_COMPLEXITY',
+  );
+}
+
+describe('adaptive n_samples via /v2/run', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    delete process.env.STANDARD_N_SAMPLES;
+    delete process.env.ISL_MAX_COMPUTE_COMPLEXITY;
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('dense graph: reduces n_samples before calling ISL and attaches SAMPLES_REDUCED_FOR_COMPLEXITY naming original and reduced depths', async () => {
+    islCalls = [];
+    // 51 factors + goal = 52 nodes, 51 edges → 4000 × 2652 = 10,608,000 > 10M
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: {
+        graph: starGraph(51),
+        options: OPTIONS,
+        goal_node_id: 'goal',
+        seed: '42',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    // ISL received the reduced depth — floor(10,000,000 / (52 × 51)) = 3,770
+    expect(islCalls.length).toBeGreaterThan(0);
+    expect(islCalls[0].graph.nodes).toHaveLength(52);
+    expect(islCalls[0].graph.edges).toHaveLength(51);
+    expect(islCalls[0].n_samples).toBe(3770);
+    // No ISL call of any kind (base or probe) may breach the budget.
+    for (const call of islCalls) {
+      expect(call.n_samples * call.graph.nodes.length * call.graph.edges.length)
+        .toBeLessThanOrEqual(ISL_COMPLEXITY_BUDGET_DEFAULT);
+    }
+
+    const body = JSON.parse(res.body);
+    // The response reports the TRUE depth used, not the requested default.
+    expect(body.meta?.n_samples).toBe(3770);
+
+    // Exactly one warning, carried on the inference_warnings surface
+    // (the CONSTRAINT_DIRECTION_SUSPECT pattern), naming both depths.
+    const warnings = findSamplesReducedWarnings(body);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].severity).toBe('warning');
+    expect(warnings[0].message).toContain('4000');
+    expect(warnings[0].message).toContain('3770');
+  });
+
+  it('ultra-dense graph: refuses with GRAPH_TOO_COMPLEX before calling ISL — never a raw ISL 422 passthrough', async () => {
+    islCalls = [];
+    // 101 factors + goal = 102 nodes, 101 edges → 10,302 > 10,000: even
+    // 1,000 samples would breach the budget (1,000 × 10,302 = 10,302,000).
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: {
+        graph: starGraph(101),
+        options: OPTIONS,
+        goal_node_id: 'goal',
+        seed: '42',
+      },
+    });
+
+    expect(res.statusCode).toBe(422);
+    const body = JSON.parse(res.body);
+    expect(body.analysis_status).toBe('blocked');
+    const critique = (body.critiques ?? []).find((c: any) => c.code === 'GRAPH_TOO_COMPLEX');
+    expect(critique).toBeDefined();
+    expect(critique.severity).toBe('blocker');
+    expect(critique.blocks_analysis).toBe(true);
+    // Actionable: names the causal size and the budget so the caller can act.
+    expect(critique.message).toMatch(/102/);
+    expect(critique.message).toMatch(/101/);
+
+    // ISL was NEVER called — the refusal is PLoT-originated, not a passthrough.
+    expect(islCalls).toHaveLength(0);
+  });
+
+  it('normal graph: default depth passes through untouched with no reduction warning', async () => {
+    islCalls = [];
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: {
+        graph: starGraph(2), // 3 nodes × 2 edges → 4000 × 6 = 24,000
+        options: OPTIONS,
+        goal_node_id: 'goal',
+        seed: '42',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(islCalls[0].n_samples).toBe(4000);
+    const body = JSON.parse(res.body);
+    expect(body.meta?.n_samples).toBe(4000);
+    expect(findSamplesReducedWarnings(body)).toHaveLength(0);
+  });
+
+  it('explicit caller n_samples over budget is reduced with the warning — not silently overridden', async () => {
+    islCalls = [];
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: {
+        graph: starGraph(51), // 52 × 51 = 2,652 → floor(10M / 2,652) = 3,770
+        options: OPTIONS,
+        goal_node_id: 'goal',
+        seed: '42',
+        n_samples: 8000,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(islCalls[0].n_samples).toBe(3770);
+    const body = JSON.parse(res.body);
+    expect(body.meta?.n_samples).toBe(3770);
+    const warnings = findSamplesReducedWarnings(body);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain('8000');
+    expect(warnings[0].message).toContain('3770');
+  });
+
+  it('explicit caller n_samples within budget is respected exactly, with no warning', async () => {
+    islCalls = [];
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: {
+        graph: starGraph(2),
+        options: OPTIONS,
+        goal_node_id: 'goal',
+        seed: '42',
+        n_samples: 8000,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(islCalls[0].n_samples).toBe(8000);
+    const body = JSON.parse(res.body);
+    expect(body.meta?.n_samples).toBe(8000);
+    expect(findSamplesReducedWarnings(body)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## ROADMAP 1.54 — density wall: adaptive n_samples + honest refusal at the ISL complexity cap

### Problem (verified live)

ISL rejects any robustness request whose `n_samples × nodes × edges` strictly exceeds its complexity cap (`ISL_MAX_COMPUTE_COMPLEXITY`, default **10,000,000** — `Inference-Service-Layer/src/api/robustness.py`). PLoT's standard depth is **4,000**, so every causal graph with `nodes × edges > 2,500` failed outright with a **raw ISL 422 passthrough** on the live CEE→PLoT→ISL path. Verified on staging (acceptance-evidence/dense-graph-test, attempt 6): a valid 48n/90e graph → 43×70 causal → `4000 × 3010 = 12,040,000` → 422, while the same graph computes fine at lower depths.

### Fix (agreed design, implemented verbatim)

Applied in `/v2/run` **after preflight, before the ISL call**, on the causal counts ISL actually receives (option/decision nodes filtered, bidirected edges dropped — mirroring `toISLRobustnessRequest`):

1. **Adaptive sampling** — if `n_samples × nodes × edges` exceeds the budget, reduce `n_samples` to `floor(budget / (nodes × edges))` (`applyComplexityBudget`, `src/config/sampling.ts`). Budget mirrors ISL via the **same env var name** (`ISL_MAX_COMPUTE_COMPLEXITY`, strictly parsed, call-time) so ops can keep both services in lock-step.
2. **Warning** — every reduction attaches `SAMPLES_REDUCED_FOR_COMPLEXITY` to `inference_warnings` (the PR #208 `CONSTRAINT_DIRECTION_SUSPECT` carrier pattern), naming **both** the original and reduced depths. Explicit caller `n_samples` gets the same treatment — never silently overridden.
3. **Floor + refusal** — reductions never go below **1,000 samples**. A graph that cannot fit even at the floor is refused **before ISL** with a structured `GRAPH_TOO_COMPLEX` blocker (422, `buildBlockedResponse` pattern, actionable message naming the causal size and the computable maximum) — never a raw 422 passthrough.
4. **True reporting** — the reduced depth is resolved before every downstream consumer (ISL request, response hash, flip-probe depth, `meta.n_samples`, brief/fact lineage), so anything that reports `n_samples` reports the depth genuinely used. Flip probes (`min(1000, base)`) can therefore never breach the budget either.

Effect at current defaults: the analysable causal density rises from `nodes × edges ≤ 2,500` to `≤ 10,000` — the full range reachable under PLoT's own graph limits (50 nodes / 100 edges → max product 5,000) now analyses instead of failing. The refusal arm is defence-in-depth for lowered env budgets and future graph-limit raises.

### Wire shape — additive only

- Zero changes to `openapi/`, `contracts/`, `schemas/`, `sdk/` (verified: empty diff). The two new codes ride existing **open string vocabularies** (`InferenceWarning.code`, `CritiqueV3.code` — open in the hand-authored OpenAPI spec and `.passthrough()` in @talchain/schemas 0.14.0), so no consumer on any pinned schema version breaks.
- No new response fields. `meta.n_samples` semantics unchanged (still "depth used" — now guaranteed true under reduction).

### Discipline

- **RED-first**: failing tests committed (`21acdbd`) before the implementation commit — 12/14 red, the 2 passing being the no-op baselines.
- Fresh worktree off `origin/staging` (9e569cd9).
- New tests (unit + route-level with mocked ISL, `tests/adaptive-n-samples-complexity.test.ts`): dense graph → reduced depth + warning; refusal → 422 `GRAPH_TOO_COMPLEX` with ISL never called; normal graph → untouched, no warning; explicit caller depth reduced-with-warning / respected-when-fits; exact-budget boundary; floor boundary; env override. Route-level refusal is exercised via a lowered `ISL_MAX_COMPUTE_COMPLEXITY` because PLoT's own `GRAPH_TOO_LARGE` preflight (50/100 canonical limits) keeps `nodes × edges > 10,000` from reaching the guard at the default budget; the default-budget refusal arithmetic is unit-covered.
- Known pre-existing CI reds tolerated exactly: `audit` (fast-uri/fastify advisories) and `gates (windows-latest)` (invalid path `tools/sdk-smoke:python.mjs`). Everything else green.
- `tools/bakeoff-v6` and `tools/edge-stability` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
