### PR TITLE
feat(v2): evidence provenance — response_content_hash + CEE digests/chain legs (ROADMAP 2.13)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4031,7 +4031,15 @@ paths:
         - `drivers_status`: 'computed' | 'unavailable' | 'skipped' | 'error'
 
         **Response Hash**:
-        - `response_hash`: 16-char hex hash computed from semantic fields only (for determinism)
+        - `response_hash`: 16-char hex hash computed from semantic fields only (for determinism).
+          BY DESIGN this hashes the canonicalised REQUEST (graph, options, seed, identifiability
+          inputs) — a determinism/reproducibility token, NOT a hash of the response content.
+          Consumers use `response_hash` equality to prove "same analysis inputs"; it does not
+          verify response integrity.
+        - `_meta.response_content_hash` (additive, 2.13): "rch_v1:"-prefixed 16-char hex hash of
+          the response CONTENT — the public semantic surface minus volatile fields (timings,
+          timestamps, per-request ids, the `_meta` subtree). Deterministic across replays of the
+          same request and independently recomputable from the body. Success responses only.
 
         **Seed Handling**:
         - Accept string (canonical) or number (legacy)

--- a/src/cee/client.ts
+++ b/src/cee/client.ts
@@ -17,7 +17,7 @@ import type {
 import { runDecisionReviewViaSdk, type EvidenceHelperItem } from './orchestrator.js';
 import { isFlagOn } from './codes.js';
 import { computeOlumiHash } from '../util/canonical.js';
-import { recordDownstreamCall, sanitizePayloadForDebug } from '../util/downstream-tracker.js';
+import { recordDownstreamCall, sanitizePayloadForDebug, computePayloadDigest } from '../util/downstream-tracker.js';
 import {
   CEE_TIMEOUT_MS as CENTRAL_CEE_TIMEOUT_MS,
   CEE_DECISION_REVIEW_TIMEOUT_MS as CENTRAL_DECISION_REVIEW_TIMEOUT_MS,
@@ -192,6 +192,10 @@ export async function callCEEWithSchemaV2<T>(
       }));
     }
 
+    // Exact request bytes — reused for the wire body AND the 2.13 byte digest
+    const bodyText = JSON.stringify(payload);
+    const requestDigest = computePayloadDigest(bodyText, payload);
+
     const response = await fetchWithTimeout(url, {
       method: 'POST',
       headers: {
@@ -200,11 +204,13 @@ export async function callCEEWithSchemaV2<T>(
         'X-Olumi-Assist-Key': config.apiKey,
         'X-Request-Id': requestId,
       },
-      body: JSON.stringify(payload),
+      body: bodyText,
       timeoutMs,
     });
 
     const latencyMs = Date.now() - startMs;
+    // 2.13 gap D: capture the downstream echo for the PLoT→CEE chain leg
+    const echoedRequestId = response.headers.get('x-request-id');
 
     if (!response.ok) {
       // Read error body first (truncate to 1000 chars for logging)
@@ -220,6 +226,8 @@ export async function callCEEWithSchemaV2<T>(
         payloadHash,
         requestId,
         errorBody,
+        requestDigest,
+        echoedRequestId,
       });
       throw new Error(`CEE ${path} failed: HTTP ${response.status} - ${errorText}`);
     }
@@ -227,7 +235,9 @@ export async function callCEEWithSchemaV2<T>(
     // Capture X-CEE-API-Version header
     const ceeApiVersion = response.headers.get('X-CEE-API-Version');
 
-    const data = await response.json() as T & { schema_version?: string; graph?: { edges?: Array<{ effect_direction?: string; strength_std?: number }> } };
+    // Raw text first (2.13): the byte digest must cover the EXACT wire bytes
+    const responseText = await response.text();
+    const data = JSON.parse(responseText) as T & { schema_version?: string; graph?: { edges?: Array<{ effect_direction?: string; strength_std?: number }> } };
     const schemaVersion = (data as any)?.schema_version;
 
     // Compute response hash for downstream tracking
@@ -242,6 +252,9 @@ export async function callCEEWithSchemaV2<T>(
       payloadHash,
       responseHash,
       requestId,
+      requestDigest,
+      responseDigest: computePayloadDigest(responseText, data),
+      echoedRequestId,
     });
 
     // V2 verification logging per acceptance criteria
