### PR TITLE
fix(claims): external-claims clean-up sweep — plot-lite-service copy class (Track S P.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Nightly Evidence Pack](https://github.com/Talchain/plot-lite-service/actions/workflows/nightly-evidence-pack.yml/badge.svg)](https://github.com/Talchain/plot-lite-service/actions/workflows/nightly-evidence-pack.yml)
 
-Deterministic causal inference engine for decision analysis. Science-powered, production-ready, no LLM calls.
+Deterministic decision-analysis engine: probabilistic simulation over user-specified causal structure, with propagated uncertainty and reproducible seeded results. No LLM calls.
 
 ## Quick Start
 
@@ -19,7 +19,7 @@ curl http://localhost:4311/v1/limits
 ## Key Features
 
 - **Deterministic inference** - Same input + seed = identical output
-- **Causal interventions** - Do-calculus with identifiability checks
+- **Interventions** - Do-operator ("what-if") interventions on the assumed structure, with backdoor identifiability checks
 - **Scenario comparison** - Compare up to 5 options side-by-side
 - **Action optimization** - Select optimal actions under budget constraints
 - **Production-ready** - p95 < 600ms, rate limiting, comprehensive health checks
@@ -28,9 +28,9 @@ curl http://localhost:4311/v1/limits
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/v1/run` | POST | Run causal inference |
+| `/v1/run` | POST | Run the simulation on a decision graph |
 | `/v1/compare` | POST | Compare 2-5 scenarios |
-| `/v1/intervene` | POST | Causal interventions |
+| `/v1/intervene` | POST | Do-operator interventions |
 | `/v1/optimise` | POST | Action selection under budget |
 | `/v1/sensitivity` | POST | Sensitivity analysis |
 | `/v1/validate` | POST | Validate graph structure |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -68,7 +68,7 @@ Current configuration limits.
 ## Core Inference Endpoints
 
 ### POST /v1/run
-Execute causal inference on a decision graph.
+Execute the probabilistic simulation over a decision graph (user-specified causal structure).
 
 **Request:**
 ```json

--- a/docs/lanes/LANE-claims-cleanup-p3-2026-07-11.md
+++ b/docs/lanes/LANE-claims-cleanup-p3-2026-07-11.md
@@ -1,0 +1,80 @@
+# Lane: external-claims clean-up sweep (Track S P.3 + Sci-Roadmap 1C/B5.29) — 2026-07-11
+
+Sources of record: `parallel-briefs/CORPUS-FIDELITY-CHECK-2026-07-11.md` (Q1/Q3),
+`Olumi_Scientific_Enhancement_Roadmap_v2.md` (§1C, §Phase 0 B5.29),
+`olumi-track-s-development-plan-v6.md` (§P.3). Full cross-repo manifest:
+`GitHub/parallel-briefs/CLAIMS-CLEANUP-MANIFEST-2026-07-11.md`.
+
+## Scope searched (complete)
+
+All five repos at pinned refs — DecisionGuideAI `d085995c`, olumi-assistants-service
+`f00a209a`, plot-lite-service `4653d447`, Inference-Service-Layer `569a2312` (all
+`origin/staging`), olumi-schemas `b02ba489` (`origin/main`). Patterns (case-insensitive
+`git grep -E`, excluding node_modules/lockfiles/dist/.tooling):
+`causality|structural_proxy|bayesian|adjustment[ _-]set|do.calculus|causal inference|identifiab|well[- _]calibrated|validated causal|95% valid`
+plus targeted passes for `95%`-validity claims, `guarantee/scientifically
+proven/validated`, `calibrat*` (non-archive), and user-visible `EVPI` strings in UI src.
+
+## Fixed in this PR (PLoT copy/docs class — no contract fields touched)
+
+| File:line (pre-fix) | Was | Now |
+|---|---|---|
+| `README.md:5` | "Deterministic causal inference engine… Science-powered, production-ready" | probabilistic simulation over user-specified causal structure |
+| `README.md:22` | "Do-calculus with identifiability checks" (full do-calculus is NOT implemented — backdoor criterion only, see `docs/archive/root/UTILITY_FIX_COMPLETE.md:184`) | do-operator interventions + backdoor identifiability checks |
+| `README.md:31,33` | "Run causal inference" / "Causal interventions" | simulation / do-operator wording |
+| `docs/api-reference.md:71` | "Execute causal inference on a decision graph." | probabilistic simulation wording |
+| `sdk/package.json:34-35` | npm keywords `causal`, `bayesian` (no Bayesian inference on the live path; SCM-Lite BMA is a dormant lib) | keyword `causal-structure` |
+
+## Filed for follow-up lanes (NOT fixed here)
+
+### CEE lane (active fixup lane owns the repo)
+- **§1C rename: ALREADY DONE — record it.** No `causality` field exists anywhere at the
+  pinned refs; `structural_proxy` is live in `src/cee/quality/index.ts:102`, openapi.yaml:3159,
+  schemas, tests, and UI fixtures. Sci-Roadmap 1C + corpus-check "unverified" row can be
+  closed with this evidence.
+- `src/cee/key-insight/index.ts:380` — `identifiability?.identifiable ?? true`: identifiability
+  **defaults to true** when ISL provides none (ISL identifiability router is disabled), and
+  line 429-430 then selects "confident causal language". Claim-integrity defect: confidence
+  from absence of evidence. Route is registered (`src/server.ts:28`).
+- `src/cee/decision-review/templates.ts:123-124` — user-facing "This interval is
+  well-calibrated based on historical data." No historical calibration loop exists (Track S
+  P.1/2.1 not closed). Currently dormant (ISL conformal disabled) but the template is live code.
+- `src/services/review/blockBuilders.ts:524` — user message "Graph contains cycles. This may
+  affect causal inference." — soften "causal inference" to "the analysis" (P.3 vocabulary).
+- `openapi.yaml:4332`, `src/cee/key-insight/index.ts:80`, `src/schemas/cee.ts:178` —
+  `adjustment_set` field + descriptions: contract-adjacent; descriptions are fixable, field
+  rename would be Paul-gated (leave the field).
+
+### UI lane (A2 owns the repo)
+- `src/canvas/components/IdentifiabilityBadge.tsx:57-61` — badge copy "Model has a unique
+  solution. Analysis results are reliable." — "results are reliable" is an over-claim
+  (identifiability ≠ reliability); also P.3 wants identifiability jargon softened in user copy.
+- `src/adapters/plot/enrichment.ts:597` — user-facing suggestion "Causal effect is not
+  identifiable… Consider adding instrumental variables…" (jargon + instrumental variables
+  are not a product capability).
+- User-visible **EVPI jargon** (Track S standing rule 6: "No EVPI jargon in user-facing
+  copy"): `src/canvas/components/RecommendationCard/RobustnessBlock.tsx:273` ("EVPI: …"),
+  `src/canvas/components/model-tab/FactorsSection.tsx:496`, `src/canvas/components/model-tab/StatusBar.tsx:83`
+  ("pp via EVPI"), `src/canvas/components/ModelTabBody.tsx:589` ("ranked by EVPI"). Note the
+  repo already has `src/test/glossaryBannedTerms.ts:68` banning `/^EVPI$/` — enforcement gap.
+
+### Paul / external-materials (not in any repo)
+- **B5.29 "95% validity" rename: NOT FOUND in any repo** at the pinned refs (patterns above,
+  plus `structural validity|95%` pass). The claim lives in external materials (pitch/website)
+  per Sci-Roadmap Phase 0 ("Docs — Paul's task"). Remains open, outside repo scope.
+- P.3's per-surface checklist (investor materials, website, decks, demo script, one-pagers,
+  outbound templates) — no such copy is tracked in these repos; the checklist remains to be
+  produced against the external surfaces.
+
+### No action (reviewed, honest or historical)
+- Implemented-capability naming: identifiability/adjustment-set code + tests in PLoT
+  (`src/trust/identifiability*.ts` — backdoor identifiability IS deployed, Sci-Roadmap Phase 0 ✅)
+  and ISL (`src/services/identifiability_analyzer.py` etc. — built, dormant). Describing
+  implemented code by its correct name is not an over-claim.
+- PLoT `docs/SCM_LITE_NOTES.md` (BMA is a real dormant lib), `contracts/openapi.yaml:2039`
+  ("full Bayesian update in future versions" — explicitly honest), `docs/archive/**` +
+  ISL `docs/_archive/**` (historical session records; left as record).
+- olumi-schemas: 140 hits reviewed — all honest discipline (`evpi_status: below_resolution`
+  never fabricates 0; calibration refs = future Brier loop). Clean.
+- ISL `docs/science-validation/REPORT.md` + benchmarks: precise statistical language
+  ("95% claim", "within-model") — exemplary, no action. (Path barred to local lanes anyway.)

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -31,8 +31,7 @@
   "keywords": [
     "plot",
     "inference",
-    "causal",
-    "bayesian",
+    "causal-structure",
     "typescript",
     "sdk"
   ],


