### PR TITLE
feat(v2): typed failure envelope for /v2/run — discriminating failure codes, revived ISL-422 passthrough, error.v1 unknown-field 400 (fragility gaps 1/2/3/6/8)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4055,6 +4055,30 @@ paths:
         - IDENTICAL_OPTIONS
         - GRAPH_CYCLE_DETECTED
         - GRAPH_TOO_LARGE (max 50 nodes, 100 edges)
+        - MISSING_GOAL_NODE
+        - GOAL_NODE_NOT_CAUSAL (goal is an option/decision node)
+        - TOO_MANY_OPTIONS
+        - TOO_MANY_CONSTRAINTS
+        - GRAPH_TOO_COMPLEX (node×edge product above the analysis complexity cap)
+        - DUPLICATE_EDGE_CONFLICT (same-relationship edges with divergent values)
+        - INVALID_NODE_ID_PATTERN
+        - INVALID_EDGE_ENDPOINT
+        - DUPLICATE_NODE_IDS
+        - IDENTIFIABILITY_ISSUE
+        - ISL_CANNOT_IDENTIFY (ISL-originated 422 critiques passed through)
+        - ISL_REQUEST_INVALID
+        - NORMALIZATION_ERROR
+        - CONSTRAINT_TARGET_NOT_FOUND / CONSTRAINT_TARGET_NOT_IN_INFERENCE / CONSTRAINT_INVALID_OPERATOR / CONSTRAINT_DUPLICATE_ID
+        - NOMINAL_INTERVENTION_NOT_SUPPORTED / ONE_HOT_MUTEX_VIOLATION / ONE_HOT_GROUPING_INCONSISTENT (categorical integrity)
+
+        **Failure classes (HTTP 200, analysis_status='failed')**:
+        Infrastructure failures return HTTP 200 with a discriminating critique carried
+        alongside the legacy ISL_CALL_FAILED critique (kept for back-compat):
+        - ISL_TIMEOUT (retryable) — analysis service timed out
+        - ISL_NETWORK_ERROR (retryable) — analysis service unreachable
+        - ISL_ERROR (retryable per status) — analysis service returned an HTTP error
+        - ISL_REJECTED (not retryable) — ISL 422 without parseable critiques
+        - PLOT_INTERNAL_ERROR (retryable) — unexpected internal error inside the handler; critiques[] is never empty
       requestBody:
         required: true
         content:
@@ -4227,6 +4251,48 @@ paths:
                         affected_option_ids: ["option_bad"]
                         affected_node_ids: ["nonexistent_node"]
                         blocks_analysis: true
