### PR TITLE
feat(contract): producer-side enrichment envelope guard at /v2/run egress (A3 lane 1)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4040,6 +4040,15 @@ paths:
           the response CONTENT — the public semantic surface minus volatile fields (timings,
           timestamps, per-request ids, the `_meta` subtree). Deterministic across replays of the
           same request and independently recomputable from the body. Success responses only.
+        - `_meta.evidence.enrichment_contract_ok` (additive, A3 lane 1): producer-side result of
+          validating this response body against the typed PLoT→CEE enrichment envelope
+          (`AnalysisEnrichmentSchema`, vendored `@talchain/schemas`). `true` = parsed clean;
+          `false` = type/enum corruption on a typed envelope key, paired with exactly one
+          `ENRICHMENT_CONTRACT_MISMATCH` entry in `inference_warnings` naming the zod issue
+          paths (never values). Absent = the guard itself errored (unassessed, not ok).
+          FAIL-OPEN: validation never blocks or mutates delivery. All HTTP-200 shapes from
+          buildResponse carry it (computed/partial/failed), same coverage as
+          `response_content_hash`.
 
         **Seed Handling**:
         - Accept string (canonical) or number (legacy)

--- a/src/routes/v2/enrichment-egress-guard.ts
+++ b/src/routes/v2/enrichment-egress-guard.ts
@@ -1,0 +1,129 @@
+/**
+ * Enrichment contract egress guard (A3 lane 1 — producer-side adoption of
+ * the typed PLoT→CEE enrichment envelope, ROLLOUT.md step 3 in
+ * olumi-schemas docs/enrichment-v1).
+ *
+ * The /v2/run success body IS the enrichment payload CEE persists verbatim
+ * (`RunAnalysisHandlerFact.result.enrichment`, CEE run-analysis.ts:808) and
+ * shadow-validates against `AnalysisEnrichmentSchema` — but until this lane
+ * the PRODUCER asserted nothing: a PLoT change that broke the typed envelope
+ * would surface only in CEE's (default-off) shadow telemetry, far from the
+ * code that caused it. This module validates the outgoing body against the
+ * SAME vendored schema at the egress boundary.
+ *
+ * FAIL-OPEN by design: validation never blocks or mutates delivery — the
+ * envelope is enrichment, and absence/degradation of enrichment is
+ * degraded-but-usable (fail-closed stays reserved for the analysis core).
+ * A mismatch is surfaced three ways, mirroring the wire-generation
+ * assertion (lane 29, src/integrations/isl/wire-generation.ts):
+ *   - `_meta.evidence.enrichment_contract_ok: false`
+ *   - one ENRICHMENT_CONTRACT_MISMATCH inference warning (issue paths only)
+ *   - one `enrichment_contract_mismatch` structured log event
+ *
+ * PII discipline: zod issues are reduced to {path, code} — issue MESSAGES
+ * are never carried (zod embeds received values in enum/literal messages)
+ * and payload values are never logged. This matches CEE's shadow validator
+ * (`v5.enrichment.schema_mismatch` — {path, code} only).
+ *
+ * The envelope (vendored @talchain/schemas 0.15.0, byte-identical to CEE's
+ * 0.16.0 copy) is passthrough at every level with all root keys optional:
+ * producer-ahead fields can never fail it; only type/enum corruption on the
+ * typed keys can. So `ok: false` always means a REAL contract break, never
+ * "PLoT moved ahead of the schema".
+ */
+
+import { AnalysisEnrichmentSchema } from '@talchain/schemas/boundary';
+import { INFERENCE_WARNING_CODES } from '../../types/engine-v3.js';
+import type { InferenceWarning } from '../../types/engine-v3.js';
+
+/**
+ * Cap on reported issues (wire message + log event). A pathological body
+ * could produce thousands of issues; the first few paths identify the
+ * defect and `issue_count` carries the true total.
+ */
+export const ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES = 10;
+
+/** One schema violation, reduced to non-sensitive coordinates. */
+export interface EnrichmentContractIssue {
+  /** Dot-joined zod issue path, e.g. 'edge_e_values.3.flip_direction' */
+  path: string;
+  /** Zod issue code, e.g. 'invalid_type' | 'invalid_enum_value' */
+  code: string;
+}
+
+/** Result of assessing one outgoing /v2/run body against the envelope. */
+export interface EnrichmentContractAssessment {
+  /** True when `AnalysisEnrichmentSchema.safeParse(body).success` */
+  ok: boolean;
+  /** First ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES issues (empty when ok) */
+  issues: EnrichmentContractIssue[];
+  /** TOTAL issue count (may exceed issues.length) */
+  issue_count: number;
+}
+
+/**
+ * Assess an outgoing /v2/run success body against the typed enrichment
+ * envelope. Pure and non-throwing over any JSON-serialisable input; callers
+ * still wrap the call site (fail-open) so a schema-library failure can never
+ * take down response delivery.
+ */
+export function assessEnrichmentContract(body: unknown): EnrichmentContractAssessment {
+  const result = AnalysisEnrichmentSchema.safeParse(body);
+  if (result.success) {
+    return { ok: true, issues: [], issue_count: 0 };
+  }
+  const all = result.error.issues;
+  return {
+    ok: false,
+    issues: all.slice(0, ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES).map((issue) => ({
+      path: issue.path.join('.'),
+      code: issue.code,
+    })),
+    issue_count: all.length,
+  };
+}
+
+/**
+ * Build the on-wire disclosure warning for a failed assessment. The entry
+ * `{code, message, severity}` conforms to the envelope's inference_warnings
+ * element schema by construction, so appending it cannot itself create a
+ * contract violation. Paths only — never values.
+ */
+export function buildEnrichmentContractWarning(
+  assessment: EnrichmentContractAssessment,
+): InferenceWarning {
+  const paths = assessment.issues.map((i) => `${i.path} (${i.code})`).join(', ');
+  const suffix =
+    assessment.issue_count > assessment.issues.length
+      ? ` and ${assessment.issue_count - assessment.issues.length} more`
+      : '';
+  return {
+    code: INFERENCE_WARNING_CODES.ENRICHMENT_CONTRACT_MISMATCH,
+    // provisional_doctrine_v0 — wording surface (diagnostic disclosure)
+    message:
+      'This response failed producer-side validation against the typed enrichment ' +
+      `envelope (@talchain/schemas AnalysisEnrichmentSchema) at: ${paths}${suffix}. ` +
+      'Delivery is unaffected (fail-open); downstream consumers of the named fields ' +
+      'should treat them as untrusted for this response.',
+    severity: 'warning',
+  };
+}
+
+/**
+ * Emit the structured log event — exactly ONE per mismatched response, none
+ * when the body verified. {path, code} coordinates only; no payload values,
+ * no zod messages.
+ */
+export function logEnrichmentContractMismatch(
+  logger: { warn: (obj: object, msg?: string) => void },
+  assessment: EnrichmentContractAssessment,
+  requestId: string,
+): void {
+  if (assessment.ok) return;
+  logger.warn({
+    event: 'enrichment_contract_mismatch',
+    request_id: requestId,
+    issue_count: assessment.issue_count,
+    issues: assessment.issues,
+  });
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -172,6 +172,11 @@ import type { ProposalCardV1 } from '../../review-pass/types.js';
 import { assembleFactObjects, type ISLResponseInput } from '../../facts/index.js';
 import type { FactObjectV1, FactLineage } from '../../facts/types.js';
 import { finiteNum, prob01, nonNeg, nonNegInt, hasAllRequiredOutcomeStats } from './numeric-egress-guards.js';
+import {
+  assessEnrichmentContract,
+  buildEnrichmentContractWarning,
+  logEnrichmentContractMismatch,
+} from './enrichment-egress-guard.js';
 
 // -----------------------------------------------------------------------------
 // Feature Flags
@@ -2934,6 +2939,45 @@ function buildResponse(
       },
     },
   };
