### PR TITLE
fix(coaching): reconcile detectHeadlineType shadow — readiness path now lever-aware (2.40 stop-condition)

### DIFF
--- a/src/coaching/m1-coaching.ts
+++ b/src/coaching/m1-coaching.ts
@@ -13,7 +13,13 @@ import type {
   OptionV3,
 } from '../types/engine-v3.js';
 import { normaliseCoachingInputs } from './normalise-inputs.js';
-import { generateHeadlines, getFragileEdgeContext } from './headlines.js';
+// 2.40: detectHeadlineType MUST be the canonical lever-aware classifier.
+// A module-local risk-blind duplicate used to shadow it here (it ignored
+// fragile edges/VoI and the A1b/A1c lever filters), so the readiness path
+// could report clear_winner/ready while story_headlines — canonical path,
+// same payload — said "could swing the outcome". Do not reintroduce a local
+// copy: tests/lane-240-detect-headline-type-shadow.test.ts pins the identity.
+import { generateHeadlines, getFragileEdgeContext, detectHeadlineType } from './headlines.js';
 // A1c: exclude lever-sourced fragile edges from top_fragile_edge.
 import { filterLeverSourcedFragileEdges } from '../lib/intervention-override.js';
 import { computeEvidenceGaps } from './evidence-gaps.js';
@@ -246,31 +252,6 @@ function safeCompute<T>(fn: () => T, fallback: T, logger: any, component: string
     });
     return fallback;
   }
-}
-
-/**
- * Detect headline type from inputs (simplified version of headlines.ts logic).
- */
-function detectHeadlineType(inputs: any): any {
-  const { options, factorSensitivity, robustness } = inputs;
-
-  if (options.length === 0 || factorSensitivity.length === 0) {
-    return 'needs_evidence';
-  }
-
-  const sorted = [...options].sort((a: any, b: any) => b.winProbability - a.winProbability);
-  const winner = sorted[0];
-  const runnerUp = sorted[1];
-
-  const winProbDelta = runnerUp ? winner.winProbability - runnerUp.winProbability : winner.winProbability;
-  const stability = robustness.recommendationStability;
-
-  if (stability === undefined) return 'needs_evidence';
-  if (winProbDelta >= 0.20 && stability >= 0.70) return 'clear_winner';
-  if (winProbDelta >= 0.10 && stability >= 0.50) return 'moderate_winner';
-  if (winProbDelta < 0.10) return 'close_call';
-
-  return 'needs_evidence';
 }
 
 // =============================================================================

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -712,18 +712,10 @@
         "target_type": "edge",
         "target_id": "out_technical_quality->goal_productivity",
         "target_label": "Technical Quality and Architecture → Increase Team Productivity"
-      },
-      {
-        "priority": 7,
-        "action": "Validate the fragile assumptions before treating Hire One Tech Lead as a decision",
-        "rationale": "Hire One Tech Lead currently leads by 18 points, but the recommendation is not yet robust",
-        "target_type": "option",
-        "target_id": "opt_tech_lead",
-        "target_label": "Hire One Tech Lead"
       }
     ],
