### PR TITLE
fix(plot): minimise decision-input PII in downstream logs (Codex F1/F3/F9)

### DIFF
--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -16,7 +16,7 @@ import type {} from './types/fastify.js';
 import { FASTIFY_REQUEST_TIMEOUT_MS } from './config/timeouts.js';
 import { registerHealthRoutes } from './routes/health.js';
 import { computeOlumiHash } from './util/canonical.js';
-import { initDownstreamTracking, clearDownstreamTracking, formatDownstreamHeader, getDownstreamCallsForLog } from './util/downstream-tracker.js';
+import { initDownstreamTracking, clearDownstreamTracking, formatDownstreamHeader, getDownstreamCallsForBoundaryLog } from './util/downstream-tracker.js';
 import { recordPayloadHashInvalid } from './metrics/registry.js';
 import {
   noteLastRequestAt,
@@ -559,7 +559,11 @@ export async function createServer(opts: ServerOpts = {}) {
     // P1: boundary.response logging (canonical schema)
     try {
       const requestId = String(req.id);
-      const downstreamCalls = getDownstreamCallsForLog(requestId);
+      // Decision-input minimiser (F1/F3): log-safe projection — hashes,
+      // digests, timing, status only. Decision-input bodies (labels, raw
+      // values, parameter_uncertainties) are dropped from this INFO log; full
+      // bodies appear only under the default-off PLOT_DIAGNOSTIC_LOG_BODIES gate.
+      const downstreamCalls = getDownstreamCallsForBoundaryLog(requestId);
       req.log.info({
         event: 'boundary.response',
         timestamp: new Date().toISOString(),

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -4614,15 +4614,19 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         }
 
         // === DIAGNOSTIC: Log parameter_uncertainties sent to ISL ===
-        // This helps diagnose why ISL may return empty factor_sensitivity
+        // This helps diagnose why ISL may return empty factor_sensitivity.
+        // Decision-input minimiser (F1): node_id is a decision-domain identifier
+        // and mean/std are raw factor values — HASH the id and DROP the raw
+        // values. Counts + a std>0 signal preserve the diagnostic value (empty
+        // factor_sensitivity correlates with degenerate/zero-std PU) without
+        // leaking decision inputs into INFO logs.
         const paramUncertainties = islRequest.parameter_uncertainties ?? [];
         req.log.info({
           event: 'isl_request_parameter_uncertainties',
           count: paramUncertainties.length,
           sample: paramUncertainties.slice(0, 3).map((p) => ({
-            node_id: p.node_id,
-            mean: p.mean,
-            std: p.std,
+            node_id_hash: createHash('sha256').update(String(p.node_id)).digest('hex').slice(0, 12),
+            has_std: typeof p.std === 'number' && Number.isFinite(p.std) && p.std > 0,
           })),
           factor_nodes_in_graph: filteredGraph.nodes.filter((n) => n.kind === 'factor').length,
           factors_with_observed_value: filteredGraph.nodes.filter(

--- a/src/util/downstream-tracker.ts
+++ b/src/util/downstream-tracker.ts
@@ -208,11 +208,97 @@ export function getDownstreamCallsForLog(requestId: string): Array<{
 }
 
 // -----------------------------------------------------------------------------
+// Decision-input minimiser — log-safe downstream projection (F1/F3)
+// -----------------------------------------------------------------------------
+
+/**
+ * Log-safe view of a downstream call. Carries ONLY correlation/observability
+ * metadata — hashes, digests (sha256 + byte size + top-level key manifest),
+ * timing, status, endpoint and request IDs. It deliberately DROPS the
+ * decision-domain payload bodies (`request_payload` / `response_payload` /
+ * `error_body`) that carry node/factor labels, raw factor values, baseline
+ * means and parameter_uncertainties — none of which belong in INFO structured
+ * logs.
+ */
+export interface LogSafeDownstreamCall {
+  service: string;
+  endpoint: string;
+  status: number;
+  elapsed_ms: number;
+  payload_hash: string;
+  response_hash: string | null;
+  request_id: string;
+  echoed_request_id?: string | null;
+  /** sha256 + byte length + sorted top-level key manifest of the request bytes */
+  request_digest?: PayloadDigest;
+  /** sha256 + byte length + sorted top-level key manifest of the response bytes */
+  response_digest?: PayloadDigest;
+  /** Present ONLY under the diagnostic body-capture gate (default off) */
+  request_payload?: unknown;
+  /** Present ONLY under the diagnostic body-capture gate (default off) */
+  response_payload?: unknown;
+  /** Present ONLY under the diagnostic body-capture gate (default off) */
+  error_body?: string;
+}
+
+/**
+ * Explicit, default-OFF diagnostic gate for capturing full (still
+ * credential-redacted) request/response bodies in structured logs. Intended
+ * for short-lived, sampled debugging only — set the env var deliberately, and
+ * unset it once the investigation is done. When unset the log path emits
+ * digests + timing + status only.
+ */
+export function isDiagnosticBodyCaptureEnabled(): boolean {
+  const v = process.env.PLOT_DIAGNOSTIC_LOG_BODIES;
+  return v === '1' || v === 'true';
+}
+
+/**
+ * Project the recorded downstream calls for a request into a LOG-SAFE shape for
+ * INFO structured logs (e.g. `boundary.response`). Retains hashes, digests,
+ * sizes (via digest.bytes), key manifests, timing, status, endpoint and request
+ * IDs so ops correlation / chain tracing / debugging still work — and drops the
+ * decision-input bodies. Full bodies are included ONLY when the explicit
+ * diagnostic gate {@link isDiagnosticBodyCaptureEnabled} is on.
+ *
+ * NOTE: this is distinct from {@link getDownstreamCallsForLog}, which still
+ * carries the bodies for the /v2/run response + `_meta` (consumer-facing
+ * contract — minimised separately).
+ */
+export function getDownstreamCallsForBoundaryLog(requestId: string): LogSafeDownstreamCall[] {
+  const includeBodies = isDiagnosticBodyCaptureEnabled();
+  return getDownstreamCalls(requestId).map((call) => {
+    const safe: LogSafeDownstreamCall = {
+      service: call.service,
+      endpoint: call.endpoint,
+      status: call.status,
+      elapsed_ms: call.elapsedMs,
+      payload_hash: call.payloadHash,
+      response_hash: call.responseHash ?? null,
+      request_id: call.requestId,
+      ...(call.echoedRequestId !== undefined && { echoed_request_id: call.echoedRequestId }),
+      ...(call.requestDigest && { request_digest: call.requestDigest }),
+      ...(call.responseDigest && { response_digest: call.responseDigest }),
+    };
+    if (includeBodies) {
+      if (call.requestPayload !== undefined) safe.request_payload = call.requestPayload;
+      if (call.responsePayload !== undefined) safe.response_payload = call.responsePayload;
+      if (call.errorBody) safe.error_body = call.errorBody;
+    }
+    return safe;
+  });
+}
+
+// -----------------------------------------------------------------------------
 // Payload Sanitization for Debug
 // -----------------------------------------------------------------------------
 
 const MAX_ARRAY_ITEMS = 30;
-const SENSITIVE_KEYS = new Set(['password', 'secret', 'token', 'api_key', 'apiKey', 'authorization']);
+// F9 (decision-input minimiser): keys are compared LOWER-CASED (see below), so
+// every entry here MUST be lower-case. Previously `apiKey` sat in this set
+// mixed-case and `key.toLowerCase()` (`apikey`) never matched it, so a
+// camelCase `apiKey` credential rode through un-redacted. Store `apikey`.
+const SENSITIVE_KEYS = new Set(['password', 'secret', 'token', 'api_key', 'apikey', 'authorization']);
 
 /**
  * Sanitize a payload for debug output.

--- a/tests/util/decision-input-minimise.test.ts
+++ b/tests/util/decision-input-minimise.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Decision-input minimiser (Codex F1/F8/F9) — PLoT must not leak decision-input
+ * PII (node/factor labels, raw factor values, baseline means,
+ * parameter_uncertainties, full ISL request/response bodies) into INFO
+ * structured logs.
+ *
+ * These tests pin the LOG path (finding F1/F3): the boundary-log projection
+ * carries only hashes/digests/timing/status/request-IDs — never raw
+ * labels/values/bodies — unless the explicit default-off diagnostic gate is on.
+ * They also pin the camelCase credential-redaction fix (F9) and green-pin that
+ * hashes/timing/status/credential-redaction still work.
+ *
+ * NOTE: the /v2/run RESPONSE `downstream_calls` bodies (finding F8) are
+ * DEFERRED, not stripped — a consumer (the A1 diligence lane, which captures
+ * `enrichment.downstream_calls.isl[0].response_payload.factor_sensitivity` from
+ * persisted facts; and PLoT's own `_meta.builds.isl` reading
+ * `response_payload.build`) depends on them. See PR description.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  initDownstreamTracking,
+  recordDownstreamCall,
+  clearDownstreamTracking,
+  getDownstreamCallsForBoundaryLog,
+  sanitizePayloadForDebug,
+  computePayloadDigest,
+} from '../../src/util/downstream-tracker.js';
+
+// A decision-input body of exactly the kind PLoT exchanges with ISL: it carries
+// person-identifying labels, raw factor values, baseline means and
+// parameter_uncertainties — plus a camelCase credential field.
+function sensitiveIslBody() {
+  return {
+    apiKey: 'sk-super-secret-do-not-log',
+    graph: {
+      nodes: [
+        { node_id: 'fac_salary', label: 'Alice Smith salary £125000', kind: 'factor' },
+      ],
+    },
+    parameter_uncertainties: [
+      { node_id: 'fac_salary', mean: 125000, std: 5000 },
+    ],
+    baseline: { mean: 125000 },
+  };
+}
+
+describe('decision-input minimiser — boundary log projection (F1/F3)', () => {
+  it('drops raw labels, values and bodies from the log-safe projection, keeping hashes/digests/timing/status', () => {
+    const requestId = 'test-req-minimise-1';
+    initDownstreamTracking(requestId);
+    try {
+      const body = sensitiveIslBody();
+      const bodyText = JSON.stringify(body);
+      const responseData = {
+        robustness: { factor_sensitivity: [{ label: 'Alice Smith salary £125000', node_id: 'fac_salary' }] },
+      };
+      const responseText = JSON.stringify(responseData);
+
+      recordDownstreamCall({
+        service: 'isl',
+        endpoint: '/v2/robustness/analyze',
+        status: 200,
+        elapsedMs: 342,
+        payloadHash: 'abc123def456',
+        responseHash: 'xyz789012345',
+        requestId,
+        // Bodies are stored exactly as the ISL client stores them today.
+        requestPayload: sanitizePayloadForDebug(body),
+        responsePayload: sanitizePayloadForDebug(responseData),
+        requestDigest: computePayloadDigest(bodyText, body),
+        responseDigest: computePayloadDigest(responseText, responseData),
+        echoedRequestId: requestId,
+      });
+
+      const projected = getDownstreamCallsForBoundaryLog(requestId);
+      expect(projected).toHaveLength(1);
+      const serialised = JSON.stringify(projected);
+
+      // No decision-input PII of ANY kind rides the log.
+      expect(serialised).not.toContain('Alice Smith');
+      expect(serialised).not.toContain('125000');
+      expect(serialised).not.toContain('salary');
+      // No body carriers.
+      expect(projected[0]).not.toHaveProperty('request_payload');
+      expect(projected[0]).not.toHaveProperty('response_payload');
+      expect(projected[0]).not.toHaveProperty('error_body');
+
+      // Correlation/observability metadata is RETAINED.
+      expect(projected[0].payload_hash).toBe('abc123def456');
+      expect(projected[0].response_hash).toBe('xyz789012345');
+      expect(projected[0].elapsed_ms).toBe(342);
+      expect(projected[0].status).toBe(200);
+      expect(projected[0].service).toBe('isl');
+      expect(projected[0].endpoint).toBe('/v2/robustness/analyze');
+      expect(projected[0].request_id).toBe(requestId);
+      // Digests (sha256 + byte size + key manifest) survive for verification.
+      expect(projected[0].request_digest?.sha256).toBeTruthy();
+      expect(projected[0].request_digest?.bytes).toBeGreaterThan(0);
+      expect(projected[0].request_digest?.key_manifest).toContain('graph');
+      expect(projected[0].response_digest?.sha256).toBeTruthy();
+    } finally {
+      clearDownstreamTracking(requestId);
+    }
+  });
+
+  it('includes bodies ONLY under the explicit default-off diagnostic gate', () => {
+    const requestId = 'test-req-minimise-gate';
+    const prev = process.env.PLOT_DIAGNOSTIC_LOG_BODIES;
+    initDownstreamTracking(requestId);
+    try {
+      const body = sensitiveIslBody();
+      recordDownstreamCall({
+        service: 'isl',
+        endpoint: '/v2/robustness/analyze',
+        status: 200,
+        elapsedMs: 10,
+        payloadHash: 'h',
+        requestId,
+        requestPayload: sanitizePayloadForDebug(body),
+        requestDigest: computePayloadDigest(JSON.stringify(body), body),
+      });
+
+      // Default (unset): body dropped.
+      delete process.env.PLOT_DIAGNOSTIC_LOG_BODIES;
+      expect(getDownstreamCallsForBoundaryLog(requestId)[0]).not.toHaveProperty('request_payload');
+
+      // Gate on: body present (still credential-redacted).
+      process.env.PLOT_DIAGNOSTIC_LOG_BODIES = '1';
+      const gated = getDownstreamCallsForBoundaryLog(requestId)[0];
+      expect(gated).toHaveProperty('request_payload');
+      expect(JSON.stringify(gated.request_payload)).toContain('[REDACTED]');
+    } finally {
+      if (prev === undefined) delete process.env.PLOT_DIAGNOSTIC_LOG_BODIES;
+      else process.env.PLOT_DIAGNOSTIC_LOG_BODIES = prev;
+      clearDownstreamTracking(requestId);
+    }
+  });
+});
+
+describe('decision-input minimiser — credential redaction (F9)', () => {
+  it('redacts camelCase apiKey (case-insensitive) as well as snake_case and other credential keys', () => {
+    const out = sanitizePayloadForDebug({
+      apiKey: 'sk-camel',
+      api_key: 'sk-snake',
+      Authorization: 'Bearer token',
+      password: 'p',
+      secret: 's',
+      token: 't',
+      keep_me: 'visible',
+    }) as Record<string, unknown>;
+
+    expect(out.apiKey).toBe('[REDACTED]'); // was leaking before the fix
+    expect(out.api_key).toBe('[REDACTED]');
+    expect(out.Authorization).toBe('[REDACTED]');
+    expect(out.password).toBe('[REDACTED]');
+    expect(out.secret).toBe('[REDACTED]');
+    expect(out.token).toBe('[REDACTED]');
+    // Non-credential fields are untouched.
+    expect(out.keep_me).toBe('visible');
+  });
+});


### PR DESCRIPTION
## Summary

Codex F1/F8/F9 (P1, LIVE): PLoT leaked decision-input PII. It recorded the **full ISL/CEE request+response bodies** — node/factor labels, raw factor values, baseline means, `parameter_uncertainties` — into INFO structured logs, and its debug sanitiser never redacted camelCase credential keys.

This PR applies a **decision-input minimiser on the log/telemetry path** and fixes the redaction miss. It does **not** touch the analysis result payload.

## What changed

- **`downstream-tracker.ts`** — new `getDownstreamCallsForBoundaryLog()`: a log-safe projection that RETAINS hashes, digests (sha256 + byte size + top-level key manifest), timing, status, endpoint and request IDs, and DROPS the decision-input bodies (`request_payload`/`response_payload`/`error_body`). Full bodies ride only under an explicit, **default-off** `PLOT_DIAGNOSTIC_LOG_BODIES` gate.
- **`createServer.ts`** — the `boundary.response` INFO log now uses the log-safe projection instead of the bodied `getDownstreamCallsForLog()`.
- **`run.ts`** — the `isl_request_parameter_uncertainties` diagnostic now emits `node_id_hash` (sha256/12) + `has_std` instead of raw `node_id`/`mean`/`std`; counts retained.
- **F9** — camelCase redaction fix: `SENSITIVE_KEYS` is compared lower-cased, so `apiKey` (mixed-case in the set) never matched; entries are now lower-case (`apikey`).

## F8 (RESPONSE `downstream_calls` bodies) — DEFERRED, not stripped

Verified consumers depend on the response bodies, so per the change brief the response is left as-is (`contract_touching_deferred`):
- The **A1 diligence lane** captures `payload.result.enrichment.downstream_calls.isl[0].response_payload.factor_sensitivity` from persisted `v5_handler_facts` (see `tests/fixtures/lane-a1/isl-factor-sensitivity-77b2891a.json`).
- PLoT's own `_meta.builds.isl` reads `response_payload.build`.

`getDownstreamCallsForLog()` (response + `_meta`) is untouched. CEE **strips** `downstream_calls` from enrichment (`INTERNAL_ENRICHMENT_KEYS` in `compose.ts`), so it is not a body consumer; the leak-minimisation of the response is a separate, contract-touching follow-up.

## Tests

`tests/util/decision-input-minimise.test.ts`:
- A request with label `"Alice Smith salary £125000"` value `125000` produces a boundary-log projection with **no raw label/value/body** — only hashes/digests/timing/status.
- Green-pins: hashes, digests, timing, status retained; body appears only under the diagnostic gate; credential redaction still works incl. camelCase.

## Gates

- `tsc -p tsconfig.json --noEmit`: clean.
- `npm run build`: clean.
- New test + `tests/evidence-capture.test.ts` + `tests/v2-evidence-provenance.test.ts` + `tests/security.no-logging.test.ts` / `security.headers` / `security.json-headers`: all green.
- Standing, unrelated CI reds (`audit`, `gates` windows) unchanged by this diff; the 2 eslint warnings in `run.ts` (unused type imports at L79/L100) are pre-existing (base has 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
