### PR TITLE
fix(levers): structural union guard on EVPI + factor-influence — a factor any option controls never publishes sensitivity/EVPI (D-U completing piece)

### DIFF
--- a/src/cee/decision-review-orchestrator.ts
+++ b/src/cee/decision-review-orchestrator.ts
@@ -32,6 +32,10 @@ import {
 import { DecisionReviewEvents, M1ReviewWarningCodes, ReviewSkipReasons, WARNING_GRADE_CODES } from './validation/m1-review-constants.js';
 import { correctUngroundedNumbers, type IslResultsForCorrection } from './validation/number-corrector.js';
 import { resolveFlipValues, type ISLInferenceFn } from '../analysis/flip-thresholds.js';
+import {
+  interventionTargetIdsFromOptions,
+  isOptionControlledLever,
+} from '../lib/intervention-override.js';
 
 // =============================================================================
 // Types
@@ -238,8 +242,14 @@ export async function orchestrateDecisionReview(
 
   const parsedReview = parseResult.data;
 
-  // Run deterministic number correction BEFORE validation
-  const islResultsForCorrection = buildIslResultsForCorrection(input.islResult);
+  // Run deterministic number correction BEFORE validation. The correction
+  // input is union-filtered (same leaf derivation as buildDecisionReviewRequest)
+  // so the corrector can never inject an option-controlled lever's elasticity
+  // into the returned narrative (public wire via the m1_review merge).
+  const islResultsForCorrection = buildIslResultsForCorrection(
+    input.islResult,
+    interventionTargetIdsFromOptions(input.options)
+  );
   const { corrected: numberCorrectedReview, corrections } = correctUngroundedNumbers(
     parsedReview,
     islResultsForCorrection,
@@ -371,8 +381,21 @@ export async function orchestrateDecisionReview(
 
 /**
  * Build ISL results format for number correction.
+ *
+ * factor_sensitivity is filtered with the combined D-U lever predicate
+ * (ISL stamp OR structural union) — the same filter as the CEE request's
+ * isl_results.factor_sensitivity — so the number-corrector's "authoritative"
+ * pool can never contain an option-controlled lever's elasticity (review
+ * fixup, PR #219: this builder previously read raw ISL with NO filter).
+ *
+ * Exported for tests (du-structural-lever-guard.decision-review.integration).
+ *
+ * @param structuralLeverIds Canonical union from interventionTargetIdsFromOptions.
  */
-function buildIslResultsForCorrection(islResult: ISLResultInput): IslResultsForCorrection {
+export function buildIslResultsForCorrection(
+  islResult: ISLResultInput,
+  structuralLeverIds?: ReadonlySet<string>
+): IslResultsForCorrection {
   const options = islResult.options ?? islResult.results ?? [];
 
   return {
@@ -385,11 +408,13 @@ function buildIslResultsForCorrection(islResult: ISLResultInput): IslResultsForC
     robustness: {
       recommendation_stability: islResult.robustness?.recommendation_stability ?? 0,
     },
-    factor_sensitivity: (islResult.factor_sensitivity ?? []).map((f) => ({
-      factor_id: f.factor_id,
-      elasticity: f.elasticity ?? 0,
-      confidence: f.confidence,
-    })),
+    factor_sensitivity: (islResult.factor_sensitivity ?? [])
+      .filter((f) => !isOptionControlledLever(f, structuralLeverIds))
+      .map((f) => ({
+        factor_id: f.factor_id,
+        elasticity: f.elasticity ?? 0,
+        confidence: f.confidence,
+      })),
   };
 }
 

--- a/src/cee/decision-review-request.ts
+++ b/src/cee/decision-review-request.ts
@@ -10,7 +10,10 @@
 import { createHash } from 'node:crypto';
 import type { EngineGraphV3, OptionV3 } from '../types/engine-v3.js';
 import type { M1Coaching, EvidenceGap, Critique } from '../coaching/types.js';
-import { filterInterventionOverrides } from '../coaching/sensitivity-filter.js';
+import {
+  interventionTargetIdsFromOptions,
+  isOptionControlledLever,
+} from '../lib/intervention-override.js';
 import type {
   DecisionReviewRequest,
   DecisionReviewNode,
@@ -25,7 +28,6 @@ import type {
 } from './validation/m1-review-types.js';
 import {
   computeFlipThresholdData,
-  getFactorsOverriddenByAllOptions,
   calculateMargin,
   getWinnerAndRunnerUp,
   type FactorSensitivityInput,
@@ -116,9 +118,16 @@ export function buildDecisionReviewRequest(
   // Build stripped graph
   const strippedGraph = buildStrippedGraph(graph);
 
+  // D-U structural lever union (same leaf + same input as the /v2/run egress
+  // guard and the coaching layer — ONE union definition, never inlined). An
+  // unstamped union lever (the live fac_salary_cost class) must not reach CEE
+  // as isl_results.factor_sensitivity, be allowlisted as a "grounded" number,
+  // feed the number-corrector, or become a flip candidate.
+  const structuralLeverIds = interventionTargetIdsFromOptions(options);
+
   // Extract ISL results
   const optionComparison = extractOptionComparison(islResult, options);
-  const factorSensitivity = extractFactorSensitivity(islResult);
+  const factorSensitivity = extractFactorSensitivity(islResult, structuralLeverIds);
   const fragileEdges = extractFragileEdges(islResult);
   const robustness = extractRobustness(islResult);
 
@@ -128,15 +137,19 @@ export function buildDecisionReviewRequest(
   // Get winner and runner-up
   const { winner, runnerUp } = getWinnerAndRunnerUp(optionComparison);
 
-  // Compute flip threshold data. Exclude factors overridden by EVERY option so
-  // this path (legacy decision-review assembly) gets the same assumption-threshold
-  // selection guard as the main /v2/run route — probing a fully-overridden factor
-  // would always return no_effect_within_bounds.
+  // Compute flip threshold data. Excluded set is the STRUCTURAL UNION, not
+  // just the all-options intersection: a some-but-not-all-options lever must
+  // not become a CEE flip candidate either (review fixup, PR #219). The union
+  // strictly contains the old getFactorsOverriddenByAllOptions(options)
+  // intersection (a factor pinned by EVERY option is pinned by SOME option),
+  // so the original probe-budget guard is preserved. Belt-and-braces with the
+  // extractFactorSensitivity filter above, which already keeps levers out of
+  // this function's input.
   const flipThresholdData = computeFlipThresholdData(
     factorSensitivity as FactorSensitivityInput[],
     optionComparison as OptionComparisonInput[],
     graph,
-    getFactorsOverriddenByAllOptions(options)
+    structuralLeverIds
   );
 
   // Calculate margin
@@ -238,12 +251,26 @@ function extractOptionComparison(
 
 /**
  * Extract factor sensitivity data from ISL result.
+ *
+ * Filters option-controlled levers with the combined D-U predicate: ISL-stamped
+ * (zero_reason === 'intervention_override') OR structural-union member (any
+ * option intervenes on the factor). The stamp alone under-covers — ISL stamps
+ * only elasticity≈0 first-option pins, so an unstamped union lever's
+ * elasticity/confidence/label would otherwise egress to CEE on the active
+ * DECISION_REVIEW_ENABLE path (review fixup, PR #219).
+ *
+ * @param structuralLeverIds Canonical union from interventionTargetIdsFromOptions.
+ *   Optional for backward compatibility — omitting reverts to stamp-only.
  */
-export function extractFactorSensitivity(islResult: ISLResultInput): FactorSensitivityData[] {
+export function extractFactorSensitivity(
+  islResult: ISLResultInput,
+  structuralLeverIds?: ReadonlySet<string>
+): FactorSensitivityData[] {
   const factorSensitivity = islResult.factor_sensitivity ?? [];
 
-  // Task 2: Filter out intervention_override factors (decision levers, not uncertainty drivers)
-  return filterInterventionOverrides(factorSensitivity).map((f) => ({
+  return factorSensitivity
+    .filter((f) => !isOptionControlledLever(f, structuralLeverIds))
+    .map((f) => ({
       factor_id: f.factor_id,
       factor_label: f.factor_label ?? f.factor_id,
       elasticity: f.elasticity ?? 0,

--- a/src/coaching/flip-thresholds.ts
+++ b/src/coaching/flip-thresholds.ts
@@ -229,10 +229,14 @@ export function getFactorsOverriddenByAllOptions(
     return new Set<string>();
   }
 
-  // Intervention-key set (factor node IDs) per option.
+  // Intervention-key set (factor node IDs) per option. Plain-object guard:
+  // arrays are objects too and `Object.keys([])` returns `["0","1",…]`, which
+  // would pollute the key sets with positional indices for malformed inputs —
+  // same defence-in-depth as interventionTargetIdsFromOptions in the shared
+  // lever-identity leaf.
   const perOptionKeys = options.map((opt) => {
     const interventions = opt?.interventions;
-    if (!interventions || typeof interventions !== 'object') {
+    if (!interventions || typeof interventions !== 'object' || Array.isArray(interventions)) {
       return new Set<string>();
     }
     return new Set<string>(Object.keys(interventions));

--- a/src/coaching/normalise-inputs.ts
+++ b/src/coaching/normalise-inputs.ts
@@ -19,6 +19,7 @@ import type {
   FactorSensitivityResultV3,
   OptionV3,
 } from '../types/engine-v3.js';
+import { interventionTargetIdsFromOptions } from '../lib/intervention-override.js';
 
 /**
  * Normalise ISL response data for coaching consumption.
@@ -136,23 +137,10 @@ export function normaliseCoachingInputs(
   // current "what to validate next" list. Source of truth is the request-side
   // `options[i].interventions` map, NOT raw ISL `zero_reason`, because ISL's
   // zero_reason is a downstream symptom rather than the canonical definition.
-  const interventionTargetIds = new Set<string>();
-  for (const opt of options) {
-    const interventions = (opt as any).interventions;
-    // Plain-object guard: arrays are objects too and `Object.keys([])` returns
-    // `["0","1",…]`, which would pollute the lever set with positional indices
-    // for malformed inputs. The route schema enforces an object shape in
-    // production, but this is cheap defence-in-depth.
-    if (
-      interventions &&
-      typeof interventions === 'object' &&
-      !Array.isArray(interventions)
-    ) {
-      for (const factorId of Object.keys(interventions)) {
-        interventionTargetIds.add(factorId);
-      }
-    }
-  }
+  // The derivation itself lives in the shared lever-identity leaf
+  // (`src/lib/intervention-override.ts`) so coaching and the public
+  // factor_sensitivity/EVPI egress share ONE union definition (D-U, ROADMAP 2.40).
+  const interventionTargetIds = interventionTargetIdsFromOptions(options);
 
   return {
     factorSensitivity,

--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -41,6 +41,35 @@ import type {
   ConfidenceFormulaVersion,
 } from '../types/engine-v3.js';
 import { ATTRIBUTION_STABILITY_BAND_SCORES } from '../review-pass/evidence-priority.js';
+import { isInterventionOverride, isOptionControlledLever } from './intervention-override.js';
+
+/**
+ * D-U lever suppression (ROADMAP 2.20/2.40): the public shape of a factor that
+ * is controlled by the user's options. Sensitivity/elasticity/VOI are 0 by
+ * contract (not measurements); `zero_reason` is stamped so downstream (UI
+ * badge, CEE coaching, decision-brief) renders the honest "controlled by your
+ * options" state; `influence_score` (graph structural importance) is
+ * deliberately NOT touched — a lever keeps its structural weight, it just is
+ * not an "investigate next" uncertainty. Field-level rationale:
+ * - sensitivity_score 0: `zero_reason: 'intervention_override'` DEFINES the
+ *   lever as not independently tunable. Forced (not copied from ISL) so an
+ *   inconsistent ISL payload can never re-leak a tunable sensitivity (A1).
+ * - elasticity 0: defensive producer value, NOT a measured elasticity — set
+ *   (not omitted) so downstream `elasticity ?? influence_score` fallbacks
+ *   short-circuit to 0 instead of re-leaking influence_score (A1b).
+ * - value_of_information 0: resolving knowledge of a value the user sets is
+ *   not an information gain; without this the EVPI enrichment in
+ *   routes/v2/run.ts would derive a positive EVPI from the graph VOI (P0a).
+ * All three are idempotent constants: re-applying to an already-suppressed
+ * factor is a no-op, so ISL-stamped levers (and, post ISL #73, union-stamped
+ * ones) pass through unchanged.
+ */
+const LEVER_SUPPRESSION_FIELDS = {
+  sensitivity_score: 0,
+  zero_reason: 'intervention_override',
+  elasticity: 0,
+  value_of_information: 0,
+} as const;
 
 /**
  * Minimal fragile edge interface for VOI and flip risk computation.
@@ -834,14 +863,28 @@ export function computeFactorSensitivityFromGraph(
  * @param graphFactors Graph-based factor sensitivity entries (with confidence_components.structural_certainty)
  * @param islFactors ISL factor sensitivity entries (with attribution_stability)
  * @param graphEdges Graph edges for computing incoming edges on ISL-only factors
+ * @param structuralLeverIds D-U structural lever union (every factor id any
+ *   option's `interventions` targets, via `interventionTargetIdsFromOptions`).
+ *   Union members are suppressed+stamped exactly like ISL-stamped levers —
+ *   ISL's stamp under-covers (elasticity≈0 first-option pins only), so a
+ *   non-first-option pin with nonzero measured elasticity would otherwise
+ *   egress as a tunable sensitivity (live fac_salary_cost case).
  */
 export function mergeIslConfidenceIntoGraphFactors(
   graphFactors: FactorSensitivityResultV3[],
   islFactors: FactorSensitivityResultV3[] | undefined,
   graphEdges?: EngineEdgeV3[],
+  structuralLeverIds?: ReadonlySet<string>,
 ): FactorSensitivityResultV3[] {
   if (!islFactors || islFactors.length === 0) {
-    // Even when there's no ISL data, graph entries get re-confirmed provenance.
+    // Even when there's no ISL data, graph entries get re-confirmed provenance —
+    // and the D-U structural guard still applies: a union-member graph factor
+    // must not egress a tunable sensitivity just because ISL returned nothing.
+    if (structuralLeverIds && structuralLeverIds.size > 0) {
+      return graphFactors.map((gf) =>
+        structuralLeverIds.has(gf.factor_id) ? { ...gf, ...LEVER_SUPPRESSION_FIELDS } : gf,
+      );
+    }
     return graphFactors;
   }
 
@@ -871,7 +914,15 @@ export function mergeIslConfidenceIntoGraphFactors(
   const merged = graphFactors.map(gf => {
     graphFactorIds.add(gf.factor_id);
     const islMatch = islMap.get(gf.factor_id);
-    if (!islMatch) return gf;
+    // D-U structural membership: suppression fires on union membership OR the
+    // ISL stamp (below), so an unstamped union lever cannot leak.
+    const structuralLever = structuralLeverIds?.has(gf.factor_id) ?? false;
+    if (!islMatch) {
+      // No ISL entry for this graph factor. Pre-D-U this returned the graph
+      // entry untouched, which let a union lever ISL never analysed publish
+      // its graph sensitivity + VOI (→ EVPI). Suppress+stamp union members.
+      return structuralLever ? { ...gf, ...LEVER_SUPPRESSION_FIELDS } : gf;
+    }
 
     // Extract attribution_stability from ISL entry
     const attrStability = islMatch.attribution_stability ?? null;
@@ -928,54 +979,36 @@ export function mergeIslConfidenceIntoGraphFactors(
       ...(islMatch.value_source !== undefined && { value_source: islMatch.value_source }),
       ...(islMatch.value_extraction_type !== undefined && { value_extraction_type: islMatch.value_extraction_type }),
       ...(islMatch.value_defaulted !== undefined && { value_defaulted: islMatch.value_defaulted }),
-      // Lane A1 — structural-vs-tunable preservation. ISL marks
+      // Lane A1 + D-U — structural-vs-tunable preservation. ISL marks
       // intervention-controlled option levers as NOT independently tunable
-      // (sensitivity_score: 0 + zero_reason: 'intervention_override'). The graph
-      // computes a non-zero topological influence for those same nodes, so the
-      // `...gf` spread above would otherwise expose that as a tunable
-      // sensitivity. Key ONLY on ISL's existing zero_reason — do not re-derive
-      // lever status from graph topology or option interventions. `influence_score`
-      // (graph structural importance) and `source` ('graph', a legacy/object
-      // provenance label) are deliberately left unchanged; the authority for
-      // tunability is `zero_reason === 'intervention_override'` + sensitivity 0.
-      ...(islMatch.zero_reason === 'intervention_override' && {
-        // `zero_reason: 'intervention_override'` DEFINES the lever as not
-        // independently tunable, so sensitivity is 0 by contract. Force 0 here
-        // (rather than copying islMatch.sensitivity_score) so PLoT enforces the
-        // invariant even if an ISL payload ever paired intervention_override with
-        // a non-zero sensitivity_score — that inconsistency must not re-leak as a
-        // tunable sensitivity. (influence_score / source stay graph-derived.)
-        sensitivity_score: 0,
-        zero_reason: 'intervention_override',
-        // A1b: defensive public producer value — NOT a measured elasticity and
-        // NO claim of low sensitivity/stability. Set to 0 (not omitted) so
-        // downstream `elasticity ?? influence_score` fallbacks short-circuit to 0
-        // instead of re-leaking the preserved non-zero influence_score. The
-        // durable guarantee is the explicit zero_reason predicate at each
-        // tunability/evidence surface; this is defence-in-depth. (A1b brief §1/§3.)
-        elasticity: 0,
-        // P0a: a lever's value_of_information is 0 by the same contract.
-        // `value_of_information` is computed pre-merge in
-        // computeFactorSensitivityFromGraph from the lever's non-zero topological
-        // influence (and carried through by the `...gf` spread above); the EVPI
-        // enrichment loop in routes/v2/run.ts derives evpi_percentage_points from
-        // it, so without this a lever would publish a positive EVPI and surface as
-        // a top "investigation priority / resolvable uncertainty" in consumers
-        // (e.g. the UI factor card). Resolving knowledge of an option-pinned value
-        // the user sets is not an information gain, so VOI is 0 — same suppression
-        // posture as sensitivity_score/elasticity above, NOT a new EVPI definition.
-        value_of_information: 0,
-      }),
+      // (sensitivity_score: 0 + zero_reason: 'intervention_override'), but its
+      // stamp under-covers: only elasticity≈0 first-option pins are stamped.
+      // D-U (adopted 13 Jul, superseding A1's stamp-only keying) fires the
+      // same suppression on STRUCTURAL union membership too, so a factor any
+      // option pins — stamped or not — never egresses a tunable sensitivity.
+      // The graph computes a non-zero topological influence for these nodes,
+      // so the `...gf` spread above would otherwise expose it. Do not
+      // re-derive lever status from graph topology; the two authorities are
+      // the request-side union and ISL's stamp. `influence_score` (graph
+      // structural importance) and `source` ('graph', a legacy/object
+      // provenance label) are deliberately left unchanged. Field-level
+      // rationale on LEVER_SUPPRESSION_FIELDS; constants, so re-applying to an
+      // ISL-stamped entry is a byte-identical no-op (idempotence).
+      ...((isInterventionOverride(islMatch) || structuralLever) && LEVER_SUPPRESSION_FIELDS),
     };
   });
 
   // Append ISL-only factors not in graph results.
-  // Skip intervention_override entries — they are decision levers, not uncertainty
-  // drivers. When unfiltered ISL entries are passed for confidence merge, we must
-  // not accidentally append them to the sensitivity output.
+  // Skip option-controlled levers (ISL-stamped OR structural union members) —
+  // they are decision levers, not uncertainty drivers. When unfiltered ISL
+  // entries are passed for confidence merge, we must not accidentally append
+  // them to the sensitivity output; and an UNSTAMPED union member (non-first
+  // option pin, nonzero elasticity) must get the same treatment the stamped
+  // ones do — skipped here, exactly as ISL-stamped levers always were on this
+  // path (an ISL-only factor has no graph influence_score to preserve).
   const edges = graphEdges ?? [];
   for (const islF of islFactors) {
-    if (!graphFactorIds.has(islF.factor_id) && islF.zero_reason !== 'intervention_override') {
+    if (!graphFactorIds.has(islF.factor_id) && !isOptionControlledLever(islF, structuralLeverIds)) {
       // Compute incoming edges for ISL-only factor (include strength for improved fallback)
       const incoming = edges
         .filter(e => e.to === islF.factor_id)

--- a/src/lib/intervention-override.ts
+++ b/src/lib/intervention-override.ts
@@ -1,21 +1,84 @@
 /**
- * Intervention-override predicate — shared neutral leaf (A1b).
+ * Lever-identity predicates — shared neutral leaf (A1b; D-U adopted 13 Jul).
  *
  * A factor with `zero_reason === 'intervention_override'` is an option-pinned
  * decision lever (the user controls its value via `options[i].interventions`),
  * NOT an independently tunable uncertainty driver. Tunability / evidence / VoI /
  * "what would change" surfaces must exclude such levers.
  *
+ * D-U (ROADMAP 2.20/2.40) makes the STRUCTURAL union the canonical lever
+ * definition: a factor that ANY option intervenes on is a lever, whether or
+ * not ISL stamped it. ISL stamps `intervention_override` only for
+ * elasticity≈0 first-option pins, so the stamp alone under-covers (live
+ * fac_salary_cost case: pinned by a non-first option with nonzero measured
+ * elasticity → arrived unstamped → PLoT published its sensitivity/EVPI while
+ * coaching suppressed it as a lever). This module therefore carries BOTH
+ * predicates — the request-side structural union
+ * (`interventionTargetIdsFromOptions`) and the ISL-stamp symptom
+ * (`isInterventionOverride`) — and the combined D-U predicate
+ * (`isOptionControlledLever`). There is no other lever-identity definition;
+ * derive from here, never inline.
+ *
  * This module is the single definition, kept import-free so any layer (lib,
- * assembly, routes, coaching) can depend on it without creating an import cycle.
- * It keys ONLY on `zero_reason` — it does NOT read `source`, re-derive lever
- * status from graph topology or option interventions, expose a public field, or
- * define a new classification taxonomy.
+ * assembly, routes, coaching) can depend on it without creating an import
+ * cycle. It does NOT read `source`, re-derive lever status from graph
+ * topology, expose a public field, or define a new classification taxonomy.
  */
 
 /** True iff the factor is an intervention-controlled lever (option-pinned). */
 export function isInterventionOverride(f: { zero_reason?: string | null }): boolean {
   return f.zero_reason === 'intervention_override';
+}
+
+/**
+ * The canonical structural lever union (D-U): every factor id that ANY
+ * option's `interventions` map targets. Source of truth is the request-side
+ * `options[i].interventions`, NOT raw ISL `zero_reason` — ISL's stamp is a
+ * downstream symptom rather than the canonical definition, and it misses
+ * non-first-option pins with nonzero measured elasticity.
+ *
+ * Extracted verbatim from `src/coaching/normalise-inputs.ts` (which now
+ * delegates here) so the coaching layer and the public
+ * factor_sensitivity/EVPI egress share ONE union definition (ROADMAP 2.40).
+ *
+ * Plain-object guard: arrays are objects too and `Object.keys([])` returns
+ * `["0","1",…]`, which would pollute the lever set with positional indices
+ * for malformed inputs. The route schema enforces an object shape in
+ * production, but this is cheap defence-in-depth.
+ */
+export function interventionTargetIdsFromOptions(
+  options: ReadonlyArray<{ interventions?: unknown }> | undefined | null,
+): Set<string> {
+  const interventionTargetIds = new Set<string>();
+  for (const opt of options ?? []) {
+    const interventions = (opt as { interventions?: unknown }).interventions;
+    if (
+      interventions &&
+      typeof interventions === 'object' &&
+      !Array.isArray(interventions)
+    ) {
+      for (const factorId of Object.keys(interventions)) {
+        interventionTargetIds.add(factorId);
+      }
+    }
+  }
+  return interventionTargetIds;
+}
+
+/**
+ * Combined D-U lever predicate: a factor is an option-controlled lever when
+ * ISL stamped it (`zero_reason === 'intervention_override'`) OR it is a
+ * member of the structural union (`interventionTargetIdsFromOptions`).
+ * Suppression surfaces (sensitivity/elasticity/VOI/EVPI) must use this — the
+ * stamp alone under-covers (see module header).
+ */
+export function isOptionControlledLever(
+  f: { factor_id?: string; node_id?: string; zero_reason?: string | null },
+  structuralLeverIds?: ReadonlySet<string>,
+): boolean {
+  if (isInterventionOverride(f)) return true;
+  const id = f.factor_id ?? f.node_id;
+  return id != null && (structuralLeverIds?.has(id) ?? false);
 }
 
 /** Drop intervention-controlled levers from a factor list. */

--- a/src/lib/intervention-override.ts
+++ b/src/lib/intervention-override.ts
@@ -16,8 +16,12 @@
  * predicates — the request-side structural union
  * (`interventionTargetIdsFromOptions`) and the ISL-stamp symptom
  * (`isInterventionOverride`) — and the combined D-U predicate
- * (`isOptionControlledLever`). There is no other lever-identity definition;
- * derive from here, never inline.
+ * (`isOptionControlledLever`). Every lever-identity consumer derives from
+ * here — the /v2/run egress guards, the coaching layer
+ * (normalise-inputs.ts), and, since the PR #219 review fixup, the M2
+ * decision-review lane (request assembly, number-corrector input,
+ * flip-candidate guard, legacy sensitive_parameters). Derive from here,
+ * never inline.
  *
  * This module is the single definition, kept import-free so any layer (lib,
  * assembly, routes, coaching) can depend on it without creating an import

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -3014,6 +3014,7 @@ function buildCeeReviewRequest(
   let islRobustness: CeeReviewRequest['isl_robustness'];
   if (islResult?.robustness) {
     const r = islResult.robustness;
+    const structuralLeverIds = interventionTargetIdsFromOptions(options);
     islRobustness = {
       overall_robustness: r.label as 'robust' | 'moderate' | 'fragile',
       // validation_status / validation_confidence reads removed: the live V2
@@ -3021,7 +3022,14 @@ function buildCeeReviewRequest(
       // were structurally undefined here — the CEE request carried no such
       // keys. Omitting the reads is behaviour-identical on the /v2 path
       // (the legacy /v1 route is a declared behaviour change — see orchestrator.ts).
-      sensitive_parameters: islResult.factor_sensitivity?.slice(0, 5).map((f: any) => ({
+      // D-U union filter (review fixup, PR #219): option-controlled levers —
+      // ISL-stamped OR structural-union members — never egress as sensitive
+      // parameters, mirroring the M2 decision-review request filter. Filter
+      // BEFORE the slice so a lever never consumes one of the 5 slots.
+      // (Hygiene: this legacy path is dead while DECISION_REVIEW_ENABLE is on.)
+      sensitive_parameters: islResult.factor_sensitivity
+        ?.filter((f: any) => !isOptionControlledLever(f, structuralLeverIds))
+        .slice(0, 5).map((f: any) => ({
         parameter: f.node_id,
         // Schema v2.6 canonical field is 'sensitivity_score'; the bare
         // 'sensitivity' key is V1-era and dead on the live V2 wire.

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -134,6 +134,7 @@ import { ReviewSkipReasons, type ReviewSkipReason } from '../../cee/validation/m
 import { getDownstreamCallsForLog, getDownstreamCalls } from '../../util/downstream-tracker.js';
 import { computeResponseContentHash } from '../../util/response-content-hash.js';
 import { computeFactorSensitivityFromGraph, buildFactorStability, mergeIslConfidenceIntoGraphFactors } from '../../lib/factor-influence.js';
+import { interventionTargetIdsFromOptions, isOptionControlledLever } from '../../lib/intervention-override.js';
 import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagMissingFromIsl } from '../../lib/auto-noise.js';
 import { sanitiseIslVoi, computeEvpiPercentagePoints } from '../../lib/evpi-emission.js';
 import {
@@ -5049,6 +5050,17 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // collapse to 0.25" behaviour is fixed at the band table itself.)
         const islFactorSensitivityUnfiltered = transformFactorSensitivityUnfiltered(islResult.factor_sensitivity, normalisationContext);
 
+        // D-U structural lever union (ROADMAP 2.20/2.40, adopted 13 Jul): every
+        // factor id any option's `interventions` targets is a LEVER, whether or
+        // not ISL stamped it (ISL stamps only elasticity≈0 first-option pins).
+        // Same derivation + same input (body.options) as the coaching layer's
+        // normaliseCoachingInputs — ONE union definition, shared via
+        // src/lib/intervention-override.ts. Threaded into the merge below and
+        // the EVPI enrichment guards so a union lever never publishes
+        // sensitivity/elasticity/VOI/EVPI (live fac_salary_cost case: sens
+        // −0.19 + top EVPI 7.8pp published while coaching suppressed it).
+        const structuralLeverIds = interventionTargetIdsFromOptions(body.options);
+
         // Graph-based is primary for influence/sensitivity scores.
         // When graph results exist, merge ISL attribution_stability into graph entries
         // and recompute unified confidence (0.5 × band_score + 0.5 × mean(incoming edges)).
@@ -5061,6 +5073,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             graphBasedFactorSensitivity,
             islFactorSensitivityUnfiltered,
             filteredGraph.edges,
+            structuralLeverIds,
           );
           factorSensitivitySource = 'graph+isl_merge';
         } else {
@@ -5068,10 +5081,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           // Pass empty graph array so all ISL factors go through the ISL-only
           // append path, which computes unified confidence + confidence_components.
           // Use filtered entries here since ISL-only factors ARE the sensitivity output.
+          // The structural union still applies: an UNSTAMPED union lever survives
+          // transformFactorSensitivity's zero_reason filter, so the append path's
+          // union check is what keeps it off the sensitivity output.
           factorSensitivity = mergeIslConfidenceIntoGraphFactors(
             [],
             islFactorSensitivity,
             filteredGraph.edges,
+            structuralLeverIds,
           );
           factorSensitivitySource = 'isl';
         }
@@ -5108,11 +5125,16 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
 
           if (islEvpiByFactor.size > 0) {
             for (const f of factorSensitivity) {
-              // P0a: never emit EVPI for an option-pinned lever
-              // (zero_reason === 'intervention_override') — resolving knowledge
-              // of a value the user sets is not an information gain. Applies to
-              // the ISL counterfactual path exactly as to the heuristic path.
-              if (f.zero_reason === 'intervention_override') continue;
+              // P0a + D-U: never emit EVPI for an option-controlled lever —
+              // ISL-stamped (zero_reason === 'intervention_override') OR a
+              // structural union member (any option intervenes on it; ISL's
+              // stamp misses non-first-option pins with nonzero elasticity).
+              // Resolving knowledge of a value the user sets is not an
+              // information gain. Applies to the ISL counterfactual path
+              // exactly as to the heuristic path. The merge upstream already
+              // stamps union members, so this is belt-and-braces against any
+              // path that bypasses the merge.
+              if (isOptionControlledLever(f, structuralLeverIds)) continue;
               const entry = islEvpiByFactor.get(f.factor_id);
               if (!entry) continue; // no ISL estimate for this factor → honest absence
               if (entry.emit_pp !== undefined) {
@@ -5141,15 +5163,16 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             const winProbSpread = winProbs.length >= 2 ? winProbs[0] - winProbs[1] : 0;
             if (winProbSpread > 0) {
               for (const f of factorSensitivity) {
-                // P0a: never emit EVPI for an option-pinned lever
-                // (zero_reason === 'intervention_override'). Its VOI is forced to 0
-                // in mergeIslConfidenceIntoGraphFactors, and computeEvpiPercentagePoints(0, …)
+                // P0a + D-U: never emit EVPI for an option-controlled lever —
+                // ISL-stamped OR structural union member (see the counterfactual
+                // loop above). A lever's VOI is forced to 0 in
+                // mergeIslConfidenceIntoGraphFactors, and computeEvpiPercentagePoints(0, …)
                 // returns a confident 0 (not undefined) — which would still render an
                 // EVPI chip and rank the lever as an "investigation priority". Skip it
                 // entirely so evpi_percentage_points is ABSENT (preserving the
                 // missing-vs-zero contract), not 0. Belt-and-braces with the
                 // producer-side VOI zeroing; suppression only, no EVPI rename/redefine.
-                if (f.zero_reason === 'intervention_override') continue;
+                if (isOptionControlledLever(f, structuralLeverIds)) continue;
                 const evpiPp = computeEvpiPercentagePoints(f.value_of_information, winProbSpread);
                 if (evpiPp !== undefined) {
                   f.evpi_percentage_points = evpiPp;

--- a/tests/contract/cee-decision-review-contract.test.ts
+++ b/tests/contract/cee-decision-review-contract.test.ts
@@ -158,6 +158,10 @@ const testIslResult = {
     },
   ],
   factor_sensitivity: [
+    // factor_a and factor_b are option-intervention targets (see testOptions)
+    // → structural-union levers, filtered out of the CEE request since the
+    // PR #219 review fixup. factor_c is the non-lever survivor that keeps the
+    // populated factor_sensitivity entry shape under contract coverage.
     {
       factor_id: 'factor_a',
       factor_label: 'Market Size',
@@ -169,6 +173,12 @@ const testIslResult = {
       factor_label: 'Competition',
       elasticity: 0.25,
       confidence: 0.7,
+    },
+    {
+      factor_id: 'factor_c',
+      factor_label: 'Brand Strength',
+      elasticity: 0.15,
+      confidence: 0.6,
     },
   ],
   robustness: {
@@ -595,29 +605,37 @@ describe('CEE Decision Review Contract', () => {
 
   // ===========================================================================
   // Flip-threshold selection guard on the legacy assembly path. The contract
-  // schema only validates shape/presence, so this exercises the by-all-options
-  // exclusion behaviour directly.
+  // schema only validates shape/presence, so this exercises the exclusion
+  // behaviour directly.
+  //
+  // RULING CHANGE (PR #219 review fixup): the excluded set is the STRUCTURAL
+  // UNION (any option intervenes), not just the all-options intersection. A
+  // some-but-not-all-options lever must not become a CEE flip candidate
+  // either — lever suppression outranks the probe-usefulness argument the old
+  // intersection guard encoded.
   // ===========================================================================
-  describe('flip-threshold overridden-by-all exclusion', () => {
+  describe('flip-threshold lever exclusion (structural union)', () => {
     // The shared testGraph omits observed_state.value, which would skip every factor
     // during flip-threshold selection. Give the factors values so they are genuinely
-    // eligible, then assert the guard removes only the fully-overridden one.
+    // eligible, then assert the union guard removes every lever and only levers.
     const graphWithValues: EngineGraphV3 = {
       nodes: [
         { id: 'goal', kind: 'goal', label: 'Maximize Revenue' },
         { id: 'factor_a', kind: 'factor', label: 'Market Size', observed_state: { value: 0.5, belief: 0.8 } },
         { id: 'factor_b', kind: 'factor', label: 'Competition', observed_state: { value: 0.5, belief: 0.7 } },
+        { id: 'factor_c', kind: 'factor', label: 'Brand Strength', observed_state: { value: 0.5, belief: 0.6 } },
       ],
       edges: testGraph.edges,
     };
 
-    it('excludes a factor overridden by EVERY option, preserves one overridden by only SOME', () => {
+    it('excludes every option-intervention target (all-options AND some-options), preserves the non-lever', () => {
       // testOptions: opt_a → {factor_a}; opt_b → {factor_a, factor_b}.
-      //   factor_a is overridden by every option → excluded from assumption-threshold probing.
-      //   factor_b is overridden by only opt_b → preserved.
-      // testIslResult.factor_sensitivity carries both factor_a (0.45) and factor_b (0.25)
-      // with no intervention_override zero_reason, so the by-all guard (not the ISL
-      // zero_reason filter) is what removes factor_a.
+      //   factor_a is overridden by every option → excluded (as before).
+      //   factor_b is overridden by only opt_b → union lever → NOW excluded.
+      //   factor_c is intervened by nobody → the surviving flip candidate.
+      // testIslResult.factor_sensitivity carries all three with no
+      // intervention_override zero_reason, so the structural-union guard (not
+      // the ISL zero_reason filter) is what removes factor_a and factor_b.
       const request = buildDecisionReviewRequest(
         'Flip-threshold exclusion unit test',
         graphWithValues,
@@ -627,8 +645,9 @@ describe('CEE Decision Review Contract', () => {
       );
 
       const flipFactorIds = request.flip_threshold_data.map((f) => f.factor_id);
-      expect(flipFactorIds).toContain('factor_b');     // partially intervened → eligible
+      expect(flipFactorIds).toContain('factor_c');     // non-lever → eligible
       expect(flipFactorIds).not.toContain('factor_a'); // overridden by all → excluded
+      expect(flipFactorIds).not.toContain('factor_b'); // some-options lever → excluded (ruling change)
     });
   });
 });

--- a/tests/du-structural-lever-guard.decision-review.integration.test.ts
+++ b/tests/du-structural-lever-guard.decision-review.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * D-U structural lever guard — M2 decision-review egress (third lever-egress
+ * path; review fixup on PR #219).
+ *
+ * The /v2/run egress guard (du-structural-lever-guard.integration.test.ts)
+ * closed the PUBLIC factor_sensitivity/EVPI wire. This file closes the CEE
+ * decision-review lane, which forwarded UNSTAMPED union-lever numbers to CEE
+ * and could launder them back onto the public wire:
+ *
+ *   1. extractFactorSensitivity read RAW islResult.factor_sensitivity with the
+ *      STAMP-ONLY filter — an unstamped union lever (the live fac_salary_cost
+ *      class) passed its elasticity+confidence+label to CEE as
+ *      isl_results.factor_sensitivity (ACTIVE path: DECISION_REVIEW_ENABLE).
+ *   2. buildValidationContext then allowlisted those elasticities as
+ *      "grounded" numbers the LLM may cite.
+ *   3. buildIslResultsForCorrection read raw ISL with NO filter and fed the
+ *      number-corrector, which can inject the lever's elasticity into the
+ *      returned narrative → public wire (run.ts m1_review merge).
+ *   4. computeFlipThresholdData was guarded only by the ALL-options
+ *      intersection, so a some-but-not-all-options lever became a CEE flip
+ *      candidate whenever preResolvedFlipData was absent.
+ *
+ * Fixture archetypes (mirrors the /v2/run guard test):
+ *   - fac_union  union lever: pinned ONLY by the NON-first option, arrives
+ *                UNSTAMPED (no zero_reason) with nonzero elasticity −0.19 and
+ *                confidence 0.77. Must reach NONE of the four surfaces.
+ *   - fac_plain  non-lever control (elasticity 0.53, confidence 0.61). Must
+ *                still flow to ALL FOUR surfaces (no over-suppression).
+ *
+ * One-union-definition discipline: the expected lever set is derived via the
+ * shared leaf (interventionTargetIdsFromOptions), never inlined.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildDecisionReviewRequest,
+  type ISLResultInput,
+} from '../src/cee/decision-review-request.js';
+import { buildIslResultsForCorrection } from '../src/cee/decision-review-orchestrator.js';
+import { buildValidationContext } from '../src/cee/validation/m1-review-validator.js';
+import { interventionTargetIdsFromOptions } from '../src/lib/intervention-override.js';
+import type { EngineGraphV3, OptionV3 } from '../src/types/engine-v3.js';
+import type { M1Coaching } from '../src/coaching/types.js';
+
+const UNION_ID = 'fac_union';
+const PLAIN_ID = 'fac_plain';
+
+// Distinctive numerics so allowlist assertions cannot collide with other
+// request numbers (win probs 0.65/0.35, margin 0.3, stability 0.82,
+// current values 0.6/0.4).
+const UNION_ELASTICITY = -0.19;
+const UNION_CONFIDENCE = 0.77;
+const PLAIN_ELASTICITY = 0.53;
+const PLAIN_CONFIDENCE = 0.61;
+
+const graph: EngineGraphV3 = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Goal' },
+    // observed_state.value present so both factors are genuinely eligible as
+    // flip-threshold candidates (missing value would mask claim 4).
+    { id: UNION_ID, kind: 'factor', label: 'Salary Cost (union lever)', observed_state: { value: 0.6 } },
+    { id: PLAIN_ID, kind: 'factor', label: 'Background Factor', observed_state: { value: 0.4 } },
+  ],
+  edges: [
+    { from: UNION_ID, to: 'goal', exists_probability: 0.95, strength: { mean: 0.9, std: 0.1 } },
+    { from: PLAIN_ID, to: 'goal', exists_probability: 0.7, strength: { mean: 0.3, std: 0.1 } },
+  ],
+};
+
+// fac_union is pinned ONLY by the NON-first option → structural union member
+// that is NOT in the all-options intersection (opt_a does not pin it), and
+// ISL did NOT stamp it. This is exactly the class the stamp-only filter and
+// the intersection-only flip guard both missed.
+const options: OptionV3[] = [
+  { id: 'opt_a', label: 'A', interventions: {} },
+  { id: 'opt_b', label: 'B', interventions: { [UNION_ID]: 0.2 } },
+];
+
+const islResult: ISLResultInput = {
+  options: [
+    { option_id: 'opt_a', option_label: 'A', win_probability: 0.65, outcome: { mean: 0.72 } },
+    { option_id: 'opt_b', option_label: 'B', win_probability: 0.35, outcome: { mean: 0.58 } },
+  ],
+  factor_sensitivity: [
+    // UNSTAMPED union lever: no zero_reason, nonzero elasticity.
+    { factor_id: UNION_ID, factor_label: 'Salary Cost (union lever)', elasticity: UNION_ELASTICITY, confidence: UNION_CONFIDENCE, direction: 'negative' },
+    { factor_id: PLAIN_ID, factor_label: 'Background Factor', elasticity: PLAIN_ELASTICITY, confidence: PLAIN_CONFIDENCE, direction: 'positive' },
+  ],
+  robustness: {
+    recommendation_stability: 0.82,
+    flip_risk_category: 'low',
+    is_robust: true,
+    fragile_edges: [],
+  },
+};
+
+const m1Coaching: M1Coaching = {
+  story_headlines: {},
+  evidence_gaps: [],
+  model_critiques: [],
+  next_actions: [],
+  readiness: 'ready',
+  headline_type: 'clear_winner',
+} as unknown as M1Coaching;
+
+const structuralLeverIds = interventionTargetIdsFromOptions(options);
+
+function buildRequest() {
+  return buildDecisionReviewRequest('Union-lever decision-review egress test', graph, options, islResult, m1Coaching);
+}
+
+describe('D-U guard — M2 decision-review lane (third egress path)', () => {
+  it('claim 1: an unstamped union lever never reaches the CEE request isl_results.factor_sensitivity; the non-lever control still flows', () => {
+    // RED pre-fixup: filter was stamp-only, fac_union has no zero_reason →
+    // its elasticity −0.19 + confidence 0.77 + label went to CEE.
+    const request = buildRequest();
+    const ids = request.isl_results.factor_sensitivity.map((f) => f.factor_id);
+    expect(ids, 'union lever must not egress to CEE').not.toContain(UNION_ID);
+    expect(ids, 'non-lever control must survive').toContain(PLAIN_ID);
+    const plain = request.isl_results.factor_sensitivity.find((f) => f.factor_id === PLAIN_ID)!;
+    expect(plain.elasticity).toBe(PLAIN_ELASTICITY);
+    expect(plain.confidence).toBe(PLAIN_CONFIDENCE);
+  });
+
+  it('claim 2: the union lever\'s elasticity/confidence are NOT allowlisted as "grounded" numbers; the control\'s are', () => {
+    // RED pre-fixup: buildValidationContext derived allowedNumbers from the
+    // leaked factor_sensitivity → the LLM could cite the lever's numbers and
+    // pass tier-validation as "grounded".
+    const context = buildValidationContext(buildRequest() as never);
+    expect(context.allowedNumbers, 'lever elasticity must not be grounded').not.toContain(UNION_ELASTICITY);
+    expect(context.allowedNumbers, 'lever confidence must not be grounded').not.toContain(UNION_CONFIDENCE);
+    expect(context.allowedNumbers, 'control elasticity stays grounded').toContain(PLAIN_ELASTICITY);
+    expect(context.allowedNumbers, 'control confidence stays grounded').toContain(PLAIN_CONFIDENCE);
+  });
+
+  it('claim 3: the union lever never appears in the number-corrector\'s ISL input; the control does', () => {
+    // RED pre-fixup: buildIslResultsForCorrection read raw ISL with NO filter
+    // → the corrector could inject the lever's elasticity into the returned
+    // narrative (public wire via the m1_review merge).
+    const corrInput = buildIslResultsForCorrection(islResult, structuralLeverIds);
+    const ids = corrInput.factor_sensitivity.map((f) => f.factor_id);
+    expect(ids, 'union lever must not feed the number-corrector').not.toContain(UNION_ID);
+    expect(ids, 'non-lever control must survive').toContain(PLAIN_ID);
+  });
+
+  it('claim 4: a some-but-not-all-options lever never becomes a CEE flip candidate; the control still can', () => {
+    // RED pre-fixup: the flip guard was getFactorsOverriddenByAllOptions —
+    // opt_a does not pin fac_union, so the intersection missed it and its
+    // |elasticity| 0.19 made it a ranked flip candidate.
+    const request = buildRequest();
+    const flipIds = request.flip_threshold_data.map((f) => f.factor_id);
+    expect(flipIds, 'union lever must not be a flip candidate').not.toContain(UNION_ID);
+    expect(flipIds, 'non-lever control stays a flip candidate').toContain(PLAIN_ID);
+  });
+});

--- a/tests/du-structural-lever-guard.integration.test.ts
+++ b/tests/du-structural-lever-guard.integration.test.ts
@@ -1,0 +1,272 @@
+/**
+ * D-U structural lever guard — /v2/run egress (ROADMAP 2.20/2.40, D-U adopted 13 Jul).
+ *
+ * D-U semantics: a factor ANY option intervenes on is a LEVER. Suppress
+ * sensitivity/elasticity/VOI/EVPI everywhere, KEEP influence_score, stamp
+ * zero_reason='intervention_override' so downstream (UI badge, CEE coaching)
+ * renders the honest "controlled by your options" state.
+ *
+ * The gap this closes (live fac_salary_cost case): ISL stamps
+ * intervention_override only for elasticity≈0 first-option pins, so a factor
+ * pinned by a NON-first option with NONZERO measured elasticity arrives
+ * unstamped — and PLoT's egress guards, keyed only on zero_reason, published
+ * its sensitivity (−0.19) and top-ranked EVPI (7.8pp) while CEE coaching
+ * correctly suppressed it as a lever (the coaching layer already unions over
+ * options[i].interventions in normalise-inputs.ts).
+ *
+ * Fixture archetypes (all four must hold simultaneously):
+ *   - fac_union       union lever (pinned ONLY by the NON-first option) with a
+ *                     nonzero ISL sensitivity and NO zero_reason.
+ *                     RED today: published sensitivity + EVPI.
+ *                     GREEN: zeroed + stamped, influence kept, EVPI absent.
+ *   - fac_graph_only  union lever (non-first option) ABSENT from ISL
+ *                     factor_sensitivity — exercises the merge's no-ISL-match
+ *                     branch, which pre-fix returned the graph entry untouched.
+ *   - fac_stamped     first-option pin that ISL already stamped — idempotence
+ *                     control: output must be byte-identical pre/post guard.
+ *   - fac_plain       non-lever with honest positive EVPI — must survive
+ *                     (no over-suppression).
+ *
+ * Both EVPI producer paths are exercised end-to-end:
+ *   Block A: heuristic path (no factor_evpi on the wire; win-prob spread > 0).
+ *   Block B: ISL counterfactual path (factor_evpi present), including a raw
+ *            NEGATIVE factor_evpi entry for a lever — ROADMAP 2.20 rider (b):
+ *            no negative EVPI may leak post-suppression, in any form.
+ *
+ * Suppression only — no EVPI rename, no new scientific claim, no schema change.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const UNION_ID = 'fac_union';
+const GRAPH_ONLY_ID = 'fac_graph_only';
+const STAMPED_ID = 'fac_stamped';
+const PLAIN_ID = 'fac_plain';
+
+// ISL factor_sensitivity, node_id-keyed ISL shape. fac_union is the D-U gap:
+// nonzero sensitivity, NO zero_reason (ISL pre-#73 behaviour for non-first
+// option pins). fac_graph_only is deliberately ABSENT. fac_stamped is the
+// ISL-stamped idempotence control.
+const ISL_FACTOR_SENSITIVITY = [
+  { node_id: UNION_ID, sensitivity: -0.19, value_of_information: 0.6, direction: 'negative' as const },
+  { node_id: STAMPED_ID, sensitivity: 0, value_of_information: 0.9, direction: 'positive' as const, zero_reason: 'intervention_override' },
+  { node_id: PLAIN_ID, sensitivity: 0.5, value_of_information: 0.6, direction: 'positive' as const },
+];
+
+// Fragile edges adjacent to fac_union / fac_graph_only / fac_plain so the
+// graph-side VOI (|sens| × (1−conf) × max marginal_switch_probability) is
+// strictly positive → the heuristic EVPI loop has something to leak pre-fix.
+const FRAGILE_EDGES = [
+  { edge_id: `${UNION_ID}::goal`, from_id: UNION_ID, to_id: 'goal', switch_probability: 0.3, marginal_switch_probability: 0.25 },
+  { edge_id: `${GRAPH_ONLY_ID}::goal`, from_id: GRAPH_ONLY_ID, to_id: 'goal', switch_probability: 0.2, marginal_switch_probability: 0.2 },
+  { edge_id: `${PLAIN_ID}::goal`, from_id: PLAIN_ID, to_id: 'goal', switch_probability: 0.2, marginal_switch_probability: 0.2 },
+];
+
+// Block B wire entries. fac_union carries the live worked example (7.8pp —
+// the published top "investigation priority" for a lever). fac_stamped
+// carries a raw NEGATIVE (MC sampling artefact) — rider (b): must never
+// egress in any form. fac_plain is the honest survivor.
+const FACTOR_EVPI = [
+  { factor_id: UNION_ID, evpi: 0.078, evpi_percentage_points: 7.8, metric_type: 'win_probability', n_evpi_samples: 1000 },
+  { factor_id: GRAPH_ONLY_ID, evpi: 0.05, evpi_percentage_points: 5.0, metric_type: 'win_probability', n_evpi_samples: 1000 },
+  { factor_id: STAMPED_ID, evpi: -0.0015, evpi_percentage_points: -0.15, metric_type: 'win_probability', n_evpi_samples: 1000 },
+  { factor_id: PLAIN_ID, evpi: 0.032, evpi_percentage_points: 3.2, metric_type: 'win_probability', n_evpi_samples: 1000 },
+];
+
+function robustnessPayload(options: any[], opts: { withFactorEvpi: boolean }) {
+  return {
+    options: options.map((opt: any, idx: number) => ({
+      option_id: opt.id,
+      win_probability: idx === 0 ? 0.7 : 0.3, // spread 0.4 > 0 ⇒ heuristic EVPI loop fires when factor_evpi absent
+      outcome: { mean: 0.7 - idx * 0.2, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+      rank: idx + 1,
+    })),
+    edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const, edge_sensitivity_status: 'available' as const,
+    factors: ISL_FACTOR_SENSITIVITY,
+    factor_sensitivity: ISL_FACTOR_SENSITIVITY,
+    value_of_information: ISL_FACTOR_SENSITIVITY.map(f => ({ factor_id: f.node_id, voi: f.value_of_information })),
+    ...(opts.withFactorEvpi && { factor_evpi: FACTOR_EVPI }),
+    factors_provenance: 'isl' as const, factor_sensitivity_status: 'available' as const,
+    // Route reads fragile edges for graph-VOI at islResult.robustness.fragile_edges (nested).
+    robustness: { score: 0.8, label: 'robust' as const, fragile_edges: FRAGILE_EDGES, robust_edges: [] },
+    overall_robustness: 'robust' as const, robustness_score: 0.8, fragile_edges: FRAGILE_EDGES, robust_edges: [],
+    latency_ms: 50, source: 'isl' as const,
+  };
+}
+
+let withFactorEvpi = false; // toggled per describe block; mock reads it at call time
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return { status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl' };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return robustnessPayload(options, { withFactorEvpi });
+  },
+  async analyseFactorSensitivity() {
+    return { factors: ISL_FACTOR_SENSITIVITY, value_of_information: ISL_FACTOR_SENSITIVITY.map(f => ({ factor_id: f.node_id, voi: f.value_of_information })), robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'isl' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    return { data: robustnessPayload(body.options || [], { withFactorEvpi }) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+const { createServer } = await import('../src/createServer.js');
+
+// fac_stamped is pinned by the FIRST option (the case ISL already stamps).
+// fac_union and fac_graph_only are pinned ONLY by the NON-first option — the
+// D-U gap ISL does not stamp today. fac_plain is pinned by nobody.
+const PAYLOAD = {
+  graph: {
+    nodes: [
+      { id: 'goal', kind: 'goal', label: 'Goal' },
+      { id: UNION_ID, kind: 'factor', label: 'Salary Cost (union lever)', observed_state: { value: 0.6 } },
+      { id: GRAPH_ONLY_ID, kind: 'factor', label: 'Graph-only Lever', observed_state: { value: 0.4 } },
+      { id: STAMPED_ID, kind: 'factor', label: 'ISL-stamped Lever', observed_state: { value: 0.5 } },
+      { id: PLAIN_ID, kind: 'factor', label: 'Background Factor', observed_state: { value: 0.5 } },
+    ],
+    edges: [
+      { from: UNION_ID, to: 'goal', exists_probability: 0.95, strength: { mean: 0.9, std: 0.1 } },
+      { from: GRAPH_ONLY_ID, to: 'goal', exists_probability: 0.9, strength: { mean: 0.7, std: 0.1 } },
+      { from: STAMPED_ID, to: 'goal', exists_probability: 0.9, strength: { mean: 0.8, std: 0.1 } },
+      { from: PLAIN_ID, to: 'goal', exists_probability: 0.7, strength: { mean: 0.3, std: 0.1 } },
+    ],
+  },
+  options: [
+    { id: 'opt_a', label: 'A', interventions: { [STAMPED_ID]: { value: 1, source: 'user_specified' } } },
+    { id: 'opt_b', label: 'B', interventions: { [UNION_ID]: { value: 0.2, source: 'user_specified' }, [GRAPH_ONLY_ID]: { value: 0.4, source: 'user_specified' } } },
+  ],
+  goal_node_id: 'goal',
+  seed: '42',
+};
+
+function expectSuppressedLever(f: any, label: string) {
+  expect(f, `${label} present in egress`).toBeDefined();
+  expect(f.zero_reason, `${label} stamped`).toBe('intervention_override');
+  expect(f.sensitivity_score, `${label} sensitivity zeroed`).toBe(0);
+  expect(f.elasticity ?? 0, `${label} elasticity zeroed`).toBe(0);
+  expect(f.value_of_information ?? 0, `${label} VOI zeroed`).toBe(0);
+  expect(typeof f.influence_score, `${label} influence kept`).toBe('number');
+  expect(f.influence_score, `${label} influence kept nonzero`).toBeGreaterThan(0);
+  expect(f.evpi_percentage_points, `${label} EVPI absent`).toBeUndefined();
+  expect(f.evpi_method, `${label} evpi_method absent`).toBeUndefined();
+  expect(f.evpi_status, `${label} evpi_status absent`).toBeUndefined();
+}
+
+async function runOnce(): Promise<{ body: any; factors: any[] }> {
+  process.env.RATE_LIMIT_ENABLED = '0';
+  process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+  const app: FastifyInstance = await createServer();
+  try {
+    const res = await app.inject({
+      method: 'POST', url: '/v2/run',
+      headers: { 'content-type': 'application/json' },
+      payload: PAYLOAD,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    return { body, factors: (body.factor_sensitivity ?? []) as any[] };
+  } finally {
+    await app.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  }
+}
+
+describe('D-U guard, Block A — heuristic EVPI path (no factor_evpi on the wire)', () => {
+  let factors: any[];
+
+  beforeAll(async () => {
+    withFactorEvpi = false;
+    ({ factors } = await runOnce());
+  });
+
+  afterAll(() => { /* app closed in runOnce */ });
+
+  it('a factor pinned by a NON-first option with nonzero unstamped ISL sensitivity is suppressed + stamped, influence kept', () => {
+    // RED pre-guard: sensitivity −0.19 egresses tunable, VOI > 0, heuristic
+    // EVPI published — the live fac_salary_cost incoherence.
+    expectSuppressedLever(factors.find((f) => f.factor_id === UNION_ID), 'union lever');
+  });
+
+  it('a union lever ABSENT from ISL factor_sensitivity (no-ISL-match merge branch) is suppressed + stamped, influence kept', () => {
+    expectSuppressedLever(factors.find((f) => f.factor_id === GRAPH_ONLY_ID), 'graph-only lever');
+  });
+
+  it('an ISL-stamped first-option lever is unchanged (idempotent — no double-transform)', () => {
+    expectSuppressedLever(factors.find((f) => f.factor_id === STAMPED_ID), 'ISL-stamped lever');
+  });
+
+  it('a non-lever still carries nonzero sensitivity and STRICTLY POSITIVE heuristic EVPI (no over-suppression)', () => {
+    const plain = factors.find((f) => f.factor_id === PLAIN_ID);
+    expect(plain, 'non-lever present').toBeDefined();
+    expect(plain.zero_reason ?? null).toBeNull();
+    expect(Math.abs(plain.sensitivity_score)).toBeGreaterThan(0);
+    expect(plain.value_of_information).toBeGreaterThan(0);
+    expect(plain.evpi_percentage_points).toBeGreaterThan(0);
+    expect(plain.evpi_method).toBe('heuristic');
+  });
+
+  it('every factor bearing EVPI is outside the option-intervention union', () => {
+    const unionIds = new Set([UNION_ID, GRAPH_ONLY_ID, STAMPED_ID]);
+    const withEvpi = factors.filter((f) => f.evpi_percentage_points !== undefined && f.evpi_percentage_points !== null);
+    expect(withEvpi.length).toBeGreaterThan(0);
+    for (const f of withEvpi) {
+      expect(unionIds.has(f.factor_id), `${f.factor_id} must not bear EVPI`).toBe(false);
+    }
+  });
+});
+
+describe('D-U guard, Block B — ISL counterfactual EVPI path (factor_evpi on the wire)', () => {
+  let body: any;
+  let factors: any[];
+
+  beforeAll(async () => {
+    withFactorEvpi = true;
+    ({ body, factors } = await runOnce());
+  });
+
+  it('the union lever\'s wire factor_evpi (7.8pp, the live worked example) is NOT published', () => {
+    // RED pre-guard: evpi_percentage_points 7.8, evpi_method 'counterfactual'
+    // — a lever ranked as the top investigation priority.
+    expectSuppressedLever(factors.find((f) => f.factor_id === UNION_ID), 'union lever');
+  });
+
+  it('the graph-only union lever\'s wire factor_evpi (5.0pp) is NOT published', () => {
+    expectSuppressedLever(factors.find((f) => f.factor_id === GRAPH_ONLY_ID), 'graph-only lever');
+  });
+
+  it('an ISL-stamped lever with a raw NEGATIVE wire factor_evpi egresses nothing — rider (b): no negative leak in any form', () => {
+    const stamped = factors.find((f) => f.factor_id === STAMPED_ID);
+    expectSuppressedLever(stamped, 'ISL-stamped lever');
+    // Belt-and-braces sweep: no factor_sensitivity entry anywhere carries a
+    // negative EVPI or a negative VOI after suppression.
+    for (const f of factors) {
+      if (f.evpi_percentage_points !== undefined && f.evpi_percentage_points !== null) {
+        expect(f.evpi_percentage_points).toBeGreaterThanOrEqual(0);
+      }
+      if (f.value_of_information !== undefined && f.value_of_information !== null) {
+        expect(f.value_of_information).toBeGreaterThanOrEqual(0);
+      }
+    }
+    expect(JSON.stringify(body.factor_sensitivity)).not.toContain('-0.15');
+  });
+
+  it('a non-lever\'s counterfactual EVPI survives (3.2pp — no over-suppression)', () => {
+    const plain = factors.find((f) => f.factor_id === PLAIN_ID);
+    expect(plain, 'non-lever present').toBeDefined();
+    expect(plain.evpi_percentage_points).toBe(3.2);
+    expect(plain.evpi_method).toBe('counterfactual');
+  });
+});

--- a/tests/du-structural-lever-guard.unit.test.ts
+++ b/tests/du-structural-lever-guard.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * D-U structural lever guard — unit coverage for the shared lever-identity
+ * leaf and the merge paths the integration fixture cannot reach.
+ *
+ * The integration test (du-structural-lever-guard.integration.test.ts) drives
+ * /v2/run end-to-end; this file pins:
+ *   1. interventionTargetIdsFromOptions — the ONE union definition (D-U /
+ *      ROADMAP 2.40), including the plain-object guard extracted verbatim
+ *      from coaching's normalise-inputs.ts.
+ *   2. isOptionControlledLever — stamp OR union membership.
+ *   3. mergeIslConfidenceIntoGraphFactors with EMPTY islFactors — the early
+ *      return that pre-D-U let a union-member graph factor egress a tunable
+ *      sensitivity whenever ISL returned no factor_sensitivity at all.
+ *   4. Idempotence at the merge level: an ISL-stamped union member produces
+ *      byte-identical output with and without the structural set (the
+ *      suppression fields are constants; no double-transform).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  interventionTargetIdsFromOptions,
+  isOptionControlledLever,
+} from '../src/lib/intervention-override.js';
+import { mergeIslConfidenceIntoGraphFactors } from '../src/lib/factor-influence.js';
+import type { FactorSensitivityResultV3 } from '../src/types/engine-v3.js';
+
+function graphFactor(id: string, over: Partial<FactorSensitivityResultV3> = {}): FactorSensitivityResultV3 {
+  return {
+    factor_id: id,
+    factor_label: id,
+    influence_score: 0.8,
+    influence_rank: 1,
+    sensitivity_score: 0.7,
+    elasticity: 0.8,
+    direction: 'positive',
+    importance_rank: 1,
+    value_of_information: 0.4,
+    confidence: 0.6,
+    confidence_source: 'plot_unified_from_graph',
+    confidence_components: { structural_certainty: 0.9, sampling_stability: null },
+    source: 'graph',
+    ...over,
+  } as FactorSensitivityResultV3;
+}
+
+describe('interventionTargetIdsFromOptions — the single union definition', () => {
+  it('unions targets across ALL options (not just the first)', () => {
+    const ids = interventionTargetIdsFromOptions([
+      { interventions: { fac_a: 1 } },
+      { interventions: { fac_b: { value: 0.2 }, fac_c: 0 } },
+    ]);
+    expect([...ids].sort()).toEqual(['fac_a', 'fac_b', 'fac_c']);
+  });
+
+  it('guards malformed inputs: array interventions must not pollute the set with indices', () => {
+    const ids = interventionTargetIdsFromOptions([
+      { interventions: [0.1, 0.2] as unknown },
+      { interventions: null as unknown },
+      { interventions: undefined },
+      {},
+    ]);
+    expect(ids.size).toBe(0);
+  });
+
+  it('handles absent options', () => {
+    expect(interventionTargetIdsFromOptions(undefined).size).toBe(0);
+    expect(interventionTargetIdsFromOptions(null).size).toBe(0);
+    expect(interventionTargetIdsFromOptions([]).size).toBe(0);
+  });
+});
+
+describe('isOptionControlledLever — stamp OR structural membership', () => {
+  const union = new Set(['fac_union']);
+  it('fires on the ISL stamp alone', () => {
+    expect(isOptionControlledLever({ factor_id: 'x', zero_reason: 'intervention_override' })).toBe(true);
+  });
+  it('fires on union membership alone (the D-U gap: unstamped non-first-option pin)', () => {
+    expect(isOptionControlledLever({ factor_id: 'fac_union' }, union)).toBe(true);
+    expect(isOptionControlledLever({ node_id: 'fac_union' }, union)).toBe(true);
+  });
+  it('does not fire for non-levers or other zero_reasons', () => {
+    expect(isOptionControlledLever({ factor_id: 'fac_other' }, union)).toBe(false);
+    expect(isOptionControlledLever({ factor_id: 'fac_other', zero_reason: 'no_path_to_goal' }, union)).toBe(false);
+    expect(isOptionControlledLever({ factor_id: 'fac_other' })).toBe(false);
+  });
+});
+
+describe('mergeIslConfidenceIntoGraphFactors — D-U guard on paths the route fixture cannot reach', () => {
+  it('EMPTY islFactors: a union-member graph factor is still suppressed + stamped, influence kept', () => {
+    const [lever, plain] = mergeIslConfidenceIntoGraphFactors(
+      [graphFactor('fac_union'), graphFactor('fac_plain')],
+      [], // ISL returned nothing — pre-D-U early return leaked the lever
+      [],
+      new Set(['fac_union']),
+    );
+    expect(lever.zero_reason).toBe('intervention_override');
+    expect(lever.sensitivity_score).toBe(0);
+    expect(lever.elasticity).toBe(0);
+    expect(lever.value_of_information).toBe(0);
+    expect(lever.influence_score).toBe(0.8); // structural importance preserved
+    // non-lever untouched
+    expect(plain.zero_reason).toBeUndefined();
+    expect(plain.sensitivity_score).toBe(0.7);
+  });
+
+  it('EMPTY islFactors + no union: graph factors pass through untouched (pre-D-U behaviour preserved)', () => {
+    const gf = graphFactor('fac_plain');
+    const [out] = mergeIslConfidenceIntoGraphFactors([gf], [], []);
+    expect(out).toBe(gf);
+  });
+
+  it('idempotence: an ISL-stamped union member is byte-identical with and without the structural set', () => {
+    const graph = () => [graphFactor('fac_lever')];
+    const isl = () => [
+      {
+        factor_id: 'fac_lever',
+        sensitivity_score: 0,
+        zero_reason: 'intervention_override',
+        value_of_information: 0,
+        source: 'isl',
+      } as unknown as FactorSensitivityResultV3,
+    ];
+    const withoutSet = mergeIslConfidenceIntoGraphFactors(graph(), isl(), []);
+    const withSet = mergeIslConfidenceIntoGraphFactors(graph(), isl(), [], new Set(['fac_lever']));
+    expect(withSet).toEqual(withoutSet);
+    expect(withSet[0].zero_reason).toBe('intervention_override');
+    expect(withSet[0].sensitivity_score).toBe(0);
+    expect(withSet[0].value_of_information).toBe(0);
+  });
+
+  it('append path: an UNSTAMPED ISL-only union member is skipped, exactly like a stamped one', () => {
+    const islOnly = [
+      {
+        factor_id: 'fac_union',
+        sensitivity_score: -0.19,
+        value_of_information: 0.6,
+        source: 'isl',
+      } as unknown as FactorSensitivityResultV3,
+      {
+        factor_id: 'fac_keep',
+        sensitivity_score: 0.5,
+        value_of_information: 0.6,
+        source: 'isl',
+      } as unknown as FactorSensitivityResultV3,
+    ];
+    const out = mergeIslConfidenceIntoGraphFactors([], islOnly, [], new Set(['fac_union']));
+    expect(out.map((f) => f.factor_id)).toEqual(['fac_keep']);
+  });
+});

--- a/tests/review-cards-integration.test.ts
+++ b/tests/review-cards-integration.test.ts
@@ -123,15 +123,22 @@ describe('Review cards in /v2/run', () => {
     await app.close();
   });
 
+  // D-U (ROADMAP 2.20/2.40): factor-a and factor-b are pinned by the options
+  // below, so they are structural LEVERS — suppressed from the evidence-priority
+  // card (a lever is not a tunable evidence gap). factor-c is pinned by nobody:
+  // it is the non-lever whose presence keeps the card alive, and the card must
+  // contain ONLY it.
   const GRAPH = {
     nodes: [
       { id: 'factor-a', kind: 'factor', label: 'Factor A', observed_state: { value: 50 } },
       { id: 'factor-b', kind: 'factor', label: 'Factor B', observed_state: { value: 30 } },
+      { id: 'factor-c', kind: 'factor', label: 'Factor C', observed_state: { value: 40 } },
       { id: 'goal', kind: 'goal', label: 'Goal' },
     ],
     edges: [
       { from: 'factor-a', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
       { from: 'factor-b', to: 'goal', exists_probability: 0.9, strength: { mean: -0.3, std: 0.1 } },
+      { from: 'factor-c', to: 'goal', exists_probability: 0.8, strength: { mean: 0.6, std: 0.1 } },
     ],
   };
 
@@ -187,6 +194,9 @@ describe('Review cards in /v2/run', () => {
       expect(typeof item.sensitivity_value).toBe('number');
       expect(item.sensitivity_value).toBeGreaterThanOrEqual(0);
       expect(typeof item.suggested_evidence).toBe('string');
+      // D-U structural lever guard: option-pinned factors (factor-a by opt-a,
+      // factor-b by opt-b) are levers, never evidence-priority items.
+      expect(['factor-a', 'factor-b']).not.toContain(item.factor_id);
     }
   });
 


### PR DESCRIPTION
## What this is

The PLoT half of the D-U lever-identity unification (ROADMAP 2.20/2.40; **D-U adopted 13 Jul** — Paul: "proceed with your recommendations", the A1 default; **Neil's async ratification of EVPI-zero-as-definitional is QUEUED and noted here as required by the ruling**). Sequencing honoured: based on the result of #218 (detectHeadlineType shadow fix) — branched from `origin/staging` @ `62d92db`, which IS #218's squash commit.

**D-U semantics:** a factor ANY option intervenes on is a LEVER → suppress its sensitivity/elasticity/VOI/EVPI everywhere, KEEP `influence_score`, stamp `zero_reason='intervention_override'` so the UI renders the honest "controlled by your options" state.

## Why this piece completes D-U

ISL PR #73 (held, merges after this) unions the lever id-set but PRESERVES the elasticity≈0 gate — so a union-pinned factor with NONZERO measured elasticity still arrives at PLoT with sensitivity/EVPI populated and NO `zero_reason` stamp. PLoT's public `factor_sensitivity` merge and both EVPI paths suppressed ONLY on `zero_reason` (factor-influence.ts:941; run.ts:5115/:5152 at pre-branch anchors) — so that factor's numbers reached users.

**Worked example (live, ROADMAP 2.20, verified on the edf2a4d9 bundle):** `fac_salary_cost`, pinned by a non-first option, was suppressed 22x by CEE coaching as a lever yet published by PLoT with **sensitivity -0.19 and TOP EVPI 7.8pp** — the same payload told the user "you control this" and "investigate this next".

Because this guard keys on the request-side union, it covers the gap NOW, independent of ISL's stamping — **merge order with ISL #73 is flexible** (with #73 unmerged, ISL stamps only elasticity≈0 first-option pins; this guard closes the rest; once #73 lands, suppression here is idempotent).

## Mechanism

One union definition (the ROADMAP 2.40 "one lever-identity" goal):

- `src/lib/intervention-override.ts` (the existing import-free lever-identity leaf) gains `interventionTargetIdsFromOptions(options)` — extracted **verbatim** (plain-object guard included) from coaching's `normalise-inputs.ts:139`, which now delegates to it — and `isOptionControlledLever(f, structuralLeverIds)` = ISL stamp OR union membership.
- `src/coaching/normalise-inputs.ts` — behaviour-preserving delegation; coaching semantics deliberately untouched.
- `src/lib/factor-influence.ts` `mergeIslConfidenceIntoGraphFactors(..., structuralLeverIds?)`:
  - merge branch fires the existing zero+stamp spread on **ISL stamp OR union membership** (`LEVER_SUPPRESSION_FIELDS`: sensitivity_score 0, elasticity 0, value_of_information 0, zero_reason stamped; influence_score untouched);
  - the **no-ISL-match branch** (previously returned the graph entry untouched) now suppresses union members;
  - the **empty-islFactors early return** (previously untouched passthrough) now suppresses union members — a union lever must not leak just because ISL returned no factor_sensitivity;
  - the ISL-only **append path** skips unstamped union members exactly as it always skipped stamped ones (an ISL-only entry has no graph influence_score to preserve).
- `src/routes/v2/run.ts`: computes the union once from `body.options` (the same input the coaching layer unions over) and threads it into both merge calls and both EVPI guards (counterfactual `factor_evpi` path and heuristic VOI-x-spread path) — EVPI for a union lever is ABSENT, not 0 (missing-vs-zero contract preserved).

Downstream surfaces that filter on the stamp AND consume the merged output (`evidence_priority` review card, sensitivity filter) inherit D-U automatically because the merge now stamps union members. **Correction (adversarial review):** the M2 decision-review lane does NOT inherit — it reads RAW `islResult.factor_sensitivity` upstream of the merge, so an unstamped union lever still egressed there. Closed by the review fixup (`a847295`, section below).

## Blast radius (NUMBER-CHANGING on staging, intended — not flag-gated per the ruling)

- Factors pinned by **non-first options** stop publishing sensitivity/elasticity/VOI/EVPI (e.g. fac_salary_cost's -0.19 / 7.8pp disappear; it keeps influence_score and gains the stamp → UI badge).
- The same factors drop out of the evidence-priority review card and the CEE decision-review factor list (they were never tunable evidence gaps).
- Non-lever factors and ISL-stamped levers: **byte-identical** (idempotence proven below).
- Driver lists do NOT hollow out: the panel is influence-ranked and influence_score is kept (the D-U ruling's containment argument).

## RED evidence (tests/du-structural-lever-guard.integration.test.ts, run at base 62d92db)

6 RED / 3 GREEN pre-fix (5 RED / 4 GREEN after a fixture correction that nested fragile_edges where the route reads them), 19/19 GREEN post-fix (9 integration + 10 unit). Pre-fix failures documented the exact leak:

- Block A (heuristic path): union lever egressed **unstamped** with published sensitivity and EVPI ("fac_union must not bear EVPI: expected true to be false"); same for a union lever ISL never analysed (no-ISL-match branch).
- Block B (counterfactual path): the union lever's wire `factor_evpi` **7.8pp was published** (the live worked example), and the graph-only union lever's 5.0pp likewise.
- Controls GREEN pre-fix AND post-fix (no behaviour change): ISL-stamped first-option lever (idempotence), non-lever heuristic EVPI survives, non-lever counterfactual EVPI survives (3.2pp), no negative EVPI egress.

## Idempotence proof

`LEVER_SUPPRESSION_FIELDS` are constants (0/0/0 + stamp), not transforms — re-applying to an ISL-stamped entry is a no-op. A unit test pins equality: merging an ISL-stamped union member **with and without** the structural set yields identical output; the integration fixture's first-option ISL-stamped lever is unchanged pre/post guard.

## Rider (b) — raw negative EVPI cannot leak post-suppression (ROADMAP 2.20)

Suppression only REMOVES emission (the guard skips a lever before any EVPI assignment: no `evpi_percentage_points`, no `evpi_status`, no clamped 0). Negative hygiene for non-suppressed factors is unchanged (`mapIslFactorEvpi` / `classifyEvpiPercentagePointsForEmission`: negatives never emitted, below-resolution labelled). The integration test drives a raw **-0.15pp** wire `factor_evpi` entry through /v2/run and asserts nothing negative appears anywhere in `factor_sensitivity` (value sweep + serialised-body check).

## Golden-hunk accounting

**Zero golden hunks.** Accounted, not assumed:
- The byte-exact replay stage (`tools/replay-fixtures.js`) targets `/draft-flows` — untouched by this diff.
- `tests/golden/` validates STORED ISL→PLoT response artifacts; no request/options are stored, so those fixtures structurally cannot exercise an option-intervention union. They passed unchanged.
- One test fixture updated (not a golden): `tests/review-cards-integration.test.ts` pinned a pre-D-U world where BOTH graph factors were option-pinned — under D-U the evidence-priority card correctly empties. Added a non-pinned `factor-c` so the test keeps proving "card present when sensitivity data present", plus an explicit assertion that option-pinned factors never appear as card items.

## Gates

- Typecheck (`tsc -p tsconfig.json --noEmit`): clean.
- Full suite (`npm test` = build + vitest + fixtures replay + OpenAPI + loadcheck): see final-run result in the lane report; first run had 2 failures — the review-cards fixture above (fixed) and `tests/sse.soak.test.ts` inflight off-by-one (**pre-existing load-sensitive flake, unrelated**: no SSE code touched; passes 2/2 in isolation on this branch).
- Pre-push validation (`scripts/pre-push-validate.sh`, 6 checks): run on push (Husky hook).
- Standing CI reds, disclosed per lane discipline: `audit` + `gates (windows-latest)` fail on every PR (pre-existing, unrelated).

No OpenAPI change: no new fields; `zero_reason`/EVPI fields already specified — only WHICH factors carry values changes.

## One-union-definition outcome

Extracted (not duplicated): `interventionTargetIdsFromOptions` lives in the shared import-free leaf `src/lib/intervention-override.ts`; coaching delegates to it; the route and merge consume it. The four divergent lever-identity sources (ROADMAP 2.40) now reduce on the PLoT side to this single definition + the ISL stamp consumed through `isOptionControlledLever`. ISL's first-option-only stamping (source 1) is ISL #73's half.

## Review fixup `a847295` — third lever-egress closed (M2 decision-review lane)

The adversarial review (MERGE-WITH-FIXUPS) found a THIRD egress path this PR's enumerated list missed: the M2 decision-review lane forwards **raw, pre-merge** `islResult.factor_sensitivity` to CEE and can launder an unstamped union lever's numbers back onto the public wire. All sub-paths now union-filtered via the PR's own primitives (`interventionTargetIdsFromOptions` / `isOptionControlledLever` from the shared leaf — no new lever-identity definition):

1. **CEE request** — `extractFactorSensitivity` (decision-review-request.ts) was stamp-only; now stamp-OR-union. The lever's elasticity/confidence/label no longer reach `isl_results.factor_sensitivity` on the ACTIVE `DECISION_REVIEW_ENABLE` path.
2. **Grounded-number allowlist** — `buildValidationContext` derives from the request, so the lever's elasticity/confidence are no longer numbers the LLM may cite as "grounded" (inherits fix 1; asserted independently in the test).
3. **Number-corrector input** — `buildIslResultsForCorrection` (decision-review-orchestrator.ts) read raw ISL with NO filter and could inject the lever's elasticity into the returned narrative (public wire via the `m1_review` merge); now union-filtered with the same leaf derivation.
4. **Flip candidates** — the `computeFlipThresholdData` guard in the request builder was the ALL-options intersection only; a some-but-not-all-options lever became a CEE flip candidate whenever `preResolvedFlipData` was absent. The excluded set is now the STRUCTURAL UNION (which strictly contains the intersection, so the original probe-budget guard is preserved). Ruling change pinned in the contract test (`factor_b` some-options lever: was "preserved", now excluded).
5. **Legacy `buildCeeReviewRequest.sensitive_parameters`** (run.ts) — also unfiltered; filtered anyway (hygiene — dead while `DECISION_REVIEW_ENABLE` is on), filter applied BEFORE the top-5 slice so a lever never consumes a slot.

P3 nits folded in: the leaf module header's "no other lever-identity definition" claim is now accurate (decision-review derives from the leaf too) and says so; `getFactorsOverriddenByAllOptions` gained the same array-pollution guard as the leaf's union builder.

**RED evidence** (`tests/du-structural-lever-guard.decision-review.integration.test.ts`, run at `754362e`): all 4 claims failed pre-fixup — the unstamped union lever (elasticity −0.19, confidence 0.77, pinned only by the non-first option) appeared in the CEE request's `factor_sensitivity`, in `allowedNumbers`, in the corrector's input, and as a flip candidate. All 4 GREEN post-fixup; non-lever control flows to all four surfaces pre AND post (no over-suppression).

**Gates (fixup):** typecheck clean; full suite 5494 passed / 25 skipped; `pre-push-validate.sh` 6/6 PASS (ran twice: standalone + Husky pre-push hook). Standing CI reds (`audit`, `gates (windows-latest)`) unchanged, pre-existing, unrelated.

## Residuals

- ISL #73 still needed for producer-side stamping (the UI badge fires from the stamp PLoT now applies, so the badge gap closes with THIS PR for /v2/run consumers; ISL's own CEE-facing surfaces are #73's scope).
- On a union lever, the stamp takes precedence over `no_path_to_goal` if both would apply (lever identity wins — it IS option-controlled; disclosed for completeness).
- The stored pricing-canary artifact (`tests/golden/pricing-canary/plot-response.json`) contains `fac_pro_price` with published sensitivity; if that scenario's options pin it, a future fixture REGENERATION will show the suppression — the stored artifact is a passthrough-validation input, not a served contract, and is not regenerated by any gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