-    "readiness": "ready",
-    "headline_type": "moderate_winner",
+    "readiness": "close_call",
+    "headline_type": "high_uncertainty",
     "top_fragile_edge": {
       "edge_id": "out_technical_quality->goal_productivity",
       "label": "Technical Quality and Architecture → Increase Team Productivity",
@@ -896,8 +888,8 @@
       "tone_low_driver_confidence_max": 0.5
     },
     "readiness_signals": {
-      "overall": "ready",
-      "overall_score": 0.85,
+      "overall": "close_call",
+      "overall_score": 0.55,
       "computed_score_raw": 0.72,
       "dimensions": {
         "evidence_quality": 0.6,
@@ -970,10 +962,10 @@
       }
     ],
     "executive_summary": {
-      "summary": "Hire One Tech Lead currently leads by 18 points, but the model is not yet strong enough for an unqualified decision. Treat this as a provisional lead until the fragile assumptions are checked. Validate the fragile assumptions before treating this as a decision.",
-      "decision_statement": "Hire One Tech Lead currently leads by 18 points, but the model is not yet strong enough for an unqualified decision.",
-      "key_qualifier": "Treat this as a provisional lead until the fragile assumptions are checked.",
-      "action_implication": "Validate the fragile assumptions before treating this as a decision."
+      "summary": "Hire One Tech Lead currently leads, but the outcome is highly uncertain. However, the 59% recommendation stability indicates the decision could shift with new information. Define tie-breaker criteria or gather additional evidence.",
+      "decision_statement": "Hire One Tech Lead currently leads, but the outcome is highly uncertain.",
+      "key_qualifier": "However, the 59% recommendation stability indicates the decision could shift with new information.",
+      "action_implication": "Define tie-breaker criteria or gather additional evidence."
     },
     "readiness_tone": "caution",
     "readiness_reasons": [
@@ -1203,7 +1195,7 @@
     "graph_hash": "195f3c2552217c57",
     "seed": 2034401427,
     "created_at": "__VOLATILE__",
-    "headline": "Hire One Tech Lead currently leads by 18 points, but the model is not yet strong enough for an unqualified decision. Treat this as a provisional lead until the fragile assumptions are checked. Validate the fragile assumptions before treating this as a decision.",
+    "headline": "Hire One Tech Lead currently leads, but the outcome is highly uncertain. However, the 59% recommendation stability indicates the decision could shift with new information. Define tie-breaker criteria or gather additional evidence.",
     "options": [
       {
         "option_id": "opt_tech_lead",
@@ -1606,7 +1598,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:ad7100190167bf5b"
+    "response_content_hash": "rch_v2:5c675374cdaeb9e3"
   },
   "meta": {
     "seed_used": "2034401427",

--- a/tests/lane-240-detect-headline-type-shadow.test.ts
+++ b/tests/lane-240-detect-headline-type-shadow.test.ts
@@ -1,0 +1,170 @@
+/**
+ * 2.40 — detectHeadlineType shadow reconciliation (readiness path).
+ *
+ * MECHANISM (pre-fix): src/coaching/m1-coaching.ts carried a module-local
+ * `detectHeadlineType` duplicate (never importing the canonical one from
+ * src/coaching/headlines.ts). The duplicate was the one called for the
+ * readiness path (m1-coaching.ts:93), and it was RISK-BLIND: it ignored
+ * fragile edges and VoI entirely (it could never return 'high_uncertainty'),
+ * hardcoded thresholds instead of getThresholds(), and applied none of the
+ * A1b/A1c lever filtering. Consequences on the served payload:
+ *
+ *   1. A genuine (non-lever) fragile edge was suppressed on the readiness
+ *      path — headline_type said 'clear_winner' and readiness said 'ready'
+ *      while story_headlines (canonical path, SAME payload) simultaneously
+ *      said "X could swing the outcome to Y". Overstated readiness +
+ *      internally inconsistent coaching.
+ *   2. Lever exclusion held only BY ACCIDENT (the duplicate ignored all risk
+ *      signals, lever and non-lever alike) — not by the A1b/A1c predicates.
+ *
+ * FIX: the duplicate is deleted; m1-coaching imports the canonical
+ * lever-aware detectHeadlineType. These tests pin:
+ *   - RED→GREEN: non-lever fragile edge now downgrades the readiness path
+ *     (headline_type high_uncertainty, readiness close_call) — pre-fix this
+ *     asserted clear_winner/ready.
+ *   - Reconciliation identity: m1_coaching.headline_type === canonical
+ *     detectHeadlineType over the same normalised inputs (anti-drift pin).
+ *   - Lever-aware guards (A1c fragile-edge arm + A1b VoI arm): an
+ *     option-controlled lever must NOT drive high_uncertainty on the
+ *     readiness path — now guaranteed by the canonical predicates, not by
+ *     accidental risk-blindness.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateM1Coaching } from '../src/coaching/m1-coaching.js';
+import { detectHeadlineType } from '../src/coaching/headlines.js';
+import { normaliseCoachingInputs } from '../src/coaching/normalise-inputs.js';
+import type { EngineGraphV3, OptionV3 } from '../src/types/engine-v3.js';
+
+const LEVER = 'fac_dev_capacity';
+const LEVER_LABEL = 'Additional Developer Capacity';
+const NONLEVER = 'fac_time_pressure';
+const NONLEVER_LABEL = 'Launch Deadline Pressure';
+
+const makeGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'On-Time Launch' },
+    { id: NONLEVER, kind: 'factor', label: NONLEVER_LABEL, category: 'external' },
+    { id: LEVER, kind: 'factor', label: LEVER_LABEL, category: 'controllable' },
+  ],
+  edges: [
+    { from: NONLEVER, to: 'goal', strength: { mean: -0.6, std: 0.2 } },
+    { from: LEVER, to: 'goal', strength: { mean: 0.7, std: 0.1 } },
+  ],
+});
+
+// 3 options incl. Status Quo → no NARROW_FRAMING blocker (which would force
+// readiness to needs_framing regardless of headline type and mask the
+// divergence under test). Winner delta 0.60 + stability 0.90 → clear_winner
+// in BOTH implementations absent any risk signal, so any downgrade observed
+// below is attributable to the fragile-edge / VoI arms alone.
+const makeOptions = (withLeverIntervention: boolean): OptionV3[] => [
+  {
+    id: 'opt1', label: 'Option A', winProbability: 0.75, expectedOutcome: 120,
+    // Request-side truth for interventionTargetIds (normalise-inputs.ts:139)
+    ...(withLeverIntervention ? { interventions: { [LEVER]: 1 } } : {}),
+  } as OptionV3,
+  { id: 'opt2', label: 'Option B', winProbability: 0.15, expectedOutcome: 80 },
+  { id: 'opt3', label: 'Status Quo', winProbability: 0.10, expectedOutcome: 70 },
+];
+
+// High-confidence non-lever factor: VoI = |elasticity| × (1 − 0.9) = 0.04,
+// far below headline_high_uncertainty_voi (0.30) and readiness_high_voi_threshold
+// (0.40) — so evidence gaps cannot drive the readiness outcome in these tests.
+const nonLeverFactor = () => ({
+  node_id: NONLEVER, label: NONLEVER_LABEL, importance_rank: 1,
+  elasticity: -0.4, influence_score: 0.6, confidence: 0.9, direction: 'negative',
+});
+
+const makeIslResult = (overrides: {
+  fragileFrom?: string;
+  factorSensitivity?: any[];
+}) => ({
+  options: [
+    { id: 'opt1', label: 'Option A', win_probability: 0.75, outcome: { mean: 120, p10: 100, p90: 140 } },
+    { id: 'opt2', label: 'Option B', win_probability: 0.15, outcome: { mean: 80, p10: 60, p90: 100 } },
+    { id: 'opt3', label: 'Status Quo', win_probability: 0.10, outcome: { mean: 70, p10: 50, p90: 90 } },
+  ],
+  factor_sensitivity: overrides.factorSensitivity ?? [nonLeverFactor()],
+  robustness: {
+    recommendation_stability: 0.9,
+    fragile_edges: overrides.fragileFrom
+      ? [{
+          edge_id: `${overrides.fragileFrom}->goal`,
+          from_id: overrides.fragileFrom,
+          to_id: 'goal',
+          // 0.5 > headline_high_uncertainty_fragile (0.25) → canonical
+          // classifier must return high_uncertainty when the edge is non-lever.
+          switch_probability: 0.5,
+          alternative_winner_id: 'opt2',
+        }]
+      : [],
+  },
+});
+
+describe('2.40 — readiness path uses the canonical lever-aware detectHeadlineType', () => {
+  it('RED→GREEN: a genuine NON-lever fragile edge downgrades the readiness path (pre-fix: clear_winner/ready while the story headline said "could swing")', () => {
+    const coaching = generateM1Coaching(
+      makeGraph(), makeOptions(false), makeIslResult({ fragileFrom: NONLEVER })
+    );
+
+    expect(coaching).toBeDefined();
+    // RED pre-fix: duplicate ignored fragile edges → 'clear_winner'
+    expect(coaching!.headline_type).toBe('high_uncertainty');
+    // RED pre-fix: 'ready' (computeReadiness maps clear_winner → ready)
+    expect(coaching!.readiness).toBe('close_call');
+    // The canonical story headline ALREADY said swing-risk pre-fix — this pins
+    // that headline_type/readiness and story_headlines now agree on one payload.
+    expect(coaching!.story_headlines['opt1']).toContain('could swing the outcome');
+    expect(coaching!.story_headlines['opt1']).toContain(NONLEVER_LABEL);
+  });
+
+  it('reconciliation identity: m1_coaching.headline_type === canonical detectHeadlineType over the same normalised inputs', () => {
+    const graph = makeGraph();
+    for (const [options, islResult] of [
+      [makeOptions(false), makeIslResult({ fragileFrom: NONLEVER })],
+      [makeOptions(true), makeIslResult({ fragileFrom: LEVER })],
+      [makeOptions(false), makeIslResult({})],
+    ] as const) {
+      const coaching = generateM1Coaching(graph, options as OptionV3[], islResult);
+      const canonical = detectHeadlineType(
+        normaliseCoachingInputs(graph, options as OptionV3[], islResult)
+      );
+      expect(coaching!.headline_type).toBe(canonical);
+    }
+  });
+
+  it('lever guard (A1c arm): a lever-SOURCED fragile edge does NOT drive high_uncertainty on the readiness path', () => {
+    const coaching = generateM1Coaching(
+      makeGraph(), makeOptions(true), makeIslResult({ fragileFrom: LEVER })
+    );
+
+    expect(coaching).toBeDefined();
+    // Lever edge excluded by isLeverSourcedEdge (interventionTargetIds from
+    // options[].interventions) → no qualifying fragile edge → clear_winner.
+    expect(coaching!.headline_type).toBe('clear_winner');
+    expect(coaching!.readiness).toBe('ready');
+    // And the lever is not named as a swing risk anywhere in the story headlines.
+    expect(Object.values(coaching!.story_headlines).join(' || ')).not.toContain(LEVER_LABEL);
+  });
+
+  it('lever guard (A1b arm): a high-elasticity intervention_override lever does NOT drive high_uncertainty via the VoI arm', () => {
+    const coaching = generateM1Coaching(
+      makeGraph(), makeOptions(true), makeIslResult({
+        factorSensitivity: [
+          nonLeverFactor(),
+          // Naive VoI would be |0.9| × (1 − 0.2) = 0.72 > 0.30 → without the
+          // A1b filter this factor alone would flip the type to high_uncertainty.
+          {
+            node_id: LEVER, label: LEVER_LABEL, importance_rank: 2,
+            elasticity: 0.9, influence_score: 0.9, confidence: 0.2,
+            direction: 'positive', zero_reason: 'intervention_override',
+          },
+        ],
+      })
+    );
+
+    expect(coaching).toBeDefined();
+    expect(coaching!.headline_type).toBe('clear_winner');
+    expect(coaching!.readiness).toBe('ready');
+  });
+});


### PR DESCRIPTION
# 2.40 — reconcile the detectHeadlineType shadow (recorded stop-condition for lever-suppression work)

## Mechanism (re-verified at origin/staging tip 9e5a25c before building)

Two `detectHeadlineType` implementations existed:

- **Canonical, lever-aware** — `src/coaching/headlines.ts:235`: applies `filterInterventionOverrides` on the VoI arm (A1b), excludes lever-sourced fragile edges via `interventionTargetIds` (A1c), uses `getThresholds()`, and can classify `high_uncertainty`.
- **Module-local duplicate** — `src/coaching/m1-coaching.ts:254` (deleted here): risk-blind. It ignored fragile edges and VoI entirely (could never return `high_uncertainty`), hardcoded thresholds, applied no lever filtering, and was typed `(inputs: any): any`.

The duplicate was the one called on the readiness path (`m1-coaching.ts:93`) — the canonical was **not imported at all** (one precision correction to the investigation note, which described it as shadowing an import; net effect identical). `headline_type`, `readiness`, `next_actions`, `executive_summary`, and `readiness_signals` were all computed from the duplicate, while `story_headlines` in the **same payload** used the canonical semantics via `generateHeadlines`.

### Direction refinement vs the investigation note

The investigation described the harm as "any factor an option controls can headline as a driver/risk on that path". Verified at tip, the duplicate is risk-blind in **both** directions: levers could not headline on the readiness path — but only *by accident*, because **no** risk signal (lever or genuine) could. The live harms were:

1. **Overstated readiness**: a genuine non-lever fragile edge (switch-prob > 0.25) or high non-lever VoI (> 0.30) was suppressed — `headline_type: clear_winner`/`moderate_winner`, `readiness: ready`.
2. **Internally inconsistent payload**: the same response could carry `top_fragile_edge` and a P3 "Validate the … assumption" action while `readiness` said `ready` (see the live-capture golden below — it did exactly this).
3. **Fragile lever guarantee**: lever exclusion on the readiness path was not enforced by the A1b/A1c predicates — any future edit teaching the duplicate about risk signals would have leaked levers. The fix makes exclusion by-construction.

## The fix

**Deleted** the duplicate; `m1-coaching.ts` now imports the canonical from `./headlines.js`. No signature threading was needed — the canonical takes exactly the `CoachingInputs` object m1-coaching already builds via `normaliseCoachingInputs` (`interventionTargetIds` is populated there from request-side `options[].interventions`, `normalise-inputs.ts:139`).

### Canonical-vs-duplicate branch analysis (why deletion is safe)

| Duplicate branch | Canonical equivalent | Behaviour change? |
|---|---|---|
| `options.length === 0 → needs_evidence` | same (call-site guard also retained) | none |
| `factorSensitivity.length === 0 → needs_evidence` | `!hasFactorSensitivity → needs_evidence` | none |
| `stability === undefined → needs_evidence` | same (step 1 of `selectHeadlineType`) | none |
| hardcoded `0.20/0.70`, `0.10/0.50`, `<0.10` | `getThresholds()` — identical default values | none at defaults; `PLOT_COACH_*` env threshold overrides now also apply to the readiness path (previously silently ignored there) |
| fall-through `→ needs_evidence` | same (step 6) | none |
| *(no high_uncertainty gate)* | non-lever VoI > 0.30 **or** non-lever fragile switch-prob > 0.25 → `high_uncertainty` (checked first) | **the fix** — genuine risk now downgrades the readiness path |
| NaN-unsafe win-probability sort | finite-safe `compareByWinProbabilityDesc` | honesty improvement on degenerate MC output |

All downstream consumers of `headline_type` (`computeReadiness`, `generateNextActions`, `generateExecutiveSummary`, `deriveReadinessTone`) already handle the full `HeadlineType` union including `high_uncertainty` — they were written for it; only the classifier feeding them was wrong.

## Live output change — deliberately NOT flag-gated (disclosed)

This is a bug fix aligning the readiness path to the canonical semantics — the same "looks broken" credibility class Paul flagged. Real example from the checked-in live staging capture (`tests/fixtures/isl-v2-live-20260707`, tech-lead hire decision, stability 59%, non-lever fragile edge `Technical Quality and Architecture → Increase Team Productivity` above the 0.25 gate):

**Before** (golden, pre-fix): `headline_type: "moderate_winner"`, `readiness: "ready"`, `readiness_signals.overall_score: 0.85`, P7 action "Validate the fragile assumptions before treating Hire One Tech Lead as a decision", executive summary "…leads by 18 points, but the model is not yet strong enough…" — while the SAME payload carried `top_fragile_edge` and the P3 validate-the-edge action.

**After**: `headline_type: "high_uncertainty"`, `readiness: "close_call"`, `readiness_signals.overall: "close_call"` (0.55), executive summary "Hire One Tech Lead currently leads, but the outcome is highly uncertain. … Define tie-breaker criteria or gather additional evidence." — consistent with the fragile-edge surfaces in the same payload.

Lever-sourced signals do **not** trigger the downgrade (A1b + A1c filters), pinned by two guard tests.

### Golden refresh

`tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json` regenerated via the pin test's documented deliberate procedure (`UPDATE_GOLDEN=1 npx vitest run tests/isl-v2-golden-response.pin.test.ts`). Every hunk in the golden diff is the coaching-readiness cluster above plus the consequent `response_content_hash`; nothing unexplained.

## RED evidence

New suite `tests/lane-240-detect-headline-type-shadow.test.ts`, run against the unmodified tip:

```
FAIL  RED→GREEN: a genuine NON-lever fragile edge downgrades the readiness path
      AssertionError: expected 'clear_winner' to be 'high_uncertainty'
FAIL  reconciliation identity: m1_coaching.headline_type === canonical detectHeadlineType
      AssertionError: expected 'clear_winner' to be 'high_uncertainty'
Tests  2 failed | 2 passed (4)   ← the 2 passes are the lever guards (accidental exclusion pre-fix)
```

Post-fix: 4/4 pass. The suite pins: the RED→GREEN downgrade, the orchestrator↔canonical identity (anti-drift), the A1c fragile-edge lever guard, and the A1b VoI-arm lever guard. The unmodified golden pin also failed pre-refresh with exactly the expected readiness/headline cluster — independent RED confirmation on a live capture.

## Gates

- `npm run typecheck` (`tsc -p tsconfig.json --noEmit`): clean
- `npm test` (tools/run-all-tests.js — build + full vitest + fixtures + OpenAPI + loadcheck): **507 test files passed / 4 skipped (511); 5471 tests passed / 25 skipped (5507); exit 0**
- `scripts/pre-push-validate.sh` (authoritative pre-push gate, ran in-line with the push): all 6 checks PASS, including the full suite a second time
- Stale-.js shadow check (`find src -name '*.js' …`): none
- Exactly one `detectHeadlineType` definition remains in `src/` (the canonical)

Push note (disclosed): the first push attempt was blocked by the pre-push hook reporting 1-of-6 checks failed; the specific check was not captured (output truncated). A direct `scripts/pre-push-validate.sh` run immediately after and the retried push (full output captured) both passed all checks with 0 failures — treated as a transient flake, not smoothed over.

## Standing CI reds (pre-existing, non-required — disclosed, not chased)

- `audit` and `gates (windows-latest)` fail on every PLoT PR (pre-existing).
- `validate-structure` fires only on SPEC-touching PRs; this PR does not touch the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