### PR DESCRIPTION
## What

Copy/docs-class claims clean-up per Track S plan v6 §P.3 + Sci-Roadmap v2 §1C/B5.29 and the corpus fidelity check (Q3 item 3: "Claims clean-up bundle… directly required by the ratified Gate-1 'no false claims' integrity floor"). **No contract fields, schemas, or wire shapes touched.**

- `README.md` — tagline "Deterministic causal inference engine… Science-powered, production-ready" → probabilistic simulation over user-specified causal structure; "Do-calculus with identifiability checks" → do-operator interventions with backdoor identifiability checks (full do-calculus is not implemented — the repo's own `docs/archive/root/UTILITY_FIX_COMPLETE.md:184` records this); endpoint-table wording to match.
- `docs/api-reference.md` — `/v1/run` "Execute causal inference" → probabilistic-simulation wording.
- `sdk/package.json` — npm keywords: drop `bayesian` (no Bayesian inference on the live path; SCM-Lite BMA is a dormant lib), `causal` → `causal-structure`.
- `docs/lanes/LANE-claims-cleanup-p3-2026-07-11.md` — lane spec: full sweep scope (5 repos, pinned refs, grep patterns), verdicts (**Sci-Roadmap §1C `causality`→`structural_proxy` rename verified ALREADY DONE on staging**; **B5.29 "95% validity" not present in any repo** — external-materials task), and exact file:line items filed for the CEE and UI (A2) follow-up lanes.

Full cross-repo manifest: `GitHub/parallel-briefs/CLAIMS-CLEANUP-MANIFEST-2026-07-11.md`.

## Gates

- `scripts/pre-push-validate.sh` in a fresh worktree off `origin/staging` (4653d44): **PASS** — tsc, full `npm test` 5,462 passed / 25 skipped, stale-js, dep policy, spectral. Re-ran automatically on push: PASS.
- Standing CI reds expected (unrelated, pre-existing): `audit`, `gates (windows-latest)`. `validate-structure` should NOT trigger (no `contracts/openapi.yaml` change).

## Review notes

Draft — lane never merges; orchestrator/Paul gate. RED-first n/a: no test pins the changed wording (checked `tests/` for the phrases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)