### PR TITLE
fix(deps): fastify 5.10.0 + fast-uri 3.1.3 — clear both high prod audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5954,9 +5954,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -5970,9 +5970,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.1.tgz",
-      "integrity": "sha512-y0kicFvvn7CYWoPOVLOcvn4YyKQz03DIY7UxmyOy21/J8eXm09R+tmb+tVDBW5h+pja30cHI5dqUcSlvY86V2A==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.10.0.tgz",
+      "integrity": "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==",
       "funding": [
         {
           "type": "github",
@@ -5991,8 +5991,8 @@
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
         "process-warning": "^5.0.0",
@@ -6017,6 +6017,65 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-uri": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.0.tgz",
+      "integrity": "sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify/node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/fastify/node_modules/pino": {
       "version": "10.3.1",
@@ -6131,9 +6190,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
-      "integrity": "sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -9627,9 +9686,9 @@
       }
     },
     "node_modules/safe-regex2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
-      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
       "funding": [
         {
           "type": "github",
@@ -9643,6 +9702,9 @@
       "license": "MIT",
       "dependencies": {
         "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
       }
     },
     "node_modules/safe-stable-stringify": {


### PR DESCRIPTION
## What

Lockfile-only production dependency bump (Codex r2 blocker 5). `package.json` ranges untouched — fastify's declared `^5.8.1` (package.json:87) already admits the fixed version.

| Package | Before | After | Advisories cleared |
|---|---|---|---|
| fastify | 5.8.1 | 5.10.0 | GHSA-247c-9743-5963 (body-schema validation bypass via leading-space Content-Type, **high**), GHSA-444r-cwp2-x5xf (request.protocol/host spoofable via X-Forwarded-* from untrusted connections, **high**) |
| fast-uri | 3.1.0 | 3.1.3 | GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments, **high**), GHSA-v39h-62p7-jpjc (host confusion via percent-encoded authority delimiters) |

Transitives moved in-range: find-my-way 9.3.0→9.6.0, safe-regex2 5.0.0→5.1.1. New nested deps of fastify 5.10: fast-json-stringify 7.0.1, fast-uri 4.1.0, json-schema-ref-resolver 3.0.0.

## Audit evidence

- Before: `npm audit --omit=dev` → **2 high** (the four advisories above, grouped per package)
- After: `npm audit --omit=dev` → **0 vulnerabilities** (exit 0)

## Verification (fresh worktree off origin/staging @ e2ae8c3)

- `scripts/pre-push-validate.sh` **PASS**: tsc clean; full suite **5494 passed / 25 skipped (5530)**; no stale .js; file:-dep policy OK; spectral lint clean. Hook also re-ran green on push.
- Route/schema lanes rerun standalone: `test:contracts` 6/6 files+tests PASS, `test:spec` (openapi dev-route) 3/3 PASS.

## Behaviour disclosure (fastify 5.8.1 → 5.10.0 changelog)

- **Stricter Content-Type parsing** (the security fix): malformed Content-Type headers (e.g. leading whitespace) that previously bypassed body-schema validation are now parsed and validated — requests that silently skipped validation can now 400. This is the intended hardening.
- **X-Forwarded-\* trust**: `request.protocol`/`request.host` no longer reflect X-Forwarded headers unless `trustProxy` is set. **PLoT unaffected**: trustProxy is already explicit env-gated (`TRUST_PROXY===1`, src/createServer.ts:191) and the proto/IP paths read raw `x-forwarded-*` headers directly (createServer.ts:509, 673; extractPrincipal gates on trustProxy itself).
- **fast-json-stringify v6→v7 major** inside fastify (response serialization). No contract change observed — contract, stream, and golden-fixture tests all green.
- 5.10.0: log-controller layer, per-request overhead reduction, `request.port` now derived from `request.host`.

## Standing CI reds (pre-existing, disclosed)

`audit` and `gates (windows-latest)` fail on every PR (known, unrelated). Note the **audit job may actually improve/turn green** on this PR since prod advisories drop to zero. `validate-structure` is path-filtered to SPEC changes and should not trigger here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)