+
+  // A3 lane 1 (enrichment producer guard): validate the fully-assembled
+  // outgoing body against the typed PLoT→CEE enrichment envelope
+  // (AnalysisEnrichmentSchema, vendored @talchain/schemas — byte-identical
+  // to the copy CEE's shadow validator runs). At the OWNER layer, like the
+  // content-hash attach below, so every run-body send site — main computed
+  // path AND the ISL_NOT_ENABLED early return — inherits it. FAIL-OPEN:
+  // never blocks or mutates delivery; a mismatch is DISCLOSED via
+  // `_meta.evidence.enrichment_contract_ok: false` + one
+  // ENRICHMENT_CONTRACT_MISMATCH inference warning + one
+  // `enrichment_contract_mismatch` log event (zod issue paths only — never
+  // payload values). Ordering: the warning is appended BEFORE the content
+  // hash is computed, so the disclosure sits INSIDE the hashed content; the
+  // evidence stamp lives in _meta, which the hash excludes by construction.
+  // The appended warning `{code, message, severity}` conforms to the
+  // envelope's inference_warnings element schema by construction, so the
+  // disclosure can never itself create a contract violation.
+  try {
+    const enrichmentAssessment = assessEnrichmentContract(response);
+    if (response._meta?.evidence) {
+      response._meta.evidence.enrichment_contract_ok = enrichmentAssessment.ok;
+    }
+    if (!enrichmentAssessment.ok) {
+      response.inference_warnings = [
+        ...(response.inference_warnings ?? []),
+        buildEnrichmentContractWarning(enrichmentAssessment),
+      ];
+      if (logger) logEnrichmentContractMismatch(logger, enrichmentAssessment, requestId);
+    }
+  } catch (err) {
+    // A guard bug is NOT a contract mismatch: stamp NOTHING (absence =
+    // unassessed — never a false claim in either direction) and log the
+    // error NAME only (error messages can embed payload values).
+    logger?.warn({
+      event: 'enrichment_contract_guard_error',
+      request_id: requestId,
+      error_name: err instanceof Error ? err.name : typeof err,
+    });
+  }
 
   // 2.13 gap A (review [10]: attach at the OWNER layer, not per send site):
   // buildResponse owns _meta, so every caller — main computed path AND the

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2039,6 +2039,21 @@ export const INFERENCE_WARNING_CODES = {
    * @see src/config/sampling.ts applyComplexityBudget
    */
   SAMPLES_REDUCED_FOR_COMPLEXITY: 'SAMPLES_REDUCED_FOR_COMPLEXITY',
+  /**
+   * A3 lane 1 (enrichment producer guard): the outgoing /v2/run success body
+   * failed producer-side validation against the typed PLoT→CEE enrichment
+   * envelope (`AnalysisEnrichmentSchema`, vendored @talchain/schemas) at the
+   * egress boundary. FAIL-OPEN: delivery is never blocked or mutated — the
+   * message names the offending zod issue paths + codes (never values) so
+   * the defect is attributable at the producer instead of surfacing only in
+   * CEE's shadow-validation telemetry. The envelope is passthrough with all
+   * root keys optional, so this fires ONLY on type/enum corruption of typed
+   * keys — never because PLoT emits fields the schema does not know.
+   * Pairs with `_meta.evidence.enrichment_contract_ok: false` and the
+   * `enrichment_contract_mismatch` log event. Severity: warning.
+   * @see src/routes/v2/enrichment-egress-guard.ts
+   */
+  ENRICHMENT_CONTRACT_MISMATCH: 'ENRICHMENT_CONTRACT_MISMATCH',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];
@@ -2428,6 +2443,18 @@ export interface EvidenceCaptureV1 {
    * @see src/integrations/isl/wire-generation.ts
    */
   isl_wire_generation_ok: boolean;
+  /**
+   * A3 lane 1 (enrichment producer guard): result of validating this very
+   * response body against the typed PLoT→CEE enrichment envelope
+   * (`AnalysisEnrichmentSchema`, vendored @talchain/schemas) at the egress
+   * boundary. True = the body parsed clean; false = type/enum corruption on
+   * a typed envelope key — see the paired ENRICHMENT_CONTRACT_MISMATCH
+   * inference warning (issue paths) and `enrichment_contract_mismatch` log
+   * event. ABSENT (never a boolean) when the guard itself errored — absence
+   * means unassessed, not ok. FAIL-OPEN: the run never hard-fails on this.
+   * @see src/routes/v2/enrichment-egress-guard.ts
+   */
+  enrichment_contract_ok?: boolean;
 }
 
 /**

--- a/src/util/structural-keys.generated.ts
+++ b/src/util/structural-keys.generated.ts
@@ -122,6 +122,7 @@ export const STRUCTURAL_KEYS: ReadonlySet<string> = new Set([
   "elasticity_std",
   "endpoint",
   "endpoint_version",
+  "enrichment_contract_ok",
   "entry_nodes",
   "epsilon_std",
   "error",

--- a/tests/enrichment-contract.fixtures.test.ts
+++ b/tests/enrichment-contract.fixtures.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Enrichment contract — fixture conformance (A3 lane 1, CI contract test).
+ *
+ * Every checked-in /v2/run response fixture must conform to the typed
+ * PLoT→CEE enrichment envelope (`AnalysisEnrichmentSchema`, VENDORED
+ * @talchain/schemas — the same bytes CEE's shadow validator runs). This is
+ * the producer-side CI tripwire: a PLoT change that lands a non-conformant
+ * shape in a fixture goes RED here, in the repo that caused it, instead of
+ * surfacing only in CEE's (default-off) shadow telemetry.
+ *
+ * Derive-don't-mirror: the fixture list is DISCOVERED on disk (every
+ * plot-response.json under contracts/examples/ and tests/golden/), never
+ * hand-listed, and the discovery itself FAILS LOUD when it finds fewer than
+ * the floor known today — an empty glob must never pass vacuously.
+ *
+ * Positive controls (an absence-of-failure assertion without a control is
+ * vacuous): deliberately corrupted variants of a real fixture MUST fail
+ * validation, one per corruption class (bad enum, bad scalar type, bad
+ * entry shape, bad container type). If the schema stops discriminating —
+ * e.g. a future vendored bump accidentally loosens the typed keys — these
+ * go RED.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AnalysisEnrichmentSchema } from '@talchain/schemas/boundary';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Known fixture count TODAY (4). Discovery asserts >= this floor so a moved
+ * directory or renamed convention fails loud instead of silently shrinking
+ * coverage to zero. New fixtures are picked up automatically.
+ */
+const FIXTURE_COUNT_FLOOR = 4;
+
+function discoverPlotResponseFixtures(): string[] {
+  const roots = ['contracts/examples', 'tests/golden'];
+  const found: string[] = [];
+  for (const root of roots) {
+    const abs = join(REPO_ROOT, root);
+    if (!existsSync(abs)) continue;
+    for (const entry of readdirSync(abs, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const candidate = join(abs, entry.name, 'plot-response.json');
+      if (existsSync(candidate)) found.push(candidate);
+    }
+  }
+  return found.sort();
+}
+
+const fixtures = discoverPlotResponseFixtures();
+
+describe('enrichment contract — checked-in /v2/run fixtures conform to the vendored envelope', () => {
+  it(`fixture discovery finds at least ${FIXTURE_COUNT_FLOOR} plot-response.json fixtures (fail-loud, never vacuous)`, () => {
+    expect(fixtures.length).toBeGreaterThanOrEqual(FIXTURE_COUNT_FLOOR);
+  });
+
+  for (const fixturePath of fixtures) {
+    const rel = relative(REPO_ROOT, fixturePath);
+
+    it(`${rel} conforms to AnalysisEnrichmentSchema`, () => {
+      const body = JSON.parse(readFileSync(fixturePath, 'utf8'));
+      const result = AnalysisEnrichmentSchema.safeParse(body);
+      if (!result.success) {
+        // Diagnostics: paths + codes only — never values.
+        const issues = result.error.issues.map((i) => `${i.path.join('.')} (${i.code})`);
+        expect.fail(`schema violations: ${issues.join(', ')}`);
+      }
+      expect(result.success).toBe(true);
+    });
+
+    it(`${rel} survives .parse() with ZERO key loss (passthrough guarantee)`, () => {
+      // The envelope is passthrough at every level BY DESIGN — a vendored
+      // bump that silently switches to strip() would start dropping
+      // producer-ahead fields at any future "use the parsed value" call
+      // site. Deep-equality of parse output vs input pins that guarantee.
+      const body = JSON.parse(readFileSync(fixturePath, 'utf8'));
+      const parsed = AnalysisEnrichmentSchema.parse(body);
+      expect(parsed).toEqual(body);
+    });
+  }
+
+  describe('positive controls — the schema DISCRIMINATES (corrupted variants must FAIL)', () => {
+    // Use a real conformant fixture as the base for each corruption so the
+    // control exercises the same shape the passing assertions do.
+    const basePath = fixtures.find((f) => f.includes(join('tests', 'golden'))) ?? fixtures[0];
+
+    function corrupt(mutate: (body: Record<string, unknown>) => void) {
+      const body = JSON.parse(readFileSync(basePath!, 'utf8'));
+      mutate(body);
+      return AnalysisEnrichmentSchema.safeParse(body);
+    }
+
+    it('bad enum: confidence_tier = "banana" → FAILS (invalid_enum_value)', () => {
+      const result = corrupt((b) => {
+        b.confidence_tier = 'banana';
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (i) => i.path.join('.') === 'confidence_tier' && i.code === 'invalid_enum_value',
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it('bad scalar type: analysis_status = 42 → FAILS (invalid_type)', () => {
+      const result = corrupt((b) => {
+        b.analysis_status = 42;
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('bad entry shape: edge_e_values[0].flip_direction = 42 (required string) → FAILS', () => {
+      const result = corrupt((b) => {
+        b.edge_e_values = [
+          ...((b.edge_e_values as unknown[]) ?? []),
+        ];
+        // Ensure at least one entry exists, then corrupt a REQUIRED string
+        // leaf. This is the same corruption vector the route-level egress
+        // tests drive end-to-end (verbatim ISL→egress passthrough field).
+        const arr = b.edge_e_values as Array<Record<string, unknown>>;
+        if (arr.length === 0) {
+          arr.push({
+            edge_id: 'a::b', from_id: 'a', to_id: 'b',
+            e_value: 1, flip_direction: 42, current_mean: 0, flip_mean: 0,
+          });
+        } else {
+          arr[0] = { ...arr[0], flip_direction: 42 };
+        }
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.join('.').endsWith('flip_direction')),
+        ).toBe(true);
+      }
+    });
+
+    it('bad container type: robustness = "yes" → FAILS (invalid_type)', () => {
+      const result = corrupt((b) => {
+        b.robustness = 'yes';
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/tests/enrichment-egress-guard.route.test.ts
+++ b/tests/enrichment-egress-guard.route.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Enrichment egress guard — /v2/run route surface (A3 lane 1).
+ *
+ * Drives the REAL route (mock ISL service serving mutated copies of the
+ * live V2 capture — same harness as isl-wire-generation.assertion.test.ts)
+ * and pins the producer-side contract guard at the egress boundary:
+ *
+ *   - `_meta.evidence.enrichment_contract_ok: true` on a conformant body —
+ *     on BOTH buildResponse callers (main computed path AND the
+ *     ISL-not-enabled early return: the guard lives at the owner layer,
+ *     run.ts buildResponse epilogue, so every run-body send site inherits
+ *     it by construction);
+ *   - a corrupted egress body (required-string envelope leaf carrying a
+ *     number, injected via the verbatim ISL→egress passthrough field
+ *     robustness.edge_e_values[].flip_direction) → ok false + exactly one
+ *     ENRICHMENT_CONTRACT_MISMATCH warning naming the issue path, NEVER the
+ *     corrupted value;
+ *   - FAIL-OPEN: the corrupted response still delivers HTTP 200,
+ *     analysis_status 'computed', and the corrupted field byte-identical on
+ *     the wire — the guard discloses, never blocks or mutates;
+ *   - hash ordering: the disclosure warning is INSIDE the hashed content
+ *     (`_meta.response_content_hash` recomputes over the delivered body).
+ *
+ * RED before the guard is wired into buildResponse:
+ * `_meta.evidence.enrichment_contract_ok` does not exist on any response
+ * and no ENRICHMENT_CONTRACT_MISMATCH warning fires on a corrupted body.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+const captureA = JSON.parse(
+  readFileSync(join(FIXTURES, 'isl-v2-live-20260707', 'isl-staging-capture.json'), 'utf8'),
+);
+const requestA = JSON.parse(
+  readFileSync(join(FIXTURES, 'isl-v2-live-20260707', 'isl-v2-request.json'), 'utf8'),
+);
+
+// Distinctive corrupted value: must be non-string (violates the REQUIRED
+// ZodString leaf) and greppable so leak assertions are unambiguous.
+const CORRUPTED_FLIP_DIRECTION = 424242;
+
+// Per-test hooks: the mock deep-clones captureA and applies the mutation,
+// so the checked-in fixture is never touched. islEnabled drives the
+// ISL-not-enabled early return (read per-request at run.ts ~4274).
+let islEnabled = true;
+let mutateCapture: ((capture: any) => void) | null = null;
+
+const mockISLService = {
+  isEnabled(): boolean { return islEnabled; },
+  async isAvailable(): Promise<boolean> { return islEnabled; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(): Promise<{ data: T | null; error: string | null }> {
+    const payload = JSON.parse(JSON.stringify(captureA));
+    if (mutateCapture) mutateCapture(payload);
+    return { data: payload as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+import { computeResponseContentHash } from '../src/util/response-content-hash.js';
+
+function buildPlotBody() {
+  return {
+    graph: {
+      nodes: requestA.graph.nodes.map((n: any) => ({
+        id: n.id,
+        kind: n.kind,
+        label: n.label,
+        ...(n.observed_state?.value !== undefined && n.observed_state?.value !== null
+          ? { observed_state: { value: n.observed_state.value } }
+          : {}),
+      })),
+      edges: requestA.graph.edges.map((e: any) => ({
+        from: e.from,
+        to: e.to,
+        exists_probability: e.exists_probability,
+        strength: { mean: e.strength.mean, std: e.strength.std },
+      })),
+    },
+    options: requestA.options.map((o: any) => ({
+      id: o.id,
+      label: o.label,
+      interventions: Object.fromEntries(
+        Object.entries(o.interventions).map(([nodeId, value]) => [
+          nodeId,
+          { value, source: 'user_specified' },
+        ]),
+      ),
+    })),
+    goal_node_id: requestA.goal_node_id,
+    seed: String(requestA.seed),
+  };
+}
+
+describe('enrichment contract egress guard on /v2/run (A3 lane 1)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    islEnabled = true;
+    mutateCapture = null;
+  });
+
+  async function run(mutation: ((c: any) => void) | null, opts: { islEnabled?: boolean } = {}) {
+    islEnabled = opts.islEnabled ?? true;
+    mutateCapture = mutation;
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v2/run',
+        headers: { 'Content-Type': 'application/json' },
+        payload: buildPlotBody(),
+      });
+      expect(res.statusCode).toBe(200);
+      return JSON.parse(res.body);
+    } finally {
+      islEnabled = true;
+      mutateCapture = null;
+    }
+  }
+
+  it('conformant body (main computed path) → enrichment_contract_ok true, no mismatch warning', async () => {
+    const body = await run(null);
+    expect(body.analysis_status).toBe('computed');
+    expect(body._meta.evidence.enrichment_contract_ok).toBe(true);
+    const markers = (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'ENRICHMENT_CONTRACT_MISMATCH',
+    );
+    expect(markers).toHaveLength(0);
+  }, 60_000);
+
+  it('ISL-not-enabled early return ALSO carries the stamp (owner-layer coverage of every run-body send site)', async () => {
+    const body = await run(null, { islEnabled: false });
+    expect(body.analysis_status).toBe('failed');
+    expect(body.status_reason).toBe('ISL service is not enabled');
+    // The failed shape is still a conformant envelope ('failed' is in the
+    // analysis_status enum) — the guard must have assessed it and said so.
+    expect(body._meta.evidence.enrichment_contract_ok).toBe(true);
+  }, 60_000);
+
+  it('corrupted egress body → ok false + ONE mismatch warning naming the path, value never leaked', async () => {
+    const body = await run((c) => {
+      // Verbatim ISL→egress passthrough (transformEdgeEValues copies
+      // flip_direction untouched; its numeric filter only drops non-finite
+      // e_value/current_mean/flip_mean) — the OUTGOING body then violates
+      // the envelope's REQUIRED-string leaf edge_e_values[].flip_direction.
+      c.robustness.edge_e_values[0].flip_direction = CORRUPTED_FLIP_DIRECTION;
+    });
+
+    expect(body._meta.evidence.enrichment_contract_ok).toBe(false);
+    const markers = (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'ENRICHMENT_CONTRACT_MISMATCH',
+    );
+    expect(markers).toHaveLength(1);
+    expect(markers[0].severity).toBe('warning');
+    // Issue PATH disclosed…
+    expect(markers[0].message).toContain('flip_direction');
+    expect(markers[0].message).toContain('invalid_type');
+    // …corrupted VALUE never (PII discipline).
+    expect(markers[0].message).not.toContain(String(CORRUPTED_FLIP_DIRECTION));
+  }, 60_000);
+
+  it('FAIL-OPEN: the corrupted response still delivers — 200, computed, corrupted field on the wire untouched', async () => {
+    const body = await run((c) => {
+      c.robustness.edge_e_values[0].flip_direction = CORRUPTED_FLIP_DIRECTION;
+    });
+    expect(body.analysis_status).toBe('computed');
+    // Delivery unmutated: the corrupted leaf reaches the consumer verbatim
+    // (disclosure, never repair — repair would hide the producer defect).
+    expect(
+      body.edge_e_values.some((e: any) => e.flip_direction === CORRUPTED_FLIP_DIRECTION),
+    ).toBe(true);
+    // Science delivered unchanged alongside the disclosure.
+    expect(body.edge_e_values.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  it('hash ordering: the disclosure warning is INSIDE the hashed content (response_content_hash recomputes)', async () => {
+    const body = await run((c) => {
+      c.robustness.edge_e_values[0].flip_direction = CORRUPTED_FLIP_DIRECTION;
+    });
+    expect(body._meta.evidence.enrichment_contract_ok).toBe(false);
+    // The warning was appended BEFORE the content hash was computed, so an
+    // independent recompute over the delivered body must match the stamp.
+    expect(computeResponseContentHash(body)).toBe(body._meta.response_content_hash);
+  }, 60_000);
+});

--- a/tests/enrichment-egress-guard.unit.test.ts
+++ b/tests/enrichment-egress-guard.unit.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Enrichment egress guard — pure-function unit tests (A3 lane 1).
+ *
+ * Pins the assessment/disclosure building blocks in isolation:
+ *   - assessEnrichmentContract: ok on conformant bodies (incl. {} — all root
+ *     keys optional BY DESIGN), not-ok with {path, code} coordinates on
+ *     corruption, issue cap honoured, corrupted VALUES never leak into the
+ *     assessment (PII discipline — positive control: the value IS absent
+ *     while its path IS present);
+ *   - buildEnrichmentContractWarning: conforms to the envelope's own
+ *     inference_warnings element schema (appending it can never create a
+ *     contract violation), names paths not values;
+ *   - logEnrichmentContractMismatch: exactly one warn per mismatch, silent
+ *     on ok, {path, code} payload only.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AnalysisEnrichmentSchema } from '@talchain/schemas/boundary';
+import {
+  assessEnrichmentContract,
+  buildEnrichmentContractWarning,
+  logEnrichmentContractMismatch,
+  ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES,
+} from '../src/routes/v2/enrichment-egress-guard.js';
+import { INFERENCE_WARNING_CODES } from '../src/types/engine-v3.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const realFixture = () =>
+  JSON.parse(
+    readFileSync(join(REPO_ROOT, 'tests', 'golden', 'pricing-canary', 'plot-response.json'), 'utf8'),
+  );
+
+describe('assessEnrichmentContract', () => {
+  it('empty object conforms (all 19 root keys optional by design)', () => {
+    const a = assessEnrichmentContract({});
+    expect(a).toEqual({ ok: true, issues: [], issue_count: 0 });
+  });
+
+  it('real checked-in /v2/run fixture conforms', () => {
+    const a = assessEnrichmentContract(realFixture());
+    expect(a.ok).toBe(true);
+    expect(a.issue_count).toBe(0);
+  });
+
+  it('producer-ahead unknown keys are NOT violations (passthrough envelope)', () => {
+    const body = realFixture();
+    body.some_future_plot_field = { anything: true };
+    expect(assessEnrichmentContract(body).ok).toBe(true);
+  });
+
+  it('corrupted enum → not-ok with {path, code}; the corrupted VALUE never appears in the assessment', () => {
+    const body = realFixture();
+    body.confidence_tier = 'banana_leak_canary';
+    const a = assessEnrichmentContract(body);
+    expect(a.ok).toBe(false);
+    expect(a.issue_count).toBeGreaterThanOrEqual(1);
+    expect(a.issues.some((i) => i.path === 'confidence_tier' && i.code === 'invalid_enum_value')).toBe(true);
+    // PII discipline positive control: path present (above) AND value absent.
+    expect(JSON.stringify(a)).not.toContain('banana_leak_canary');
+  });
+
+  it('non-object body → not-ok (never throws)', () => {
+    expect(assessEnrichmentContract('not an object').ok).toBe(false);
+    expect(assessEnrichmentContract(null).ok).toBe(false);
+    expect(assessEnrichmentContract(undefined).ok).toBe(false);
+  });
+
+  it(`caps reported issues at ${ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES} while issue_count carries the true total`, () => {
+    const body = realFixture();
+    // One invalid_type issue per corrupted required-string leaf.
+    body.edge_e_values = Array.from({ length: ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES + 5 }, (_, i) => ({
+      edge_id: `a${i}::b${i}`, from_id: `a${i}`, to_id: `b${i}`,
+      e_value: 1, flip_direction: 42, current_mean: 0, flip_mean: 0,
+    }));
+    const a = assessEnrichmentContract(body);
+    expect(a.ok).toBe(false);
+    expect(a.issues).toHaveLength(ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES);
+    expect(a.issue_count).toBeGreaterThan(ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES);
+  });
+});
+
+describe('buildEnrichmentContractWarning', () => {
+  function mismatchedAssessment() {
+    const body = realFixture();
+    body.confidence_tier = 'banana_leak_canary';
+    return assessEnrichmentContract(body);
+  }
+
+  it('carries the registered code, warning severity, and the issue paths', () => {
+    const w = buildEnrichmentContractWarning(mismatchedAssessment());
+    expect(w.code).toBe(INFERENCE_WARNING_CODES.ENRICHMENT_CONTRACT_MISMATCH);
+    expect(w.severity).toBe('warning');
+    expect(w.message).toContain('confidence_tier');
+    expect(w.message).toContain('invalid_enum_value');
+    // Values never leak into the wire message.
+    expect(w.message).not.toContain('banana_leak_canary');
+  });
+
+  it('the warning entry itself conforms to the envelope inference_warnings element schema', () => {
+    const w = buildEnrichmentContractWarning(mismatchedAssessment());
+    // Appending the disclosure can never create a new contract violation.
+    const probe = AnalysisEnrichmentSchema.safeParse({ inference_warnings: [w] });
+    expect(probe.success).toBe(true);
+  });
+
+  it('discloses the surplus when issues were capped', () => {
+    const body = realFixture();
+    body.edge_e_values = Array.from({ length: ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES + 5 }, (_, i) => ({
+      edge_id: `a${i}::b${i}`, from_id: `a${i}`, to_id: `b${i}`,
+      e_value: 1, flip_direction: 42, current_mean: 0, flip_mean: 0,
+    }));
+    const w = buildEnrichmentContractWarning(assessEnrichmentContract(body));
+    expect(w.message).toContain('and 5 more');
+  });
+});
+
+describe('logEnrichmentContractMismatch', () => {
+  it('emits exactly one warn with {path, code} coordinates only', () => {
+    const body = realFixture();
+    body.confidence_tier = 'banana_leak_canary';
+    const a = assessEnrichmentContract(body);
+    const warn = vi.fn();
+    logEnrichmentContractMismatch({ warn }, a, 'req-123');
+    expect(warn).toHaveBeenCalledTimes(1);
+    const payload = warn.mock.calls[0]![0];
+    expect(payload).toMatchObject({
+      event: 'enrichment_contract_mismatch',
+      request_id: 'req-123',
+      issue_count: a.issue_count,
+    });
+    expect(JSON.stringify(payload)).not.toContain('banana_leak_canary');
+  });
+
+  it('is silent when the assessment verified', () => {
+    const warn = vi.fn();
+    logEnrichmentContractMismatch({ warn }, assessEnrichmentContract({}), 'req-123');
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/isl-v2-golden-response.pin.test.ts
+++ b/tests/isl-v2-golden-response.pin.test.ts
@@ -10,9 +10,11 @@
  *
  * The golden was generated on staging base 524c488 BEFORE the lane 29 code
  * changes, so this test proves the lane's fixes leave well-formed V2
- * responses byte-identical apart from the ONE spec-mandated additive field:
- *   _meta.evidence.isl_wire_generation_ok   (spec §2.1)
- * which the normaliser strips before comparison. Nothing else may change.
+ * responses byte-identical apart from the spec-mandated additive evidence
+ * stamps, which the normaliser strips before comparison:
+ *   _meta.evidence.isl_wire_generation_ok   (lane 29, spec §2.1)
+ *   _meta.evidence.enrichment_contract_ok   (A3 lane 1, enrichment guard)
+ * Nothing else may change.
  *
  * Volatile fields masked (all environment/clock/RNG-dependent, never
  * wire-shape): request ids + request_id_chain values, per-request latency
@@ -151,11 +153,16 @@ function normalise(node: any): any {
   return node;
 }
 
-/** Strip the ONE spec-mandated additive lane 29 field (spec §2.1) so the
- * golden generated on pre-lane base 524c488 pins everything else. */
-function stripLane29Additions(body: any): any {
+/** Strip the spec-mandated additive evidence stamps so the golden generated
+ * on pre-lane base 524c488 pins everything else:
+ *   - lane 29 (spec §2.1): isl_wire_generation_ok
+ *   - A3 lane 1 (enrichment producer guard): enrichment_contract_ok — same
+ *     additive-evidence-stamp class; its VALUE surface is pinned by
+ *     tests/enrichment-egress-guard.route.test.ts, not by this byte pin. */
+function stripAdditiveEvidenceStamps(body: any): any {
   if (body?._meta?.evidence) {
     delete body._meta.evidence.isl_wire_generation_ok;
+    delete body._meta.evidence.enrichment_contract_ok;
   }
   return body;
 }
@@ -182,7 +189,7 @@ describe('/v2/run golden byte-identity pin (well-formed V2 envelope, build 9a22a
     expect(res.statusCode).toBe(200);
     rawBody = JSON.parse(res.body);
     normalisedText = JSON.stringify(
-      normalise(stripLane29Additions(JSON.parse(res.body))),
+      normalise(stripAdditiveEvidenceStamps(JSON.parse(res.body))),
       null,
       2,
     );


### PR DESCRIPTION
## What

Producer-side adoption of the typed PLoT→CEE enrichment contract (olumi-schemas `docs/enrichment-v1/ROLLOUT.md` step 3): the `/v2/run` success body — which CEE persists verbatim as the enrichment payload (`RunAnalysisHandlerFact.result.enrichment`) — is now validated at the egress boundary against the VENDORED `AnalysisEnrichmentSchema` (`@talchain/schemas` 0.15.0, byte-identical to the 0.16.0 copy CEE's shadow validator runs).

**FAIL-OPEN, disclosure-only** — no behaviour change on conformant traffic (live wire conforms today; see evidence below):

- `_meta.evidence.enrichment_contract_ok: true|false` stamped on every HTTP-200 run body (absent = the guard itself errored: unassessed, never a false claim).
- On mismatch: exactly one `ENRICHMENT_CONTRACT_MISMATCH` inference warning (severity `warning`) naming the zod issue paths + codes — **never values** — plus one `enrichment_contract_mismatch` structured log event ({path, code} coordinates only, matching CEE's shadow-validator PII discipline).
- Delivery is never blocked or mutated; the corrupted field reaches the consumer verbatim (repair would hide the producer defect).

Pattern follows PR #206's drift alarm (`_meta.evidence.isl_wire_generation_ok` + `EDGE_E_VALUES_UNAVAILABLE_V2_WIRE`) exactly: evidence stamp + paired warning + structured log, at the owner layer.

## Why here (placement)

The guard lives in the `buildResponse` epilogue, immediately before the `response_content_hash` attach — the repo's own owner-layer precedent ("attach at the OWNER layer, not per send site"). Complete send-site manifest for the run body: `reply.send(buildResponse(...))` at the main computed path AND the ISL-not-enabled early return — both (and any future caller) inherit the guard by construction; a route test pins the ISL-not-enabled path explicitly. Ordering: the warning is appended BEFORE the content hash is computed (disclosure sits INSIDE the hashed content — pinned by a test that independently recomputes the hash over the delivered body); the evidence stamp lives in `_meta`, which the hash excludes by construction. The appended warning `{code, message, severity}` conforms to the envelope's own `inference_warnings` element schema, so the disclosure can never itself create a contract violation.

Because the envelope is passthrough at every level with all 19 root keys optional, `ok: false` always means REAL type/enum corruption of a typed key — never "PLoT moved ahead of the schema".

## Conformance evidence (why this ships as a guard, not a fix)

A3 verification item 3 (2026-07-16, `acceptance-evidence/a3-verify-2026-07-16/item3-enrichment-conformance.md` in the programme workspace): live staging `POST /v2/run` (deployed build `e0293fe` == this branch's base) passed `AnalysisEnrichmentSchema.safeParse` first-attempt; 7/7 static fixtures pass; positive/mutation controls prove the schema discriminates; `.parse()` drops ZERO keys. So this lane adds a tripwire for FUTURE drift, not a behaviour change.

## Tests (RED→GREEN)

New suites (29 tests):

- `tests/enrichment-contract.fixtures.test.ts` — CI contract test. Fixture list is DISCOVERED on disk (every `plot-response.json` under `contracts/examples/` + `tests/golden/`), never hand-listed, with a fail-loud floor (≥4) so an empty glob can never pass vacuously. Positive controls: 4 corruption classes (bad enum / bad scalar type / bad entry shape / bad container type) must FAIL validation. Plus a passthrough-guarantee pin: `.parse()` output deep-equals input for every fixture.
- `tests/enrichment-egress-guard.unit.test.ts` — pure-fn tests incl. PII positive control (corrupted value's PATH present, VALUE absent from assessment/warning/log) and the issue cap.
- `tests/enrichment-egress-guard.route.test.ts` — drives the REAL route with a mock ISL serving mutated live captures (same harness as `isl-wire-generation.assertion.test.ts`). Egress corruption vector: `robustness.edge_e_values[0].flip_direction = 424242` flows VERBATIM through `transformEdgeEValues` to the wire, violating the envelope's REQUIRED-string leaf end-to-end.

**RED (pre-wiring):** `npx vitest run` on the three suites → `Test Files 1 failed | 2 passed (3) · Tests 4 failed | 25 passed (29)` — the 4 REDs are exactly the wiring-dependent route assertions (`expected undefined to be true/false` on `_meta.evidence.enrichment_contract_ok`). The 5th route test (FAIL-OPEN delivery) passes pre-wiring BY DESIGN — it asserts the invariant that must hold with and without the guard.

**GREEN (post-wiring):** same command → `Test Files 3 passed (3) · Tests 29 passed (29)`, with the structured log observed live: `{"event":"enrichment_contract_mismatch","issue_count":1,"issues":[{"path":"edge_e_values.0.flip_direction","code":"invalid_type"}]}`.

**Adjacent suites (no regression):** golden 27 ✓ · near-tie 19 ✓ · wire-gen unit 13 ✓ · wire-gen assertion 5 ✓ · structural-keys drift 3 ✓ · determinism-replay 3 ✓ · v2-determinism 27 ✓ (v2-determinism required `npm run build` first — it spawns `node dist/main.js`; its initial red in a fresh clone was the missing `dist/`, failing at spawn before any request, and it passes against the compiled server that includes the guard).

**One intended byte-surface change, disclosed:** the full gate's first run flagged `tests/isl-v2-golden-response.pin.test.ts` (full-response byte pin) — the diff was EXACTLY the one additive `_meta.evidence.enrichment_contract_ok: true` key, nothing else. Resolved via the pin test's own lane-29 precedent for additive evidence stamps: the normaliser (`stripLane29Additions` → `stripAdditiveEvidenceStamps`) now strips both stamps before comparison; the checked-in golden is UNTOUCHED (it remains a true pre-lane byte capture; the stamp's value surface is pinned by the new route tests instead). Pin suite 4/4 green after.

## Files

- NEW `src/routes/v2/enrichment-egress-guard.ts` — pure assess/warning/log building blocks
- MOD `src/routes/v2/run.ts` — buildResponse epilogue wiring (fail-open try/catch)
- MOD `src/types/engine-v3.ts` — `ENRICHMENT_CONTRACT_MISMATCH` in `INFERENCE_WARNING_CODES` + `EvidenceCaptureV1.enrichment_contract_ok?`
- GEN `src/util/structural-keys.generated.ts` — regenerated (`node tools/gen-structural-keys.mjs`, +1 key)
- MOD `contracts/openapi.yaml` — /v2/run description bullet (prose only)
- MOD `tests/isl-v2-golden-response.pin.test.ts` — normaliser strips the new additive evidence stamp (lane-29 precedent; golden untouched)
- NEW `tests/enrichment-contract.fixtures.test.ts`, `tests/enrichment-egress-guard.unit.test.ts`, `tests/enrichment-egress-guard.route.test.ts`

## Mutation check (throwaway copy — build tree untouched)

```
cp -a lane1-build lane1-mutation && cd lane1-mutation
git checkout origin/staging -- src/routes/v2/run.ts   # reverts ONLY the wiring; module + tests remain
grep -c assessEnrichmentContract src/routes/v2/run.ts  # → 0
npx vitest run tests/enrichment-egress-guard.route.test.ts
```

Result: **`Tests 4 failed | 1 passed (5)`** — exactly the 4 guard-dependent assertions go RED (conformant-path stamp, ISL-not-enabled stamp, corrupted-egress disclosure, hash ordering); the FAIL-OPEN invariant test stays green by design. A merge that loses the wiring cannot stay green.

## Overhead (validated every response — no sampling)

No established sampling/flag convention for response validation exists in this repo, so the guard runs on every response. Measured `safeParse` on the largest in-repo fixture (`contracts/examples/cee-graph-supplied/plot-response.json`, 45,782-byte body — same order as the 47,221-byte live staging capture), warmup 50 + N=1000: **mean 0.047 ms · p50 0.042 ms · p95 0.089 ms · max 0.456 ms**. Negligible vs `/v2/run` latency.

## OpenAPI / validate-structure

The spec documents neither the `_meta` subtree nor `inference_warnings` as schema components (zero grep hits; #206 added its evidence key with no spec change). Added a description-prose bullet for `enrichment_contract_ok` + the paired warning code under the existing `_meta.response_content_hash` bullet — the maximal consistent surface. **Redocly problem-set diff verified EMPTY**: ran the exact CI command (`npx @redocly/cli lint contracts/openapi.yaml --skip-rule=no-unused-components`) on this branch's spec and on `git show origin/staging:contracts/openapi.yaml`; ruleId+pointer problem sets are identical (76 == 76). Any `validate-structure` red on this PR is pre-existing, not introduced.

## Known CI reds

`gates (windows-latest)` fails on every PR (pre-existing). `audit` is green these days — a red there would be this PR's to own.

## Residuals (honest limits)

- Scope = HTTP-200 run bodies from `buildResponse` (computed/partial/failed). The 422 blocked (`buildBlockedResponse`) and `buildV2RunError` shapes are not the enrichment success envelope and are un-guarded; CEE's error-path persistence twin remains untyped seam territory.
- Typed keys `status_reason`, `decision_review`, `results` are still exercised by no fixture (inherited from the conformance evidence; all-optional, cannot mismatch unless PLoT starts emitting them wrongly typed).
- The guard-error path (`enrichment_contract_guard_error`, stamp absent) has no test driving an actual validator throw — no known input produces one; the catch is defensive.
- Consumer-side counterpart (flipping CEE `CEE_ENRICHMENT_VALIDATION` to `shadow`) is out of this repo's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
