### PR TITLE
fix(science): denormalise stability bands in lockstep with flip_mean (units coherence) (A3 lane 4)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4058,7 +4058,7 @@ paths:
           entry via `flip_reason` ('timeout'/'error'/...). Non-blocking: all other analyses are
           unaffected.
         - `edge_e_values[].stability` (additive, A3 lane 3): seed-sweep flip-threshold
-          stability band carried VERBATIM from ISL (ISL PR #71). Present ONLY when ISL runs
+          stability band carried from ISL (ISL PR #71). Present ONLY when ISL runs
           with `ISL_FLIP_STABILITY_BANDS` enabled (default OFF — absent from every entry on
           today's live wire); when ISL omits it the key is absent, never null. Shape:
           `{ n_seeds, n_seeds_flipped, band_min?, band_median?, band_max?, band_width?,
@@ -4066,8 +4066,12 @@ paths:
           is 0; `seed_flip_means` entries are null where that seed's background admits no
           flip. CAUTION: `band_width` is 0.0 BY CONSTRUCTION when `n_seeds_flipped` is 1
           (a single value has zero range) — condition any width-based confidence rubric on
-          `n_seeds_flipped`. Band values are in ISL flip-mean space and are NOT
-          denormalised, even when the entry's `current_mean`/`flip_mean` were.
+          `n_seeds_flipped`. UNITS INVARIANT (A3 lane 4): band values are ALWAYS in the
+          same space as the entry's `flip_mean` — when PLoT denormalises
+          `current_mean`/`flip_mean` into goal units, `band_min`/`band_median`/`band_max`
+          and non-null `seed_flip_means` cells receive the identical map and `band_width`
+          is recomputed from the mapped endpoints; where `flip_mean` is verbatim
+          (no normalisation, or `_normalised: true`), the band is verbatim too.
 
         **Seed Handling**:
         - Accept string (canonical) or number (legacy)

--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -158,17 +158,22 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     // include_path_decomposition).
     'sensitivity_reference_option_id',   // Disclosure: option the sensitivity/fragile-edge analysis was computed against.
     'path_decomposition',                // Request-gated structural pathway decomposition (opt-in; not a causal claim).
-    // A3 lane 3 (ISL PR #71): seed-sweep flip-stability band — verbatim
-    // additive passthrough on edge_e_values entries, NOT an enrichment.
+    // A3 lane 3 (ISL PR #71): seed-sweep flip-stability band — additive
+    // passthrough on edge_e_values entries, NOT an enrichment.
     // Present only when ISL runs with ISL_FLIP_STABILITY_BANDS enabled
     // (default OFF — absent on today's live wire); key absent, never null,
     // when ISL omits it. Lever edges: e-values (now incl. stability) are
     // currently PUBLISHED for levers — same surface as the open R2 doctrine
     // bullet on lever flip_thresholds/e-values; this lane invents no new
     // suppression pending that ruling.
-    // ⚠ band_width == 0.0 BY CONSTRUCTION when n_seeds_flipped == 1; band
-    // values stay in ISL flip-mean space even when the entry's
-    // current_mean/flip_mean were denormalised (see ISLFlipStabilityBandV2).
+    // ⚠ band_width == 0.0 BY CONSTRUCTION when n_seeds_flipped == 1.
+    // UNITS INVARIANT (A3 lane 4, Paul's 17 Jul ruling): band values are
+    // ALWAYS in the same space as the entry's flip_mean — when
+    // current_mean/flip_mean are denormalised into goal units, band_min/
+    // band_median/band_max and non-null seed_flip_means cells receive the
+    // IDENTICAL map and band_width is RECOMPUTED from the mapped endpoints
+    // (never offset-mapped); on the verbatim paths the band is verbatim too
+    // (see ISLFlipStabilityBandV2).
     'edge_e_values[].stability',
   ],
 } as const;

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -329,8 +329,9 @@ export interface ISLPathDecompositionV2 {
  * Seed-sweep stability band for one edge's flip threshold (ISL Track S
  * Phase 1, ISL PR #71). Flag-gated in ISL by `ISL_FLIP_STABILITY_BANDS`
  * (default OFF): the field is simply ABSENT from every edge_e_values entry
- * until the flag is enabled — PLoT carries it through VERBATIM when present
- * and emits nothing when absent (dark carry-through, A3 lane 3).
+ * until the flag is enabled — PLoT carries it through when present and emits
+ * nothing when absent (dark carry-through, A3 lane 3; units alignment, A3
+ * lane 4 — see the UNITS invariant below).
  *
  * Shape derived from ISL `FlipStabilityBandV2`
  * (src/models/response_v2.py:368-415 at ISL tip 5745154e) serialised with
@@ -349,14 +350,20 @@ export interface ISLPathDecompositionV2 {
  * from a single flipped background. Any consumer confidence rubric MUST
  * condition on `n_seeds_flipped`, never on `band_width` alone.
  *
- * ⚠ UNITS: band values are flip MEANS in the same space as ISL's raw
- * `flip_mean`. PLoT denormalises the entry's `current_mean`/`flip_mean` into
- * outcome units when normalisation is active but carries `stability`
- * VERBATIM (no reinterpretation, per the dark-carry-through contract), so
- * under active normalisation the band values remain in ISL-normalised space
- * while the sibling `flip_mean` is outcome-space. Consumers comparing the
- * two must account for this; any denormalisation decision belongs to the
- * flag-flip/consumption lane.
+ * ⚠ UNITS INVARIANT (A3 lane 4, Paul's 17 Jul ruling): on the /v2/run wire,
+ * band values are ALWAYS in the same space as `flip_mean` on the same entry.
+ * When PLoT denormalises the entry's `current_mean`/`flip_mean` into goal
+ * units (active normalisation + resolvable goal range), `band_min`/
+ * `band_median`/`band_max` and every non-null `seed_flip_means` cell receive
+ * the IDENTICAL affine map, and `band_width` is RECOMPUTED from the mapped
+ * endpoints (a width is a difference — it never receives the affine offset).
+ * On the paths where `flip_mean` stays verbatim (no normalisation context;
+ * `_normalised: true`), the band stays verbatim too. Consumers may therefore
+ * compare band values with the sibling `flip_mean` directly, on every path.
+ * NOTE: whether mapping a flip mean (an EDGE-STRENGTH-space quantity at the
+ * ISL producer) through the GOAL-NODE outcome range is semantically right is
+ * an open question logged for Neil covering flip_mean AND bands together —
+ * this invariant guarantees internal consistency, not that semantics.
  */
 export interface ISLFlipStabilityBandV2 {
   /** Number of child seeds swept (ISL default 5, clamped [2, 20]) */
@@ -418,9 +425,10 @@ export interface ISLEdgeEValue {
   /**
    * Seed-sweep flip-threshold stability band (ISL PR #71). Present ONLY when
    * ISL runs with `ISL_FLIP_STABILITY_BANDS` enabled (default OFF — absent on
-   * the live wire today). Carried through to the /v2/run response VERBATIM
-   * (A3 lane 3 dark carry-through); see ISLFlipStabilityBandV2 for the
-   * band_width/n_seeds_flipped interpretation trap and units note.
+   * the live wire today). Carried through to the /v2/run response in the SAME
+   * space as the entry's flip_mean (A3 lane 3 carry-through + lane 4 units
+   * alignment); see ISLFlipStabilityBandV2 for the band_width/n_seeds_flipped
+   * interpretation trap and the units invariant.
    */
   stability?: ISLFlipStabilityBandV2;
 }

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -454,6 +454,7 @@ export function transformEdgeEValues(
     // using goal node range when normalisation was active.
     let currentMean = e.current_mean;
     let flipMean = e.flip_mean;
+    let stability = e.stability;
     let eValueNormalised: boolean | undefined;
     if (normContext && goalRange) {
       if (typeof currentMean === 'number') {
@@ -461,6 +462,41 @@ export function transformEdgeEValues(
       }
       if (typeof flipMean === 'number') {
         flipMean = denormaliseValue(flipMean, goalRange);
+      }
+      // A3 lane 4 (Paul's 17 Jul ruling): the stability band receives EXACTLY
+      // the same map as the sibling flip_mean above — units-coherence
+      // invariant: band values are ALWAYS in the same space as flip_mean on
+      // the same entry. Counts (n_seeds/n_seeds_flipped) are space-invariant.
+      if (stability !== undefined) {
+        const bandMin = typeof stability.band_min === 'number'
+          ? denormaliseValue(stability.band_min, goalRange) : undefined;
+        const bandMedian = typeof stability.band_median === 'number'
+          ? denormaliseValue(stability.band_median, goalRange) : undefined;
+        const bandMax = typeof stability.band_max === 'number'
+          ? denormaliseValue(stability.band_max, goalRange) : undefined;
+        stability = {
+          // Spread first so any future additive ISL band field still rides
+          // (the named-field-rebuild silent-drop trap this file's lane-3
+          // comment documents); mapped fields override below.
+          ...stability,
+          ...(bandMin !== undefined && { band_min: bandMin }),
+          ...(bandMedian !== undefined && { band_median: bandMedian }),
+          ...(bandMax !== undefined && { band_max: bandMax }),
+          // band_width RECOMPUTED from the MAPPED endpoints (mapped band_max −
+          // mapped band_min), NEVER passed through denormaliseValue itself: a
+          // width is a difference, and the affine `+ min` offset would corrupt
+          // it. Absent endpoints (n_seeds_flipped == 0) ⇒ width stays absent;
+          // a degenerate goal range (max − min <= 0) collapses both endpoints
+          // to the same constant ⇒ width 0, consistent with flip_mean there.
+          ...(bandMin !== undefined && bandMax !== undefined &&
+            { band_width: bandMax - bandMin }),
+          // Per-seed means: map non-null cells, preserve nulls AS NULL (a
+          // null means that seed's background admits no flip — not a value).
+          ...(Array.isArray(stability.seed_flip_means) && {
+            seed_flip_means: stability.seed_flip_means.map((v) =>
+              typeof v === 'number' ? denormaliseValue(v, goalRange) : v),
+          }),
+        };
       }
     } else if (normContext) {
       // Normalisation was active but goal range unavailable — flag
@@ -477,16 +513,18 @@ export function transformEdgeEValues(
       flip_direction: e.flip_direction,
       current_mean: currentMean,
       flip_mean: flipMean,
-      // A3 lane 3: seed-sweep flip-stability band (ISL PR #71, flag-gated
-      // ISL_FLIP_STABILITY_BANDS — absent on the live wire until the flag
-      // flips). Carried VERBATIM when present, key absent (never null) when
-      // not: this field-by-field rebuild used to silently DROP it. NOT
-      // denormalised — band values stay in ISL flip-mean space even when
-      // currentMean/flipMean above were denormalised (see the units note on
-      // ISLFlipStabilityBandV2). ⚠ band_width == 0 is BY CONSTRUCTION when
-      // n_seeds_flipped == 1 — carried as-is, consumers must condition on
-      // n_seeds_flipped.
-      ...(e.stability !== undefined && { stability: e.stability }),
+      // A3 lane 3 + lane 4: seed-sweep flip-stability band (ISL PR #71,
+      // flag-gated ISL_FLIP_STABILITY_BANDS — absent on the live wire until
+      // the flag flips). Key absent (never null) when ISL omits it: this
+      // field-by-field rebuild used to silently DROP it. UNITS-COHERENCE
+      // INVARIANT (Paul's 17 Jul ruling): band values are ALWAYS in the same
+      // space as flip_mean on the same entry — mapped above via the same
+      // denormaliseValue when flipMean was denormalised (band_width recomputed
+      // from mapped endpoints); verbatim on the fallback and _normalised:true
+      // paths where flipMean is verbatim too (see ISLFlipStabilityBandV2).
+      // ⚠ band_width == 0 is BY CONSTRUCTION when n_seeds_flipped == 1 —
+      // consumers must condition on n_seeds_flipped.
+      ...(stability !== undefined && { stability }),
       ...(eValueNormalised !== undefined && { _normalised: eValueNormalised }),
     };
     // Numeric-egress guard (Codex round-2): e_value/current_mean/flip_mean are

--- a/tests/lane3-stability-bands-carrythrough.test.ts
+++ b/tests/lane3-stability-bands-carrythrough.test.ts
@@ -7,10 +7,14 @@
  * field-by-field, so before this lane an incoming `stability` band was
  * silently DROPPED. These tests pin the carry-through contract:
  *
- *   1. VERBATIM carry: a stability-bearing ISL entry reaches the /v2/run
- *      wire with the band deep-equal to the ISL bytes (no reinterpretation,
- *      no denormalisation of band values — see the units note on
- *      ISLFlipStabilityBandV2).
+ *   1. UNITS COHERENCE (A3 lane 4, Paul's 17 Jul ruling): band values are
+ *      ALWAYS in the same space as `flip_mean` on the same entry. On the
+ *      path where flip_mean is denormalised (normContext + goal range) the
+ *      band receives the IDENTICAL affine map, with `band_width` RECOMPUTED
+ *      from the mapped endpoints (never offset-mapped) and null
+ *      `seed_flip_means` cells preserved. On the paths where flip_mean is
+ *      verbatim (no normContext; `_normalised:true`) the band is verbatim
+ *      too — see the units note on ISLFlipStabilityBandV2.
  *   2. Honest absence: when ISL omits `stability` (the live wire today —
  *      flag OFF), the outward entry carries NO `stability` key (absent,
  *      never null).
@@ -183,6 +187,28 @@ const OPTIONS = [
   { id: 'opt2', label: 'Reduce Spend', interventions: { 'factor-a': 0.3 } },
 ];
 
+// --- A3 lane 4: request that ACTIVATES normalisation (raw intervention
+// values outside [0,1]) with an explicit goal range whose affine map is a
+// positive control (min ≠ 0, width ≠ 1): v → v·50 + 10.
+const NORM_GOAL_RANGE = { min: 10, max: 60 };
+const dnGoal = (v: number) => v * (NORM_GOAL_RANGE.max - NORM_GOAL_RANGE.min) + NORM_GOAL_RANGE.min;
+
+const NORM_GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue', state_space: { range: NORM_GOAL_RANGE } },
+    { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', state_space: { range: { min: 0, max: 100000 } } },
+    { id: 'factor-b', kind: 'factor', label: 'Churn Rate', observed_state: { value: 0.4 } },
+    { id: 'factor-c', kind: 'factor', label: 'Pricing', observed_state: { value: 0.5 } },
+    { id: 'factor-d', kind: 'factor', label: 'Headcount', observed_state: { value: 0.3 } },
+  ],
+  edges: GRAPH.edges,
+};
+
+const NORM_OPTIONS = [
+  { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 80000 } },
+  { id: 'opt2', label: 'Reduce Spend', interventions: { 'factor-a': 30000 } },
+];
+
 describe('lane 3 — transformEdgeEValues stability carry-through (unit)', () => {
   it('carries a stability band through VERBATIM (deep-equal to the ISL bytes)', () => {
     const out = transformEdgeEValues(ISL_EDGE_E_VALUES as unknown as ISLEdgeEValue[]);
@@ -211,19 +237,89 @@ describe('lane 3 — transformEdgeEValues stability carry-through (unit)', () =>
     expect(out[3]!.stability).toBeUndefined();
   });
 
-  it('keeps stability verbatim while current_mean/flip_mean are denormalised', () => {
+  it('maps the stability band IDENTICALLY to flip_mean under active normalisation (A3 lane 4 units coherence)', () => {
+    // Positive-control range: min ≠ 0 AND (max − min) ≠ 1, so BOTH a dropped
+    // scale and a dropped/spurious offset are visible — an identity range
+    // ({0,1}) would make this test pass vacuously against verbatim carry.
+    const RANGE = { min: 10, max: 60 };
+    // Mirror of denormaliseValue's affine map: v → v·(max−min) + min.
+    const dn = (v: number) => v * (RANGE.max - RANGE.min) + RANGE.min;
     const normContext = {
-      goal_context: { range: { min: 0, max: 100 } },
+      goal_context: { range: RANGE },
     } as unknown as NonNullable<Parameters<typeof transformEdgeEValues>[2]>;
     const out = transformEdgeEValues(
       ISL_EDGE_E_VALUES as unknown as ISLEdgeEValue[],
       undefined,
       normContext,
     );
-    // Denormalisation moved the sibling numerics out of [0,1]…
-    expect(out[0]!.flip_mean).not.toBe(0.47);
-    // …but the band is byte-verbatim ISL space (no reinterpretation).
-    expect(out[0]!.stability).toEqual(FULL_BAND);
+
+    // Sibling flip_mean is denormalised (pre-existing #227-era behaviour —
+    // this is the reference space the band must share)…
+    expect(out[0]!.flip_mean).toBe(dn(0.47)); // 33.5
+    // …and the band receives EXACTLY the same affine map:
+    const band = out[0]!.stability!;
+    expect(band.band_min).toBe(dn(0.41));     // 30.5
+    expect(band.band_median).toBe(dn(0.47));  // 33.5
+    // Same input (0.47), same map ⇒ literally equal to the sibling flip_mean.
+    expect(band.band_median).toBe(out[0]!.flip_mean);
+    expect(band.band_max).toBe(dn(0.62));     // 41
+    // band_width RECOMPUTED from the MAPPED endpoints — scale only, NO offset:
+    // dn(0.62) − dn(0.41) = 0.21·50 = 10.5. An offset-mapped width
+    // (dn(0.21) = 20.5) would be corrupt; pin against it explicitly.
+    expect(band.band_width).toBe(dn(0.62) - dn(0.41));
+    expect(band.band_width).toBeCloseTo(10.5, 10);
+    expect(band.band_width).not.toBeCloseTo(dn(0.21), 10);
+    // Null seed cells preserved AS NULL; non-null cells mapped:
+    expect(band.seed_flip_means).toEqual([dn(0.41), null, dn(0.47), dn(0.62), null]);
+    // Counts are space-invariant — untouched:
+    expect(band.n_seeds).toBe(5);
+    expect(band.n_seeds_flipped).toBe(3);
+    // Positive control: the map genuinely moved every value.
+    expect(band.band_min).not.toBe(FULL_BAND.band_min);
+    expect(band.band_max).not.toBe(FULL_BAND.band_max);
+
+    // Single-flip trap entry: the point band collapses to the mapped point;
+    // zero width maps to zero width (offset corruption would read 10 here).
+    const single = out[1]!.stability!;
+    expect(single.band_min).toBe(dn(0.55));   // 37.5
+    expect(single.band_median).toBe(dn(0.55));
+    expect(single.band_max).toBe(dn(0.55));
+    expect(single.band_width).toBe(0);
+    expect(out[1]!.flip_mean).toBe(dn(0.55)); // band == flip_mean space
+    expect(single.seed_flip_means).toEqual([null, null, dn(0.55), null, null]);
+    expect(single.n_seeds_flipped).toBe(1);
+
+    // No-flip entry: band_* keys stay ABSENT (nothing to map — never
+    // fabricated), all-null seed cells stay null.
+    const noFlip = out[2]!.stability as Record<string, unknown>;
+    for (const k of ['band_min', 'band_median', 'band_max', 'band_width']) {
+      expect(k in noFlip).toBe(false);
+    }
+    expect(noFlip.seed_flip_means).toEqual([null, null, null, null, null]);
+    expect(noFlip.n_seeds_flipped).toBe(0);
+
+    // Flag-off entry: still no stability key under normalisation.
+    expect('stability' in out[3]!).toBe(false);
+  });
+
+  it('keeps bands VERBATIM on the _normalised:true path — flip_mean is verbatim there too (coherence, not transformation)', () => {
+    // normContext active but goal range unavailable: flip_mean stays in
+    // normalised space and the entry is flagged `_normalised: true`. Band and
+    // sibling share ONE space (ISL flip-mean space) — the invariant is
+    // coherence, so the band must stay verbatim here.
+    const normContext = {
+      goal_context: {},
+    } as unknown as NonNullable<Parameters<typeof transformEdgeEValues>[2]>;
+    const out = transformEdgeEValues(
+      ISL_EDGE_E_VALUES as unknown as ISLEdgeEValue[],
+      undefined,
+      normContext,
+    );
+    expect(out[0]!.flip_mean).toBe(0.47);          // sibling verbatim
+    expect(out[0]!._normalised).toBe(true);        // disclosed
+    expect(out[0]!.stability).toEqual(FULL_BAND);  // band verbatim — same space
+    expect(out[1]!.stability).toEqual(SINGLE_FLIP_BAND);
+    expect(out[2]!.stability).toEqual(NO_FLIP_BAND);
   });
 
   it('numeric-egress guard still drops whole entries with non-finite numerics — stability rides, never rescues', () => {
@@ -287,6 +383,46 @@ describe('lane 3 — /v2/run stability carry-through (route, end-to-end)', () =>
 
   it('flag-off shape: an entry without stability emits NO stability key on the wire (absent, not null)', async () => {
     const body = await run();
+    const bare = body.edge_e_values.find((e: { edge_id: string }) => e.edge_id === 'factor-d::goal');
+    expect(bare).toBeDefined();
+    expect('stability' in bare).toBe(false);
+  });
+
+  it('under ACTIVE normalisation, egressed bands are mapped identically to flip_mean (A3 lane 4, end-to-end)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: NORM_GRAPH, options: NORM_OPTIONS, goal_node_id: 'goal', seed: 'lane4-units-test' }),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+
+    const full = body.edge_e_values.find((e: { edge_id: string }) => e.edge_id === 'factor-a::goal');
+    expect(full).toBeDefined();
+    // Sibling flip_mean denormalised into the goal range (the reference space)…
+    expect(full.flip_mean).toBe(dnGoal(0.47)); // 33.5
+    // …and the band shares it exactly:
+    expect(full.stability.band_min).toBe(dnGoal(0.41));
+    expect(full.stability.band_median).toBe(full.flip_mean);
+    expect(full.stability.band_max).toBe(dnGoal(0.62));
+    // Recomputed width — scale only, no offset:
+    expect(full.stability.band_width).toBe(dnGoal(0.62) - dnGoal(0.41));
+    expect(full.stability.seed_flip_means).toEqual([dnGoal(0.41), null, dnGoal(0.47), dnGoal(0.62), null]);
+    expect(full.stability.n_seeds).toBe(5);
+    expect(full.stability.n_seeds_flipped).toBe(3);
+    // Positive control: this wire genuinely differs from the ISL bytes.
+    expect(full.stability.band_min).not.toBe(FULL_BAND.band_min);
+
+    // No-flip entry: band_* stay absent even under the map.
+    const noFlip = body.edge_e_values.find((e: { edge_id: string }) => e.edge_id === 'factor-c::goal');
+    expect(noFlip).toBeDefined();
+    for (const k of ['band_min', 'band_median', 'band_max', 'band_width']) {
+      expect(k in noFlip.stability).toBe(false);
+    }
+    expect(noFlip.stability.seed_flip_means).toEqual([null, null, null, null, null]);
+
+    // Flag-off entry: still no stability key.
     const bare = body.edge_e_values.find((e: { edge_id: string }) => e.edge_id === 'factor-d::goal');
     expect(bare).toBeDefined();
     expect('stability' in bare).toBe(false);


### PR DESCRIPTION
## Ruling implemented (Paul, 17 Jul)

Stability bands become **default-on in ISL** (flag removed) — this lane must merge+deploy FIRST so bands arrive unit-coherent. The ruling: bands get the **SAME transform as the adjacent `flip_mean`** — internal consistency. This PR implements exactly that, on top of #227's dark carry-through (base = staging tip `35fdaf92`, #227 merged).

## The invariant

**Band values are always in the same space as `flip_mean` on the same entry.**

- **Main path** (`normContext` + resolvable goal range — where `flip_mean` is denormalised, run.ts `transformEdgeEValues`): `band_min`/`band_median`/`band_max` and every non-null `seed_flip_means` cell receive the IDENTICAL affine `denormaliseValue` (v·(max−min)+min). **`band_width` is RECOMPUTED from the mapped endpoints** (mapped band_max − mapped band_min) — never offset-mapped: a width is a difference, and the `+min` offset would corrupt it (the lane-3 reviewer's explicit arithmetic note). Null seed cells stay null; counts (`n_seeds`/`n_seeds_flipped`) are space-invariant; key absent (never null) when ISL omits it; `band_*` absent stays absent (`n_seeds_flipped == 0` — nothing fabricated).
- **Fallback path** (no normContext) and **`_normalised: true` path** (normContext, no goal range): `flip_mean` is verbatim there, so bands stay VERBATIM — coherence is the invariant, not transformation. Degenerate goal range (max−min ≤ 0): both endpoints collapse to the constant → width 0, consistent with what `flip_mean` does there.

All four #227 documentation surfaces now state the invariant and the mixed-units caveat is removed: `isl-types.ts` type doc, `isl-to-ui.contract.ts` registry, OpenAPI prose, and the transform comment.

## RED → GREEN

Tests extended FIRST (transform unchanged): `Tests 2 failed | 8 passed (10)` — the REDs are exactly the 2 new mapping pins:
1. **Unit** (extends #227's normContext-path test): exact affine arithmetic on range **{min 10, max 60}** (positive control — min ≠ 0 AND width ≠ 1, so identity ranges can't pass vacuously): 0.41→30.5, 0.47→33.5, 0.62→41; `band_median === flip_mean` literal equality (same input, same map); **width 10.5 = dn(0.62)−dn(0.41), with the offset-corrupt value (dn(0.21)=20.5) pinned AGAINST**; single-flip point band collapses to the mapped point with width 0 (offset corruption would read 10); null-bearing `seed_flip_means` → `[30.5, null, 33.5, 41, null]`; no-flip `band_*` stay absent; counts untouched.
2. **Route e2e** under genuinely ACTIVE normalisation (interventions 80000/30000 trigger `needsNormalisation`; goal `state_space.range` {10,60}) — the RED failed at `band_min` AFTER its `flip_mean === 33.5` assertion passed, proving activation + sibling denorm work and only the band mapping was missing.

Plus a new coherence pin: on the `_normalised:true` path bands remain verbatim alongside verbatim `flip_mean`. After the change: **10/10 GREEN**.

## Mutation check (throwaway copy)

`git checkout origin/staging -- src/routes/v2/run.ts` in a throwaway `cp -a` clone (mapping gone, grep = 0 hits) → **`Tests 2 failed | 8 passed (10)`**, named split via verbose reporter:
- **RED**: "maps the stability band IDENTICALLY to flip_mean under active normalisation" (unit) + "under ACTIVE normalisation, egressed bands are mapped identically to flip_mean" (route) — exactly the 2 new pins.
- **GREEN**: all 5 #227 verbatim-path pins (unit verbatim ×2, unit absence, route verbatim, route flag-off) + envelope guard + numeric filter + the `_normalised:true` coherence test (verbatim both ways BY DESIGN). #227's contract undisturbed; the pin bites.

## Gates

- `npx tsc --noEmit` → exit 0.
- **Redocly problem-set diff** (exact CI command, `--skip-rule=no-unused-components`, ruleId+pointer sets vs `git show origin/staging:contracts/openapi.yaml`): head **76** vs base **76**, **SET DIFF EMPTY** — description prose only.
- `tools/gen-structural-keys.mjs` re-run → generated file IDENTICAL (same fields, new values — no new keys).
- Targeted suites (post `npm run build`): lane3 + numeric-egress-guards + isl-to-plot + boundary-isl-to-ui + track-s + enrichment-guard (route+unit) + structural-keys-drift + **isl-v2-golden-response byte pin UNCHANGED** + isl-wire-generation + intervention-normaliser + normalisation-parity (+.http) + golden + near-tie + determinism-replay + v2-determinism → **17 files / 308 tests PASS**.
- Pre-push hook full gate on push: **PASSED, Failures: 0** (`Tests 5585 passed | 25 skipped (5621)`; tsc, stale-js, file-dep policy, spectral — 6 checks).

## NOTE — Neil docket item (do not resolve here)

The deeper **strength-vs-outcome semantics** question is deliberately NOT redesigned here: ISL documents `flip_mean` as an EDGE-STRENGTH-space quantity, while PLoT's pre-existing denormalisation maps it through the GOAL-NODE outcome range. Whether that mapping is semantically right is logged for Neil **covering `flip_mean` AND bands together** — this PR guarantees internal consistency (bands ride whatever space `flip_mean` is in, on every path), so a future semantics ruling changes ONE transform site and coherence is preserved by construction.

Evidence: `acceptance-evidence/a3-verify-2026-07-16/lane4-BUILD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
