### PR TITLE
fix(ci): engine-gates paths-filter matches package-lock.json (not phantom pnpm-lock.yaml)

### DIFF
--- a/.github/workflows/engine-gates.yml
+++ b/.github/workflows/engine-gates.yml
@@ -31,7 +31,7 @@ jobs:
               - 'tests/**'
               - 'tools/**'
               - 'package.json'
-              - 'pnpm-lock.yaml'
+              - 'package-lock.json'
             maintenance:
               - '.gitignore'
               - '.github/workflows/**'


### PR DESCRIPTION
## Problem
This is an npm repo (`package-lock.json`), but `.github/workflows/engine-gates.yml`'s `non_maintenance` paths-filter listed `pnpm-lock.yaml` — which never exists here. A lockfile-only PR (every dependency bump, e.g. #220) therefore matched **neither** the `non_maintenance` nor the `maintenance` filter, so all three `gates (os)` matrix jobs passed **vacuously in 3–6s** with Checkout / Install / Run Engine Gates all skipped.

Verified on #220: sibling run 29216329485 — every gate step `skipped`, job green in ~3s. This is also why the formerly-red `gates (windows)` check 'passed' on #220 — a skip, not a fix.

## Fix
Swap the phantom `pnpm-lock.yaml` entry for `package-lock.json` in the `non_maintenance` filter (one line), so dependency-only changes actually run the engine gates.

## Notes
- Minimal — single filter entry, no other change.
- This PR itself touches only `.github/workflows/**`, which is in the `maintenance` filter, so it won't run the gates — expected; the next real dependency bump is the first to exercise the corrected filter.
- Tracked as ROADMAP 2.51; found by the #220 adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)