+        '401':
+          description: Unauthorized - Bearer token required (emitted only when AUTH_ENABLED=1 and AUTH_V2_ENABLED=1; both default off)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorV1'
+        '403':
+          description: Forbidden - Bearer token not recognised (emitted only when AUTH_ENABLED=1 and AUTH_V2_ENABLED=1; both default off)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorV1'
+        '413':
+          description: Payload Too Large - request body exceeds the endpoint body limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorV1'
+        '429':
+          description: Too Many Requests - rate limited (retryable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorV1'
+        '500':
+          description: Internal Server Error - unexpected failure outside the /v2/run handler. Inside the handler, internal errors return HTTP 200 with analysis_status='failed' and a PLOT_INTERNAL_ERROR critique.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorV1'
+        '503':
+          description: Service Unavailable - circuit breaker open (retryable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorV1'
+        '504':
+          description: Gateway Timeout - request timed out (retryable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorV1'
 
 
 components:
@@ -6536,6 +6602,19 @@ components:
             - GRAPH_CYCLE_DETECTED: Graph contains cycles
             - IDENTIFIABILITY_ISSUE: Causal model cannot be identified
             - ISL_CANNOT_IDENTIFY: ISL layer cannot identify effect
+            - GRAPH_TOO_COMPLEX: Node×edge product above the analysis complexity cap
+            - DUPLICATE_EDGE_CONFLICT: Same-relationship edges with divergent values
+            - TOO_MANY_CONSTRAINTS: Constraint count exceeds the limit
+            - ISL_REQUEST_INVALID: Analysis request rejected before dispatch
+            - NORMALIZATION_ERROR: Model could not be normalised
+
+            Failure-class codes (HTTP 200, analysis_status='failed'):
+            - ISL_CALL_FAILED: Legacy generic ISL failure (kept for back-compat)
+            - ISL_TIMEOUT: Analysis service timed out
+            - ISL_NETWORK_ERROR: Analysis service unreachable
+            - ISL_ERROR: Analysis service returned an HTTP error
+            - ISL_REJECTED: ISL 422 without parseable critiques
+            - PLOT_INTERNAL_ERROR: Unexpected internal error (critiques[] never empty)
         severity:
           type: string
           enum: [info, warning, error, blocker]
@@ -6551,7 +6630,7 @@ components:
             keyed by critique code. Falls back to a generic message for unrecognised codes.
         source:
           type: string
-          enum: [validation, isl]
+          enum: [validation, engine, cee, isl]
         affected_option_ids:
           type: array
           items:

--- a/src/critique-humaniser.ts
+++ b/src/critique-humaniser.ts
@@ -199,6 +199,24 @@ export const TEMPLATE_MAP: Record<string, TemplateEntry> = {
   ISL_ERROR:
     'The analysis engine encountered an error. Please try again.',
 
+  ISL_TIMEOUT:
+    'The analysis took too long and timed out. This is usually temporary — try running it again.',
+
+  ISL_NETWORK_ERROR:
+    'We could not reach the analysis service. Try again shortly — if this keeps happening, the service may be down.',
+
+  ISL_REJECTED:
+    'The analysis service rejected this request, so the analysis could not run. Adjust the model and try again.',
+
+  PLOT_INTERNAL_ERROR:
+    'Something went wrong on our side while preparing the analysis. Your model is unaffected — try running the analysis again.',
+
+  GRAPH_TOO_COMPLEX:
+    'This model is too complex to analyse reliably. Reduce the number of factors or connections and re-run.',
+
+  DUPLICATE_EDGE_CONFLICT:
+    'The model has duplicate connections between the same factors with conflicting values. Keep one connection per relationship.',
+
   OPTION_ID_MISMATCH: (c, g, opts) => {
     const label = resolveOptionLabel(
       c.affected_option_ids?.[0] ?? c.affected_node_ids?.[0], opts, g,

--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -18,7 +18,8 @@
  */
 
 import { ISLClient, getISLClientConfig } from './client.js';
-import { ISLTimeoutError, ISLNetworkError, isRetryableError } from './errors.js';
+import { ISLTimeoutError, ISLNetworkError, ISLHttpError, isRetryableError } from './errors.js';
+import type { ISLCritique } from './errors.js';
 import {
   adaptValidationResponse,
   createFallbackValidation,
@@ -86,6 +87,10 @@ export interface ISLAnalysisResult<T> {
     code: string;
     message: string;
     retryable: boolean;
+    /** HTTP status from ISL when the failure was an HTTP-level rejection */
+    status?: number;
+    /** Structured critiques from an ISL 422 (V2/V1/Pydantic formats normalised) */
+    critiques?: ISLCritique[];
   };
   /** Request latency in milliseconds */
   latency_ms: number;
@@ -656,23 +661,32 @@ export function createISLService(): ISLService {
         const err = error as Error;
         const isTimeout = err instanceof ISLTimeoutError;
         const isNetwork = err instanceof ISLNetworkError;
+        const httpError = error instanceof ISLHttpError ? error : undefined;
 
         logError(`isl_analysis_failed:${endpoint}`, error, requestId);
 
-        // Determine error code based on error type
+        // Determine error code based on error type. HTTP-level rejections keep
+        // their status (and 422 critiques) so callers can discriminate instead
+        // of collapsing every failure class into one generic code.
         let code = 'ISL_ERROR';
         if (isTimeout) {
           code = 'ISL_TIMEOUT';
         } else if (isNetwork) {
           code = 'ISL_NETWORK_ERROR';
+        } else if (httpError?.is422()) {
+          code = 'ISL_REJECTED';
         }
+
+        const critiques = httpError?.is422() ? httpError.getCritiques() : undefined;
 
         return {
           data: null,
           error: {
             code,
-            message: err.message || 'ISL analysis request failed',
+            message: (httpError?.is422() ? httpError.getErrorMessage() : err.message) || 'ISL analysis request failed',
             retryable: isRetryableError(error),
+            ...(httpError ? { status: httpError.status } : {}),
+            ...(critiques && critiques.length > 0 ? { critiques } : {}),
           },
           latency_ms: Date.now() - startMs,
           isl_echoed_request_id: (err as any).islEchoedRequestId ?? null,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -89,6 +89,8 @@ import {
 } from '../../logging/preflight-logger.js';
 import { getISLService } from '../../integrations/isl/index.js';
 import { ISLHttpError } from '../../integrations/isl/errors.js';
+import type { ISLCritique } from '../../integrations/isl/errors.js';
+import { errorResponse } from '../../errors.js';
 import { buildRobustnessDataForCee } from '../../integrations/isl/adapters/robustness-enrichment.js';
 import {
   normalizeFragileEdges,
@@ -1266,6 +1268,45 @@ function buildBlockedResponse(
     computedAt,
     critiques: addUserMessages(critiques, graph, options),
   });
+}
+
+/**
+ * Honest per-class failure detail for ISL infrastructure failures
+ * (fragility gap 2, FRAGILITY-PAIR-FINDINGS-2026-07-10): the discriminating
+ * code computed by callAnalysisEndpoint reaches the wire as a critique
+ * instead of being discarded, so consumers can distinguish "service down,
+ * retry" from "request rejected, don't retry". Codes not listed here
+ * (e.g. ISL_NOT_ENABLED) keep the legacy response byte-identically.
+ */
+function buildIslFailureDetail(
+  error: { code: string; message: string; status?: number } | undefined,
+): { statusReason: string; critique?: CritiqueV3 } {
+  // user_message copy lives in the critique-humaniser TEMPLATE_MAP (single
+  // source, coverage-tested) — callers run the critique through addUserMessages.
+  const classStatusReasons: Record<string, string> = {
+    ISL_TIMEOUT: 'The analysis service timed out before returning a result.',
+    ISL_NETWORK_ERROR: 'The analysis service is unreachable.',
+    ISL_ERROR: 'The analysis service returned an error.',
+    ISL_REJECTED: 'The analysis service rejected this request.',
+  };
+  const classStatusReason = error ? classStatusReasons[error.code] : undefined;
+  if (!error || !classStatusReason) {
+    return { statusReason: 'ISL analysis failed' };
+  }
+  const statusReason = error.code === 'ISL_ERROR' && error.status
+    ? `The analysis service returned an error (HTTP ${error.status}).`
+    : classStatusReason;
+  return {
+    statusReason,
+    critique: {
+      id: randomUUID(),
+      code: error.code,
+      severity: 'error',
+      message: error.message,
+      source: 'isl',
+      blocks_analysis: false,
+    },
+  };
 }
 
 /**
@@ -3272,11 +3313,20 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           const keys = Object.keys(body);
           const unknown = keys.filter(k => !V2_RUN_ALLOWED_KEYS.has(k));
           if (unknown.length > 0) {
-            return reply.status(400).send({
-              statusCode: 400,
-              error: 'Bad Request',
-              message: `Unknown field: ${unknown[0]}. /v2/run does not accept additional properties.`,
-            });
+            // Fragility gap 6: this was the ONE /v2/run error path emitting the
+            // bare Fastify shape (no schema, no stable code). Normalised into
+            // the error.v1 envelope every other lifecycle error uses.
+            const preValidationRequestId =
+              (req.headers['x-request-id'] as string | undefined)?.trim()
+              || (body as { request_id?: string }).request_id
+              || String(req.id);
+            return reply.status(400).send(errorResponse(
+              'BAD_INPUT',
+              `Unknown field: ${unknown[0]}. /v2/run does not accept additional properties.`,
+              `Remove '${unknown[0]}' or check spelling`,
+              undefined,
+              preValidationRequestId,
+            ));
           }
         }
       },
@@ -4574,6 +4624,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         let islSuccess = false;
         let islStatusCode = 0;
         let islError: ISLHttpError | undefined;
+        // Full error object from callAnalysisEndpoint's no-throw contract —
+        // carries the discriminating code (+ status/critiques for HTTP-level
+        // rejections). Fragility gaps 2/3: previously only `retryable` was
+        // kept and the code was discarded.
+        let islCallError: { code: string; message: string; retryable: boolean; status?: number; critiques?: ISLCritique[] } | undefined;
         let islFallbackExecuted = false;
         let computedAt: string | undefined;
         let islEchoedRequestId: string | null = null;
@@ -4692,10 +4747,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               });
             }
           } else {
-            islStatusCode = 500;
+            islStatusCode = response.error?.status ?? 500;
             islFallbackExecuted = true;
             islEchoedRequestId = response.isl_echoed_request_id ?? null;
             islResponseRetryable = response.error?.retryable;
+            islCallError = response.error;
             req.log.error({
               event: 'isl_call_failed',
               error: response.error?.message ?? 'Unknown error',
@@ -4806,6 +4862,24 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           ));
         }
 
+        // Fragility gap 3: the branch above never fires on the live path —
+        // callAnalysisEndpoint catches ISLHttpError and RETURNS the error
+        // rather than throwing, so ISL's structured 422 critiques arrive
+        // here. Same 422-blocked contract as the throw path.
+        if (islCallError?.status === 422 && islCallError.critiques && islCallError.critiques.length > 0) {
+          const islCritiques = mapISLCritiquesToV2(islCallError.critiques);
+          critiques.push(...islCritiques);
+
+          return reply.status(422).send(buildBlockedResponse(
+            islCallError.message || 'ISL validation failed',
+            critiques,
+            filteredGraph,
+            normalizedOptions,
+            requestId,
+            computedAt ?? requestComputedAt,
+          ));
+        }
+
         // Handle ISL failure (non-422)
         if (!islSuccess) {
           const chain = buildRequestIdChain(hasExplicitRequestId, requestId, true, islEchoedRequestId);
@@ -4814,20 +4888,35 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           // V2 contract: failed = 200, communicates failure via analysis_status
           // Use service-computed retryable if available; fall back to status-based logic.
           const islRetryable = islResponseRetryable ?? retryableFromIslStatus(islStatusCode || undefined);
+          // Fragility gap 2: carry the discriminating failure class (timeout /
+          // unreachable / HTTP error / rejected) alongside the legacy
+          // ISL_CALL_FAILED critique, which stays for existing consumers.
+          const islFailure = buildIslFailureDetail(islCallError);
           return reply.send(buildV2RunError({
             analysisStatus: 'failed',
-            statusReason: 'ISL analysis failed',
+            statusReason: islFailure.statusReason,
             retryable: islRetryable,
             requestId,
             computedAt: computedAt ?? requestComputedAt,
-            critiques: [...critiques, {
-              id: randomUUID(),
-              code: 'ISL_CALL_FAILED',
-              severity: 'error' as const,
-              message: 'ISL analysis failed. Please try again.',
-              source: 'isl' as const,
-              blocks_analysis: false,
-            }],
+            // addUserMessages on the whole array matches the blocked-path
+            // behaviour (buildBlockedResponse) — the spec requires
+            // user_message on every critique; the failed path never set it.
+            critiques: addUserMessages(
+              [
+                ...critiques,
+                ...(islFailure.critique ? [islFailure.critique] : []),
+                {
+                  id: randomUUID(),
+                  code: 'ISL_CALL_FAILED',
+                  severity: 'error' as const,
+                  message: 'ISL analysis failed. Please try again.',
+                  source: 'isl' as const,
+                  blocks_analysis: false,
+                },
+              ],
+              filteredGraph,
+              normalizedOptions,
+            ),
           }));
         }
 
@@ -5791,12 +5880,24 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // Outermost safety net: guarantee V2RunError on any unexpected throw.
         // error.v1 must never leak from this endpoint.
         // V2 contract: failed = 200, communicates failure via analysis_status
+        // Fragility gap 1: the most severe failure class no longer returns an
+        // EMPTY critiques[] — it carries a typed PLOT_INTERNAL_ERROR critique.
+        // Copy is deliberately generic: the raw exception goes to the log
+        // above, never to the wire.
         return reply.send(buildV2RunError({
           analysisStatus: 'failed',
           statusReason: 'Internal server error',
           retryable: true,
           requestId,
           computedAt: requestComputedAt,
+          critiques: addUserMessages([{
+            id: randomUUID(),
+            code: 'PLOT_INTERNAL_ERROR',
+            severity: 'error',
+            message: 'Unexpected internal error while assembling the analysis response.',
+            source: 'engine',
+            blocks_analysis: false,
+          }]),
         }));
       }
     }

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -588,6 +588,15 @@ export const INLINE_CRITIQUE_CODES = [
   'ISL_CALL_FAILED',
   'ISL_EMPTY_RESULTS',
   'ISL_ERROR',
+  // Typed failure envelope (fragility pair 2026-07-10): discriminating ISL
+  // failure classes + typed internal-exception critique.
+  'ISL_TIMEOUT',                      // ISL request timed out
+  'ISL_NETWORK_ERROR',                // ISL unreachable
+  'ISL_REJECTED',                     // ISL HTTP 422 (with critiques → 422 blocked; without → failed)
+  'PLOT_INTERNAL_ERROR',              // outermost /v2/run catch — never an empty critiques[]
+  // Registered late (both already emitted via buildBlockedResponse):
+  'GRAPH_TOO_COMPLEX',                // complexity refusal at the ISL cap (ROADMAP 1.54)
+  'DUPLICATE_EDGE_CONFLICT',          // same-relationship edges with divergent values
   'MIXED_RANGE_DERIVATION',           // factors use 2+ different derivation tiers
   // preflight-v2.ts
   'SCALE_MISMATCH_WARNING',

--- a/tests/v2-typed-failure-envelope.test.ts
+++ b/tests/v2-typed-failure-envelope.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Typed failure envelope for /v2/run — "generic analysis-failure UX beyond
+ * the density codes" (ROADMAP §B session-robustness, fragility pair 2026-07-10).
+ *
+ * Pins the four confirmed gaps from FRAGILITY-PAIR-FINDINGS-2026-07-10.md:
+ *
+ *  GAP 2 — every ISL infrastructure failure collapsed to the single code
+ *          ISL_CALL_FAILED: the discriminating codes (ISL_TIMEOUT /
+ *          ISL_NETWORK_ERROR / ISL_ERROR) were computed in
+ *          integrations/isl/index.ts then discarded by run.ts. The caller
+ *          could not distinguish "analysis service down, retry" from
+ *          "request rejected, don't retry".
+ *  GAP 3 — ISL's structured 422 critiques were lost: callAnalysisEndpoint
+ *          swallows ISLHttpError, so the route's is422() passthrough was
+ *          dead code and ISL validation detail flattened into GAP 2.
+ *  GAP 1 — an unexpected internal throw returned HTTP 200,
+ *          analysis_status:'failed' with an EMPTY critiques[] — the most
+ *          severe failure class carried the least structure.
+ *  GAP 6 — the unknown-top-level-key 400 was the only /v2/run error emitted
+ *          in the bare Fastify shape (no `schema`, no stable `code`) —
+ *          every other lifecycle error uses the error.v1 envelope.
+ *
+ * Back-compat pins in the same file: the legacy ISL_CALL_FAILED critique
+ * stays present on infrastructure failures (dashboards/consumers key on it),
+ * and the happy path is byte-shape-unchanged.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Switchable ISL mock — each test sets `islBehaviour` before injecting.
+// ---------------------------------------------------------------------------
+type IslBehaviour =
+  | { kind: 'computed' }
+  | { kind: 'error'; error: { code: string; message: string; retryable: boolean; status?: number; critiques?: Array<{ code: string; severity: string; message: string }> } }
+  | { kind: 'malformed-data' };
+
+let islBehaviour: IslBehaviour = { kind: 'computed' };
+
+function computedIslResponse() {
+  return {
+    analysis_status: 'computed',
+    seed_used: 42,
+    options: [
+      {
+        option_id: 'opt-a',
+        outcome: { mean: 0.7, std: 0.05, p10: 0.6, p50: 0.7, p90: 0.8, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+        win_probability: 0.7,
+        status: 'computed',
+      },
+      {
+        option_id: 'opt-b',
+        outcome: { mean: 0.4, std: 0.05, p10: 0.3, p50: 0.4, p90: 0.5, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+        win_probability: 0.3,
+        status: 'computed',
+      },
+    ],
+    factor_sensitivity: [],
+    robustness: { confidence: 0.8, level: 'high', is_robust: true, fragile_edges: [], robust_edges: [] },
+    inference_warnings: [],
+  };
+}
+
+const mockISLService = {
+  isEnabled: () => true,
+  async callAnalysisEndpoint<T>(): Promise<any> {
+    if (islBehaviour.kind === 'error') {
+      return { data: null, error: islBehaviour.error, latency_ms: 5, isl_echoed_request_id: null };
+    }
+    if (islBehaviour.kind === 'malformed-data') {
+      // ISL "succeeds" but the payload detonates downstream processing —
+      // drives the route's outermost catch (GAP 1). A Proxy that throws on
+      // any property access is the most reliable detonator.
+      const bomb = new Proxy({}, {
+        get(_t, prop) {
+          if (prop === 'analysis_status') return 'computed';
+          if (prop === 'then') return undefined; // not a thenable
+          throw new Error(`synthetic downstream explosion reading ${String(prop)}`);
+        },
+      });
+      return { data: bomb as T, latency_ms: 5, isl_echoed_request_id: null };
+    }
+    return { data: computedIslResponse() as T, latency_ms: 5, isl_echoed_request_id: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Minimal valid request (2 options — schema minimum)
+// ---------------------------------------------------------------------------
+function validBody(extra: Record<string, unknown> = {}) {
+  return {
+    graph: {
+      nodes: [
+        { id: 'factor-0', kind: 'factor', label: 'Factor 0', observed_state: { value: 0.5 } },
+        { id: 'goal', kind: 'goal', label: 'Goal' },
+      ],
+      edges: [
+        { from: 'factor-0', to: 'goal', exists_probability: 0.8, strength: { mean: 0.3, std: 0.05 } },
+      ],
+    },
+    options: [
+      { id: 'opt-a', label: 'Option A', interventions: { 'factor-0': { value: 0.8, source: 'user_specified' } } },
+      { id: 'opt-b', label: 'Option B', interventions: { 'factor-0': { value: 0.2, source: 'user_specified' } } },
+    ],
+    goal_node_id: 'goal',
+    ...extra,
+  };
+}
+
+function critiqueCodes(body: any): string[] {
+  return (body.critiques ?? []).map((c: any) => c.code);
+}
+
+describe('/v2/run typed failure envelope', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Back-compat pin: happy path unchanged
+  // -------------------------------------------------------------------------
+  it('happy path: computed run returns 200 computed (regression pin)', async () => {
+    islBehaviour = { kind: 'computed' };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.analysis_status).toBe('computed');
+  });
+
+  // -------------------------------------------------------------------------
+  // GAP 2 — ISL infrastructure failures carry their discriminating code
+  // -------------------------------------------------------------------------
+  it('ISL timeout: failed response carries ISL_TIMEOUT critique, honest status_reason, retryable', async () => {
+    islBehaviour = { kind: 'error', error: { code: 'ISL_TIMEOUT', message: 'ISL request to /api/v1/robustness/analyze/v2 timed out after 30000ms', retryable: true } };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    expect(res.statusCode).toBe(200); // V2 contract: failed = 200
+    const body = res.json();
+    expect(body.analysis_status).toBe('failed');
+    expect(critiqueCodes(body)).toContain('ISL_TIMEOUT');
+    expect(critiqueCodes(body)).toContain('ISL_CALL_FAILED'); // legacy pin
+    expect(body.status_reason.toLowerCase()).toContain('timed out');
+    expect(body.retryable).toBe(true);
+    const specific = body.critiques.find((c: any) => c.code === 'ISL_TIMEOUT');
+    expect(specific.user_message).toBeTruthy();
+    expect(specific.source).toBe('isl');
+  });
+
+  it('ISL unreachable: failed response carries ISL_NETWORK_ERROR critique + honest status_reason', async () => {
+    islBehaviour = { kind: 'error', error: { code: 'ISL_NETWORK_ERROR', message: 'connect ECONNREFUSED', retryable: true } };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.analysis_status).toBe('failed');
+    expect(critiqueCodes(body)).toContain('ISL_NETWORK_ERROR');
+    expect(critiqueCodes(body)).toContain('ISL_CALL_FAILED');
+    expect(body.status_reason.toLowerCase()).toContain('unreachable');
+    expect(body.retryable).toBe(true);
+    expect(body.critiques.find((c: any) => c.code === 'ISL_NETWORK_ERROR').user_message).toBeTruthy();
+  });
+
+  it('ISL HTTP 5xx: failed response keeps ISL_ERROR discriminator and status-derived retryable', async () => {
+    islBehaviour = { kind: 'error', error: { code: 'ISL_ERROR', message: 'ISL request failed with status 503', retryable: true, status: 503 } };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.analysis_status).toBe('failed');
+    expect(critiqueCodes(body)).toContain('ISL_ERROR');
+    expect(critiqueCodes(body)).toContain('ISL_CALL_FAILED');
+    expect(body.retryable).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // GAP 3 — ISL structured 422 passthrough revived
+  // -------------------------------------------------------------------------
+  it('ISL 422 with structured critiques: 422 blocked with the ISL critiques mapped through', async () => {
+    islBehaviour = {
+      kind: 'error',
+      error: {
+        code: 'ISL_REJECTED',
+        message: 'Causal effect not identifiable from this structure',
+        retryable: false,
+        status: 422,
+        critiques: [
+          { code: 'ISL_CANNOT_IDENTIFY', severity: 'blocker', message: 'Effect of factor-0 on goal is not identifiable' },
+        ],
+      },
+    };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    expect(res.statusCode).toBe(422);
+    const body = res.json();
+    expect(body.analysis_status).toBe('blocked');
+    expect(critiqueCodes(body)).toContain('ISL_CANNOT_IDENTIFY');
+    expect(body.retryable).toBe(false);
+    expect(body.status_reason).toContain('identifiable');
+  });
+
+  it('ISL 422 WITHOUT parseable critiques: stays a failed response with the ISL_REJECTED discriminator (never blocked-with-empty-critiques)', async () => {
+    islBehaviour = { kind: 'error', error: { code: 'ISL_REJECTED', message: 'ISL validation failed', retryable: false, status: 422 } };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.analysis_status).toBe('failed');
+    expect(critiqueCodes(body)).toContain('ISL_REJECTED');
+    expect(body.retryable).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // GAP 1 — internal exception carries a typed critique
+  // -------------------------------------------------------------------------
+  it('internal PLoT exception: failed response carries PLOT_INTERNAL_ERROR critique (never an empty critiques[])', async () => {
+    islBehaviour = { kind: 'malformed-data' };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    expect(res.statusCode).toBe(200); // outermost net: error.v1 must never leak
+    const body = res.json();
+    expect(body.analysis_status).toBe('failed');
+    expect(critiqueCodes(body)).toContain('PLOT_INTERNAL_ERROR');
+    const internal = body.critiques.find((c: any) => c.code === 'PLOT_INTERNAL_ERROR');
+    expect(internal.user_message).toBeTruthy();
+    // Internal wording must not leak the raw exception into user_message
+    expect(internal.user_message).not.toContain('synthetic downstream explosion');
+    expect(body.meta.request_id).toBeTruthy();
+  });
+
+  // -------------------------------------------------------------------------
+  // GAP 6 — unknown-field 400 joins the error.v1 envelope
+  // -------------------------------------------------------------------------
+  it('unknown top-level field: 400 in the error.v1 envelope with code BAD_INPUT (message text preserved)', async () => {
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody({ bogus_key: 1 }) });
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.schema).toBe('error.v1');
+    expect(body.code).toBe('BAD_INPUT');
+    expect(body.message).toContain('Unknown field: bogus_key');
+    expect(body.retryable).toBe(false);
+  });
+});


### PR DESCRIPTION
# Typed failure envelope for /v2/run (fragility gaps 1/2/3/6/8)

PLoT half of `parallel-briefs/FRAGILITY-PAIR-FINDINGS-2026-07-10.md` (§seam split). RED-first:
`tests/v2-typed-failure-envelope.test.ts` committed RED (7 fail / 1 pass on base `1eaedd9f`),
now 8/8 GREEN.

## What changed, per gap

| Gap | Before | After |
|---|---|---|
| **2** | Every ISL infrastructure failure collapsed to `ISL_CALL_FAILED`; the discriminating codes computed in `integrations/isl/index.ts` were discarded at the route; `status_reason` always `'ISL analysis failed'`; `islStatusCode` hardcoded 500 | Discriminating critique (`ISL_TIMEOUT` / `ISL_NETWORK_ERROR` / `ISL_ERROR` / `ISL_REJECTED`) carried **alongside** the legacy `ISL_CALL_FAILED` critique (back-compat kept); honest per-class `status_reason`; `islStatusCode` = ISL's real HTTP status |
| **3** | ISL's structured 422 critiques were dead code — `callAnalysisEndpoint` swallows `ISLHttpError`, so the route's `is422()` branch never fired; ISL validation detail flattened into gap 2 | `callAnalysisEndpoint` keeps its no-throw contract but attaches `status` + normalised `critiques` to the returned error; route maps them through `mapISLCritiquesToV2` → same 422-blocked contract as the throw path (which stays as belt). A 422 **without** parseable critiques returns failed(200) with the `ISL_REJECTED` discriminator — never blocked-with-empty-critiques |
| **1** | Internal PLoT exception → HTTP 200, `analysis_status:'failed'`, **empty `critiques[]`** | Typed `PLOT_INTERNAL_ERROR` critique (source `engine`), generic user-safe copy; raw exception goes to the log, never the wire; `meta.request_id` carried |
| **6** | Unknown-top-level-key 400 was the ONE /v2/run error in bare Fastify shape (`{statusCode,error,message}`, no stable code) | `error.v1` envelope via `errorResponse('BAD_INPUT', …)`; message text preserved (`Unknown field: <key>. /v2/run does not accept additional properties.`) so existing message-keyed consumers/tests still match — `tests/cil-phase0-unknown-keys.test.ts` green unmodified |
| **8** | OpenAPI declared only 200/400/422; blocker-code list materially incomplete | Additive: 401/403/413/429/500/503/504 declared (all `errorV1`); blocker list completed (incl. `GRAPH_TOO_COMPLEX`, `DUPLICATE_EDGE_CONFLICT`, categorical trio); failure-class codes documented; `critiqueV3.source` enum extended `[validation, isl]` → `[validation, engine, cee, isl]` to match `CritiqueSourceV3` (enum-value addition only; no removals anywhere) |

## Registry & copy discipline

- New codes registered in `INLINE_CRITIQUE_CODES` (engine-v3.ts) with `TEMPLATE_MAP` entries
  (critique-humaniser.ts) — enforced by the template-coverage test.
- **Late registrations**: `GRAPH_TOO_COMPLEX` (#209) and `DUPLICATE_EDGE_CONFLICT` were already
  emitted via `buildBlockedResponse` but had escaped the registry (generic fallback copy). Now
  registered + templated.
- Failed-path critiques now run through `addUserMessages`, matching the blocked path — the spec
  marks `user_message` required on every critique; the failed path never set it (pre-existing
  spec drift, now closed).

## Wire-change disclosure (deliberate, pinned by tests)

- ISL failure classes: `status_reason` VALUE changes (was always `'ISL analysis failed'`; that
  string remains for unclassified codes, e.g. `ISL_NOT_ENABLED`, which stays byte-identical).
- Failed-path critiques gain the discriminator entry + `user_message` fields — additive.
- ISL 422 with parseable critiques now returns 422-blocked instead of failed(200)+`ISL_CALL_FAILED`
  — this is the gap-3 revival, restoring the shape the route always declared for ISL 422s.
- Unknown-field 400: bare-Fastify → `error.v1`. The one shape replacement; message preserved.

## Skew pre-check (mandated; 4-hop workflow, all claims file:line-cited)

No consumer hop strict-rejects or schema-strips the new codes:
- **PLoT egress**: `/v2/run` route has NO Fastify `response` schema (no fast-json-stringify
  stripping); no zod parse of the outgoing response; openapi `critiqueV3.code` is `type: string`.
- **@talchain/schemas 0.15.0**: every critique-adjacent `code` is `z.string().min(1)`, never enum
  (identical since 0.14.0; 0.13.x had no critique schema at all). No exported code-list constant
  consumers could filter on.
- **UI (staging f0dcca4c)**: no crash, no strip on the direct BFF path. Unknown codes survive to
  `createErrorReport` on the failed(200) path; unknown top-level codes fall back to
  DEFAULT_ERROR copy until the U3 templates land (below).
- **CEE (staging tip)**: ingestion is `z.record` passthrough — **no strict-422 risk**. But
  `sanitise-enrichment.ts` `CRITIQUE_BUCKETS` fail-safes unknown codes to bucket D
  (diagnostics-only) on the ORCHESTRATED path → see follow-up below.

## For A2 (U3 — UI templates for the new codes)

Add entries for: `ISL_TIMEOUT`, `ISL_NETWORK_ERROR`, `ISL_ERROR`, `ISL_REJECTED`,
`PLOT_INTERNAL_ERROR` (and optionally `GRAPH_TOO_COMPLEX`, `DUPLICATE_EDGE_CONFLICT` if missing).
Registry note from the findings file: blocker codes → `userFriendlyErrors.ts` `ERROR_MESSAGES`
(+ promotion at `useV2Run.ts:588`); warning/error critiques → `humaniseCritique.ts`
`CODE_TEMPLATES`. They are SEPARATE registries. Retryability guidance: timeout/network/ISL-5xx =
"try again"; `ISL_REJECTED` = "adjust the model"; `PLOT_INTERNAL_ERROR` = "try again, model unaffected".
Every new critique now carries a PLoT-authored `user_message` as fallback copy.

## For the orchestrator (CEE follow-up — conscious decision needed)

On the CEE-orchestrated path, `src/orchestrator-v5/compose/sanitise-enrichment.ts`
`CRITIQUE_BUCKETS` routes unknown codes to bucket D (suppressed → `_diagnostics`, wire-dropped by
default). The five new codes are absent → invisible to users on that path (the semantically
closest existing entries `INFERENCE_TIMEOUT`/`INTERNAL_ERROR` are also D, so this matches current
suppression doctrine). If the orchestrated path should surface analysis-failure identity, promote
them to bucket U or S — CEE lane, not this PR.

## Verification

- RED→GREEN: 7-fail RED on base (commit `2290813`) → 8/8 GREEN.
- Targeted: `critique-humaniser` (coverage incl. new codes) + `cil-phase0-unknown-keys` (3/3
  after `npm run build`; fresh-worktree failures without dist/ are the KNOWN env-only issue).
- Full `scripts/pre-push-validate.sh` green before push (result in comments if late-breaking).
- CI: expect ONLY the standing pre-existing reds (`audit`, `gates (windows-latest)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