@@ -401,6 +414,10 @@ export async function factorReviewV2(
     const url = `${baseUrl}${path}?schema=v2`;
     const payloadHash = computeOlumiHash(payload);
 
+    // Exact request bytes — reused for the wire body AND the 2.13 byte digest
+    const bodyText = JSON.stringify(payload);
+    const requestDigest = computePayloadDigest(bodyText, payload);
+
     const response = await fetchWithTimeout(url, {
       method: 'POST',
       headers: {
@@ -409,11 +426,12 @@ export async function factorReviewV2(
         'X-Olumi-Assist-Key': config.apiKey,
         'X-Request-Id': requestId,
       },
-      body: JSON.stringify(payload),
+      body: bodyText,
       timeoutMs: FACTOR_REVIEW_TIMEOUT_MS,
     });
 
     const latencyMs = Date.now() - startMs;
+    const echoedRequestId = response.headers.get('x-request-id');
 
     if (!response.ok) {
       // Read error body first (truncate to 1000 chars for logging)
@@ -429,6 +447,8 @@ export async function factorReviewV2(
         payloadHash,
         requestId,
         errorBody,
+        requestDigest,
+        echoedRequestId,
       });
 
       console.warn(JSON.stringify({
@@ -442,7 +462,9 @@ export async function factorReviewV2(
       return undefined;
     }
 
-    const data = await response.json() as CeeFactorReviewResponse;
+    // Raw text first (2.13): the byte digest must cover the EXACT wire bytes
+    const responseText = await response.text();
+    const data = JSON.parse(responseText) as CeeFactorReviewResponse;
     const responseHash = computeOlumiHash(data);
 
     // Record successful downstream call
@@ -454,6 +476,9 @@ export async function factorReviewV2(
       payloadHash,
       responseHash,
       requestId,
+      requestDigest,
+      responseDigest: computePayloadDigest(responseText, data),
+      echoedRequestId,
     });
 
     console.log(JSON.stringify({
@@ -545,6 +570,10 @@ export async function callDecisionReview(
     const payloadHash = computeOlumiHash(request);
 
     const effectiveTimeoutMs = config.timeoutMs ?? DECISION_REVIEW_TIMEOUT_MS;
+    // Exact request bytes — reused for the wire body AND the 2.13 byte digest
+    const bodyText = JSON.stringify(request);
+    const requestDigest = computePayloadDigest(bodyText, request);
+
     const response = await fetchWithTimeout(url, {
       method: 'POST',
       headers: {
@@ -553,11 +582,12 @@ export async function callDecisionReview(
         'X-Olumi-Assist-Key': config.apiKey,
         'X-Request-Id': requestId,
       },
-      body: JSON.stringify(request),
+      body: bodyText,
       timeoutMs: effectiveTimeoutMs,
     });
 
     const latencyMs = Date.now() - startMs;
+    const echoedRequestId = response.headers.get('x-request-id');
 
     if (!response.ok) {
       // Read error body first (truncate to 1000 chars for logging)
@@ -577,6 +607,8 @@ export async function callDecisionReview(
         errorBody,
         requestPayload: sanitizePayloadForDebug(request),
         responsePayload: sanitizePayloadForDebug(errorPayload),
+        requestDigest,
+        echoedRequestId,
       });
 
       console.warn(JSON.stringify({
@@ -597,7 +629,9 @@ export async function callDecisionReview(
       };
     }
 
-    const data = await response.json() as { review?: unknown; _meta?: { model?: string; latency_ms?: number; tokens?: number } };
+    // Raw text first (2.13): the byte digest must cover the EXACT wire bytes
+    const responseText = await response.text();
+    const data = JSON.parse(responseText) as { review?: unknown; _meta?: { model?: string; latency_ms?: number; tokens?: number } };
     const responseHash = computeOlumiHash(data);
 
     // Record successful downstream call with full payloads for debug
@@ -611,6 +645,9 @@ export async function callDecisionReview(
       requestId,
       requestPayload: sanitizePayloadForDebug(request),
       responsePayload: sanitizePayloadForDebug(data),
+      requestDigest,
+      responseDigest: computePayloadDigest(responseText, data),
+      echoedRequestId,
     });
 
     console.log(JSON.stringify({

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -131,7 +131,8 @@ import { filterInterventionOverrides } from '../../coaching/sensitivity-filter.j
 import type { M1Review } from '../../cee/validation/m1-review-types.js';
 import type { ReviewStatus } from '../../cee/validation/m1-review-constants.js';
 import { ReviewSkipReasons, type ReviewSkipReason } from '../../cee/validation/m1-review-constants.js';
-import { getDownstreamCallsForLog } from '../../util/downstream-tracker.js';
+import { getDownstreamCallsForLog, getDownstreamCalls } from '../../util/downstream-tracker.js';
+import { computeResponseContentHash } from '../../util/response-content-hash.js';
 import { computeFactorSensitivityFromGraph, buildFactorStability, mergeIslConfidenceIntoGraphFactors } from '../../lib/factor-influence.js';
 import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagMissingFromIsl } from '../../lib/auto-noise.js';
 import { sanitiseIslVoi, computeEvpiPercentagePoints } from '../../lib/evpi-emission.js';
@@ -1184,9 +1185,16 @@ interface MetaParams {
     isl: string | null;
     /** Request ID ISL echoed back (null if ISL didn't echo) */
     isl_echoed: string | null;
-    /** true ONLY when all four are non-null AND identical */
+    /**
+     * 2.13 gap D (additive): request ID PLoT sent to CEE (null if CEE not
+     * called) and CEE's echo. Informational — deliberately NOT part of
+     * all_match/chain_complete (Brief 4 header spec back-compat).
+     */
+    cee: string | null;
+    cee_echoed: string | null;
+    /** true ONLY when all four ISL-leg fields are non-null AND identical */
     all_match: boolean;
-    /** true ONLY when all four are non-null */
+    /** true ONLY when all four ISL-leg fields are non-null */
     chain_complete: boolean;
   };
   /** Filtered constraint records for _meta.filtered_constraints */
@@ -1759,19 +1767,27 @@ export function buildRequestIdChain(
   requestId: string,
   islCalled: boolean,
   islEchoedRequestId: string | null,
+  ceeCalled: boolean = false,
+  ceeEchoedRequestId: string | null = null,
 ): NonNullable<MetaParams['requestIdChain']> {
   const ui = hasExplicitRequestId ? requestId : null;
   const plot = requestId;
   const isl = islCalled ? requestId : null;
   const isl_echoed = islEchoedRequestId;
+  // all_match/chain_complete stay computed over the ISL four ONLY — the CEE
+  // legs (2.13 gap D) are additive/informational so existing consumers of
+  // the Brief 4 semantics are unaffected.
   const chain_complete = ui !== null && plot !== null && isl !== null && isl_echoed !== null;
   const all_match = chain_complete && ui === plot && plot === isl && isl === isl_echoed;
-  return { ui, plot, isl, isl_echoed, all_match, chain_complete };
+  const cee = ceeCalled ? requestId : null;
+  const cee_echoed = ceeEchoedRequestId;
+  return { ui, plot, isl, isl_echoed, cee, cee_echoed, all_match, chain_complete };
 }
 
 /**
  * Build X-Olumi-Request-Id-Chain header JSON from request ID chain.
- * Field names match _meta.request_id_chain (Brief 4 spec — 6 fields).
+ * Field names match _meta.request_id_chain (Brief 4 spec — original 6
+ * fields; 2.13 adds the additive cee/cee_echoed legs).
  */
 function buildRequestIdChainHeader(chain: MetaParams['requestIdChain']): string | null {
   if (!chain) return null;
@@ -5813,10 +5829,22 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
 
         const finalTotalMs = performance.now() - startTime;
 
-        const chain = buildRequestIdChain(hasExplicitRequestId, requestId, true, islEchoedRequestId);
+        // 2.13 gap D: derive the PLoT→CEE chain legs from the downstream
+        // tracker (CEE calls are made inside orchestration; the tracker is
+        // the single record of whether/what CEE echoed).
+        const ceeDownstreamCalls = getDownstreamCalls(requestId).filter((c) => c.service === 'cee');
+        const ceeEchoedRequestId = ceeDownstreamCalls.find((c) => c.echoedRequestId)?.echoedRequestId ?? null;
+        const chain = buildRequestIdChain(
+          hasExplicitRequestId,
+          requestId,
+          true,
+          islEchoedRequestId,
+          ceeDownstreamCalls.length > 0,
+          ceeEchoedRequestId,
+        );
         reply.header('X-Olumi-Request-Id-Chain', buildRequestIdChainHeader(chain)!);
 
-        return reply.send(buildResponse(
+        const successBody = buildResponse(
           requestId,
           topLevelStatus,
           topLevelStatus !== 'computed' ? (islStatusReason || 'Some analyses unavailable') : undefined,
@@ -5869,7 +5897,17 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           toIdentifiabilityResponse(identifiabilityResult),  // B1.5a: always-present mapped response
           factorStability,  // 3C: ISL stability assessment per factor
           req.log  // logger for fact_objects assembly logging
-        ));
+        );
+
+        // 2.13 gap A: deterministic response-CONTENT hash, attached AFTER the
+        // body is fully built so it can never hash itself. Success surface
+        // only — V2RunError carries no _meta. response_hash (request-canonical
+        // determinism token) is deliberately untouched.
+        if (successBody._meta) {
+          successBody._meta.response_content_hash = computeResponseContentHash(successBody);
+        }
+
+        return reply.send(successBody);
       } catch (err) {
         req.log.error({
           event: 'v2_run_error',

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2362,6 +2362,14 @@ export interface CanonicalMeta {
   hash_version?: number;
   /** Determinism hash of canonical request (semantic fields only) */
   response_hash?: string;
+  /**
+   * 2.13 gap A: deterministic hash of the response CONTENT ("rch_v1:<16 hex>")
+   * — the public semantic surface minus the volatile set (see
+   * util/response-content-hash.ts). Complements response_hash, which is
+   * request-canonical by design and must not change meaning. Success
+   * responses only; attached after the body is fully built.
+   */
+  response_content_hash?: string;
   /** Per-factor range derivation source (maps factor_id → derivation tier) */
   range_derivation_sources?: Record<string, string>;
   /** Snapshot of all feature flags for this run (diagnostic only) */

--- a/src/util/downstream-tracker.ts
+++ b/src/util/downstream-tracker.ts
@@ -68,6 +68,8 @@ export interface DownstreamCall {
   requestDigest?: PayloadDigest;
   /** Lane PLoT-R3 (2.13): digest of the exact response bytes received */
   responseDigest?: PayloadDigest;
+  /** 2.13 gap D: request id the downstream service echoed back (x-request-id), null if absent */
+  echoedRequestId?: string | null;
 }
 
 /**

--- a/src/util/response-content-hash.ts
+++ b/src/util/response-content-hash.ts
@@ -58,6 +58,12 @@ export const RESPONSE_CONTENT_HASH_EXCLUDED_KEYS: readonly string[] = [
   'thresholds_status',
   'thresholds_meta',
   'threshold_analysis',
+  // Deployment/environment provenance, not response content: meta.build is
+  // the deployed git SHA (changes every commit — a checked-in golden or
+  // cross-deploy replay would flip the hash with identical content), and
+  // meta.feature_flags is an environment snapshot carried for diagnostics.
+  'build',
+  'feature_flags',
   // Safety: never self-referential wherever it is attached
   'response_content_hash',
 ];

--- a/src/util/response-content-hash.ts
+++ b/src/util/response-content-hash.ts
@@ -1,0 +1,119 @@
+/**
+ * Deterministic response-CONTENT hash for /v2/run (ROADMAP 2.13).
+ *
+ * The existing `response_hash` is a REQUEST-canonical determinism token
+ * (sha256 of the canonicalised request; by design — the UI freshness gate
+ * keys on it and it must never change meaning). Until 2.13 there was NO
+ * deterministic hash of what PLoT actually returned: the only body hash was
+ * the x-olumi-response-hash header, which covers volatile fields
+ * (latency_ms, timestamps) and is therefore not reproducible across runs.
+ *
+ * `response_content_hash` closes that gap: sha256 (16 hex, "rch_v1:"-prefixed)
+ * over the PUBLIC semantic surface of the response — the full body minus
+ * the `_meta` diagnostic subtree and minus the volatile field set below —
+ * with the natural-key array sorts the determinism-replay suite uses, so a
+ * replayed identical request yields an identical hash. It is attached to
+ * `_meta.response_content_hash` AFTER computation, so it never hashes itself,
+ * and it never feeds `hashRequest` (request-hash stability preserved).
+ *
+ * The exclusion list is exported so tests (and external verifiers) recompute
+ * the hash independently — "zero hash mismatches" is asserted, not assumed.
+ * Keep it aligned with tests/determinism-replay.test.ts IGNORE_FIELDS: a new
+ * volatile field that breaks replay-stability of this hash must be added in
+ * BOTH places, as a conscious decision.
+ */
+
+import { createHash } from 'node:crypto';
+import { canonicalJson } from '../facts/hash.js';
+
+export const RESPONSE_CONTENT_HASH_VERSION = 'rch_v1';
+
+/** Field names stripped (deep, by key) before hashing — the volatile set. */
+export const RESPONSE_CONTENT_HASH_EXCLUDED_KEYS: readonly string[] = [
+  // Diagnostic subtree (builds, digests, payloads, this hash itself)
+  '_meta',
+  // Per-request identity & call traces
+  'request_id',
+  'request_id_chain',
+  'requestId',
+  'plot_request_id',
+  'cee_sent_request_id',
+  'downstream_calls',
+  // Timing
+  'computed_at',
+  'processing_time_ms',
+  'latency_ms',
+  'timing',
+  'normalization_ms',
+  'validation_ms',
+  'isl_ms',
+  'cee_ms',
+  'timestamp',
+  // Per-run generated identifiers
+  'id',        // critique UUIDs (semantic ids use option_id/edge_id/factor_id)
+  'brief_id',
+  'created_at',
+  'fact_objects',
+  // Presence depends on ISL call timing, not deterministic inputs (B10.3)
+  'thresholds_status',
+  'thresholds_meta',
+  'threshold_analysis',
+  // Safety: never self-referential wherever it is attached
+  'response_content_hash',
+];
+
+/**
+ * Top-level arrays sorted by natural key before hashing — mirrors the
+ * determinism-replay suite's SORT_ARRAYS_BY so element-order jitter can't
+ * flip the hash between replays.
+ */
+export const RESPONSE_CONTENT_HASH_SORTED_ARRAYS: Readonly<Record<string, string>> = {
+  option_comparison: 'option_id',
+  edge_sensitivity: 'edge_id',
+  factor_sensitivity: 'factor_id',
+  critiques: 'code',
+};
+
+function stripVolatile(value: unknown, excluded: ReadonlySet<string>): unknown {
+  if (Array.isArray(value)) {
+    return value.map((v) => stripVolatile(v, excluded));
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (excluded.has(k)) continue;
+      out[k] = stripVolatile(v, excluded);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Compute the deterministic content hash of a /v2/run response body.
+ * Pass the body WITHOUT `_meta.response_content_hash` attached (the field is
+ * stripped defensively anyway via the exclusion list).
+ */
+export function computeResponseContentHash(body: unknown): string {
+  const excluded = new Set(RESPONSE_CONTENT_HASH_EXCLUDED_KEYS);
+  const stripped = stripVolatile(body, excluded);
+
+  if (stripped !== null && typeof stripped === 'object' && !Array.isArray(stripped)) {
+    const record = stripped as Record<string, unknown>;
+    for (const [field, sortKey] of Object.entries(RESPONSE_CONTENT_HASH_SORTED_ARRAYS)) {
+      const arr = record[field];
+      if (Array.isArray(arr)) {
+        record[field] = [...arr].sort((a, b) =>
+          String((a as Record<string, unknown>)?.[sortKey] ?? '')
+            .localeCompare(String((b as Record<string, unknown>)?.[sortKey] ?? '')),
+        );
+      }
+    }
+  }
+
+  const digest = createHash('sha256')
+    .update(canonicalJson(stripped), 'utf8')
+    .digest('hex')
+    .slice(0, 16);
+  return `${RESPONSE_CONTENT_HASH_VERSION}:${digest}`;
+}

--- a/tests/b3-numeric-invariance.test.ts
+++ b/tests/b3-numeric-invariance.test.ts
@@ -299,6 +299,11 @@ describe('B3: numeric invariance under auto-noise disclosure (audit-feedback bri
       'processing_time_ms',
       // ISL status text varies if ISL provides one.
       'isl_status_reason',
+      // 2.13: deterministic hash OF the response content — a derived
+      // function of the B3 fields this test deliberately lets differ, so
+      // it must be masked here (its own correctness is pinned in
+      // tests/v2-evidence-provenance.test.ts).
+      'response_content_hash',
     ]);
     const B3_KEYS = new Set(['auto_noise_applied', 'auto_noise_provenance']);
 

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -1547,6 +1547,8 @@
       "plot": "__VOLATILE__",
       "isl": "__VOLATILE__",
       "isl_echoed": null,
+      "cee": null,
+      "cee_echoed": null,
       "all_match": false,
       "chain_complete": false
     },
@@ -1603,7 +1605,8 @@
     },
     "decision_brief_assembled": true,
     "review_cards_count": 0,
-    "evidence_priority_card_present": false
+    "evidence_priority_card_present": false,
+    "response_content_hash": "rch_v1:c1926e261773448f"
   },
   "meta": {
     "seed_used": "2034401427",
@@ -1623,6 +1626,8 @@
       "plot": "__VOLATILE__",
       "isl": "__VOLATILE__",
       "isl_echoed": null,
+      "cee": null,
+      "cee_echoed": null,
       "all_match": false,
       "chain_complete": false
     },

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -1606,7 +1606,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v1:c1926e261773448f"
+    "response_content_hash": "rch_v1:41cf78c41d8a44ce"
   },
   "meta": {
     "seed_used": "2034401427",

--- a/tests/v2-evidence-provenance.test.ts
+++ b/tests/v2-evidence-provenance.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Diligence-grade evidence provenance for /v2/run (ROADMAP 2.13 completion).
+ *
+ * The 2.13 sweep (2026-07-10) found the row largely landed (Lane PLoT-R3:
+ * _meta.evidence digests, request-id chain, downstream capture). These tests
+ * pin the four REMAINING gaps:
+ *
+ *  GAP A — no deterministic response-CONTENT hash exists in the body. The
+ *          field named `response_hash` hashes the canonicalised REQUEST
+ *          (by design — determinism token; UI freshness keys on it and it
+ *          must NOT change). The only true body hash is the
+ *          x-olumi-response-hash header: header-only, and non-reproducible
+ *          across runs (covers latency/timestamps).
+ *          → additive `_meta.response_content_hash` ("rch_v1:<sha256-16>")
+ *            over the public semantic surface minus the volatile set.
+ *  GAP B — "zero hash mismatches" was never ASSERTED anywhere: nothing
+ *          compared header-vs-body or recorded-digest-vs-actual-bytes.
+ *          → within-run consistency assertions live here.
+ *  GAP C — CEE downstream calls carry no byte digests (ISL-only today):
+ *          cee/client.ts never computed request/response PayloadDigests.
+ *  GAP D — request-id chain is PLoT→ISL only; no PLoT→CEE leg. Additive
+ *          cee/cee_echoed fields; all_match/chain_complete semantics are
+ *          PINNED UNCHANGED (computed over the original ISL four).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { createHash } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Switchable ISL mock — deterministic; `meanA` varies semantic content.
+// ---------------------------------------------------------------------------
+let meanA = 0.7;
+
+function computedIslResponse() {
+  return {
+    analysis_status: 'computed',
+    seed_used: 42,
+    options: [
+      {
+        option_id: 'opt-a',
+        outcome: { mean: meanA, std: 0.05, p10: meanA - 0.1, p50: meanA, p90: meanA + 0.1, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+        win_probability: 0.7,
+        status: 'computed',
+      },
+      {
+        option_id: 'opt-b',
+        outcome: { mean: 0.4, std: 0.05, p10: 0.3, p50: 0.4, p90: 0.5, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+        win_probability: 0.3,
+        status: 'computed',
+      },
+    ],
+    factor_sensitivity: [],
+    robustness: { confidence: 0.8, level: 'high', is_robust: true, fragile_edges: [], robust_edges: [] },
+    inference_warnings: [],
+  };
+}
+
+const mockISLService = {
+  isEnabled: () => true,
+  async callAnalysisEndpoint<T>(): Promise<any> {
+    return { data: computedIslResponse() as T, latency_ms: 5, isl_echoed_request_id: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+import { computeOlumiHash } from '../src/util/canonical.js';
+import {
+  computeResponseContentHash,
+  RESPONSE_CONTENT_HASH_VERSION,
+} from '../src/util/response-content-hash.js';
+import { buildRequestIdChain } from '../src/routes/v2/run.js';
+import { callCEEWithSchemaV2 } from '../src/cee/client.js';
+import { getDownstreamCalls, clearDownstreamTracking } from '../src/util/downstream-tracker.js';
+
+function validBody(extra: Record<string, unknown> = {}) {
+  return {
+    graph: {
+      nodes: [
+        { id: 'factor-0', kind: 'factor', label: 'Factor 0', observed_state: { value: 0.5 } },
+        { id: 'goal', kind: 'goal', label: 'Goal' },
+      ],
+      edges: [
+        { from: 'factor-0', to: 'goal', exists_probability: 0.8, strength: { mean: 0.3, std: 0.05 } },
+      ],
+    },
+    options: [
+      { id: 'opt-a', label: 'Option A', interventions: { 'factor-0': { value: 0.8, source: 'user_specified' } } },
+      { id: 'opt-b', label: 'Option B', interventions: { 'factor-0': { value: 0.2, source: 'user_specified' } } },
+    ],
+    goal_node_id: 'goal',
+    seed: '42',
+    ...extra,
+  };
+}
+
+describe('/v2/run evidence provenance (2.13 completion)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // GAP A — deterministic response-content hash
+  // -------------------------------------------------------------------------
+  it('success response carries _meta.response_content_hash (rch_v1:<16 hex>)', async () => {
+    meanA = 0.7;
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.analysis_status).toBe('computed');
+    expect(body._meta.response_content_hash).toMatch(/^rch_v1:[0-9a-f]{16}$/);
+  });
+
+  it('identical request replayed → identical response_content_hash (determinism)', async () => {
+    meanA = 0.7;
+    const r1 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    const r2 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    const h1 = r1.json()._meta.response_content_hash;
+    const h2 = r2.json()._meta.response_content_hash;
+    expect(h1).toMatch(/^rch_v1:/);
+    expect(h2).toBe(h1);
+  });
+
+  it('semantically different response → different response_content_hash', async () => {
+    meanA = 0.7;
+    const r1 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    meanA = 0.6;
+    const r2 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    meanA = 0.7;
+    expect(r2.json()._meta.response_content_hash).not.toBe(r1.json()._meta.response_content_hash);
+  });
+
+  it('response_content_hash is independently recomputable from the body (zero-mismatch)', async () => {
+    meanA = 0.7;
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    const body = res.json();
+    const claimed = body._meta.response_content_hash;
+    const clone = JSON.parse(JSON.stringify(body));
+    delete clone._meta.response_content_hash;
+    expect(computeResponseContentHash(clone)).toBe(claimed);
+    expect(claimed.startsWith(`${RESPONSE_CONTENT_HASH_VERSION}:`)).toBe(true);
+  });
+
+  it('response_hash (request-canonical determinism token) is UNCHANGED by the new field', async () => {
+    meanA = 0.7;
+    const r1 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    meanA = 0.6; // different response CONTENT, same request
+    const r2 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    meanA = 0.7;
+    // request-canonical: same request → same response_hash even when content differs
+    expect(r2.json().meta.response_hash).toBe(r1.json().meta.response_hash);
+  });
+
+  // -------------------------------------------------------------------------
+  // GAP B — within-run wire-integrity assertion (header vs body)
+  // -------------------------------------------------------------------------
+  it('x-olumi-response-hash header matches an independent recompute over the body', async () => {
+    meanA = 0.7;
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
+    const headerHash = res.headers['x-olumi-response-hash'];
+    expect(headerHash).toMatch(/^[0-9a-f]{12}$/);
+    expect(computeOlumiHash(res.json())).toBe(headerHash);
+  });
+
+  // -------------------------------------------------------------------------
+  // GAP D — request-id chain gains additive CEE legs; ISL-four semantics pinned
+  // -------------------------------------------------------------------------
+  it('buildRequestIdChain: cee legs are additive and informational (all_match over the ISL four only)', () => {
+    const chain = buildRequestIdChain(true, 'req-1', true, 'req-1', true, 'other-id');
+    expect(chain.cee).toBe('req-1');
+    expect(chain.cee_echoed).toBe('other-id');
+    // all_match/chain_complete pinned to the original four — a divergent CEE
+    // echo must NOT break them (back-compat with the Brief 4 header spec).
+    expect(chain.all_match).toBe(true);
+    expect(chain.chain_complete).toBe(true);
+
+    const noCee = buildRequestIdChain(true, 'req-1', true, 'req-1');
+    expect(noCee.cee).toBeNull();
+    expect(noCee.cee_echoed).toBeNull();
+    expect(noCee.all_match).toBe(true);
+  });
+
+  it('success response chain carries cee:null when CEE is not called', async () => {
+    meanA = 0.7;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      payload: validBody(),
+      headers: { 'x-request-id': 'chain-test-1' },
+    });
+    const chain = res.json().meta.request_id_chain;
+    expect(chain.ui).toBe('chain-test-1');
+    expect(chain.cee).toBeNull();
+    expect(chain.cee_echoed).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GAP C — CEE downstream byte digests + echoed request id (client unit test)
+// ---------------------------------------------------------------------------
+describe('CEE client downstream digests (2.13 gap C)', () => {
+  const REQUEST_ID = 'cee-digest-test-1';
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+    clearDownstreamTracking(REQUEST_ID);
+  });
+
+  it('callCEEWithSchemaV2 records request/response PayloadDigests over exact bytes + echoed id', async () => {
+    const responseBody = { schema_version: 'v2', graph: { edges: [] }, ok: true };
+    const responseText = JSON.stringify(responseBody);
+
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(responseText, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json', 'X-Request-Id': REQUEST_ID },
+      })
+    ));
+
+    const payload = { brief: 'digest test', nested: { a: 1 } };
+    await callCEEWithSchemaV2(
+      { baseUrl: 'https://cee.example.test', apiKey: 'k' },
+      '/assist/v1/draft-graph',
+      payload,
+      REQUEST_ID,
+    );
+
+    const calls = getDownstreamCalls(REQUEST_ID).filter((c) => c.service === 'cee');
+    expect(calls.length).toBeGreaterThan(0);
+    const call = calls[0];
+
+    const expectedReqSha = createHash('sha256').update(JSON.stringify(payload), 'utf8').digest('hex');
+    const expectedResSha = createHash('sha256').update(responseText, 'utf8').digest('hex');
+
+    expect(call.requestDigest?.sha256).toBe(expectedReqSha);
+    expect(call.requestDigest?.bytes).toBe(Buffer.byteLength(JSON.stringify(payload), 'utf8'));
+    expect(call.requestDigest?.key_manifest).toEqual(['brief', 'nested']);
+    expect(call.responseDigest?.sha256).toBe(expectedResSha);
+    expect(call.responseDigest?.key_manifest).toEqual(['graph', 'ok', 'schema_version']);
+    expect(call.echoedRequestId).toBe(REQUEST_ID);
+  });
+});

--- a/tests/v2-evidence-provenance.test.ts
+++ b/tests/v2-evidence-provenance.test.ts
@@ -28,44 +28,51 @@ import type { FastifyInstance } from 'fastify';
 import { createHash } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
-// Switchable ISL mock — deterministic; `meanA` varies semantic content.
+// Switchable ISL mock — deterministic; `state.meanA` varies semantic content.
+// vi.hoisted: this file also imports run.js directly (buildRequestIdChain),
+// so the mock factory can fire before module-body consts initialise.
 // ---------------------------------------------------------------------------
-let meanA = 0.7;
+const islMock = vi.hoisted(() => {
+  const state = { meanA: 0.7 };
 
-function computedIslResponse() {
-  return {
-    analysis_status: 'computed',
-    seed_used: 42,
-    options: [
-      {
-        option_id: 'opt-a',
-        outcome: { mean: meanA, std: 0.05, p10: meanA - 0.1, p50: meanA, p90: meanA + 0.1, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
-        win_probability: 0.7,
-        status: 'computed',
-      },
-      {
-        option_id: 'opt-b',
-        outcome: { mean: 0.4, std: 0.05, p10: 0.3, p50: 0.4, p90: 0.5, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
-        win_probability: 0.3,
-        status: 'computed',
-      },
-    ],
-    factor_sensitivity: [],
-    robustness: { confidence: 0.8, level: 'high', is_robust: true, fragile_edges: [], robust_edges: [] },
-    inference_warnings: [],
+  function computedIslResponse() {
+    const meanA = state.meanA;
+    return {
+      analysis_status: 'computed',
+      seed_used: 42,
+      options: [
+        {
+          option_id: 'opt-a',
+          outcome: { mean: meanA, std: 0.05, p10: meanA - 0.1, p50: meanA, p90: meanA + 0.1, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+          win_probability: 0.7,
+          status: 'computed',
+        },
+        {
+          option_id: 'opt-b',
+          outcome: { mean: 0.4, std: 0.05, p10: 0.3, p50: 0.4, p90: 0.5, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+          win_probability: 0.3,
+          status: 'computed',
+        },
+      ],
+      factor_sensitivity: [],
+      robustness: { confidence: 0.8, level: 'high', is_robust: true, fragile_edges: [], robust_edges: [] },
+      inference_warnings: [],
+    };
+  }
+
+  const mockISLService = {
+    isEnabled: () => true,
+    async callAnalysisEndpoint<T>(): Promise<any> {
+      return { data: computedIslResponse() as T, latency_ms: 5, isl_echoed_request_id: null };
+    },
   };
-}
 
-const mockISLService = {
-  isEnabled: () => true,
-  async callAnalysisEndpoint<T>(): Promise<any> {
-    return { data: computedIslResponse() as T, latency_ms: 5, isl_echoed_request_id: null };
-  },
-};
+  return { state, mockISLService };
+});
 
 vi.mock('../src/integrations/isl/index.ts', async () => {
   const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
-  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+  return { ...actual, getISLService: () => islMock.mockISLService, islService: islMock.mockISLService };
 });
 
 import { createServer } from '../src/createServer.js';
@@ -76,7 +83,7 @@ import {
 } from '../src/util/response-content-hash.js';
 import { buildRequestIdChain } from '../src/routes/v2/run.js';
 import { callCEEWithSchemaV2 } from '../src/cee/client.js';
-import { getDownstreamCalls, clearDownstreamTracking } from '../src/util/downstream-tracker.js';
+import { getDownstreamCalls, clearDownstreamTracking, initDownstreamTracking } from '../src/util/downstream-tracker.js';
 
 function validBody(extra: Record<string, unknown> = {}) {
   return {
@@ -119,7 +126,7 @@ describe('/v2/run evidence provenance (2.13 completion)', () => {
   // GAP A — deterministic response-content hash
   // -------------------------------------------------------------------------
   it('success response carries _meta.response_content_hash (rch_v1:<16 hex>)', async () => {
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
     expect(res.statusCode).toBe(200);
     const body = res.json();
@@ -128,7 +135,7 @@ describe('/v2/run evidence provenance (2.13 completion)', () => {
   });
 
   it('identical request replayed → identical response_content_hash (determinism)', async () => {
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     const r1 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
     const r2 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
     const h1 = r1.json()._meta.response_content_hash;
@@ -138,16 +145,16 @@ describe('/v2/run evidence provenance (2.13 completion)', () => {
   });
 
   it('semantically different response → different response_content_hash', async () => {
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     const r1 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
-    meanA = 0.6;
+    islMock.state.meanA = 0.6;
     const r2 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     expect(r2.json()._meta.response_content_hash).not.toBe(r1.json()._meta.response_content_hash);
   });
 
   it('response_content_hash is independently recomputable from the body (zero-mismatch)', async () => {
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
     const body = res.json();
     const claimed = body._meta.response_content_hash;
@@ -158,11 +165,11 @@ describe('/v2/run evidence provenance (2.13 completion)', () => {
   });
 
   it('response_hash (request-canonical determinism token) is UNCHANGED by the new field', async () => {
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     const r1 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
-    meanA = 0.6; // different response CONTENT, same request
+    islMock.state.meanA = 0.6; // different response CONTENT, same request
     const r2 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     // request-canonical: same request → same response_hash even when content differs
     expect(r2.json().meta.response_hash).toBe(r1.json().meta.response_hash);
   });
@@ -171,7 +178,7 @@ describe('/v2/run evidence provenance (2.13 completion)', () => {
   // GAP B — within-run wire-integrity assertion (header vs body)
   // -------------------------------------------------------------------------
   it('x-olumi-response-hash header matches an independent recompute over the body', async () => {
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
     const headerHash = res.headers['x-olumi-response-hash'];
     expect(headerHash).toMatch(/^[0-9a-f]{12}$/);
@@ -197,7 +204,7 @@ describe('/v2/run evidence provenance (2.13 completion)', () => {
   });
 
   it('success response chain carries cee:null when CEE is not called', async () => {
-    meanA = 0.7;
+    islMock.state.meanA = 0.7;
     const res = await app.inject({
       method: 'POST',
       url: '/v2/run',
@@ -223,6 +230,9 @@ describe('CEE client downstream digests (2.13 gap C)', () => {
   });
 
   it('callCEEWithSchemaV2 records request/response PayloadDigests over exact bytes + echoed id', async () => {
+    // recordDownstreamCall silently ignores un-initialised request ids —
+    // mirror the request lifecycle's init.
+    initDownstreamTracking(REQUEST_ID);
     const responseBody = { schema_version: 'v2', graph: { edges: [] }, ok: true };
     const responseText = JSON.stringify(responseBody);
 


### PR DESCRIPTION
# Evidence-provenance completion for /v2/run (ROADMAP 2.13)

Closes the PLoT half of the 2.13 residual gaps identified by the 2026-07-10 six-explorer sweep
(the row was otherwise largely landed by Lane PLoT-R3: `_meta.evidence` digests, downstream
capture, request-id chain, UI `evidence_capture`). RED-first: `tests/v2-evidence-provenance.test.ts`
committed RED (module-absent), now 9/9 GREEN.

## The four gaps closed

| Gap | Before | After |
|---|---|---|
| **A — content hash** | No deterministic hash of what PLoT RETURNED existed. `response_hash` hashes the canonicalised REQUEST (by design — determinism token; the UI freshness gate keys on `response_hash === results.hash`). The only body hash was the `x-olumi-response-hash` header: header-only, covers latency/timestamps → non-reproducible | Additive **`_meta.response_content_hash`** = `rch_v1:<sha256-16>` over the public semantic surface minus the exported volatile set (`src/util/response-content-hash.ts`), with the determinism-replay natural-key array sorts. Attached after the body is built (never hashes itself); success responses only (`V2RunError` has no `_meta`). Replay-stable (determinism-replay suite green). `response_hash` untouched; its request-canonical semantics now DOCUMENTED as by-design in the OpenAPI endpoint description (the row's "fix or document" → document + add distinctly-named content hash) |
| **B — zero-mismatch assertions** | "Zero hash mismatches" was never asserted: nothing compared header-vs-body or recorded-digest-vs-actual-bytes | Within-run assertions in the new suite: `x-olumi-response-hash` header == independent body recompute; `response_content_hash` independently recomputable from the body (exclusion list is exported precisely so external verifiers can recompute) |
| **C — CEE byte digests** | `cee/client.ts` never computed `PayloadDigest`s — diligence-grade byte digests were ISL-only | All 3 CEE call sites now read raw text-then-parse (matching the ISL client) and record `requestDigest`/`responseDigest` over the exact wire bytes + the echoed `x-request-id` |
| **D — CEE chain leg** | `request_id_chain` was PLoT→ISL only | Additive `cee`/`cee_echoed` legs, derived from the downstream tracker at response build. **`all_match`/`chain_complete` stay computed over the original ISL four** (Brief 4 header spec back-compat) — pinned by test: a divergent CEE echo cannot flip them |

## Deliberate pin updates (each verified, none papering)

- `tests/b3-numeric-invariance.test.ts`: `response_content_hash` added to the ambient mask — it is
  a derived function of the two B3 fields that test deliberately lets differ; its own correctness
  is pinned in the new suite.
- ISL-V2 golden regenerated TWICE, both diffs fully explained: (1) the three designed additive
  fields (cee legs ×2 locations + content hash); (2) after the golden itself caught `meta.build`
  (deployed git SHA) inside the hash — every commit flipped the hash on identical content →
  `build` + `feature_flags` moved to the exclusion list as deployment/environment provenance,
  golden regenerated, delta = hash value only. This is the golden doing exactly its job.

## Consciously out of scope

- **State-selection trace** — pure UI-half (extend `analysis_state_source`, fill the stubbed
  `cross_surface_events: []`); routed to A2 via the orchestrator (sweep report has the seam).
- **`UI_CANONICAL_META` staging flip** — `_meta.payloads.isl_request/response` (full sanitized
  bodies) stay gated; un-gating is an env/exposure decision for the orchestrator, not this lane.
  The always-on digest surface (`_meta.evidence`) is unaffected.
- CEE-side echo: CEE may not echo `x-request-id` today — `cee_echoed` reports the honest null
  until it does (no CEE change required for the field to be truthful).

## Verification

- RED (commit `e0408ca`, module-absent) → GREEN 9/9; affected set green: determinism-replay,
  b3-numeric-invariance, evidence-capture, auto-constraint-fallback, cil-phase02 (the latter two
  needed `npm run build` first — known fresh-worktree dist/ env issue).
- Full `scripts/pre-push-validate.sh` PASSED (5,45x tests). Two intermediate gate runs flaked on
  DIFFERENT server-spawning files (v2-determinism, counterfactual.zero-baseline) — each passes in
  isolation, neither touched by this diff; known load-flake class (ROADMAP hygiene row).
- CI: expect the standing reds only — `audit`, `gates (windows-latest)`, and `validate-structure`
  (spec-touching PRs only; 37 pre-existing Redocly errors, proven identical on base — see PR #212
  comment for the evidence pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
