### PR TITLE
fix(honesty): wire-disclose whole-block flip-probe failure + suppress lever elasticity_std (A3 lane 2)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4049,6 +4049,14 @@ paths:
           FAIL-OPEN: validation never blocks or mutates delivery. All HTTP-200 shapes from
           buildResponse carry it (computed/partial/failed), same coverage as
           `response_content_hash`.
+        - `FLIP_THRESHOLDS_UNAVAILABLE` in `inference_warnings` (additive, A3 lane 2): the
+          flip-threshold computation was attempted but the ENTIRE block failed, so
+          `flip_thresholds` is empty (`flip_thresholds_status: 'unavailable'`) because
+          computation failed — not because nothing was probed and not because no factor could
+          flip the leading option. The message names the thrown error's name only (never its
+          message or values). Per-factor failures do NOT emit this — they remain disclosed per
+          entry via `flip_reason` ('timeout'/'error'/...). Non-blocking: all other analyses are
+          unaffected.
 
         **Seed Handling**:
         - Accept string (canonical) or number (legacy)

--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -60,15 +60,23 @@ import { isInterventionOverride, isOptionControlledLever } from './intervention-
  * - value_of_information 0: resolving knowledge of a value the user sets is
  *   not an information gain; without this the EVPI enrichment in
  *   routes/v2/run.ts would derive a positive EVPI from the graph VOI (P0a).
