### PR TITLE
fix(review): xhigh-review hardening — wire-leak, hash determinism (rch_v2), v1 contract, dead belt

### DIFF
--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -697,6 +697,20 @@ export function createISLService(): ISLService {
 }
 
 /**
+ * Public projection of an ISLAnalysisResult error for v1 proxy responses
+ * (review [6]): the enriched fields (status, critiques — added for the
+ * /v2/run typed failure envelope) are internal discriminators for /v2/run
+ * and must not widen the declared v1 `isl_error` contract
+ * {code, message, retryable} or leak ISL-internal critique detail.
+ */
+export function toPublicIslError(
+  error: { code: string; message: string; retryable: boolean } | undefined,
+): { code: string; message: string; retryable: boolean } | undefined {
+  if (!error) return undefined;
+  return { code: error.code, message: error.message, retryable: error.retryable };
+}
+
+/**
  * Transform PLoT Graph to ISL DAG structure
  */
 function graphToISLDAG(graph: Graph): ISLDAGStructure {

--- a/src/routes/v1/analysis-conditional-recommend.ts
+++ b/src/routes/v1/analysis-conditional-recommend.ts
@@ -14,7 +14,7 @@ import { normalizeGraph } from '../../util/normalize.js';
 import { detectPrimaryOutcome } from '../../services/ranking/outcome-detector.js';
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import { validateSequentialGraph, isSequentialGraph } from '../../util/sequential-validation.js';
 import type {
   ConditionalRecommendRequest,
@@ -273,7 +273,7 @@ export async function registerConditionalRecommendRoute(app: FastifyInstance) {
         );
 
         recommendation = islResult.data;
-        islError = islResult.error;
+        islError = toPublicIslError(islResult.error);
 
         if (recommendation) {
           provenance = 'isl';

--- a/src/routes/v1/analysis-dominance.ts
+++ b/src/routes/v1/analysis-dominance.ts
@@ -15,7 +15,7 @@ import { detectPrimaryOutcome } from '../../services/ranking/outcome-detector.js
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { isWinnerDominant } from '../../trust/ranking-confidence.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import type {
   DominanceAnalysisRequest,
   DominanceAnalysisResponse,
@@ -234,7 +234,7 @@ export async function registerDominanceAnalysisRoute(app: FastifyInstance) {
         );
 
         analysis = islResult.data;
-        islError = islResult.error;
+        islError = toPublicIslError(islResult.error);
 
         if (analysis) {
           provenance = 'isl';

--- a/src/routes/v1/analysis-multi-criteria.ts
+++ b/src/routes/v1/analysis-multi-criteria.ts
@@ -13,7 +13,7 @@ import { getInferenceEngine } from '../../inference/index.js';
 import { normalizeGraph } from '../../util/normalize.js';
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import type {
   MultiCriteriaRequest,
   MultiCriteriaResponse,
@@ -382,7 +382,7 @@ export async function registerMultiCriteriaAnalysisRoute(app: FastifyInstance) {
         );
 
         aggregation = islResult.data;
-        islError = islResult.error;
+        islError = toPublicIslError(islResult.error);
         islMs = islResult.latency_ms;
 
         if (aggregation) {

--- a/src/routes/v1/analysis-optimise.ts
+++ b/src/routes/v1/analysis-optimise.ts
@@ -14,7 +14,7 @@ import { replyWithAppError } from '../../errors.js';
 import { normalizeGraph } from '../../util/normalize.js';
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import type {
   ContinuousOptimiseRequest,
   ContinuousOptimiseResponse,
@@ -273,7 +273,7 @@ export async function registerAnalysisOptimiseRoute(app: FastifyInstance) {
           );
 
           result = islResult.data;
-          islError = islResult.error;
+          islError = toPublicIslError(islResult.error);
 
           // Record result with circuit breaker
           if (result) {

--- a/src/routes/v1/analysis-pareto.ts
+++ b/src/routes/v1/analysis-pareto.ts
@@ -14,7 +14,7 @@ import { normalizeGraph } from '../../util/normalize.js';
 import { detectPrimaryOutcome } from '../../services/ranking/outcome-detector.js';
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import type {
   ParetoAnalysisRequest,
   ParetoAnalysisResponse,
@@ -257,7 +257,7 @@ export async function registerParetoAnalysisRoute(app: FastifyInstance) {
         islMs = islResult.latency_ms;
 
         analysis = islResult.data;
-        islError = islResult.error;
+        islError = toPublicIslError(islResult.error);
 
         if (analysis) {
           provenance = 'isl';

--- a/src/routes/v1/analysis-policy-tree.ts
+++ b/src/routes/v1/analysis-policy-tree.ts
@@ -15,7 +15,7 @@ import { detectPrimaryOutcome } from '../../services/ranking/outcome-detector.js
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { validateSequentialGraph, getMaxStage } from '../../util/sequential-validation.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import type {
   PolicyTreeRequest,
   PolicyTreeResponse,
@@ -333,7 +333,7 @@ export async function registerPolicyTreeRoute(app: FastifyInstance) {
         );
 
         tree = islResult.data;
-        islError = islResult.error;
+        islError = toPublicIslError(islResult.error);
 
         if (tree) {
           provenance = 'isl';

--- a/src/routes/v1/analysis-risk-adjust.ts
+++ b/src/routes/v1/analysis-risk-adjust.ts
@@ -14,7 +14,7 @@ import { normalizeGraph } from '../../util/normalize.js';
 import { detectPrimaryOutcome } from '../../services/ranking/outcome-detector.js';
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import type {
   RiskAdjustRequest,
   RiskAdjustResponse,
@@ -305,7 +305,7 @@ export async function registerRiskAdjustRoute(app: FastifyInstance) {
         );
 
         analysis = islResult.data;
-        islError = islResult.error;
+        islError = toPublicIslError(islResult.error);
 
         if (analysis) {
           provenance = 'isl';

--- a/src/routes/v1/analysis-sequential.ts
+++ b/src/routes/v1/analysis-sequential.ts
@@ -15,7 +15,7 @@ import { detectPrimaryOutcome } from '../../services/ranking/outcome-detector.js
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { validateSequentialGraph, getMaxStage } from '../../util/sequential-validation.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import type {
   SequentialAnalysisRequest,
   SequentialAnalysisResponse,
@@ -340,7 +340,7 @@ export async function registerSequentialAnalysisRoute(app: FastifyInstance) {
           );
 
           analysis = islResult.data;
-          islError = islResult.error;
+          islError = toPublicIslError(islResult.error);
 
           // Record result with circuit breaker
           if (analysis) {

--- a/src/routes/v1/analysis-thresholds.ts
+++ b/src/routes/v1/analysis-thresholds.ts
@@ -14,7 +14,7 @@ import { normalizeGraph } from '../../util/normalize.js';
 import { detectPrimaryOutcome } from '../../services/ranking/outcome-detector.js';
 import { inferEdgeTypes } from '../../services/ranking/edge-type-inference.js';
 import { isFlagOn } from '../../cee/codes.js';
-import { islService } from '../../integrations/isl/index.js';
+import { islService, toPublicIslError } from '../../integrations/isl/index.js';
 import type {
   ThresholdRequest,
   ThresholdResponse,
@@ -355,7 +355,7 @@ export async function registerThresholdsRoute(app: FastifyInstance) {
         );
 
         analysis = islResult.data;
-        islError = islResult.error;
+        islError = toPublicIslError(islResult.error);
         islMs = islResult.latency_ms;
 
         if (analysis) {

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -88,6 +88,7 @@ import {
   logISLCall,
 } from '../../logging/preflight-logger.js';
 import { getISLService } from '../../integrations/isl/index.js';
+import { ISLHttpError } from '../../integrations/isl/errors.js';
 import type { ISLCritique } from '../../integrations/isl/errors.js';
 import { errorResponse } from '../../errors.js';
 import { buildRobustnessDataForCee } from '../../integrations/isl/adapters/robustness-enrichment.js';
@@ -4794,13 +4795,16 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             });
           }
         } catch (err) {
-          // Defensive only: callAnalysisEndpoint has a no-throw contract
-          // (it catches ISLHttpError/timeouts/network internally and RETURNS
-          // the error object — handled via islCallError below). Review [9]
-          // removed the dead ISLHttpError belt that duplicated the live
-          // islCallError 422 branch.
+          // Defensive only: the real callAnalysisEndpoint has a no-throw
+          // contract (it catches ISLHttpError/timeouts/network internally and
+          // RETURNS the error object — handled via islCallError below).
+          // Review [9] removed the dead ISLHttpError 422 belt that duplicated
+          // the live islCallError branch, but a thrown ISLHttpError (swapped
+          // service implementation, test double) keeps its status semantics —
+          // retryableFromIslStatus(401/404) = false is pinned by
+          // v2-run-error-shapes.test.ts.
           islFallbackExecuted = true;
-          islStatusCode = 500;
+          islStatusCode = err instanceof ISLHttpError ? err.status : 500;
 
           req.log.error({
             event: 'isl_call_exception',

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -88,7 +88,6 @@ import {
   logISLCall,
 } from '../../logging/preflight-logger.js';
 import { getISLService } from '../../integrations/isl/index.js';
-import { ISLHttpError } from '../../integrations/isl/errors.js';
 import type { ISLCritique } from '../../integrations/isl/errors.js';
 import { errorResponse } from '../../errors.js';
 import { buildRobustnessDataForCee } from '../../integrations/isl/adapters/robustness-enrichment.js';
@@ -1310,7 +1309,11 @@ function buildIslFailureDetail(
       id: randomUUID(),
       code: error.code,
       severity: 'error',
-      message: error.message,
+      // Review [17]: class-safe copy, never the raw ISL error.message — raw
+      // detail carries internals (endpoint paths, timeout config) and already
+      // goes to the logs (isl_call_failed / isl_analysis_failed events); the
+      // wire gets the same claim-safe posture as PLOT_INTERNAL_ERROR.
+      message: statusReason,
       source: 'isl',
       blocks_analysis: false,
     },
@@ -2546,7 +2549,12 @@ function buildResponse(
     });
   }
 
-  return {
+  // Snapshot the downstream call log ONCE — _meta.builds, _meta.payloads,
+  // _meta.evidence and downstream_calls below all read it (review [7]: was
+  // re-scanned + re-mapped per consumer, copying sanitized ISL bodies each time).
+  const downstreamCallsForLog = getDownstreamCallsForLog(requestId);
+
+  const response: RunResponseV3 = {
     request_schema_version: 'v3',
     endpoint_version: 'v2/run',
     preflight_version: PREFLIGHT_VERSION_VALUE,
@@ -2776,7 +2784,7 @@ function buildResponse(
 
       // Extended _meta fields only when feature flag enabled
       if (isCanonicalMetaEnabled()) {
-        const allCalls = getDownstreamCallsForLog(requestId);
+        const allCalls = downstreamCallsForLog;
         const islCall = allCalls.find(c => c.service === 'isl');
 
         // Build versions for all services in the pipeline
@@ -2837,7 +2845,7 @@ function buildResponse(
       // primary exchange is the first robustness/analyze call; flip probes and
       // follow-ups remain visible in downstream_calls when captured.
       baseMeta.evidence = (() => {
-        const calls = getDownstreamCallsForLog(requestId);
+        const calls = downstreamCallsForLog;
         const primaryIslCall =
           calls.find((c) => c.service === 'isl' && c.endpoint.includes('/robustness/analyze')) ??
           calls.find((c) => c.service === 'isl');
@@ -2873,7 +2881,7 @@ function buildResponse(
 
     // Downstream service calls (ISL, CEE) for debugging and tracing
     downstream_calls: (() => {
-      const allCalls = getDownstreamCallsForLog(requestId);
+      const allCalls = downstreamCallsForLog;
       if (allCalls.length === 0) return undefined;
       const islCalls = allCalls.filter(c => c.service === 'isl');
       const ceeCalls = allCalls.filter(c => c.service === 'cee');
@@ -2914,6 +2922,18 @@ function buildResponse(
       },
     },
   };
+
+  // 2.13 gap A (review [10]: attach at the OWNER layer, not per send site):
+  // buildResponse owns _meta, so every caller — main computed path AND the
+  // ISL_NOT_ENABLED early return — carries the deterministic content hash.
+  // Attached after assembly so it never hashes itself (_meta is excluded
+  // from the hash by construction). response_hash (request-canonical
+  // determinism token) is deliberately untouched.
+  if (response._meta) {
+    response._meta.response_content_hash = computeResponseContentHash(response);
+  }
+
+  return response;
 }
 
 // -----------------------------------------------------------------------------
@@ -4639,7 +4659,6 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         let islResult: any;
         let islSuccess = false;
         let islStatusCode = 0;
-        let islError: ISLHttpError | undefined;
         // Full error object from callAnalysisEndpoint's no-throw contract —
         // carries the discriminating code (+ status/critiques for HTTP-level
         // rejections). Fragility gaps 2/3: previously only `retryable` was
@@ -4775,24 +4794,13 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             });
           }
         } catch (err) {
+          // Defensive only: callAnalysisEndpoint has a no-throw contract
+          // (it catches ISLHttpError/timeouts/network internally and RETURNS
+          // the error object — handled via islCallError below). Review [9]
+          // removed the dead ISLHttpError belt that duplicated the live
+          // islCallError 422 branch.
           islFallbackExecuted = true;
-          if (err instanceof ISLHttpError) {
-            islError = err;
-            islStatusCode = err.status;
-            islEchoedRequestId = (err as any).islEchoedRequestId ?? null;
-
-            // Handle 422 from ISL with structured critiques (V2, V1, or Pydantic format)
-            if (err.is422()) {
-              req.log.info({
-                event: 'isl_422_received',
-                format: err.isV2Format() ? 'v2' : 'legacy',
-                message: err.getErrorMessage(),
-                critiques_count: err.getCritiques().length,
-              });
-            }
-          } else {
-            islStatusCode = 500;
-          }
+          islStatusCode = 500;
 
           req.log.error({
             event: 'isl_call_exception',
@@ -4863,32 +4871,17 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           });
         }
 
-        // Handle ISL 422 with structured critiques (V2, V1, or Pydantic format)
-        if (islError?.is422()) {
-          const islCritiques = mapISLCritiquesToV2(islError.getCritiques());
-          critiques.push(...islCritiques);
-
-          return reply.status(422).send(buildBlockedResponse(
-            islError.getErrorMessage(),
-            critiques,
-            filteredGraph,
-            normalizedOptions,
-            requestId,
-            computedAt ?? requestComputedAt,
-          ));
-        }
-
-        // Fragility gap 3: the branch above never fires on the live path —
-        // callAnalysisEndpoint catches ISLHttpError and RETURNS the error
-        // rather than throwing, so ISL's structured 422 critiques arrive
-        // here. Same 422-blocked contract as the throw path.
+        // Fragility gap 3: ISL 422 with structured critiques. callAnalysisEndpoint
+        // catches ISLHttpError and RETURNS the error object (no-throw contract),
+        // so ISL's structured 422 critiques arrive here. ISL blockers go FIRST
+        // (review [0]: CEE plot-client renders critiques[0].message — an info
+        // NORMALIZATION_WARNING must not displace the blocking ISL critique).
         if (islCallError?.status === 422 && islCallError.critiques && islCallError.critiques.length > 0) {
           const islCritiques = mapISLCritiquesToV2(islCallError.critiques);
-          critiques.push(...islCritiques);
 
           return reply.status(422).send(buildBlockedResponse(
             islCallError.message || 'ISL validation failed',
-            critiques,
+            [...islCritiques, ...critiques],
             filteredGraph,
             normalizedOptions,
             requestId,
@@ -5844,7 +5837,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         );
         reply.header('X-Olumi-Request-Id-Chain', buildRequestIdChainHeader(chain)!);
 
-        const successBody = buildResponse(
+        return reply.send(buildResponse(
           requestId,
           topLevelStatus,
           topLevelStatus !== 'computed' ? (islStatusReason || 'Some analyses unavailable') : undefined,
@@ -5897,17 +5890,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           toIdentifiabilityResponse(identifiabilityResult),  // B1.5a: always-present mapped response
           factorStability,  // 3C: ISL stability assessment per factor
           req.log  // logger for fact_objects assembly logging
-        );
-
-        // 2.13 gap A: deterministic response-CONTENT hash, attached AFTER the
-        // body is fully built so it can never hash itself. Success surface
-        // only — V2RunError carries no _meta. response_hash (request-canonical
-        // determinism token) is deliberately untouched.
-        if (successBody._meta) {
-          successBody._meta.response_content_hash = computeResponseContentHash(successBody);
-        }
-
-        return reply.send(successBody);
+        ));
       } catch (err) {
         req.log.error({
           event: 'v2_run_error',

--- a/src/util/response-content-hash.ts
+++ b/src/util/response-content-hash.ts
@@ -8,30 +8,41 @@
  * the x-olumi-response-hash header, which covers volatile fields
  * (latency_ms, timestamps) and is therefore not reproducible across runs.
  *
- * `response_content_hash` closes that gap: sha256 (16 hex, "rch_v1:"-prefixed)
+ * `response_content_hash` closes that gap: sha256 (16 hex, versioned prefix)
  * over the PUBLIC semantic surface of the response — the full body minus
- * the `_meta` diagnostic subtree and minus the volatile field set below —
- * with the natural-key array sorts the determinism-replay suite uses, so a
- * replayed identical request yields an identical hash. It is attached to
- * `_meta.response_content_hash` AFTER computation, so it never hashes itself,
- * and it never feeds `hashRequest` (request-hash stability preserved).
+ * the `_meta` diagnostic subtree and minus the volatile field set below.
+ * It is attached inside buildResponse AFTER the body is assembled, so it
+ * never hashes itself, and it never feeds `hashRequest` (request-hash
+ * stability preserved).
+ *
+ * rch_v2 (review-hardening, 2026-07-11) changed the recipe from rch_v1:
+ *   - array pre-sort uses locale-independent code-unit comparison (was
+ *     localeCompare — ICU/locale-dependent, so the "independently
+ *     recomputable" promise could break across Node builds);
+ *   - equal natural keys tie-break on the elements' canonical serialisation
+ *     (edge_sensitivity carries each edge_id twice — existence+magnitude —
+ *     so a key-only sort left upstream order leaking into the hash);
+ *   - `id` is stripped ONLY inside the `critiques` subtree (critique UUIDs),
+ *     no longer globally — nested semantic `id` fields (e.g. review-card
+ *     supporting_refs) are hashed content again;
+ *   - single-pass serialisation (no intermediate deep clones).
  *
  * The exclusion list is exported so tests (and external verifiers) recompute
  * the hash independently — "zero hash mismatches" is asserted, not assumed.
- * Keep it aligned with tests/determinism-replay.test.ts IGNORE_FIELDS: a new
- * volatile field that breaks replay-stability of this hash must be added in
- * BOTH places, as a conscious decision.
+ * SHARED_VOLATILE_KEYS is the single source the determinism-replay suite
+ * derives its ignore-list from: a new volatile field is added ONCE, here.
  */
 
 import { createHash } from 'node:crypto';
-import { canonicalJson } from '../facts/hash.js';
 
-export const RESPONSE_CONTENT_HASH_VERSION = 'rch_v1';
+export const RESPONSE_CONTENT_HASH_VERSION = 'rch_v2';
 
-/** Field names stripped (deep, by key) before hashing — the volatile set. */
-export const RESPONSE_CONTENT_HASH_EXCLUDED_KEYS: readonly string[] = [
-  // Diagnostic subtree (builds, digests, payloads, this hash itself)
-  '_meta',
+/**
+ * Volatile-by-key field names shared with the determinism-replay suite
+ * (tests/determinism-replay.test.ts derives its IGNORE_FIELDS from this —
+ * single source; do not fork a second list).
+ */
+export const SHARED_VOLATILE_KEYS: readonly string[] = [
   // Per-request identity & call traces
   'request_id',
   'request_id_chain',
@@ -49,8 +60,7 @@ export const RESPONSE_CONTENT_HASH_EXCLUDED_KEYS: readonly string[] = [
   'isl_ms',
   'cee_ms',
   'timestamp',
-  // Per-run generated identifiers
-  'id',        // critique UUIDs (semantic ids use option_id/edge_id/factor_id)
+  // Per-run generated identifiers / containers of them
   'brief_id',
   'created_at',
   'fact_objects',
@@ -58,20 +68,32 @@ export const RESPONSE_CONTENT_HASH_EXCLUDED_KEYS: readonly string[] = [
   'thresholds_status',
   'thresholds_meta',
   'threshold_analysis',
-  // Deployment/environment provenance, not response content: meta.build is
-  // the deployed git SHA (changes every commit — a checked-in golden or
-  // cross-deploy replay would flip the hash with identical content), and
-  // meta.feature_flags is an environment snapshot carried for diagnostics.
+];
+
+/**
+ * Additional exclusions specific to the content hash (NOT for the replay
+ * suite, which deliberately still compares `_meta` contents):
+ * `_meta` = diagnostic subtree (builds, digests, payloads, this hash);
+ * `build`/`feature_flags` = deployment/environment provenance (meta.build is
+ * the deployed git SHA — a checked-in golden or cross-deploy replay would
+ * flip the hash with identical content); self-reference guard. `id` is NOT
+ * here — it is stripped context-scoped, only inside `critiques` (see
+ * serialize()).
+ */
+export const RESPONSE_CONTENT_HASH_EXCLUDED_KEYS: readonly string[] = [
+  ...SHARED_VOLATILE_KEYS,
+  '_meta',
   'build',
   'feature_flags',
-  // Safety: never self-referential wherever it is attached
   'response_content_hash',
 ];
 
 /**
- * Top-level arrays sorted by natural key before hashing — mirrors the
- * determinism-replay suite's SORT_ARRAYS_BY so element-order jitter can't
- * flip the hash between replays.
+ * Top-level arrays pre-sorted by natural key before hashing, so element-order
+ * jitter can't flip the hash between replays. The determinism-replay suite
+ * derives its SORT_ARRAYS_BY from this map (single source). Ties on the
+ * natural key (edge_sensitivity legitimately repeats edge_id) fall back to
+ * the elements' canonical serialisation, so upstream ordering never leaks in.
  */
 export const RESPONSE_CONTENT_HASH_SORTED_ARRAYS: Readonly<Record<string, string>> = {
   option_comparison: 'option_id',
@@ -80,46 +102,79 @@ export const RESPONSE_CONTENT_HASH_SORTED_ARRAYS: Readonly<Record<string, string
   critiques: 'code',
 };
 
-function stripVolatile(value: unknown, excluded: ReadonlySet<string>): unknown {
+/** Locale-independent code-unit string comparison (never localeCompare). */
+function cmpCodeUnit(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Single-pass canonical serialiser: sorted object keys (code-unit order),
+ * excluded keys dropped, `id` dropped only inside the `critiques` subtree.
+ * Emits JSON text directly — no intermediate clone of the body.
+ */
+function serialize(value: unknown, insideCritiques: boolean, excluded: ReadonlySet<string>): string | undefined {
+  if (value === null) return 'null';
+  switch (typeof value) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return JSON.stringify(value);
+    case 'undefined':
+    case 'function':
+    case 'symbol':
+      return undefined;
+  }
   if (Array.isArray(value)) {
-    return value.map((v) => stripVolatile(v, excluded));
+    const parts = value.map((v) => serialize(v, insideCritiques, excluded) ?? 'null');
+    return `[${parts.join(',')}]`;
   }
-  if (value !== null && typeof value === 'object') {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (excluded.has(k)) continue;
-      out[k] = stripVolatile(v, excluded);
-    }
-    return out;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record)
+    .filter((k) => !excluded.has(k) && !(insideCritiques && k === 'id'))
+    .sort(cmpCodeUnit);
+  const parts: string[] = [];
+  for (const k of keys) {
+    const v = serialize(record[k], insideCritiques || k === 'critiques', excluded);
+    if (v !== undefined) parts.push(`${JSON.stringify(k)}:${v}`);
   }
-  return value;
+  return `{${parts.join(',')}}`;
 }
 
 /**
  * Compute the deterministic content hash of a /v2/run response body.
- * Pass the body WITHOUT `_meta.response_content_hash` attached (the field is
- * stripped defensively anyway via the exclusion list).
+ * Safe to pass the fully-built body: `_meta` (and therefore any attached
+ * response_content_hash) is excluded by construction.
  */
 export function computeResponseContentHash(body: unknown): string {
   const excluded = new Set(RESPONSE_CONTENT_HASH_EXCLUDED_KEYS);
-  const stripped = stripVolatile(body, excluded);
+  let surface = body;
 
-  if (stripped !== null && typeof stripped === 'object' && !Array.isArray(stripped)) {
-    const record = stripped as Record<string, unknown>;
+  if (body !== null && typeof body === 'object' && !Array.isArray(body)) {
+    const record = body as Record<string, unknown>;
+    const overrides: Record<string, unknown> = {};
     for (const [field, sortKey] of Object.entries(RESPONSE_CONTENT_HASH_SORTED_ARRAYS)) {
       const arr = record[field];
-      if (Array.isArray(arr)) {
-        record[field] = [...arr].sort((a, b) =>
-          String((a as Record<string, unknown>)?.[sortKey] ?? '')
-            .localeCompare(String((b as Record<string, unknown>)?.[sortKey] ?? '')),
+      if (!Array.isArray(arr)) continue;
+      const insideCritiques = field === 'critiques';
+      overrides[field] = [...arr].sort((a, b) => {
+        const ka = String((a as Record<string, unknown>)?.[sortKey] ?? '');
+        const kb = String((b as Record<string, unknown>)?.[sortKey] ?? '');
+        const primary = cmpCodeUnit(ka, kb);
+        if (primary !== 0) return primary;
+        // Tie-break: full canonical serialisation, so duplicate natural keys
+        // (e.g. edge_sensitivity existence+magnitude rows) order stably.
+        return cmpCodeUnit(
+          serialize(a, insideCritiques, excluded) ?? 'null',
+          serialize(b, insideCritiques, excluded) ?? 'null',
         );
-      }
+      });
+    }
+    if (Object.keys(overrides).length > 0) {
+      surface = { ...record, ...overrides };
     }
   }
 
-  const digest = createHash('sha256')
-    .update(canonicalJson(stripped), 'utf8')
-    .digest('hex')
-    .slice(0, 16);
+  const canonical = serialize(surface, false, excluded) ?? 'null';
+  const digest = createHash('sha256').update(canonical, 'utf8').digest('hex').slice(0, 16);
   return `${RESPONSE_CONTENT_HASH_VERSION}:${digest}`;
 }

--- a/tests/determinism-replay.test.ts
+++ b/tests/determinism-replay.test.ts
@@ -15,6 +15,10 @@ import {
   canonicalCompare,
   DEFAULT_IGNORE_FIELDS,
 } from './utils/canonical-compare.js';
+import {
+  SHARED_VOLATILE_KEYS,
+  RESPONSE_CONTENT_HASH_SORTED_ARRAYS,
+} from '../src/util/response-content-hash.js';
 
 // ---------------------------------------------------------------------------
 // ISL Mock — deterministic responses keyed by option ID
@@ -116,43 +120,33 @@ const OPTIONS = [
   { id: 'opt2', label: 'Reduce Churn', interventions: { 'factor-b': 0.3 } },
 ];
 
-/** Volatile fields that vary between runs (timestamps, durations, UUIDs). */
+/**
+ * Volatile fields that vary between runs (timestamps, durations, UUIDs).
+ * Review [13]: the shared volatile set is single-sourced from
+ * src/util/response-content-hash.ts (SHARED_VOLATILE_KEYS) so a new volatile
+ * field added there automatically stays out of BOTH this replay comparison
+ * and response_content_hash. Test-only additions below: `id` (critique UUIDs
+ * — the content hash strips these context-scoped inside `critiques` only,
+ * but this suite compares the whole body) and the _meta.evidence digests
+ * (cover exact ISL wire bytes incl. the per-request request_id; the content
+ * hash excludes all of _meta wholesale, which this suite deliberately does
+ * NOT — evidence.plot_build/isl_build stay compared).
+ */
 const IGNORE_FIELDS = [
   ...DEFAULT_IGNORE_FIELDS,
-  'timing',
-  'latency_ms',
-  'normalization_ms',
-  'validation_ms',
-  'isl_ms',
-  'cee_ms',
+  ...SHARED_VOLATILE_KEYS,
   'id', // critique UUIDs
-  'downstream_calls', // per-request ISL/CEE call traces (IDs, timings, payloads)
-  'request_id_chain', // per-request UUID chain across services
-  'requestId', // ceeTrace.requestId (per-request UUID)
-  'timestamp', // ceeTrace.timestamp, downstream_calls timestamps
-  'plot_request_id', // ceeTrace.plot_request_id (per-request UUID)
-  'cee_sent_request_id', // ceeTrace.cee_sent_request_id (per-request UUID)
-  'thresholds_status',   // B10.3: depends on ISL call timing, not deterministic inputs
-  'thresholds_meta',     // B10.3: contains duration_ms (volatile timing)
-  'threshold_analysis',  // B10.3: presence depends on ISL call success/timing
-  'brief_id',            // decision_brief: deterministic SHA-256-derived UUID (excluded for backwards compat with existing snapshots)
-  'created_at',          // decision_brief: timestamp per assembly
-  'fact_objects',        // F.7: fact_objects contain per-request IDs (fact_id, isl_request_id, content_hash); tested separately
-  // Lane PLoT-R3 (2.13): _meta.evidence digests cover the EXACT ISL wire bytes,
-  // which include the per-request request_id — legitimately volatile per run
-  // (same class as downstream_calls / request_id, already ignored above).
-  // evidence.plot_build and evidence.isl_build remain compared.
   'isl_request_digest',
   'isl_response_digest',
 ];
 
-/** Sort arrays by their natural key so element order doesn't cause false mismatches. */
-const SORT_ARRAYS_BY = {
-  '$.option_comparison': 'option_id',
-  '$.edge_sensitivity': 'edge_id',
-  '$.factor_sensitivity': 'factor_id',
-  '$.critiques': 'code',
-};
+/**
+ * Sort arrays by their natural key so element order doesn't cause false
+ * mismatches — derived from the content-hash module's map (single source).
+ */
+const SORT_ARRAYS_BY = Object.fromEntries(
+  Object.entries(RESPONSE_CONTENT_HASH_SORTED_ARRAYS).map(([field, key]) => [`$.${field}`, key]),
+);
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -1606,7 +1606,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v1:41cf78c41d8a44ce"
+    "response_content_hash": "rch_v2:ad7100190167bf5b"
   },
   "meta": {
     "seed_used": "2034401427",

--- a/tests/helpers/run-fixtures.ts
+++ b/tests/helpers/run-fixtures.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared /v2/run test fixtures (review [16]: previously duplicated
+ * near-identically in v2-typed-failure-envelope.test.ts and
+ * v2-evidence-provenance.test.ts — a request-contract change had to be
+ * edited in both copies or one suite silently exercised a stale body).
+ *
+ * NOTE: files that build their ISL mock inside vi.hoisted() cannot import
+ * this module there (hoisted blocks run before imports resolve) — those
+ * keep a local response builder and reference this file in a comment.
+ */
+
+/** Minimal valid /v2/run request body (2 options — schema minimum). */
+export function makeValidRunBody(extra: Record<string, unknown> = {}) {
+  return {
+    graph: {
+      nodes: [
+        { id: 'factor-0', kind: 'factor', label: 'Factor 0', observed_state: { value: 0.5 } },
+        { id: 'goal', kind: 'goal', label: 'Goal' },
+      ],
+      edges: [
+        { from: 'factor-0', to: 'goal', exists_probability: 0.8, strength: { mean: 0.3, std: 0.05 } },
+      ],
+    },
+    options: [
+      { id: 'opt-a', label: 'Option A', interventions: { 'factor-0': { value: 0.8, source: 'user_specified' } } },
+      { id: 'opt-b', label: 'Option B', interventions: { 'factor-0': { value: 0.2, source: 'user_specified' } } },
+    ],
+    goal_node_id: 'goal',
+    seed: '42',
+    ...extra,
+  };
+}
+
+/** Deterministic computed ISL response; `meanA` varies semantic content. */
+export function makeComputedIslResponse(meanA = 0.7) {
+  return {
+    analysis_status: 'computed',
+    seed_used: 42,
+    options: [
+      {
+        option_id: 'opt-a',
+        outcome: { mean: meanA, std: 0.05, p10: meanA - 0.1, p50: meanA, p90: meanA + 0.1, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+        win_probability: 0.7,
+        status: 'computed',
+      },
+      {
+        option_id: 'opt-b',
+        outcome: { mean: 0.4, std: 0.05, p10: 0.3, p50: 0.4, p90: 0.5, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
+        win_probability: 0.3,
+        status: 'computed',
+      },
+    ],
+    factor_sensitivity: [],
+    robustness: { confidence: 0.8, level: 'high', is_robust: true, fragile_edges: [], robust_edges: [] },
+    inference_warnings: [],
+  };
+}

--- a/tests/v2-evidence-provenance.test.ts
+++ b/tests/v2-evidence-provenance.test.ts
@@ -11,7 +11,7 @@
  *          must NOT change). The only true body hash is the
  *          x-olumi-response-hash header: header-only, and non-reproducible
  *          across runs (covers latency/timestamps).
- *          → additive `_meta.response_content_hash` ("rch_v1:<sha256-16>")
+ *          → additive `_meta.response_content_hash` ("rch_v2:<sha256-16>")
  *            over the public semantic surface minus the volatile set.
  *  GAP B — "zero hash mismatches" was never ASSERTED anywhere: nothing
  *          compared header-vs-body or recorded-digest-vs-actual-bytes.
@@ -84,27 +84,10 @@ import {
 import { buildRequestIdChain } from '../src/routes/v2/run.js';
 import { callCEEWithSchemaV2 } from '../src/cee/client.js';
 import { getDownstreamCalls, clearDownstreamTracking, initDownstreamTracking } from '../src/util/downstream-tracker.js';
+import { makeValidRunBody } from './helpers/run-fixtures.js';
+import { toPublicIslError } from '../src/integrations/isl/index.js';
 
-function validBody(extra: Record<string, unknown> = {}) {
-  return {
-    graph: {
-      nodes: [
-        { id: 'factor-0', kind: 'factor', label: 'Factor 0', observed_state: { value: 0.5 } },
-        { id: 'goal', kind: 'goal', label: 'Goal' },
-      ],
-      edges: [
-        { from: 'factor-0', to: 'goal', exists_probability: 0.8, strength: { mean: 0.3, std: 0.05 } },
-      ],
-    },
-    options: [
-      { id: 'opt-a', label: 'Option A', interventions: { 'factor-0': { value: 0.8, source: 'user_specified' } } },
-      { id: 'opt-b', label: 'Option B', interventions: { 'factor-0': { value: 0.2, source: 'user_specified' } } },
-    ],
-    goal_node_id: 'goal',
-    seed: '42',
-    ...extra,
-  };
-}
+const validBody = makeValidRunBody;
 
 describe('/v2/run evidence provenance (2.13 completion)', () => {
   let app: FastifyInstance;
@@ -125,13 +108,13 @@ describe('/v2/run evidence provenance (2.13 completion)', () => {
   // -------------------------------------------------------------------------
   // GAP A — deterministic response-content hash
   // -------------------------------------------------------------------------
-  it('success response carries _meta.response_content_hash (rch_v1:<16 hex>)', async () => {
+  it('success response carries _meta.response_content_hash (rch_v2:<16 hex>)', async () => {
     islMock.state.meanA = 0.7;
     const res = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.analysis_status).toBe('computed');
-    expect(body._meta.response_content_hash).toMatch(/^rch_v1:[0-9a-f]{16}$/);
+    expect(body._meta.response_content_hash).toMatch(/^rch_v2:[0-9a-f]{16}$/);
   });
 
   it('identical request replayed → identical response_content_hash (determinism)', async () => {
@@ -140,7 +123,7 @@ describe('/v2/run evidence provenance (2.13 completion)', () => {
     const r2 = await app.inject({ method: 'POST', url: '/v2/run', payload: validBody() });
     const h1 = r1.json()._meta.response_content_hash;
     const h2 = r2.json()._meta.response_content_hash;
-    expect(h1).toMatch(/^rch_v1:/);
+    expect(h1).toMatch(/^rch_v2:/);
     expect(h2).toBe(h1);
   });
 
@@ -264,5 +247,58 @@ describe('CEE client downstream digests (2.13 gap C)', () => {
     expect(call.responseDigest?.sha256).toBe(expectedResSha);
     expect(call.responseDigest?.key_manifest).toEqual(['graph', 'ok', 'schema_version']);
     expect(call.echoedRequestId).toBe(REQUEST_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rch_v2 determinism properties (review-hardening 2026-07-11: [12]/[15]/[18])
+// ---------------------------------------------------------------------------
+describe('computeResponseContentHash rch_v2 determinism', () => {
+  it('duplicate natural keys (edge_sensitivity existence+magnitude rows) hash order-invariantly', () => {
+    const rowA = { edge_id: 'e1', kind: 'existence', value: 0.2 };
+    const rowB = { edge_id: 'e1', kind: 'magnitude', value: 0.7 };
+    const h1 = computeResponseContentHash({ analysis_status: 'computed', edge_sensitivity: [rowA, rowB] });
+    const h2 = computeResponseContentHash({ analysis_status: 'computed', edge_sensitivity: [rowB, rowA] });
+    expect(h2).toBe(h1);
+  });
+
+  it('critique UUIDs are excluded (context-scoped id strip inside critiques)', () => {
+    const base = { analysis_status: 'failed', critiques: [{ id: 'uuid-1', code: 'X', severity: 'error', message: 'm' }] };
+    const other = { analysis_status: 'failed', critiques: [{ id: 'uuid-2', code: 'X', severity: 'error', message: 'm' }] };
+    expect(computeResponseContentHash(other)).toBe(computeResponseContentHash(base));
+  });
+
+  it('nested semantic id fields OUTSIDE critiques are hashed content (no global id strip)', () => {
+    const base = { analysis_status: 'computed', review_cards: [{ supporting_refs: [{ id: 'fact-1' }] }] };
+    const other = { analysis_status: 'computed', review_cards: [{ supporting_refs: [{ id: 'fact-2' }] }] };
+    expect(computeResponseContentHash(other)).not.toBe(computeResponseContentHash(base));
+  });
+
+  it('array pre-sort is locale-independent (code-unit order, never localeCompare)', () => {
+    // Under ICU primary-level collation 'a-b' and 'ab' can reorder by locale;
+    // code-unit order is fixed: '-' (0x2D) < 'b' (0x62).
+    const h1 = computeResponseContentHash({
+      option_comparison: [{ option_id: 'a-b', v: 1 }, { option_id: 'ab', v: 2 }],
+    });
+    const h2 = computeResponseContentHash({
+      option_comparison: [{ option_id: 'ab', v: 2 }, { option_id: 'a-b', v: 1 }],
+    });
+    expect(h2).toBe(h1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v1 proxy contract projection (review [6])
+// ---------------------------------------------------------------------------
+describe('toPublicIslError', () => {
+  it('projects only the declared v1 isl_error contract fields (never status/critiques)', () => {
+    const enriched = {
+      code: 'ISL_REJECTED',
+      message: 'rejected',
+      retryable: false,
+      status: 422,
+      critiques: [{ code: 'ISL_CANNOT_IDENTIFY', severity: 'blocker', message: 'internal detail' }],
+    };
+    expect(toPublicIslError(enriched)).toEqual({ code: 'ISL_REJECTED', message: 'rejected', retryable: false });
   });
 });

--- a/tests/v2-typed-failure-envelope.test.ts
+++ b/tests/v2-typed-failure-envelope.test.ts
@@ -39,30 +39,6 @@ type IslBehaviour =
 
 let islBehaviour: IslBehaviour = { kind: 'computed' };
 
-function computedIslResponse() {
-  return {
-    analysis_status: 'computed',
-    seed_used: 42,
-    options: [
-      {
-        option_id: 'opt-a',
-        outcome: { mean: 0.7, std: 0.05, p10: 0.6, p50: 0.7, p90: 0.8, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
-        win_probability: 0.7,
-        status: 'computed',
-      },
-      {
-        option_id: 'opt-b',
-        outcome: { mean: 0.4, std: 0.05, p10: 0.3, p50: 0.4, p90: 0.5, n_samples: 100, n_valid_samples: 100, validity_ratio: 1.0 },
-        win_probability: 0.3,
-        status: 'computed',
-      },
-    ],
-    factor_sensitivity: [],
-    robustness: { confidence: 0.8, level: 'high', is_robust: true, fragile_edges: [], robust_edges: [] },
-    inference_warnings: [],
-  };
-}
-
 const mockISLService = {
   isEnabled: () => true,
   async callAnalysisEndpoint<T>(): Promise<any> {
@@ -82,7 +58,7 @@ const mockISLService = {
       });
       return { data: bomb as T, latency_ms: 5, isl_echoed_request_id: null };
     }
-    return { data: computedIslResponse() as T, latency_ms: 5, isl_echoed_request_id: null };
+    return { data: makeComputedIslResponse() as T, latency_ms: 5, isl_echoed_request_id: null };
   },
 };
 
@@ -92,29 +68,10 @@ vi.mock('../src/integrations/isl/index.ts', async () => {
 });
 
 import { createServer } from '../src/createServer.js';
+import { makeValidRunBody, makeComputedIslResponse } from './helpers/run-fixtures.js';
 
-// ---------------------------------------------------------------------------
-// Minimal valid request (2 options — schema minimum)
-// ---------------------------------------------------------------------------
-function validBody(extra: Record<string, unknown> = {}) {
-  return {
-    graph: {
-      nodes: [
-        { id: 'factor-0', kind: 'factor', label: 'Factor 0', observed_state: { value: 0.5 } },
-        { id: 'goal', kind: 'goal', label: 'Goal' },
-      ],
-      edges: [
-        { from: 'factor-0', to: 'goal', exists_probability: 0.8, strength: { mean: 0.3, std: 0.05 } },
-      ],
-    },
-    options: [
-      { id: 'opt-a', label: 'Option A', interventions: { 'factor-0': { value: 0.8, source: 'user_specified' } } },
-      { id: 'opt-b', label: 'Option B', interventions: { 'factor-0': { value: 0.2, source: 'user_specified' } } },
-    ],
-    goal_node_id: 'goal',
-    ...extra,
-  };
-}
+// Minimal valid request (2 options — schema minimum), shared fixture
+const validBody = makeValidRunBody;
 
 function critiqueCodes(body: any): string[] {
   return (body.critiques ?? []).map((c: any) => c.code);
@@ -163,6 +120,10 @@ describe('/v2/run typed failure envelope', () => {
     const specific = body.critiques.find((c: any) => c.code === 'ISL_TIMEOUT');
     expect(specific.user_message).toBeTruthy();
     expect(specific.source).toBe('isl');
+    // Review [17]: raw ISL error detail (endpoint paths, timeout config)
+    // stays in the logs — the wire carries the class-safe copy only.
+    expect(specific.message).not.toContain('/api/');
+    expect(specific.message).not.toContain('30000ms');
   });
 
   it('ISL unreachable: failed response carries ISL_NETWORK_ERROR critique + honest status_reason', async () => {
@@ -210,6 +171,9 @@ describe('/v2/run typed failure envelope', () => {
     const body = res.json();
     expect(body.analysis_status).toBe('blocked');
     expect(critiqueCodes(body)).toContain('ISL_CANNOT_IDENTIFY');
+    // Review [0]: ISL blockers order FIRST — CEE plot-client renders
+    // critiques[0].message, which must never be a co-occurring info warning.
+    expect(body.critiques[0].code).toBe('ISL_CANNOT_IDENTIFY');
     expect(body.retryable).toBe(false);
     expect(body.status_reason).toContain('identifiable');
   });


### PR DESCRIPTION
# xhigh-review hardening for #212 + #213 (+ CEE relays)

Paul requested an xhigh-effort review of tonight's merges with fixes applied. Review ran as a
37-agent workflow (10 finder angles → dedup → 1-vote adversarial verify → gap sweep):
33 raw → 23 deduped → 6 REFUTED → **19 survived** (14 CONFIRMED / 5 PLAUSIBLE). This PR applies
every PLoT-side finding; CEE-side findings are relayed to the orchestrator (below).

## Fixes in this PR

| # | Verdict | Fix |
|---|---|---|
| [17] | CONFIRMED correctness | **Wire leak**: `buildIslFailureDetail` shipped raw ISL `error.message` (internal endpoint path + timeout config) in `critiques[].message`. Now the class-safe copy; raw stays in logs (`isl_call_failed`/`isl_analysis_failed`). Pinned: message must not contain `/api/` or timeout config. |
| [6] | CONFIRMED wrapper | **v1 contract widening**: 9 v1 analysis routes spread the (2.13-enriched) ISL error object into `isl_error`, leaking `status` + ISL-internal `critiques[]` past the declared `{code,message,retryable}`. `toPublicIslError()` projection at all 9 assignment sites; unit-pinned. |
| [15] | CONFIRMED | **localeCompare in the content hash** — ICU/locale-dependent ordering broke the "independently recomputable" promise across Node builds. Now code-unit comparison. |
| [12] | PLAUSIBLE | **Non-unique sort key**: `edge_sensitivity` repeats each `edge_id` (existence+magnitude rows), so key-only sort let upstream order leak into the hash. Canonical-serialisation tie-break; property-tested. |
| [18] | PLAUSIBLE | **Over-broad `id` strip** erased nested semantic ids (e.g. review-card `supporting_refs[].id`) from the hashed surface. Now context-scoped: `id` stripped only inside the `critiques` subtree. Property-tested both directions. |
| — | — | ↑ the three hash-recipe changes ship as **`rch_v2`** (versioned prefix exists for exactly this; `rch_v1` was live <2h with no consumers). Golden regenerated; **delta = the hash value only**. |
| [10] | CONFIRMED altitude | Hash attach moved **inside buildResponse** (the `_meta` owner) — the ISL_NOT_ENABLED early return now carries it too; no per-send-site fragility. |
| [14] | CONFIRMED efficiency | Single-pass canonical serialiser — was deep-clone (stripVolatile) + second full clone inside canonicalJson on every success. |
| [9] | CONFIRMED simplification | Dead ISLHttpError throw-path belt removed (~30 lines): `callAnalysisEndpoint` has a no-throw contract, so `islError` was always undefined; the live `islCallError` branch is now the single 422 path. |
| [0] | PLAUSIBLE cross-file | ISL blockers now order **first** on 422 responses — CEE plot-client renders `critiques[0].message`, which a co-occurring info `NORMALIZATION_WARNING` could displace. Pinned. |
| [7] | CONFIRMED efficiency | `getDownstreamCallsForLog` snapshotted once per response build (was 3×, each re-copying sanitized ISL payloads). |
| [11]/[13] | CONFIRMED reuse | Volatile/sort lists single-sourced: determinism-replay now derives `IGNORE_FIELDS`/`SORT_ARRAYS_BY` from the module's exported `SHARED_VOLATILE_KEYS`/`RESPONSE_CONTENT_HASH_SORTED_ARRAYS` (replay's `_meta` coverage deliberately preserved — it still compares `_meta`, unlike the hash). |
| [16] | CONFIRMED reuse | Shared `tests/helpers/run-fixtures.ts` replaces the duplicated `validBody`/`computedIslResponse` copies (the vi.hoisted mock keeps a local builder — hoisted blocks can't import). |

## Verified, deliberately NOT changed

- [8] PLAUSIBLE: the unknown-field 400's bare-Fastify→error.v1 shape change — verifier found no
  consumer keying on the old shape; the new shape IS the #212 fix, already pinned.

## Relayed to the orchestrator (CEE-side, not this repo)

- [1]/[2] CONFIRMED (top severity): the guest-claim strand race is worse than the #410 review
  framed it — a **single successful claim** strands concurrently-streamed NULL rows with NO
  repair path (the replay heal only fires on retry). The FOR SHARE append-read fix is the
  orchestrator's claimed lane; the review evidence elevates its priority and it should get a
  tracked row.
- [3] CONFIRMED efficiency: claim RPC re-SELECTs the row it already locked (fold into the
  FOR UPDATE select).
- [4] PLAUSIBLE conventions: the new `guest_claimed` journey event has no traced CEE/UI
  consumer (Journey-tab render check owed).

## Verification

- Typecheck clean; 191/191 across the five affected suites incl. 4 new rch_v2 property tests,
  the leak pin, the blocker-first pin, and the refactored determinism-replay.
- Golden regenerated once; diff vs previous = `response_content_hash` value only (rch_v1→rch_v2)
  — proving the belt removal, ordering change, and hoisting left the success wire byte-identical.
- Full `scripts/pre-push-validate.sh` before push; CI: standing reds only (audit, gates-windows;
  validate-structure does NOT fire — no contracts/ change in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
