### PR TITLE
fix(cee-proxy): accept empty body on /v1/cee/prompts/warm (warm 400 on every page load)

### DIFF
--- a/src/routes/v1/cee-proxy.ts
+++ b/src/routes/v1/cee-proxy.ts
@@ -42,6 +42,16 @@ const TIMEOUTS = {
 type CeeEndpoint = keyof typeof TIMEOUTS;
 
 /**
+ * Endpoints for which an empty body is a valid request.
+ *
+ * prompts/warm: {} means "warm all prompts" — CEE /assist/v1/prompts/warm
+ * accepts it (200), and the UI's prompt-preloader sends exactly {} on every
+ * page load. Rejecting it caused a silent warm-up failure on every page load
+ * (ROADMAP 2.54(c), SCORECARD §3).
+ */
+const EMPTY_BODY_ALLOWED: ReadonlySet<CeeEndpoint> = new Set(['prompts/warm']);
+
+/**
  * Create a CEE proxy route handler.
  *
  * Error handling follows the cee-draft-graph.ts passthrough pattern:
@@ -56,13 +66,15 @@ function createCeeProxyHandler(endpoint: CeeEndpoint) {
     const requestId = (req.headers['x-request-id'] as string) || randomUUID();
     const correlationId = (req.headers['x-correlation-id'] as string) || requestId;
 
-    // Validate body exists
-    if (!req.body || typeof req.body !== 'object' || Object.keys(req.body as object).length === 0) {
+    // Validate body exists (endpoints in EMPTY_BODY_ALLOWED accept {} / no body)
+    const allowEmptyBody = EMPTY_BODY_ALLOWED.has(endpoint);
+    if (!allowEmptyBody && (!req.body || typeof req.body !== 'object' || Object.keys(req.body as object).length === 0)) {
       return reply.code(400).send({
         error: 'Request body required',
         request_id: requestId,
       });
     }
+    const forwardBody = (req.body && typeof req.body === 'object') ? req.body : {};
 
     const baseUrl = process.env.CEE_BASE_URL?.trim();
     const apiKey = process.env.CEE_API_KEY?.trim();
@@ -119,7 +131,7 @@ function createCeeProxyHandler(endpoint: CeeEndpoint) {
           'X-Request-Id': requestId,
           'X-Correlation-Id': correlationId,
         },
-        body: JSON.stringify(req.body),
+        body: JSON.stringify(forwardBody),
         signal: controller.signal,
       });
 

--- a/tests/cee-proxy-smoke.test.ts
+++ b/tests/cee-proxy-smoke.test.ts
@@ -547,16 +547,60 @@ describe('CEE Proxy — Behavioural Smoke Tests', () => {
       expect(body.error).toContain('body');
     });
 
-    it('POST /v1/cee/prompts/warm returns 400 for empty body', async () => {
+    // prompts/warm: {} is the VALID "warm all prompts" request — the UI's
+    // prompt-preloader (DecisionGuideAI src/lib/prompt-preloader.ts) sends
+    // exactly {} on every page load, and CEE /assist/v1/prompts/warm accepts
+    // it (200). Rejecting it caused a silent warm-up failure on every page
+    // load (ROADMAP 2.54(c), SCORECARD §3).
+    it('POST /v1/cee/prompts/warm accepts empty object body and forwards {} to CEE', async () => {
+      let capturedBody: string | undefined;
+
+      globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: async () => '{"success":true}',
+          json: async () => ({ success: true }),
+        };
+      }) as unknown as typeof fetch;
+
       const res = await app.inject({
         method: 'POST',
         url: '/v1/cee/prompts/warm',
         payload: {},
       });
 
-      expect(res.statusCode).toBe(400);
-      const body = JSON.parse(res.payload);
-      expect(body.error).toContain('body');
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload)).toEqual({ success: true });
+      expect(capturedBody).toBeDefined();
+      expect(JSON.parse(capturedBody!)).toEqual({});
+    });
+
+    it('POST /v1/cee/prompts/warm accepts a missing body and forwards {} to CEE', async () => {
+      let capturedBody: string | undefined;
+
+      globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: async () => '{"success":true}',
+          json: async () => ({ success: true }),
+        };
+      }) as unknown as typeof fetch;
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/cee/prompts/warm',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload)).toEqual({ success: true });
+      expect(capturedBody).toBeDefined();
+      expect(JSON.parse(capturedBody!)).toEqual({});
     });
   });
 });


### PR DESCRIPTION
## Problem (ROADMAP 2.54(c), SCORECARD §3)

Every UI page load fires a background prompt warm-up: `DecisionGuideAI src/lib/prompt-preloader.ts` POSTs body `{}` to `/v1/cee/prompts/warm`. PLoT's CEE proxy rejects it with **HTTP 400 `Request body required`** because the blanket empty-body guard in `src/routes/v1/cee-proxy.ts` treats `{}` as no body (`Object.keys(req.body).length === 0`). The failure is silent (fire-and-forget), so prompts were never pre-warmed.

## Diagnosis evidence

- Reproduced on staging: `POST https://plot-lite-service-staging.onrender.com/v1/cee/prompts/warm` with body `{}` → 400 `{"error":"Request body required"}` (request_id d221373c-3954-4877-97b2-47e323f32f1c).
- CEE accepts the same request directly: `POST https://cee-staging.onrender.com/assist/v1/prompts/warm` with `{}` → **200**, `{"success":true,"summary":{"total_tasks":23,...}}` — `{}` is the valid "warm all prompts" request.
- Verdict: **PLoT is rejecting a valid request**; the UI request shape is correct and untouched.

## Fix

- Per-endpoint `EMPTY_BODY_ALLOWED` set containing only `prompts/warm`; empty/missing body forwards `{}` upstream.
- `graph-readiness`, `bias-check`, `sensitivity-coach` keep the 400 guard unchanged.
- RED-first: the two tests in `tests/cee-proxy-smoke.test.ts` that codified the old 400-on-`{}` behaviour were replaced with tests asserting 200 + `{}` forwarded (confirmed failing before the fix, passing after).

## Gates

- Full `npm test` (build + vitest + fixtures + OpenAPI + loadcheck): exit 0, 510 files / 5495 tests passed.
- Known pre-existing CI reds (`audit`, `gates (windows-latest)`) are unrelated.

## Observation (out of scope, no change made)

Cold CEE warm took ~16s on staging while the proxy timeout `CEE_PROXY_PROMPTS_WARM_TIMEOUT_MS` is 10s — on a cold hit PLoT may return 504/499 after this fix, but CEE continues warming server-side, so the fire-and-forget purpose is still served. Separately, that 10s abort was returned as 499 `ClientDisconnectError` even though the client (curl) stayed connected — possible misclassification in the abort taxonomy (`req.raw.closed` check), worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)