- * All three are idempotent constants: re-applying to an already-suppressed
- * factor is a no-op, so ISL-stamped levers (and, post ISL #73, union-stamped
- * ones) pass through unchanged.
+ * - elasticity_std 0: bootstrap spread of the (contractually zero)
+ *   elasticity. Left unsuppressed, a non-zero spread republishes measurement
+ *   texture for the very metric the contract zeroes — the live universality
+ *   re-run (r2 residual R1, 2026-07-16) caught suppressed lever
+ *   fac_salary_cost egressing elasticity_std 0.00396846. Forced to 0 so the
+ *   suppression covers the variance statistic of the value it suppresses
+ *   (A3 lane 2).
+ * All the numeric fields are idempotent constants: re-applying to an
+ * already-suppressed factor is a no-op, so ISL-stamped levers (and, post
+ * ISL #73, union-stamped ones) pass through unchanged.
  */
 const LEVER_SUPPRESSION_FIELDS = {
   sensitivity_score: 0,
   zero_reason: 'intervention_override',
   elasticity: 0,
   value_of_information: 0,
+  elasticity_std: 0,
 } as const;
 
 /**

--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -1091,7 +1091,25 @@ const VALID_ATTRIBUTION_STABILITY = new Set(['high', 'moderate', 'low', 'negligi
  */
 export function buildFactorStability(
   islFactorSensitivity: unknown,
-  graph: EngineGraphV3
+  graph: EngineGraphV3,
+  /**
+   * A3 lane 2 fixup (r2 residual R1, second surface): D-U structural lever
+   * union. This builder reads RAW ISL entries — the merge-layer
+   * LEVER_SUPPRESSION_FIELDS never touches them — so without this the
+   * stability surface republishes the variance statistic of the suppressed
+   * elasticity (live fac_salary_cost: factor_stability[0].elasticity_std
+   * 0.00396846 alongside a zeroed factor_sensitivity entry). Option-controlled
+   * levers (union membership OR the ISL zero_reason stamp — the same
+   * isOptionControlledLever predicate every other suppression site uses) keep
+   * their entry — attribution_stability/rank_flip_rate/stability_method are
+   * untouched diagnostics — but egress elasticity_std 0, zero-in-place like
+   * the sibling factor_sensitivity surface. No stamp is added: the entry type
+   * has no zero_reason field, and the authoritative stamp for the same
+   * factor_id rides the factor_sensitivity entry. The domain-validity gate
+   * below still applies to the RAW value first (an invalid raw std skips the
+   * entry, never zero-launders it).
+   */
+  structuralLeverIds?: ReadonlySet<string>,
 ): FactorStabilityEntry[] {
   if (!Array.isArray(islFactorSensitivity) || islFactorSensitivity.length === 0) return [];
 
@@ -1121,7 +1139,10 @@ export function buildFactorStability(
     result.push({
       factor_id: factorId,
       factor_label: f.label ?? nodeLabelMap.get(factorId) ?? factorId,
-      elasticity_std: f.elasticity_std,
+      // Lever suppression (see the structuralLeverIds param doc): a factor
+      // any option pins must not publish a non-zero spread of its
+      // contractually-zero elasticity on this surface either.
+      elasticity_std: isOptionControlledLever(f, structuralLeverIds) ? 0 : f.elasticity_std,
       attribution_stability: f.attribution_stability,
       rank_flip_rate: f.rank_flip_rate,
       stability_method: f.stability_method,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -5321,7 +5321,10 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
 
         // Build factor_stability from ISL's raw factor_sensitivity (3C bootstrap fields).
         // Independent of factor_sensitivity source — always derived from ISL when available.
-        const factorStability = buildFactorStability(islResult.factor_sensitivity, filteredGraph);
+        // A3 lane 2 fixup: thread the D-U lever union so this RAW-input surface
+        // cannot republish a suppressed lever's elasticity_std (r2 residual R1
+        // saw the live leak on BOTH factor_sensitivity AND factor_stability).
+        const factorStability = buildFactorStability(islResult.factor_sensitivity, filteredGraph, structuralLeverIds);
 
         // Recompute response hash (v6: ISL-derived fields excluded — identifiability
         // and factor_stability are passed for API backwards compat but ignored by

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -1162,6 +1162,15 @@ interface MetaParams {
   originalNSamples?: number;
   /** Track S: sample depth used for flip probes (decoupled from nSamples). Omitted when no flip search ran. */
   flipProbeNSamples?: number;
+  /**
+   * A3 lane 2 (whole-block flip honesty): the JS error NAME (never the
+   * message or any value) captured when the ENTIRE flip-threshold block was
+   * attempted but threw. Presence drives the FLIP_THRESHOLDS_UNAVAILABLE
+   * inference warning. Absent when the block succeeded, produced no
+   * candidates, or was never attempted. Per-factor failures do NOT set this —
+   * they ride `flip_reason` on each flip_thresholds entry.
+   */
+  flipThresholdsFailedErrorName?: string;
   detailLevel: string;
   latencyMs: number;
   normalizationMs?: number;
@@ -2401,6 +2410,22 @@ function buildResponse(
       code: INFERENCE_WARNING_CODES.SAMPLES_REDUCED_FOR_COMPLEXITY,
       // provisional_doctrine_v0 — wording surface (diagnostic disclosure)
       message: `Monte Carlo sample depth was reduced from ${meta.originalNSamples} to ${meta.nSamples} samples so this graph fits the analysis engine's complexity budget (sample depth × nodes × edges). All reported results were computed at ${meta.nSamples} samples; displayed probabilities may be slightly less stable than at the standard depth.`,
+      severity: 'warning',
+    });
+  }
+
+  // A3 lane 2 (ROADMAP 2.31 adjacency — whole-block flip honesty): the entire
+  // flip-threshold block was attempted but threw. Without this warning the
+  // response ships flip_thresholds: [] + flip_thresholds_status 'unavailable'
+  // with only a server-side WARN — indistinguishable on the wire from "nothing
+  // to probe". Per-factor failures are NOT this case: they ride flip_reason
+  // ('timeout'/'error'/...) on each entry and never set this meta field. The
+  // message names the thrown error's NAME only — never its message or values.
+  if (meta.flipThresholdsFailedErrorName) {
+    inferenceWarnings.push({
+      code: INFERENCE_WARNING_CODES.FLIP_THRESHOLDS_UNAVAILABLE,
+      // provisional_doctrine_v0 — wording surface (diagnostic disclosure)
+      message: `Flip thresholds (tipping points) were attempted for this analysis but the computation failed as a whole (${meta.flipThresholdsFailedErrorName}) — flip_thresholds is empty because computation failed, not because no factor could flip the leading option. All other analyses are unaffected.`,
       severity: 'warning',
     });
   }
@@ -5527,6 +5552,10 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // Track S: depth actually used for flip probes (decoupled from base nSamples).
         // Set when a flip search runs; surfaced in response meta for transparency.
         let flipProbeNSamples: number | undefined;
+        // A3 lane 2: error NAME captured when the ENTIRE flip block throws —
+        // drives the FLIP_THRESHOLDS_UNAVAILABLE inference warning (wire
+        // disclosure of the previously server-log-only degradation).
+        let flipThresholdsFailedErrorName: string | undefined;
 
         if (islSuccess && factorSensitivity && optionComparisonData && optionComparisonData.length >= 2) {
           try {
@@ -5608,6 +5637,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               );
             }
           } catch (err) {
+            // A3 lane 2 (ROADMAP 2.31 adjacency): wire-disclose the
+            // whole-block failure. Capture the error NAME only (never the
+            // message or any value) — buildResponse turns its presence into a
+            // FLIP_THRESHOLDS_UNAVAILABLE inference warning so the absent
+            // flip_thresholds field is attributable on the wire, not just in
+            // this server-side WARN. Per-factor failures never reach this
+            // catch (resolveFlipValues handles them per entry via flip_reason).
+            flipThresholdsFailedErrorName = (err as Error)?.name || 'Error';
             req.log.warn({
               event: 'flip_thresholds_error',
               request_id: requestId,
@@ -5949,6 +5986,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             nSamples,
             originalNSamples,
             flipProbeNSamples,
+            flipThresholdsFailedErrorName,
             detailLevel,
             latencyMs: finalTotalMs,
             normalizationMs,

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2054,6 +2054,21 @@ export const INFERENCE_WARNING_CODES = {
    * @see src/routes/v2/enrichment-egress-guard.ts
    */
   ENRICHMENT_CONTRACT_MISMATCH: 'ENRICHMENT_CONTRACT_MISMATCH',
+  /**
+   * A3 lane 2 (ROADMAP 2.31 adjacency — whole-block flip honesty): the
+   * flip-threshold computation was ATTEMPTED for this analysis but the ENTIRE
+   * block threw, so `flip_thresholds` is empty (`flip_thresholds_status:
+   * 'unavailable'`) because computation failed — not because no factor could
+   * flip the leading option and not because nothing was probed. Without this
+   * marker the whole-block case degraded to an absent field + a server-side
+   * `flip_thresholds_error` WARN only, indistinguishable on the wire from
+   * "no candidates". Per-factor failures are NOT this case — they remain
+   * disclosed per entry via `flip_reason` ('timeout'/'error'/...). The
+   * message carries the thrown error's NAME only, never its message or any
+   * value. Non-blocking: all other analyses are unaffected.
+   * Severity: warning.
+   */
+  FLIP_THRESHOLDS_UNAVAILABLE: 'FLIP_THRESHOLDS_UNAVAILABLE',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];

--- a/tests/3c-factor-sensitivity-enrichment.test.ts
+++ b/tests/3c-factor-sensitivity-enrichment.test.ts
@@ -712,14 +712,19 @@ describe('FS6: Route-level factor_stability via /v2/run', () => {
     const stabA = body.factor_stability.find((f: any) => f.factor_id === 'factor-a');
     const stabB = body.factor_stability.find((f: any) => f.factor_id === 'factor-b');
 
+    // A3 lane 2 fixup (r2 residual R1, second surface): BOTH fixture factors
+    // are option-pinned levers (opt1 pins factor-a, opt2 pins factor-b), so
+    // buildFactorStability now zeroes their elasticity_std in-place — the
+    // pre-lane assertions (0.042 / 0.11) were pinning the stability-surface
+    // leak itself. Entry presence and the other 3C diagnostics are retained.
     expect(stabA).toBeDefined();
-    expect(stabA.elasticity_std).toBe(0.042);
+    expect(stabA.elasticity_std).toBe(0);
     expect(stabA.attribution_stability).toBe('high');
     expect(stabA.rank_flip_rate).toBe(0.03);
     expect(stabA.stability_method).toBe('bootstrap_1000');
 
     expect(stabB).toBeDefined();
-    expect(stabB.elasticity_std).toBe(0.11);
+    expect(stabB.elasticity_std).toBe(0);
     expect(stabB.attribution_stability).toBe('moderate');
     expect(stabB.rank_flip_rate).toBe(0.15);
     expect(stabB.stability_method).toBe('bootstrap_1000');

--- a/tests/b8-8-3c-field-segregation.test.ts
+++ b/tests/b8-8-3c-field-segregation.test.ts
@@ -262,10 +262,10 @@ describe('B8-8: 3C field handling in /v2/run response', () => {
       // suppression contract (LEVER_SUPPRESSION_FIELDS) now forces
       // elasticity_std to 0 on the public factor_sensitivity entry — the
       // pre-lane assertion `toBe(0.12)` was pinning the leak itself (a
-      // non-zero variance statistic of the suppressed elasticity). The raw
-      // ISL value (0.12) still reaches factor_stability[] below: that surface
-      // reads raw ISL input and sits outside the suppression contract
-      // (disclosed residual, 2.25 hygiene sweep).
+      // non-zero variance statistic of the suppressed elasticity). The
+      // factor_stability[] surface below is suppressed the same way (lane 2
+      // fixup: buildFactorStability zeroes lever elasticity_std in-place;
+      // entry presence and the other 3C diagnostics are retained).
       expect(factor.elasticity_std).toBe(0);
       expect(factor.rank_flip_rate).toBe(0.08);
       expect(factor.stability_method).toBe('bootstrap');

--- a/tests/b8-8-3c-field-segregation.test.ts
+++ b/tests/b8-8-3c-field-segregation.test.ts
@@ -257,7 +257,16 @@ describe('B8-8: 3C field handling in /v2/run response', () => {
     for (const factor of [factorA, factorB]) {
       expect(factor.confidence_source).toBe('plot_unified_from_isl_bootstrap');
       expect(factor.attribution_stability).toBe('moderate');
-      expect(factor.elasticity_std).toBe(0.12);
+      // A3 lane 2 (r2 residual R1): BOTH fixture factors are option-pinned
+      // levers (opt-a pins factor-a, opt-b pins factor-b), so the D-U
+      // suppression contract (LEVER_SUPPRESSION_FIELDS) now forces
+      // elasticity_std to 0 on the public factor_sensitivity entry — the
+      // pre-lane assertion `toBe(0.12)` was pinning the leak itself (a
+      // non-zero variance statistic of the suppressed elasticity). The raw
+      // ISL value (0.12) still reaches factor_stability[] below: that surface
+      // reads raw ISL input and sits outside the suppression contract
+      // (disclosed residual, 2.25 hygiene sweep).
+      expect(factor.elasticity_std).toBe(0);
       expect(factor.rank_flip_rate).toBe(0.08);
       expect(factor.stability_method).toBe('bootstrap');
     }

--- a/tests/lane2-flip-block-disclosure.test.ts
+++ b/tests/lane2-flip-block-disclosure.test.ts
@@ -1,0 +1,258 @@
+/**
+ * A3 lane 2 Fix A (ROADMAP 2.31 adjacency — whole-block flip honesty).
+ *
+ * Before this lane, a whole-BLOCK flip-threshold failure degraded to an
+ * ABSENT/empty `flip_thresholds` + `flip_thresholds_status: 'unavailable'`
+ * with only a server-side `flip_thresholds_error` WARN — indistinguishable on
+ * the wire from "nothing to probe" — while per-factor failures were honestly
+ * disclosed per entry (`flip_reason: 'timeout' | 'error' | ...`).
+ *
+ * This file pins the new disclosure AND that the per-factor paths are
+ * byte-level unchanged:
+ *   1. whole-block throw → FLIP_THRESHOLDS_UNAVAILABLE inference warning,
+ *      severity 'warning', message carries the error NAME only (a sentinel
+ *      value embedded in the error MESSAGE must never reach the wire),
+ *      response stays 200/computed (non-blocking).
+ *   2. per-factor probe ERROR → entries with flip_reason 'error', NO
+ *      whole-block warning.
+ *   3. per-factor TIMEOUT (deterministic: FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS=0
+ *      expires the factor deadline before Step 0) → entries with flip_reason
+ *      'timeout', NO whole-block warning.
+ *   4. positive control: successful probes → NO new warning, flip_thresholds
+ *      populated, probe traffic actually observed (the mock can see presence,
+ *      so the absence assertions above are not vacuous).
+ *
+ * Harness modelled on tests/v2-run.flip-probe-seed.contract.test.ts (mock ISL
+ * captures probe bodies) + the importOriginal-spread rule for module mocks
+ * (only resolveFlipValues is wrapped, and it delegates to the REAL
+ * implementation unless the whole-block toggle is armed).
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Toggles read at call time by the mocks
+// ---------------------------------------------------------------------------
+let blockThrow = false;      // arm → resolveFlipValues throws (whole-block failure)
+let probeError = false;      // arm → ISL probe calls fail (per-factor 'error' path)
+const capturedBodies: any[] = [];
+
+/** Sentinel that must NEVER egress: lives only in the thrown error MESSAGE. */
+const SECRET_VALUE = '0.987654321';
+
+// ---------------------------------------------------------------------------
+// Flip module mock — importOriginal spread; only resolveFlipValues wrapped
+// ---------------------------------------------------------------------------
+vi.mock('../src/analysis/flip-thresholds.ts', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    resolveFlipValues: async (...args: any[]) => {
+      if (blockThrow) {
+        const err = new Error(`synthetic whole-block failure carrying secret ${SECRET_VALUE}`);
+        err.name = 'MockFlipBlockError';
+        throw err;
+      }
+      return actual.resolveFlipValues(...args);
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// ISL mock — same shape as the flip-probe-seed contract test
+// ---------------------------------------------------------------------------
+function optionComparison(options: any[]) {
+  return (options ?? []).map((opt: any, idx: number) => ({
+    option_id: opt.id,
+    win_probability: 0.6 - idx * 0.2,
+    outcome: { mean: 0.65 + idx * 0.12, std: 0.08, p10: 0.45, p50: 0.65, p90: 0.85, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+    rank: idx + 1,
+  }));
+}
+
+function robustnessData(options: any[]) {
+  return {
+    options: optionComparison(options),
+    edges: [
+      { from: 'factor-a', to: 'goal', sensitivity: 0.5, confidence: 0.8, direction: 'positive' },
+      { from: 'factor-b', to: 'goal', sensitivity: -0.3, confidence: 0.7, direction: 'negative' },
+    ],
+    factors: [
+      { node_id: 'factor-a', sensitivity: 0.5, confidence: 0.8, direction: 'positive' },
+      { node_id: 'factor-b', sensitivity: -0.3, confidence: 0.7, direction: 'negative' },
+    ],
+    value_of_information: [],
+    overall_robustness: 'robust', robustness_score: 0.82,
+    fragile_edges: [], robust_edges: [],
+  };
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock validation', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      ...robustnessData(options),
+      edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      factor_sensitivity_status: 'available' as const,
+      latency_ms: 42, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.82, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    capturedBodies.push(body);
+    const isProbe = typeof body?.request_id === 'string' && body.request_id.includes('__flip');
+    if (probeError && isProbe) {
+      return { data: null, error: 'probe unavailable (mock)' };
+    }
+    return { data: robustnessData(body?.options ?? []) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// Two factors each intervened by a DIFFERENT option → neither overridden-by-all
+// → both stay flip candidates → the probe path runs.
+const PAYLOAD = {
+  graph: {
+    nodes: [
+      { id: 'goal', kind: 'goal', label: 'Revenue' },
+      { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+      { id: 'factor-b', kind: 'factor', label: 'Customer Churn', observed_state: { value: 0.5 } },
+    ],
+    edges: [
+      { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+      { from: 'factor-b', to: 'goal', strength: { mean: -0.3, std: 0.1 } },
+    ],
+  },
+  options: [
+    { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 0.8 } },
+    { id: 'opt2', label: 'Reduce Churn', interventions: { 'factor-b': 0.3 } },
+  ],
+  goal_node_id: 'goal',
+  seed: '424242',
+};
+
+function flipProbeBodies() {
+  return capturedBodies.filter((b) => typeof b?.request_id === 'string' && b.request_id.includes('__flip'));
+}
+
+function blockWarning(body: any) {
+  return (body.inference_warnings ?? []).find((w: any) => w.code === 'FLIP_THRESHOLDS_UNAVAILABLE');
+}
+
+describe('V2 Run · whole-block flip failure is wire-disclosed; per-factor paths unchanged', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  async function run() {
+    const res = await app.inject({
+      method: 'POST', url: '/v2/run',
+      headers: { 'content-type': 'application/json' },
+      payload: PAYLOAD,
+    });
+    expect(res.statusCode).toBe(200);
+    return res.json();
+  }
+
+  it('whole-block failure → FLIP_THRESHOLDS_UNAVAILABLE warning with error NAME only; non-blocking; field honestly empty', async () => {
+    blockThrow = true; probeError = false; capturedBodies.length = 0;
+    try {
+      const body = await run();
+      // non-blocking degradation preserved
+      expect(body.analysis_status).not.toBe('failed'); // non-blocking: mock fixture computes 'partial' (a sub-feature is unavailable in the mock shape); the flip block must never degrade it to 'failed'
+      expect(body.flip_thresholds).toEqual([]);
+      expect(body.flip_thresholds_status).toBe('unavailable');
+      // NEW: the failure is on the wire, not just in the server log
+      const warning = blockWarning(body);
+      expect(warning).toBeDefined();
+      expect(warning.severity).toBe('warning');
+      expect(warning.message).toContain('attempted');
+      // error NAME only — never the message or any value
+      expect(warning.message).toContain('MockFlipBlockError');
+      expect(JSON.stringify(body)).not.toContain(SECRET_VALUE);
+    } finally {
+      blockThrow = false;
+    }
+  });
+
+  it('per-factor probe ERROR path unchanged: flip_reason entries on the wire, NO whole-block warning', async () => {
+    blockThrow = false; probeError = true; capturedBodies.length = 0;
+    try {
+      const body = await run();
+      expect(body.analysis_status).not.toBe('failed'); // non-blocking: mock fixture computes 'partial' (a sub-feature is unavailable in the mock shape); the flip block must never degrade it to 'failed'
+      // probes were attempted and failed per factor
+      expect(flipProbeBodies().length).toBeGreaterThan(0);
+      const entries = body.flip_thresholds ?? [];
+      expect(entries.length).toBeGreaterThan(0);
+      for (const e of entries) {
+        expect(e.flip_value ?? null).toBeNull();
+        expect(e.flip_reason).toBe('error');
+      }
+      // the whole-block warning must NOT fire for per-factor failures
+      expect(blockWarning(body)).toBeUndefined();
+    } finally {
+      probeError = false;
+    }
+  });
+
+  it('per-factor TIMEOUT path unchanged: flip_reason "timeout" entries, NO whole-block warning', async () => {
+    blockThrow = false; probeError = false; capturedBodies.length = 0;
+    process.env.FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS = '0';
+    try {
+      const body = await run();
+      expect(body.analysis_status).not.toBe('failed'); // non-blocking: mock fixture computes 'partial' (a sub-feature is unavailable in the mock shape); the flip block must never degrade it to 'failed'
+      const entries = body.flip_thresholds ?? [];
+      expect(entries.length).toBeGreaterThan(0);
+      for (const e of entries) {
+        expect(e.flip_value ?? null).toBeNull();
+        expect(e.flip_reason).toBe('timeout');
+      }
+      expect(blockWarning(body)).toBeUndefined();
+    } finally {
+      delete process.env.FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS;
+    }
+  });
+
+  it('positive control: successful probes → NO new warning, flip_thresholds populated, probe traffic observed', async () => {
+    blockThrow = false; probeError = false; capturedBodies.length = 0;
+    const body = await run();
+    expect(body.analysis_status).not.toBe('failed'); // non-blocking: mock fixture computes 'partial' (a sub-feature is unavailable in the mock shape); the flip block must never degrade it to 'failed'
+    expect(flipProbeBodies().length).toBeGreaterThan(0);
+    expect((body.flip_thresholds ?? []).length).toBeGreaterThan(0);
+    expect(body.flip_thresholds_status).not.toBe('unavailable');
+    expect(blockWarning(body)).toBeUndefined();
+  });
+});

--- a/tests/lane2-lever-elasticity-std-suppression.test.ts
+++ b/tests/lane2-lever-elasticity-std-suppression.test.ts
@@ -25,7 +25,7 @@
  */
 import { describe, it, expect, beforeAll, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
-import { mergeIslConfidenceIntoGraphFactors } from '../src/lib/factor-influence.js';
+import { mergeIslConfidenceIntoGraphFactors, buildFactorStability } from '../src/lib/factor-influence.js';
 import type { FactorSensitivityResultV3 } from '../src/types/engine-v3.js';
 
 // ---------------------------------------------------------------------------
@@ -259,6 +259,124 @@ describe('/v2/run egress: lever elasticity_std suppressed, unpinned preserved', 
     expect(plain).toBeDefined();
     expect(plain.zero_reason ?? null).toBeNull();
     expect(typeof plain.elasticity_std).toBe('number');
+    expect(plain.elasticity_std).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixup (coordinator, same lane): the SECOND surface. The r2 evidence saw the
+// live lever elasticity_std leak in BOTH factor_sensitivity[2] AND
+// factor_stability[0] — suppressing only the first would ship a half-true
+// suppression claim. factor_stability had NO lever handling at all (pure
+// validity-gate + dedup over RAW ISL entries), so the closest precedent
+// applies: zero-in-place like the sibling factor_sensitivity surface (entry
+// presence retained — dropping entries would be a bigger behaviour change
+// than the ruled leak; FactorStabilityEntry has no zero_reason field, and the
+// authoritative stamp for the same factor_id rides factor_sensitivity).
+// ---------------------------------------------------------------------------
+
+describe('buildFactorStability: lever elasticity_std suppressed on the stability surface (unit)', () => {
+  const GRAPH_MIN = {
+    nodes: [
+      { id: 'fac_union', kind: 'factor', label: 'Union Lever' },
+      { id: 'fac_stamped', kind: 'factor', label: 'Stamped Lever' },
+      { id: 'fac_plain', kind: 'factor', label: 'Plain Factor' },
+    ],
+    edges: [],
+  } as any;
+
+  function rawIsl(id: string, over: Record<string, unknown> = {}) {
+    return {
+      node_id: id,
+      sensitivity: 0.3,
+      elasticity_std: 0.00396846,
+      attribution_stability: 'low',
+      rank_flip_rate: 0.3,
+      stability_method: 'bootstrap_20',
+      ...over,
+    };
+  }
+
+  it('a union lever (unstamped) egresses elasticity_std 0; entry presence + other 3C fields retained', () => {
+    const out = buildFactorStability(
+      [rawIsl('fac_union'), rawIsl('fac_plain', { elasticity_std: 0.00750934, rank_flip_rate: 0.05 })],
+      GRAPH_MIN,
+      new Set(['fac_union']),
+    );
+    const lever = out.find((e) => e.factor_id === 'fac_union');
+    expect(lever).toBeDefined();
+    expect(lever!.elasticity_std).toBe(0);
+    expect(lever!.attribution_stability).toBe('low');
+    expect(lever!.rank_flip_rate).toBe(0.3);
+    expect(lever!.stability_method).toBe('bootstrap_20');
+    // positive control in the same call: unpinned raw value preserved verbatim
+    const plain = out.find((e) => e.factor_id === 'fac_plain');
+    expect(plain!.elasticity_std).toBe(0.00750934);
+  });
+
+  it('an ISL-STAMPED lever (zero_reason, no union set) also egresses elasticity_std 0', () => {
+    const out = buildFactorStability(
+      [rawIsl('fac_stamped', { sensitivity: 0, zero_reason: 'intervention_override', elasticity_std: 0.005 })],
+      GRAPH_MIN,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].factor_id).toBe('fac_stamped');
+    expect(out[0].elasticity_std).toBe(0);
+  });
+
+  it('suppression keys ONLY on the lever predicate: unstamped + no union set → raw value preserved', () => {
+    const out = buildFactorStability([rawIsl('fac_plain', { elasticity_std: 0.00750934 })], GRAPH_MIN);
+    expect(out[0].elasticity_std).toBe(0.00750934);
+  });
+
+  it('domain validity gate still applies to the RAW value (a lever with invalid raw std is skipped, not zero-laundered)', () => {
+    const out = buildFactorStability(
+      [rawIsl('fac_union', { elasticity_std: -1 })],
+      GRAPH_MIN,
+      new Set(['fac_union']),
+    );
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('/v2/run egress: factor_stability surface (fixup — second surface of r2 R1)', () => {
+  let stability: any[];
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    const app: FastifyInstance = await createServer();
+    try {
+      const res = await app.inject({
+        method: 'POST', url: '/v2/run',
+        headers: { 'content-type': 'application/json' },
+        payload: PAYLOAD,
+      });
+      expect(res.statusCode).toBe(200);
+      stability = (res.json().factor_stability ?? []) as any[];
+    } finally {
+      await app.close();
+      delete process.env.RATE_LIMIT_ENABLED;
+      delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    }
+  });
+
+  it('the union lever RETAINS its factor_stability entry but egresses elasticity_std 0', () => {
+    const lever = stability.find((e) => e.factor_id === UNION_ID);
+    expect(lever).toBeDefined();
+    expect(lever.elasticity_std).toBe(0);
+    expect(lever.attribution_stability).toBe('low');
+  });
+
+  it('the ISL-stamped lever egresses elasticity_std 0 in factor_stability', () => {
+    const lever = stability.find((e) => e.factor_id === STAMPED_ID);
+    expect(lever).toBeDefined();
+    expect(lever.elasticity_std).toBe(0);
+  });
+
+  it('positive control: the unpinned factor keeps a non-zero elasticity_std in factor_stability', () => {
+    const plain = stability.find((e) => e.factor_id === PLAIN_ID);
+    expect(plain).toBeDefined();
     expect(plain.elasticity_std).toBeGreaterThan(0);
   });
 });

--- a/tests/lane2-lever-elasticity-std-suppression.test.ts
+++ b/tests/lane2-lever-elasticity-std-suppression.test.ts
@@ -1,0 +1,264 @@
+/**
+ * A3 lane 2 Fix B (r2 residual R1, 2026-07-16): `elasticity_std` joins the
+ * D-U lever suppression contract (LEVER_SUPPRESSION_FIELDS).
+ *
+ * The live universality re-run on the verbatim-original fac_salary_cost graph
+ * proved the shipped contract zeroes sensitivity/elasticity/VOI + stamps
+ * zero_reason for option-controlled levers, but the lever still egressed
+ * `elasticity_std: 0.00396846` — a non-zero variance statistic of the very
+ * metric the contract suppresses.
+ *
+ * Coverage — every merge branch where LEVER_SUPPRESSION_FIELDS is spread
+ * (src/lib/factor-influence.ts):
+ *   1. islMatch branch (suppression spread last in the merge literal): union
+ *      lever AND ISL-stamped lever with non-zero ISL elasticity_std → 0.
+ *   2. empty-islFactors early-return branch: union member → key forced to 0.
+ *   3. no-islMatch branch (ISL returned entries, none for this factor) → 0.
+ *   (4. The ISL-only append branch never spreads the contract — levers are
+ *      SKIPPED there entirely, so omission ≥ zeroing by construction.)
+ *
+ * Positive controls (an absence assertion needs a visible presence):
+ *   - an unpinned factor's non-zero elasticity_std is preserved verbatim at
+ *     the unit level and remains non-zero on the wire at the route level.
+ *   - idempotence: an ISL-stamped lever already carrying elasticity_std 0 is
+ *     deep-equal with and without the structural union set.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { mergeIslConfidenceIntoGraphFactors } from '../src/lib/factor-influence.js';
+import type { FactorSensitivityResultV3 } from '../src/types/engine-v3.js';
+
+// ---------------------------------------------------------------------------
+// Unit level — mergeIslConfidenceIntoGraphFactors branches
+// ---------------------------------------------------------------------------
+
+function graphFactor(id: string, over: Partial<FactorSensitivityResultV3> = {}): FactorSensitivityResultV3 {
+  return {
+    factor_id: id,
+    factor_label: id,
+    influence_score: 0.8,
+    influence_rank: 1,
+    sensitivity_score: 0.7,
+    elasticity: 0.8,
+    direction: 'positive',
+    importance_rank: 1,
+    value_of_information: 0.4,
+    confidence: 0.6,
+    confidence_source: 'plot_unified_from_graph',
+    confidence_components: { structural_certainty: 0.9, sampling_stability: null },
+    source: 'graph',
+    ...over,
+  } as FactorSensitivityResultV3;
+}
+
+function islEntry(id: string, over: Record<string, unknown> = {}): FactorSensitivityResultV3 {
+  return {
+    factor_id: id,
+    sensitivity_score: 0.3,
+    direction: 'positive',
+    attribution_stability: 'low',
+    source: 'isl',
+    ...over,
+  } as unknown as FactorSensitivityResultV3;
+}
+
+describe('LEVER_SUPPRESSION_FIELDS covers elasticity_std (unit, all spread branches)', () => {
+  it('islMatch branch: a union lever with non-zero ISL elasticity_std egresses elasticity_std 0 (the live fac_salary_cost leak)', () => {
+    const [lever] = mergeIslConfidenceIntoGraphFactors(
+      [graphFactor('fac_lever')],
+      [islEntry('fac_lever', { elasticity_std: 0.00396846 })],
+      [],
+      new Set(['fac_lever']),
+    );
+    expect(lever.zero_reason).toBe('intervention_override');
+    expect(lever.elasticity_std).toBe(0);
+    // the rest of the contract still holds alongside the new field
+    expect(lever.sensitivity_score).toBe(0);
+    expect(lever.elasticity).toBe(0);
+    expect(lever.value_of_information).toBe(0);
+  });
+
+  it('islMatch branch: an ISL-STAMPED lever (no union set) with non-zero elasticity_std is also forced to 0', () => {
+    const [lever] = mergeIslConfidenceIntoGraphFactors(
+      [graphFactor('fac_stamped')],
+      [islEntry('fac_stamped', { sensitivity_score: 0, zero_reason: 'intervention_override', elasticity_std: 0.005 })],
+      [],
+    );
+    expect(lever.zero_reason).toBe('intervention_override');
+    expect(lever.elasticity_std).toBe(0);
+  });
+
+  it('empty-islFactors branch: a union member carries elasticity_std 0 (key forced, not just absent)', () => {
+    const [lever] = mergeIslConfidenceIntoGraphFactors(
+      [graphFactor('fac_union')],
+      [],
+      [],
+      new Set(['fac_union']),
+    );
+    expect(lever.zero_reason).toBe('intervention_override');
+    expect(lever.elasticity_std).toBe(0);
+  });
+
+  it('no-islMatch branch: a union member absent from a NON-empty ISL set carries elasticity_std 0', () => {
+    const [lever, plain] = mergeIslConfidenceIntoGraphFactors(
+      [graphFactor('fac_union'), graphFactor('fac_plain')],
+      [islEntry('fac_plain', { elasticity_std: 0.00750934 })],
+      [],
+      new Set(['fac_union']),
+    );
+    expect(lever.zero_reason).toBe('intervention_override');
+    expect(lever.elasticity_std).toBe(0);
+    // positive control in the same merge: the unpinned factor keeps its value
+    expect(plain.zero_reason ?? null).toBeNull();
+    expect(plain.elasticity_std).toBe(0.00750934);
+  });
+
+  it('positive control: an unpinned factor with non-zero ISL elasticity_std is preserved verbatim', () => {
+    const [plain] = mergeIslConfidenceIntoGraphFactors(
+      [graphFactor('fac_plain')],
+      [islEntry('fac_plain', { elasticity_std: 0.00750934 })],
+      [],
+      new Set(['fac_other']),
+    );
+    expect(plain.zero_reason ?? null).toBeNull();
+    expect(plain.elasticity_std).toBe(0.00750934);
+    expect(plain.sensitivity_score).not.toBe(0);
+  });
+
+  it('idempotence: an ISL-stamped lever already at elasticity_std 0 is deep-equal with and without the union set', () => {
+    const graph = () => [graphFactor('fac_lever')];
+    const isl = () => [islEntry('fac_lever', { sensitivity_score: 0, zero_reason: 'intervention_override', elasticity_std: 0 })];
+    const withUnion = mergeIslConfidenceIntoGraphFactors(graph(), isl(), [], new Set(['fac_lever']));
+    const withoutUnion = mergeIslConfidenceIntoGraphFactors(graph(), isl(), []);
+    expect(JSON.stringify(withUnion)).toBe(JSON.stringify(withoutUnion));
+    expect(withUnion[0].elasticity_std).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route level — /v2/run egress (mirrors the r2 universality-rerun probe set)
+// ---------------------------------------------------------------------------
+
+const UNION_ID = 'fac_union_lever';   // pinned ONLY by the NON-first option, unstamped (the leak class)
+const STAMPED_ID = 'fac_stamped_lever'; // first-option pin, ISL-stamped
+const PLAIN_ID = 'fac_plain';         // pinned by nobody — positive control
+
+const ISL_FACTOR_SENSITIVITY = [
+  { node_id: UNION_ID, sensitivity: -0.19, direction: 'negative' as const, elasticity_std: 0.00396846, attribution_stability: 'low', rank_flip_rate: 0.3, stability_method: 'bootstrap_20' },
+  { node_id: STAMPED_ID, sensitivity: 0, zero_reason: 'intervention_override', direction: 'positive' as const, elasticity_std: 0.005, attribution_stability: 'low', rank_flip_rate: 0.2, stability_method: 'bootstrap_20' },
+  { node_id: PLAIN_ID, sensitivity: 0.5, direction: 'positive' as const, elasticity_std: 0.00750934, attribution_stability: 'low', rank_flip_rate: 0.05, stability_method: 'bootstrap_20' },
+];
+
+function robustnessPayload(options: any[]) {
+  return {
+    options: (options ?? []).map((opt: any, idx: number) => ({
+      option_id: opt.id,
+      win_probability: idx === 0 ? 0.7 : 0.3,
+      outcome: { mean: 0.7 - idx * 0.2, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+      rank: idx + 1,
+    })),
+    edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const, edge_sensitivity_status: 'available' as const,
+    factors: ISL_FACTOR_SENSITIVITY,
+    factor_sensitivity: ISL_FACTOR_SENSITIVITY,
+    value_of_information: [],
+    factors_provenance: 'isl' as const, factor_sensitivity_status: 'available' as const,
+    robustness: { score: 0.8, label: 'robust' as const, fragile_edges: [], robust_edges: [] },
+    overall_robustness: 'robust' as const, robustness_score: 0.8, fragile_edges: [], robust_edges: [],
+    latency_ms: 50, source: 'isl' as const,
+  };
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return { status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl' };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return robustnessPayload(options);
+  },
+  async analyseFactorSensitivity() {
+    return { factors: ISL_FACTOR_SENSITIVITY, value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'isl' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    return { data: robustnessPayload(body?.options ?? []) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+const { createServer } = await import('../src/createServer.js');
+
+const PAYLOAD = {
+  graph: {
+    nodes: [
+      { id: 'goal', kind: 'goal', label: 'Goal' },
+      { id: UNION_ID, kind: 'factor', label: 'Union Lever', observed_state: { value: 0.6 } },
+      { id: STAMPED_ID, kind: 'factor', label: 'Stamped Lever', observed_state: { value: 0.5 } },
+      { id: PLAIN_ID, kind: 'factor', label: 'Background Factor', observed_state: { value: 0.5 } },
+    ],
+    edges: [
+      { from: UNION_ID, to: 'goal', exists_probability: 0.95, strength: { mean: 0.9, std: 0.1 } },
+      { from: STAMPED_ID, to: 'goal', exists_probability: 0.9, strength: { mean: 0.8, std: 0.1 } },
+      { from: PLAIN_ID, to: 'goal', exists_probability: 0.7, strength: { mean: 0.3, std: 0.1 } },
+    ],
+  },
+  options: [
+    { id: 'opt_a', label: 'A', interventions: { [STAMPED_ID]: { value: 1, source: 'user_specified' } } },
+    { id: 'opt_b', label: 'B', interventions: { [UNION_ID]: { value: 0.2, source: 'user_specified' } } },
+  ],
+  goal_node_id: 'goal',
+  seed: '42',
+};
+
+describe('/v2/run egress: lever elasticity_std suppressed, unpinned preserved', () => {
+  let factors: any[];
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    const app: FastifyInstance = await createServer();
+    try {
+      const res = await app.inject({
+        method: 'POST', url: '/v2/run',
+        headers: { 'content-type': 'application/json' },
+        payload: PAYLOAD,
+      });
+      expect(res.statusCode).toBe(200);
+      factors = (res.json().factor_sensitivity ?? []) as any[];
+    } finally {
+      await app.close();
+      delete process.env.RATE_LIMIT_ENABLED;
+      delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    }
+  });
+
+  it('the non-first-option (unstamped) lever egresses elasticity_std 0', () => {
+    const lever = factors.find((f) => f.factor_id === UNION_ID);
+    expect(lever).toBeDefined();
+    expect(lever.zero_reason).toBe('intervention_override');
+    expect(lever.elasticity_std).toBe(0);
+  });
+
+  it('the ISL-stamped lever egresses elasticity_std 0', () => {
+    const lever = factors.find((f) => f.factor_id === STAMPED_ID);
+    expect(lever).toBeDefined();
+    expect(lever.zero_reason).toBe('intervention_override');
+    expect(lever.elasticity_std).toBe(0);
+  });
+
+  it('positive control: the unpinned factor keeps a non-zero elasticity_std on the wire', () => {
+    const plain = factors.find((f) => f.factor_id === PLAIN_ID);
+    expect(plain).toBeDefined();
+    expect(plain.zero_reason ?? null).toBeNull();
+    expect(typeof plain.elasticity_std).toBe('number');
+    expect(plain.elasticity_std).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Two small mechanical honesty fixes (A3 lane 2), both RED-first, both mutation-checked. Base = staging tip `1f8c0951` (post lane-1 #225). Evidence dossier: `acceptance-evidence/a3-verify-2026-07-16/lane2-BUILD.md` (+ `item4-flip-probe-integrity.md`, `r2-universality-rerun.md`).

## Fix A — wire-disclose whole-block flip-probe failure (ROADMAP 2.31 adjacency)

**What:** when the ENTIRE flip-threshold block throws, the response previously shipped `flip_thresholds: []` + `flip_thresholds_status: 'unavailable'` with only a server-side `flip_thresholds_error` WARN — indistinguishable on the wire from "nothing to probe" — while per-factor failures were already honestly disclosed per entry (`flip_reason: 'timeout' | 'error'`). Now the whole-block case emits a registered `FLIP_THRESHOLDS_UNAVAILABLE` inference warning (severity `warning`): states the probes were attempted, why they're absent (thrown error's NAME only — never its message or any value), and that all other analyses are unaffected. Non-blocking degradation is unchanged.

**How:** new code in `INFERENCE_WARNING_CODES` (engine-v3.ts, doc'd); route catch captures `(err as Error).name` into `MetaParams.flipThresholdsFailedErrorName`; `buildResponse` (owner of `inference_warnings` assembly) turns presence into the warning. ISL-not-enabled early return never attempts the block → no warning (attempted-only semantics). Per-factor paths untouched.

**Code name delta:** the task sketch suggested `FLIP_PROBES_UNAVAILABLE`; the registry convention names the absent WIRE FIELD (`EDGE_E_VALUES_UNAVAILABLE_V2_WIRE` etc.), so this uses `FLIP_THRESHOLDS_UNAVAILABLE`.

**Row 2.31 scope note:** the verbatim row text is the *generation-assertion* residual ("flip-probe calls are not generation-asserted; wire-generation assertion covers the base path only"). That is a DIFFERENT (adjacent) gap and remains OPEN, folded with the 2.25 hygiene sweep. This PR ships the whole-block *disclosure* nuance recorded next to it in `item4-flip-probe-integrity.md` (Premise B verdict).

## Fix B — suppress lever `elasticity_std` (r2 universality-rerun residual R1)

**What:** `LEVER_SUPPRESSION_FIELDS` zeroed sensitivity_score/elasticity/value_of_information + stamped `zero_reason` for option-controlled levers, but NOT `elasticity_std` — the live wire published `elasticity_std: 0.00396846` for suppressed lever `fac_salary_cost` (a non-zero variance statistic of the very metric the contract zeroes). Added `elasticity_std: 0` to the contract with field-level rationale.

**Branch coverage:** all 3 spread sites at this tip (factor-influence.ts :893, :932, :1005: empty-islFactors early return, no-islMatch, islMatch merge — suppression spread is LAST in the merge literal, so it wins over the ISL carry). The 4th "merge branch" from the pre-#225 note (ISL-only append, :1019) SKIPS levers entirely via `isOptionControlledLever` — omission covers it by construction. Unit tests pin each spread branch; route tests pin the wire.

**Second surface (commit 2, coordinator-ruled fixup): `factor_stability[]`.** The r2 evidence saw the live leak on BOTH surfaces (`factor_sensitivity[2]` AND `factor_stability[0]`); covering only the first would ship a half-true suppression claim. `buildFactorStability` reads RAW ISL entries (the merge-layer suppression never touches them) and had NO lever handling at all — it now takes the same D-U `structuralLeverIds` union and zeroes `elasticity_std` IN-PLACE for option-controlled levers (same `isOptionControlledLever` predicate as every other suppression site). Semantics choice, disclosed: entry presence + the other 3C diagnostics retained; **no stamp** (FactorStabilityEntry has no `zero_reason` field — the authoritative stamp for the same factor_id rides the factor_sensitivity entry); **omission rejected** (a bigger behaviour change than the ruled leak: presence assertions would break and the golden's legitimate std-0 lever entries would vanish). The domain-validity gate still applies to the RAW value first (an invalid raw std skips the entry, never zero-launders it — pinned by test). `factorStability` is ignored by the v6 response hash — no hash impact.

## RED → GREEN

- RED (src fixes stashed, tests present): `Tests 10 failed | 3 passed (13)` — all 4 Fix-A disclosure tests + all 6 elasticity_std-zeroing assertions RED (e.g. `expected 0.00396846 to be +0`); the 3 pre-fix passes are by-design invariants (positive controls + idempotence).
- GREEN (fixes restored): 13/13. New files: `tests/lane2-flip-block-disclosure.test.ts`, `tests/lane2-lever-elasticity-std-suppression.test.ts`.
- Positive controls: unpinned factor keeps its real elasticity_std (unit verbatim + wire non-zero); successful probes emit NO new warning with probe traffic observed; per-factor ERROR and deterministic per-factor TIMEOUT (`FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS=0`) still ride `flip_reason` per entry with NO block warning; a sentinel value embedded in the thrown error MESSAGE never egresses (name-only proof).
- Module mock discipline: `importOriginal`-spread, only `resolveFlipValues` wrapped, delegating to the real implementation unless the block-throw toggle is armed.
- Fixup (commit 2), genuinely test-first: 4 new factor_stability tests RED (`4 failed | 12 passed (16)`) before the code, lane suites 25/25 after.

## Mutation checks (throwaway `cp -a` copies; build tree untouched)

- **Fix A** (`git checkout origin/staging -- src/routes/v2/run.ts`; code stays registered, wiring gone): `Tests 1 failed | 3 passed (4)` — disclosure test RED, invariants green by design. The pin bites.
- **Fix B** (`git checkout origin/staging -- src/lib/factor-influence.ts`): `Tests 6 failed | 3 passed (9)` — ALL zeroing assertions RED across all 3 spread branches + both route levers; positive controls green by design.
- **Fixup site, independently** (`git checkout HEAD -- src/lib/factor-influence.ts src/routes/v2/run.ts` with HEAD = commit 1, so ONLY the fixup reverts): `Tests 5 failed | 33 passed (38)` — exactly the 4 new factor_stability tests + FS6 RED; every commit-1 test stays green.

## Golden byte-pin decision

`tests/isl-v2-golden-response.pin.test.ts` **passes UNCHANGED — no golden update, no normaliser change.** Pre-analysed then confirmed: both levers in the golden capture are ISL-stamped with `elasticity_std: 0` already (the 0→0 overwrite is byte-identical at the same key position); unpinned factors (0.01101973/0.00657316) untouched; Fix A's warning fires only on failure paths and the golden is a success capture.

## Pre-existing test updated (real behaviour change, disclosed)

- `tests/b8-8-3c-field-segregation.test.ts` asserted `elasticity_std toBe(0.12)` on entries that are BOTH option-pinned levers in its own fixture — the pre-lane assertion was pinning the R1 leak itself. Updated to `toBe(0)` with reasoning; its `factor_stability[]` test needed no change (presence-only assertions, retained by construction).
- `tests/3c-factor-sensitivity-enrichment.test.ts` (FS6, commit 2): asserted factor_stability `elasticity_std` 0.042/0.11 on factor-a/factor-b — VERIFIED both are option-pinned levers in its own fixture (opt1 pins factor-a, opt2 pins factor-b) before touching it; updated to 0 with reasoning. Same leak-pinning class, second surface.

## Gates

- `npx tsc --noEmit` → exit 0.
- Targeted adjacent suites (flip ×3, lever/merge ×6, golden ×1, b8-8): all green.
- Full `bash scripts/pre-push-validate.sh` (dist built first): round 1 FAILED exactly 1/5604 (the b8-8 leak-pinning assertion above — nothing else moved); round 2 after the disclosed update: **PASSED, 0 failures** (`Tests 5568 passed | 25 skipped (5604)`; tsc, stale-js, file-dep policy, spectral all PASS).
- Spec: description-prose bullet for the new code in the `/v2/run` POST description (lane-1 precedent — the spec documents neither `inference_warnings` nor `_meta` as schema components). Redocly problem-set diff vs base (exact CI command, ruleId+pointer): **EMPTY — 76 == 76**. Any `validate-structure` red is pre-existing.
- Known tolerable CI reds: `gates (windows-latest)` fails on every PR.

## Residuals (disclosed, out of scope)

- ~~`factor_stability[]` can still carry a lever's non-zero `elasticity_std`~~ — **CLOSED-IN-LANE (commit 2)**: the coordinator ruled the deferral out (half-true suppression claim); `buildFactorStability` now suppresses the lever `elasticity_std` on this surface too (see Fix B, second surface).
- `flip_thresholds` emission for levers untouched (r2 residual R2 — open doctrine question, explicitly out of scope).
- Row 2.31's generation-assertion residual itself remains open (this PR ships the adjacent disclosure gap, not the assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
