### PR TITLE
feat(quality): lenient latency limits — probes at base precision, raised budgets (A3 lane 5, Paul ruling)

### DIFF
--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -18,6 +18,7 @@
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
 import { computeMarginSensitivity, type MarginSensitivity } from './margin-sensitivity.js';
 import { resolveBoundedIntEnvOrWarn, MIN_N_SAMPLES, MAX_N_SAMPLES } from '../config/env-int.js';
+import { STANDARD_N_SAMPLES_DEFAULT } from '../config/sampling.js';
 
 // =============================================================================
 // Types
@@ -62,44 +63,88 @@ export interface FlipSearchConfig {
   overallTimeoutMs: number;
 }
 
+/**
+ * Paul-ruled lenient defaults 2026-07-17 — flip-search time budgets.
+ *
+ * Raised from 5_000/10_000 to 10_000/30_000 (per-factor/overall), the values
+ * MEASURED by the A3 budget-scout (acceptance-evidence/a3-verify-2026-07-16/
+ * budget-review.md, task 2c + ruling table): probes at base depth crowd the
+ * old 10 s overall budget (~10 probes × ~700 ms staging at depth 4000), and
+ * Paul's ruling is that analysis must not be cut off — a slow search should
+ * DISCLOSE itself, not truncate. Worst case with these budgets is ~35 s of
+ * flip search, well inside the UI's 120 s client timeout (the binding
+ * envelope hop; Render's platform cap is 100 MINUTES and never binds).
+ * The overall budget is additionally clamped at the call site
+ * (src/routes/v2/run.ts) to the REMAINING request budget so the raised
+ * default can never outlive the caller. Timeouts remain fully disclosed:
+ * flip_reason 'timeout' per entry + elapsed_ms on every diagnostics entry.
+ *
+ * ⚠ Watch-item (recorded in the lane-5 PR): with the base-depth raise to
+ * 10k, probes run at 10k (min(cap, base)) — ~2.5× the scout's depth-4000
+ * probe timings — so factors needing a full bisection may trip the 10 s
+ * per-factor budget on staging and disclose 'timeout'. The no-deploy
+ * mitigation knob is FLIP_PROBE_N_SAMPLES=4000 (env).
+ */
+export const DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS = 10_000;
+export const DEFAULT_FLIP_OVERALL_TIMEOUT_MS = 30_000;
+
+/** Env-or-default overall flip-search budget (before call-site budget clamping). */
+export function resolveFlipOverallTimeoutMs(): number {
+  return parseInt(process.env.FLIP_SEARCH_OVERALL_TIMEOUT_MS ?? String(DEFAULT_FLIP_OVERALL_TIMEOUT_MS), 10);
+}
+
+/** Env-or-default per-factor flip-search budget. Also caps each probe's ISL call. */
+export function resolveFlipPerFactorTimeoutMs(): number {
+  return parseInt(process.env.FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS ?? String(DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS), 10);
+}
+
 function getDefaultConfig(): FlipSearchConfig {
   const precisionTarget = 0.01;
   return {
     maxIterations: Math.ceil(Math.log2(1 / precisionTarget)),  // ~7 for [0,1]
     precisionTarget,
     maxGridPoints: 11,
-    perFactorTimeoutMs: parseInt(process.env.FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS ?? '5000', 10),
-    overallTimeoutMs: parseInt(process.env.FLIP_SEARCH_OVERALL_TIMEOUT_MS ?? '10000', 10),
+    perFactorTimeoutMs: resolveFlipPerFactorTimeoutMs(),
+    overallTimeoutMs: resolveFlipOverallTimeoutMs(),
   };
 }
 
 /**
- * Track S — Flip-probe sample depth (decoupled from base analysis depth).
+ * Flip-probe sample depth cap (probes run at BASE precision up to this cap).
  *
- * Each flip probe is a full ISL `comparison` call inside a binary search under a
- * fixed per-factor/overall time budget. If probes inherited the base analysis
- * `n_samples`, raising the base depth would slow every probe and push the search
- * into timeout (observed: flip-threshold timeouts rose from ~1/12 runs at 1000
- * samples to ~3/12 at 4000). Decoupling lets the base analysis use a higher depth
- * for display-stable probabilities while flip probes stay fast.
+ * Paul-ruled lenient defaults 2026-07-17: raised 1_000 → 10_000. Paul's
+ * ruling — prioritise analysis quality and scientific credibility over
+ * latency: flip thresholds computed at 1,000 samples while the base analysis
+ * runs at 4,000+ meant tipping points were an order of magnitude noisier than
+ * the probabilities displayed next to them. Probes now inherit the base
+ * analysis depth up to this cap (== MAX_N_SAMPLES, the /v2/run schema bound),
+ * so flip values carry the base analysis's precision. The flip-search time
+ * budgets were raised in step (see DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS /
+ * DEFAULT_FLIP_OVERALL_TIMEOUT_MS); a slow search now DISCLOSES itself
+ * (flip_reason 'timeout' + elapsed_ms) instead of silently shipping
+ * low-precision values. Track-S decoupling survives as the cap + the
+ * FLIP_PROBE_N_SAMPLES env override, no longer as a hard 1,000 floor-pin.
  */
-export const DEFAULT_FLIP_PROBE_N_SAMPLES = 1000;
+export const DEFAULT_FLIP_PROBE_N_SAMPLES = 10_000;
 
 /**
- * Resolve the sample depth to use for flip probes, independent of base depth.
+ * Resolve the sample depth to use for flip probes.
  *
  * Precedence:
  *  1. `FLIP_PROBE_N_SAMPLES` env — strictly parsed, in-bounds (100..10000) ops
  *     override (may exceed base); malformed/out-of-bounds values are ignored;
- *  2. otherwise `min(DEFAULT_FLIP_PROBE_N_SAMPLES, baseNSamples)` — probes never
- *     run deeper than the base, and crucially do NOT scale up when the base does.
+ *  2. otherwise `min(DEFAULT_FLIP_PROBE_N_SAMPLES, baseNSamples)` — probes run
+ *     at the base analysis's depth (base precision), capped at 10k; they never
+ *     run deeper than the base.
  */
 export function resolveFlipProbeNSamples(baseNSamples?: number): number {
   const envOverride = resolveBoundedIntEnvOrWarn('FLIP_PROBE_N_SAMPLES', MIN_N_SAMPLES, MAX_N_SAMPLES);
   if (envOverride !== null) return envOverride;
+  // Unknown base depth → assume the standard base default (4,000), never the
+  // 10k cap: "base precision" means matching the base, not maxing out.
   const base = typeof baseNSamples === 'number' && Number.isFinite(baseNSamples) && baseNSamples > 0
     ? baseNSamples
-    : DEFAULT_FLIP_PROBE_N_SAMPLES;
+    : STANDARD_N_SAMPLES_DEFAULT;
   return Math.min(DEFAULT_FLIP_PROBE_N_SAMPLES, base);
 }
 
@@ -138,6 +183,14 @@ export interface FlipDiagnostics {
    * non-finite baseline, or exception during the parallel probe phase).
    */
   margin_sensitivity?: MarginSensitivity;
+  /**
+   * Wall-clock ms this factor's search took, stamped on EVERY diagnostics
+   * entry (found / timeout / error / no_effect alike). Paul-ruled lenient
+   * defaults 2026-07-17: slowness must be VISIBLE — a 'timeout' trip without
+   * its elapsed time is an undiagnosable cutoff. Log-only (diagnostics never
+   * reach the public response).
+   */
+  elapsed_ms?: number;
 }
 
 // =============================================================================
@@ -200,6 +253,22 @@ export async function resolveFlipValues(
  * 7. Max iterations from precision target: ceil(log2(1 / precision_target))
  */
 async function searchFlipForFactor(
+  candidate: FlipThresholdInputData,
+  inferenceFn: ISLInferenceFn,
+  originalWinnerId: string,
+  config: FlipSearchConfig,
+  overallDeadline: number
+): Promise<{ result: FlipThresholdInputData; diagnostics: FlipDiagnostics }> {
+  // Stamp elapsed_ms on every diagnostics entry (all exit paths return the
+  // shared `diag` object). Paul-ruled lenient defaults 2026-07-17: slowness
+  // must be visible, especially on 'timeout' trips.
+  const searchStartedAt = Date.now();
+  const out = await searchFlipForFactorInner(candidate, inferenceFn, originalWinnerId, config, overallDeadline);
+  out.diagnostics.elapsed_ms = Date.now() - searchStartedAt;
+  return out;
+}
+
+async function searchFlipForFactorInner(
   candidate: FlipThresholdInputData,
   inferenceFn: ISLInferenceFn,
   originalWinnerId: string,

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -1,4 +1,5 @@
 import pino from 'pino';
+import { ISL_TIMEOUT_MS, CEE_TIMEOUT_MS } from './config/timeouts.js';
 
 const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
@@ -147,9 +148,14 @@ export function validateEnv(): void {
   // Ensure worst-case latency fits within proxy timeout
   // Default 600s (10 min) to accommodate long-running ISL/CEE operations with retries
   const PROXY_TIMEOUT_MS = Number(process.env.PROXY_TIMEOUT_MS || '600000');
-  const islTimeoutMs = Number(process.env.ISL_TIMEOUT_MS || '15000');
+  // Paul-ruled lenient defaults 2026-07-17: derive the resolved values from
+  // config/timeouts.ts instead of hand-mirroring defaults here — the mirrors
+  // had already drifted (15000 vs the real 30000 ISL default, 5000 vs the real
+  // 60000 CEE default), so this warn was doing its arithmetic on a codebase
+  // that didn't exist.
+  const islTimeoutMs = ISL_TIMEOUT_MS;
   const islMaxRetries = Number(process.env.ISL_MAX_RETRIES || '3');
-  const ceeTimeoutMs = Number(process.env.CEE_TIMEOUT_MS || '5000');
+  const ceeTimeoutMs = CEE_TIMEOUT_MS;
   const computeBudgetMs = Number(process.env.MAX_COMPUTE_MS || '10000');
 
   // ISL worst-case: timeout × retries (sequential retries with exponential backoff)

--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -23,8 +23,21 @@ import { resolveBoundedIntEnvOrWarn, MIN_N_SAMPLES, MAX_N_SAMPLES } from './env-
  * Compile-time standard base-analysis sample depth. Fixed (not env-derived) so
  * it can anchor deterministic, environment-independent fallbacks (e.g. the
  * canonical-hash default). The live request path uses resolveStandardNSamples().
+ *
+ * Paul-ruled lenient defaults 2026-07-17: raised 4000 → 10000 (the schema
+ * ceiling). A3 budget-scout measurement (acceptance-evidence/
+ * a3-verify-2026-07-16/budget-review.md, task 2a): depth is near-linear at
+ * ~22 ms per +1000 samples local (~110 ms staging), so 4000 → 10000 costs
+ * ~+0.7 s staging on the base call — trivially inside the UI's 120 s client
+ * timeout — while displayed probabilities gain ~sqrt(2.5) stability. The
+ * `STANDARD_N_SAMPLES` env var remains the emergency rollback knob.
+ * NOTE: the canonical request hash is sample-aware by design, so requests
+ * that omit n_samples hash differently after this raise — post-deploy
+ * freshness correctly sees a NEW analysis config (results at 10k are not
+ * results at 4k), invalidating stale-at-4k caches rather than forking
+ * identity.
  */
-export const STANDARD_N_SAMPLES_DEFAULT = 4000;
+export const STANDARD_N_SAMPLES_DEFAULT = 10_000;
 
 /**
  * Resolve the standard base-analysis sample depth for a request whose
@@ -58,8 +71,25 @@ export function resolveStandardNSamples(): number {
  * — real dense decision graphs hit a raw ISL 422 on the live path (verified:
  * acceptance-evidence/dense-graph-test attempt 6, 43 × 70 causal = 12,040,000).
  * PLoT mirrors the budget so it can adapt the depth BEFORE calling ISL.
+ *
+ * Paul-ruled lenient defaults 2026-07-17: raised 10M → 30M. Without this the
+ * base-depth raise (STANDARD_N_SAMPLES_DEFAULT 4000 → 10000) silently no-ops
+ * on any graph with filtered nodes × edges > 1000: the A3 budget-scout
+ * measured a 40n/120e graph at requested K=10000 being adaptively clamped
+ * back to n=4873 under the 10M budget (budget-review.md task 2e) — the
+ * silent-cap class. 30M keeps the worst-fit dense-graph base call inside the
+ * ISL client timeout with margin (scout: ~15-17 s staging); do NOT jump to
+ * 100M, which would breach it.
+ *
+ * ⚠ DEPLOY-ORDER COUPLING: ISL enforces the SAME budget (env
+ * `ISL_MAX_COMPUTE_COMPLEXITY`, ISL code default 10M at tip 5745154e). If
+ * PLoT's mirror is 30M while ISL still enforces 10M, PLoT under-reduces and
+ * dense graphs get a raw ISL 422 instead of today's disclosed adaptive
+ * reduction. ISL's matching raise (or `ISL_MAX_COMPUTE_COMPLEXITY=30000000`
+ * set on BOTH services) must land BEFORE or WITH this deploy — recorded as a
+ * CALLER ASK in the lane-5 PR.
  */
-export const ISL_COMPLEXITY_BUDGET_DEFAULT = 10_000_000;
+export const ISL_COMPLEXITY_BUDGET_DEFAULT = 30_000_000;
 
 /**
  * The floor for ADAPTIVE reductions: PLoT never lowers a requested depth

--- a/src/config/timeouts.ts
+++ b/src/config/timeouts.ts
@@ -63,25 +63,57 @@ export const CEE_PROXY_PROMPTS_WARM_TIMEOUT_MS =
 // ISL Timeouts
 // -----------------------------------------------------------------------------
 
-/** ISL request timeout */
+/**
+ * ISL request timeout.
+ *
+ * Paul-ruled lenient defaults 2026-07-17: raised 30_000 → 60_000. Paul's
+ * ruling: better to learn something is slow than have analysis cut off —
+ * prioritise analysis quality and scientific credibility. 60s accommodates
+ * ISL's own internal leniency raises (parallel ISL lane) plus the measured
+ * worst-fit dense-graph base call at the raised depth/complexity budget
+ * (A3 budget-scout: ~15-17s staging at K=10000/30M — inside 30s but without
+ * margin once ISL's raised internal budgets stack on top). Sits within the
+ * derived caller envelope: UI /v2 adapter 120s is the BINDING hop (Render's
+ * platform cap is 100 minutes, never binding). NOTE: CEE's non-brief
+ * PLOT_RUN_TIMEOUT_MS is 30s — a CALLER ASK to raise it is recorded in the
+ * lane-5 PR; until then CEE non-brief runs cannot benefit from the full 60s.
+ */
 export const ISL_TIMEOUT_MS =
-  Number(process.env.ISL_REQUEST_TIMEOUT_MS || process.env.ISL_TIMEOUT_MS) || 30_000;
+  Number(process.env.ISL_REQUEST_TIMEOUT_MS || process.env.ISL_TIMEOUT_MS) || 60_000;
 
 /** ISL health-check timeout */
 export const ISL_HEALTH_CHECK_TIMEOUT_MS =
   Number(process.env.ISL_HEALTH_CHECK_TIMEOUT_MS) || 5_000;
 
-/** ISL threshold analysis: maximum per-call timeout cap */
+/**
+ * ISL threshold analysis: maximum per-call timeout cap.
+ *
+ * Paul-ruled lenient defaults 2026-07-17: raised 10_000 → 30_000. Still
+ * min()-ed at the call site against (remaining request budget − 1s safety
+ * margin), so the effective timeout can never outlive the request budget —
+ * the raise only stops the CAP from truncating threshold analysis when
+ * budget remains.
+ */
 export const ISL_THRESHOLDS_TIMEOUT_MS_CAP =
-  Number(process.env.ISL_THRESHOLDS_TIMEOUT_MS_CAP) || 10_000;
+  Number(process.env.ISL_THRESHOLDS_TIMEOUT_MS_CAP) || 30_000;
 
 /** ISL threshold analysis: minimum remaining request budget to attempt call */
 export const THRESHOLDS_MIN_REMAINING_BUDGET_MS =
   Number(process.env.THRESHOLDS_MIN_REMAINING_BUDGET_MS) || 5_000;
 
-/** Overall request budget for /v2/run (used for threshold budget gating) */
+/**
+ * Overall request budget for /v2/run (used for threshold + flip-search
+ * budget gating).
+ *
+ * Paul-ruled lenient defaults 2026-07-17: raised 60_000 → 70_000, ≤58% of
+ * the BINDING caller bound — the UI /v2 adapter's 120s client timeout
+ * (verified at the bytes; Render's platform cap is 100 minutes and never
+ * binds). An internal budget that outlives the caller delivers nothing —
+ * this is deliberately NOT raised nearer 120s while the CEE non-brief
+ * caller sits at 30s (CALLER ASK recorded in the lane-5 PR).
+ */
 export const REQUEST_BUDGET_MS =
-  Number(process.env.REQUEST_BUDGET_MS) || 60_000;
+  Number(process.env.REQUEST_BUDGET_MS) || 70_000;
 
 // -----------------------------------------------------------------------------
 // Fastify server timeout

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -112,7 +112,7 @@ import {
   THRESHOLDS_MIN_REMAINING_BUDGET_MS,
   REQUEST_BUDGET_MS,
 } from '../../config/timeouts.js';
-import { createISLInferenceFn, resolveFlipValues, resolveFlipProbeNSamples } from '../../analysis/flip-thresholds.js';
+import { createISLInferenceFn, resolveFlipValues, resolveFlipProbeNSamples, resolveFlipOverallTimeoutMs, resolveFlipPerFactorTimeoutMs } from '../../analysis/flip-thresholds.js';
 import { computeFlipThresholdData, getFactorsOverriddenByAllOptions } from '../../coaching/flip-thresholds.js';
 import { denormaliseFlipThresholds, type DenormalisedFlipThreshold } from '../../lib/flip-threshold-denormaliser.js';
 import { classifyFlipThresholdsStatus } from '../../lib/flip-threshold-status.js';
@@ -5656,17 +5656,51 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                 // (`nSamples`), so raising base depth cannot silently push probes into
                 // timeout. See resolveFlipProbeNSamples / FLIP_PROBE_N_SAMPLES.
                 flipProbeNSamples = resolveFlipProbeNSamples(nSamples);
+                // Paul-ruled lenient defaults 2026-07-17: each probe's ISL call is
+                // capped at the per-factor budget — a probe has no use for time its
+                // factor no longer has. (Without this cap a single in-flight probe
+                // could add a full ISL_TIMEOUT_MS tail past the flip deadline.)
+                const flipProbeIslTimeoutMs = resolveFlipPerFactorTimeoutMs();
                 const flipInferenceFn = createISLInferenceFn(
-                  (endpoint, body, rid) => islService.callAnalysisEndpoint(endpoint, body, rid),
+                  (endpoint, body, rid) => islService.callAnalysisEndpoint(endpoint, body, rid, flipProbeIslTimeoutMs),
                   islRequest,
                   requestId,
                   flipProbeNSamples
                 );
 
+                // Envelope guard (Paul-ruled lenient defaults 2026-07-17): the raised
+                // flip budget is clamped to the REMAINING request budget. Before the
+                // raises, base ISL (30s) + flip (10s) could never exceed the 60s
+                // request budget; after them (60s + 60s) it could — and an internal
+                // budget that outlives the caller's timeout delivers nothing. The
+                // clamp is DISCLOSED, never silent: a clamped/exhausted search trips
+                // per-entry flip_reason 'timeout' with elapsed_ms, and the clamp
+                // itself is logged below.
+                const flipStartMs = performance.now();
+                const flipConfiguredOverallMs = resolveFlipOverallTimeoutMs();
+                const flipRequestBudgetMs = Number(process.env.REQUEST_BUDGET_MS) || REQUEST_BUDGET_MS;
+                const flipRemainingBudgetMs = flipRequestBudgetMs - (flipStartMs - startTime);
+                const flipSafetyMarginMs = 1_000;
+                const flipOverallTimeoutMs = Math.min(
+                  flipConfiguredOverallMs,
+                  Math.max(0, flipRemainingBudgetMs - flipSafetyMarginMs)
+                );
+                if (flipOverallTimeoutMs < flipConfiguredOverallMs) {
+                  req.log.info({
+                    event: 'flip_thresholds_budget_clamped',
+                    request_id: requestId,
+                    configured_overall_timeout_ms: flipConfiguredOverallMs,
+                    clamped_overall_timeout_ms: Math.round(flipOverallTimeoutMs),
+                    remaining_budget_ms: Math.round(flipRemainingBudgetMs),
+                    request_budget_ms: flipRequestBudgetMs,
+                  });
+                }
+
                 const flipResult = await resolveFlipValues(
                   flipCandidates,
                   flipInferenceFn,
-                  winnerId
+                  winnerId,
+                  { overallTimeoutMs: flipOverallTimeoutMs }
                 );
                 resolvedFlipData = flipResult.results;
 
@@ -5674,6 +5708,10 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                   event: 'flip_thresholds_resolved',
                   request_id: requestId,
                   count: resolvedFlipData.length,
+                  // Paul-ruled lenient defaults 2026-07-17: slowness visible — block
+                  // wall-time + probe depth alongside per-factor elapsed_ms in factors.
+                  elapsed_ms: Math.round(performance.now() - flipStartMs),
+                  flip_probe_n_samples: flipProbeNSamples,
                   factors: flipResult.diagnostics,
                 });
               } else {
@@ -5700,6 +5738,10 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               event: 'flip_thresholds_error',
               request_id: requestId,
               error: (err as Error).message,
+              // Paul-ruled lenient defaults 2026-07-17: failures carry their
+              // wall-time too — a crash after 55s and a crash after 50ms are
+              // different diagnoses.
+              elapsed_ms: Math.round(performance.now() - startTime),
             });
             // Continue without flip thresholds — non-blocking
           }

--- a/tests/adaptive-n-samples-complexity.test.ts
+++ b/tests/adaptive-n-samples-complexity.test.ts
@@ -38,56 +38,57 @@ import {
 
 describe('applyComplexityBudget (unit)', () => {
   it('leaves depth unchanged when complexity is within the ISL budget', () => {
-    // 4000 × 3 × 2 = 24,000 ≪ 10,000,000
+    // 4000 × 3 × 2 = 24,000 ≪ 30,000,000 (Paul-ruled lenient default 2026-07-17)
     const d = applyComplexityBudget(4000, 3, 2);
     expect(d.kind).toBe('unchanged');
     if (d.kind === 'unchanged') expect(d.nSamples).toBe(4000);
   });
 
   it('allows complexity exactly at the budget (ISL blocks only strictly above the limit)', () => {
-    // 1000 × 100 × 100 = 10,000,000 == budget → allowed, unchanged
-    const d = applyComplexityBudget(1000, 100, 100);
+    // 3000 × 100 × 100 = 30,000,000 == budget → allowed, unchanged
+    const d = applyComplexityBudget(3000, 100, 100);
     expect(d.kind).toBe('unchanged');
   });
 
   it('reduces depth to floor(budget / (nodes × edges)) when over budget', () => {
-    // 4000 × 52 × 51 = 10,608,000 > 10,000,000
-    // floor(10,000,000 / 2,652) = 3,770 → 3,770 × 2,652 = 9,998,040 ≤ budget
-    const d = applyComplexityBudget(4000, 52, 51);
+    // 10000 × 60 × 51 = 30,600,000 > 30,000,000
+    // floor(30,000,000 / 3,060) = 9,803 → 9,803 × 3,060 = 29,997,180 ≤ budget
+    const d = applyComplexityBudget(10_000, 60, 51);
     expect(d.kind).toBe('reduced');
     if (d.kind === 'reduced') {
-      expect(d.nSamples).toBe(3770);
-      expect(d.originalNSamples).toBe(4000);
-      expect(d.nSamples * 52 * 51).toBeLessThanOrEqual(ISL_COMPLEXITY_BUDGET_DEFAULT);
+      expect(d.nSamples).toBe(9803);
+      expect(d.originalNSamples).toBe(10_000);
+      expect(d.nSamples * 60 * 51).toBeLessThanOrEqual(ISL_COMPLEXITY_BUDGET_DEFAULT);
       // One more sample would breach the budget — maximal honest depth.
-      expect((d.nSamples + 1) * 52 * 51).toBeGreaterThan(ISL_COMPLEXITY_BUDGET_DEFAULT);
+      expect((d.nSamples + 1) * 60 * 51).toBeGreaterThan(ISL_COMPLEXITY_BUDGET_DEFAULT);
     }
   });
 
   it('reduces to exactly the 1,000-sample floor when that is what fits', () => {
-    // nodes × edges = 10,000 → floor(10,000,000 / 10,000) = 1,000 == floor
-    const d = applyComplexityBudget(4000, 100, 100);
+    // nodes × edges = 30,000 → floor(30,000,000 / 30,000) = 1,000 == floor
+    const d = applyComplexityBudget(4000, 150, 200);
     expect(d.kind).toBe('reduced');
     if (d.kind === 'reduced') expect(d.nSamples).toBe(ADAPTIVE_N_SAMPLES_FLOOR);
   });
 
   it('refuses when even the 1,000-sample floor exceeds the budget', () => {
-    // nodes × edges = 10,302 → floor(10,000,000 / 10,302) = 970 < 1,000
-    const d = applyComplexityBudget(4000, 102, 101);
+    // nodes × edges = 30,625 → floor(30,000,000 / 30,625) = 979 < 1,000
+    const d = applyComplexityBudget(4000, 175, 175);
     expect(d.kind).toBe('refused');
   });
 
   it('respects an explicit low depth that already fits (no raise, no reduction)', () => {
-    // 500 × 100 × 150 = 7,500,000 ≤ budget — even though nodes × edges > 10,000
-    // would refuse AT the floor, the caller's smaller explicit depth fits as-is.
-    const d = applyComplexityBudget(500, 100, 150);
+    // 500 × 200 × 160 = 16,000,000 ≤ budget — even though nodes × edges (32,000)
+    // would refuse AT the floor (32M > 30M), the caller's smaller explicit
+    // depth fits as-is.
+    const d = applyComplexityBudget(500, 200, 160);
     expect(d.kind).toBe('unchanged');
     if (d.kind === 'unchanged') expect(d.nSamples).toBe(500);
   });
 
   it('refuses an explicit depth whose graph cannot fit even at the floor', () => {
-    // 1500 × 102 × 101 = 15,453,000 > budget; fitting depth 970 < floor → refuse
-    const d = applyComplexityBudget(1500, 102, 101);
+    // 1500 × 175 × 175 = 45,937,500 > budget; fitting depth 979 < floor → refuse
+    const d = applyComplexityBudget(1500, 175, 175);
     expect(d.kind).toBe('refused');
   });
 
@@ -99,10 +100,12 @@ describe('applyComplexityBudget (unit)', () => {
   it('honours the ISL_MAX_COMPUTE_COMPLEXITY env override at call time', () => {
     const prev = process.env.ISL_MAX_COMPUTE_COMPLEXITY;
     try {
-      process.env.ISL_MAX_COMPUTE_COMPLEXITY = '20000000';
-      expect(resolveComplexityBudget()).toBe(20_000_000);
-      // 4000 × 52 × 51 = 10,608,000 ≤ 20,000,000 → unchanged under the raised budget
-      expect(applyComplexityBudget(4000, 52, 51).kind).toBe('unchanged');
+      // A LOWERED override must win over the raised 30M default — an override
+      // that merely re-allows what the default already allows proves nothing.
+      process.env.ISL_MAX_COMPUTE_COMPLEXITY = '5000000';
+      expect(resolveComplexityBudget()).toBe(5_000_000);
+      // 4000 × 52 × 51 = 10,608,000 > 5,000,000 → reduced under the lowered budget
+      expect(applyComplexityBudget(4000, 52, 51).kind).toBe('reduced');
     } finally {
       if (prev === undefined) delete process.env.ISL_MAX_COMPUTE_COMPLEXITY;
       else process.env.ISL_MAX_COMPUTE_COMPLEXITY = prev;
@@ -234,7 +237,7 @@ describe('adaptive n_samples via /v2/run', () => {
 
   it('dense graph: reduces n_samples before calling ISL and attaches SAMPLES_REDUCED_FOR_COMPLEXITY naming original and reduced depths', async () => {
     islCalls = [];
-    // 43 factors + goal = 44 nodes, 85 edges → 4000 × 3,740 = 14,960,000 > 10M
+    // 43 factors + goal = 44 nodes, 85 edges → 10000 × 3,740 = 37,400,000 > 30M
     const res = await app.inject({
       method: 'POST',
       url: '/v2/run',
@@ -249,11 +252,11 @@ describe('adaptive n_samples via /v2/run', () => {
 
     expect(res.statusCode).toBe(200);
 
-    // ISL received the reduced depth — floor(10,000,000 / (44 × 85)) = 2,673
+    // ISL received the reduced depth — floor(30,000,000 / (44 × 85)) = 8,021
     expect(islCalls.length).toBeGreaterThan(0);
     expect(islCalls[0].graph.nodes).toHaveLength(44);
     expect(islCalls[0].graph.edges).toHaveLength(85);
-    expect(islCalls[0].n_samples).toBe(2673);
+    expect(islCalls[0].n_samples).toBe(8021);
     // No ISL call of any kind (base or probe) may breach the budget.
     for (const call of islCalls) {
       expect(call.n_samples * call.graph.nodes.length * call.graph.edges.length)
@@ -262,19 +265,19 @@ describe('adaptive n_samples via /v2/run', () => {
 
     const body = JSON.parse(res.body);
     // The response reports the TRUE depth used, not the requested default.
-    expect(body.meta?.n_samples).toBe(2673);
+    expect(body.meta?.n_samples).toBe(8021);
 
     // Exactly one warning, carried on the inference_warnings surface
     // (the CONSTRAINT_DIRECTION_SUSPECT pattern), naming both depths.
     const warnings = findSamplesReducedWarnings(body);
     expect(warnings).toHaveLength(1);
     expect(warnings[0].severity).toBe('warning');
-    expect(warnings[0].message).toContain('4000');
-    expect(warnings[0].message).toContain('2673');
+    expect(warnings[0].message).toContain('10000');
+    expect(warnings[0].message).toContain('8021');
   });
 
   it('graph too complex even at the floor: refuses with GRAPH_TOO_COMPLEX before calling ISL — never a raw ISL 422 passthrough', async () => {
-    // At the DEFAULT budget the refusal arm needs nodes × edges > 10,000,
+    // At the DEFAULT budget the refusal arm needs nodes × edges > 30,000,
     // which PLoT's own 50-node/100-edge graph limits keep out of reach
     // (max product 5,000) — preflight GRAPH_TOO_LARGE fires first. The arm
     // is live protection for a lowered ISL_MAX_COMPUTE_COMPLEXITY (the env
@@ -324,7 +327,7 @@ describe('adaptive n_samples via /v2/run', () => {
       url: '/v2/run',
       headers: { 'Content-Type': 'application/json' },
       payload: {
-        graph: denseGraph(2), // 3 nodes × 3 edges → 4000 × 9 = 36,000
+        graph: denseGraph(2), // 3 nodes × 3 edges → 10000 × 9 = 90,000
         options: OPTIONS,
         goal_node_id: 'goal',
         seed: '42',
@@ -332,9 +335,9 @@ describe('adaptive n_samples via /v2/run', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(islCalls[0].n_samples).toBe(4000);
+    expect(islCalls[0].n_samples).toBe(10_000);
     const body = JSON.parse(res.body);
-    expect(body.meta?.n_samples).toBe(4000);
+    expect(body.meta?.n_samples).toBe(10_000);
     expect(findSamplesReducedWarnings(body)).toHaveLength(0);
   });
 
@@ -345,22 +348,22 @@ describe('adaptive n_samples via /v2/run', () => {
       url: '/v2/run',
       headers: { 'Content-Type': 'application/json' },
       payload: {
-        graph: denseGraph(43), // 44 × 85 = 3,740 → floor(10M / 3,740) = 2,673
+        graph: denseGraph(43), // 44 × 85 = 3,740 → floor(30M / 3,740) = 8,021
         options: OPTIONS,
         goal_node_id: 'goal',
         seed: '42',
-        n_samples: 8000,
+        n_samples: 10000,
       },
     });
 
     expect(res.statusCode).toBe(200);
-    expect(islCalls[0].n_samples).toBe(2673);
+    expect(islCalls[0].n_samples).toBe(8021);
     const body = JSON.parse(res.body);
-    expect(body.meta?.n_samples).toBe(2673);
+    expect(body.meta?.n_samples).toBe(8021);
     const warnings = findSamplesReducedWarnings(body);
     expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain('8000');
-    expect(warnings[0].message).toContain('2673');
+    expect(warnings[0].message).toContain('10000');
+    expect(warnings[0].message).toContain('8021');
   });
 
   it('explicit caller n_samples within budget is respected exactly, with no warning', async () => {

--- a/tests/cil-canonical-hash-v3.test.ts
+++ b/tests/cil-canonical-hash-v3.test.ts
@@ -134,7 +134,7 @@ describe('CIL C2: Canonical hash with goal_constraints', () => {
 
     // Track S: HASH_VERSION bumped 6→7 (n_samples added to canonical form).
     expect(parsed.version).toBe(7);
-    expect(parsed.n_samples).toBe(4000); // PR-E: standard default depth raised 1000→4000
+    expect(parsed.n_samples).toBe(10_000); // Paul-ruled lenient defaults 2026-07-17: standard depth 4000→10000 (PR-E was 1000→4000)
     expect(parsed.goal_constraints).toBeDefined();
     expect(parsed.goal_constraints).toHaveLength(1);
     expect(parsed.goal_constraints[0].constraint_id).toBe('c1');

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -1188,11 +1188,11 @@
     "reason": "CEE feature disabled"
   },
   "processing_time_ms": "__VOLATILE__",
-  "response_hash": "195f3c2552217c57",
+  "response_hash": "60e3ac213554be4f",
   "decision_brief": {
-    "brief_id": "4cabf774-12b1-4aa1-b28b-fb88093a683f",
+    "brief_id": "599e531e-c6b4-4f60-9926-a1c19f9bf367",
     "version": "1",
-    "graph_hash": "195f3c2552217c57",
+    "graph_hash": "60e3ac213554be4f",
     "seed": 2034401427,
     "created_at": "__VOLATILE__",
     "headline": "Hire One Tech Lead currently leads, but the outcome is highly uncertain. However, the 59% recommendation stability indicates the decision could shift with new information. Define tie-breaker criteria or gather additional evidence.",
@@ -1257,9 +1257,9 @@
       }
     ],
     "lineage": {
-      "config_version": "2b3c700a4863",
-      "response_hash": "195f3c2552217c57",
-      "n_samples": 4000
+      "config_version": "0c29e308b4b3",
+      "response_hash": "60e3ac213554be4f",
+      "n_samples": 10000
     },
     "headline_banded": {
       "text": "Hire One Tech Lead is slightly ahead.",
@@ -1310,7 +1310,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "3e7a7ee90a6f2460"
     },
@@ -1335,7 +1335,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "d085afe35bc8cc9f"
     },
@@ -1360,7 +1360,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "80a265760799c6c3"
     },
@@ -1385,7 +1385,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "83b435b6b5b3df12"
     },
@@ -1414,7 +1414,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "6328d59d1577f9e9"
     },
@@ -1443,7 +1443,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "1b078eb246e060e2"
     },
@@ -1472,7 +1472,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "29dd19919af45252"
     },
@@ -1501,7 +1501,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "43d316b1bc131bbd"
     },
@@ -1522,7 +1522,7 @@
         "seed": 2034401427,
         "config_version": "1",
         "isl_request_id": "__VOLATILE__",
-        "n_samples": 4000
+        "n_samples": 10000
       },
       "content_hash": "746563481e476303"
     }
@@ -1533,7 +1533,7 @@
     "request_id": "__VOLATILE__",
     "plot_build": "__VOLATILE__",
     "hash_version": 7,
-    "response_hash": "195f3c2552217c57",
+    "response_hash": "60e3ac213554be4f",
     "request_id_chain": {
       "ui": null,
       "plot": "__VOLATILE__",
@@ -1598,13 +1598,12 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:5c675374cdaeb9e3"
+    "response_content_hash": "rch_v2:96feaa2a2e028dfd"
   },
   "meta": {
     "seed_used": "2034401427",
     "seed_source": "client_generated",
-    "n_samples": 4000,
-    "flip_probe_n_samples": 1000,
+    "n_samples": 10000,
     "detail_level": "standard",
     "latency_ms": "__VOLATILE__",
     "normalization_ms": "__VOLATILE__",

--- a/tests/flip-probe-depth-decoupling.test.ts
+++ b/tests/flip-probe-depth-decoupling.test.ts
@@ -1,9 +1,14 @@
 /**
- * Track S — Flip-probe sample-depth decoupling (H3)
+ * Track S (revised) — Flip-probe sample-depth control
  *
- * Flip probes must NOT inherit the base analysis `n_samples`. Raising the base
- * depth (for display-stable probabilities) must not silently push flip probes
- * into timeout. These tests pin the contract: probe depth is its own control.
+ * HISTORY: Track S originally pinned probes to min(1000, base) so raising the
+ * base depth could not push probes into the (then 5s/10s) flip timeouts.
+ * Paul-ruled lenient defaults 2026-07-17 inverted the trade: probes now run at
+ * BASE precision up to a 10k cap (flip values carry the precision of the
+ * displayed probabilities), and the flip time budgets were raised 6x in step.
+ * What SURVIVES of decoupling — and is pinned here — is the control itself:
+ * the 10k cap, the never-deeper-than-base rule, and the FLIP_PROBE_N_SAMPLES
+ * env override with strict parsing.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -23,7 +28,7 @@ const ORIGINAL = {
   },
   options: [{ id: 'opt1' }, { id: 'opt2' }],
   goal_node_id: 'goal',
-  n_samples: 4000, // base analysis depth (raised)
+  n_samples: 4000, // base analysis depth
   parameter_uncertainties: [{ node_id: 'factor-a', distribution: 'normal', mean: 1.0, std: 0.3 }],
   seed: '42',
 };
@@ -46,17 +51,18 @@ beforeEach(() => { vi.spyOn(console, 'warn').mockImplementation(() => {}); });
 afterEach(() => { delete process.env[ENV_KEY]; vi.restoreAllMocks(); });
 
 describe('resolveFlipProbeNSamples', () => {
-  it('does NOT scale up when the base depth is raised (decoupled)', () => {
+  it('runs probes at BASE precision up to the 10k cap (Paul ruling 2026-07-17)', () => {
     expect(resolveFlipProbeNSamples(1000)).toBe(1000);
-    expect(resolveFlipProbeNSamples(4000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES); // stays at 1000
-    expect(resolveFlipProbeNSamples(8000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES);
+    expect(resolveFlipProbeNSamples(4000)).toBe(4000); // was pinned to 1000 pre-ruling
+    expect(resolveFlipProbeNSamples(8000)).toBe(8000);
+    expect(resolveFlipProbeNSamples(12_000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES); // capped at 10k
   });
 
   it('never runs probes deeper than the base depth', () => {
     expect(resolveFlipProbeNSamples(500)).toBe(500);
   });
 
-  it('honours an explicit FLIP_PROBE_N_SAMPLES env override (may exceed default)', () => {
+  it('honours an explicit FLIP_PROBE_N_SAMPLES env override (decoupled from base)', () => {
     process.env[ENV_KEY] = '2000';
     expect(resolveFlipProbeNSamples(4000)).toBe(2000);
     expect(resolveFlipProbeNSamples(1000)).toBe(2000);
@@ -64,25 +70,26 @@ describe('resolveFlipProbeNSamples', () => {
 
   it('ignores a malformed env value', () => {
     process.env[ENV_KEY] = 'not-a-number';
-    expect(resolveFlipProbeNSamples(4000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES);
+    expect(resolveFlipProbeNSamples(4000)).toBe(4000); // falls back to min(cap, base)
   });
 
   it('ignores parseInt foot-guns and out-of-bounds env values (falls back, never misparses)', () => {
     for (const bad of ['1,000', '4_000', '1000abc', '1.5', '-5', '50000', '99', '0']) {
       process.env[ENV_KEY] = bad;
-      // Falls back to min(1000, base) — never to a misparsed value like 1 or 4.
-      expect(resolveFlipProbeNSamples(4000)).toBe(DEFAULT_FLIP_PROBE_N_SAMPLES);
+      // Falls back to min(10000, base) — never to a misparsed value like 1 or 4.
+      expect(resolveFlipProbeNSamples(4000)).toBe(4000);
     }
   });
 });
 
 describe('createISLInferenceFn probe depth', () => {
-  it('sends the probe depth, not the base depth, to ISL', async () => {
-    const probeDepth = resolveFlipProbeNSamples(ORIGINAL.n_samples); // 1000, base is 4000
+  it('sends the RESOLVED probe depth to ISL (env override proves the control is live)', async () => {
+    process.env[ENV_KEY] = '2000';
+    const probeDepth = resolveFlipProbeNSamples(ORIGINAL.n_samples); // 2000: env wins over base 4000
     const { fn, seen } = recordingInference(probeDepth);
     await fn('factor-a', 0.5);
-    expect(seen).toEqual([1000]);
-    expect(seen[0]).not.toBe(ORIGINAL.n_samples); // base raise did not reach the probe
+    expect(seen).toEqual([2000]);
+    expect(seen[0]).not.toBe(ORIGINAL.n_samples); // the probe-depth control reached the wire
   });
 
   it('falls back to base depth when no probe depth is supplied (legacy)', async () => {

--- a/tests/lenient-latency-values.pin.test.ts
+++ b/tests/lenient-latency-values.pin.test.ts
@@ -1,0 +1,148 @@
+/**
+ * A3 lane 5 — VALUE PINS for the Paul-ruled lenient latency defaults (2026-07-17).
+ *
+ * Paul's ruling: raise latency limits to be much more lenient — better to learn
+ * something is slow than have analysis cut off; prioritise analysis quality and
+ * scientific credibility.
+ *
+ * Every raised default is pinned to its EXACT value so a silent revert (merge
+ * accident, "helpful" tidy-up, stale-mirror re-introduction) goes RED, not
+ * quiet. If you change one of these numbers deliberately, update the pin in the
+ * same commit WITH the reasoning — that is the point of the pin.
+ *
+ * Envelope (derived at the bytes + scout-measured, 2026-07-17 — see PR body
+ * and acceptance-evidence/a3-verify-2026-07-16/budget-review.md):
+ * UI /v2 adapter 120s = the BINDING hop; CEE non-brief 30s (CALLER ASK
+ * recorded to raise); CEE brief 75s; Render platform cap 100 MINUTES
+ * (never binds).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  DEFAULT_FLIP_PROBE_N_SAMPLES,
+  DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS,
+  DEFAULT_FLIP_OVERALL_TIMEOUT_MS,
+  resolveFlipProbeNSamples,
+  resolveFlipPerFactorTimeoutMs,
+  resolveFlipOverallTimeoutMs,
+  resolveFlipValues,
+  type ISLInferenceFn,
+} from '../src/analysis/flip-thresholds.js';
+import {
+  ISL_TIMEOUT_MS,
+  ISL_THRESHOLDS_TIMEOUT_MS_CAP,
+  REQUEST_BUDGET_MS,
+} from '../src/config/timeouts.js';
+import {
+  STANDARD_N_SAMPLES_DEFAULT,
+  ISL_COMPLEXITY_BUDGET_DEFAULT,
+} from '../src/config/sampling.js';
+import type { FlipThresholdInputData } from '../src/cee/validation/m1-review-types.js';
+
+const ENV_KEYS = [
+  'FLIP_PROBE_N_SAMPLES',
+  'FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS',
+  'FLIP_SEARCH_OVERALL_TIMEOUT_MS',
+] as const;
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+  vi.restoreAllMocks();
+});
+
+describe('Paul-ruled lenient defaults 2026-07-17 — exact value pins', () => {
+  it('flip-probe depth cap is 10,000 (probes at base precision up to 10k)', () => {
+    expect(DEFAULT_FLIP_PROBE_N_SAMPLES).toBe(10_000);
+  });
+
+  it('flip-search budgets are 10s per factor / 30s overall (scout-measured raise)', () => {
+    expect(DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS).toBe(10_000);
+    expect(DEFAULT_FLIP_OVERALL_TIMEOUT_MS).toBe(30_000);
+    // The resolvers feed getDefaultConfig AND the run.ts probe/clamp call sites —
+    // pin them too so the constants cannot be silently bypassed.
+    expect(resolveFlipPerFactorTimeoutMs()).toBe(10_000);
+    expect(resolveFlipOverallTimeoutMs()).toBe(30_000);
+  });
+
+  it('base MC depth default is 10,000 and the complexity mirror is 30M (paired raise)', () => {
+    // Scout task 2e: raising K without raising the complexity budget silently
+    // no-ops on graphs with nodes x edges > 1000 (measured: 10000 -> 4873).
+    expect(STANDARD_N_SAMPLES_DEFAULT).toBe(10_000);
+    expect(ISL_COMPLEXITY_BUDGET_DEFAULT).toBe(30_000_000);
+  });
+
+  it('ISL request timeout default is 60s', () => {
+    // NOTE: read at module import from env; the test env must not set
+    // ISL_TIMEOUT_MS / ISL_REQUEST_TIMEOUT_MS (env-guard setup does not).
+    expect(ISL_TIMEOUT_MS).toBe(60_000);
+  });
+
+  it('ISL thresholds per-call cap default is 30s', () => {
+    expect(ISL_THRESHOLDS_TIMEOUT_MS_CAP).toBe(30_000);
+  });
+
+  it('/v2/run request budget default is 70s (70% of the ~100s platform bound)', () => {
+    expect(REQUEST_BUDGET_MS).toBe(70_000);
+  });
+});
+
+describe('flip probes run at base precision (behavioural, not just the constant)', () => {
+  it('inherits the base depth up to the 10k cap — the old 1,000 pin is gone', () => {
+    // RED against the pre-ruling code, which returned min(1000, base):
+    expect(resolveFlipProbeNSamples(4000)).toBe(4000);
+    expect(resolveFlipProbeNSamples(8000)).toBe(8000);
+    expect(resolveFlipProbeNSamples(10_000)).toBe(10_000);
+  });
+
+  it('still never probes deeper than the base, and caps at 10k', () => {
+    expect(resolveFlipProbeNSamples(500)).toBe(500);
+    expect(resolveFlipProbeNSamples(20_000)).toBe(10_000);
+  });
+
+  it('unknown base depth falls back to the standard base default (now 10k)', () => {
+    expect(resolveFlipProbeNSamples(undefined)).toBe(STANDARD_N_SAMPLES_DEFAULT);
+  });
+});
+
+describe('timeout trips are visible: elapsed_ms on flip diagnostics', () => {
+  const candidate: FlipThresholdInputData = {
+    factor_id: 'factor-a',
+    factor_label: 'Factor A',
+    current_value: 0.5,
+    flip_value: null,
+    direction: 'increase',
+  };
+
+  const neverFlips: ISLInferenceFn = async () => ({
+    options: [
+      { option_id: 'opt1', win_probability: 0.7 },
+      { option_id: 'opt2', win_probability: 0.3 },
+    ],
+  });
+
+  it('a timeout trip carries elapsed_ms (slowness is diagnosable)', async () => {
+    const { results, diagnostics } = await resolveFlipValues(
+      [candidate],
+      neverFlips,
+      'opt1',
+      { perFactorTimeoutMs: 0, overallTimeoutMs: 0 }
+    );
+    expect(results[0]!.flip_reason).toBe('timeout');
+    expect(typeof diagnostics[0]!.elapsed_ms).toBe('number');
+    expect(diagnostics[0]!.elapsed_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('positive control: a completed (non-timeout) search carries elapsed_ms too', async () => {
+    const { results, diagnostics } = await resolveFlipValues(
+      [candidate],
+      neverFlips,
+      'opt1'
+    );
+    expect(results[0]!.flip_reason).toBe('no_effect_within_bounds');
+    expect(typeof diagnostics[0]!.elapsed_ms).toBe('number');
+  });
+});

--- a/tests/sample-depth-provenance.test.ts
+++ b/tests/sample-depth-provenance.test.ts
@@ -63,12 +63,13 @@ describe('Decision-brief lineage sample-depth awareness', () => {
 
   it('omitted depth reproduces the standard-default config_version', () => {
     // A brief with no depth hashes the same as one at the standard default
-    // (PR-E: 4000), and differs from a non-default depth.
+    // (Paul-ruled lenient defaults 2026-07-17: 10000; PR-E was 4000), and
+    // differs from a non-default depth.
     expect(assembleBrief(baseInput(undefined))?.lineage.config_version).toBe(
-      assembleBrief(baseInput(4000))?.lineage.config_version
+      assembleBrief(baseInput(10_000))?.lineage.config_version
     );
     expect(assembleBrief(baseInput(undefined))?.lineage.config_version).not.toBe(
-      assembleBrief(baseInput(1000))?.lineage.config_version
+      assembleBrief(baseInput(4000))?.lineage.config_version
     );
   });
 });

--- a/tests/standard-n-samples-default.test.ts
+++ b/tests/standard-n-samples-default.test.ts
@@ -1,11 +1,16 @@
 /**
- * Track S PR-E — Standard MC sample depth default 1000→4000, with env rollback.
+ * Track S PR-E (revised) — Standard MC sample depth default, with env rollback.
+ *
+ * HISTORY: PR-E raised the default 1000→4000; Paul-ruled lenient defaults
+ * 2026-07-17 raised it again 4000→10000 (the schema ceiling; scout-measured
+ * +0.7s staging — budget-review.md task 2a) and flip probes now RUN AT base
+ * precision up to the 10k cap instead of being pinned to 1000.
  *
  * Machine-enforced acceptance proof:
- *  - default unset → standard depth resolves to 4000;
+ *  - default unset → standard depth resolves to 10000;
  *  - STANDARD_N_SAMPLES=1000 → resolves to 1000 (emergency rollback);
- *  - response hash differs between 1000 and 4000;
- *  - flip probes stay at their independent depth (do NOT inherit base 4000).
+ *  - response hash differs between depths (sample-aware hash);
+ *  - flip probes follow base depth up to the 10k cap (Paul ruling).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -38,10 +43,10 @@ const REQ = {
 } as unknown as RunRequestV3;
 
 describe('PR-E standard sample depth', () => {
-  it('default (env unset) resolves to 4000', () => {
+  it('default (env unset) resolves to 10000 (Paul-ruled lenient default 2026-07-17)', () => {
     delete process.env[ENV_KEY];
-    expect(STANDARD_N_SAMPLES_DEFAULT).toBe(4000);
-    expect(resolveStandardNSamples()).toBe(4000);
+    expect(STANDARD_N_SAMPLES_DEFAULT).toBe(10_000);
+    expect(resolveStandardNSamples()).toBe(10_000);
   });
 
   it('STANDARD_N_SAMPLES=1000 rolls back to 1000', () => {
@@ -62,7 +67,7 @@ describe('PR-E standard sample depth', () => {
     // parseInt would yield 1 / 4 / 1000 for the first three — all unsafe.
     for (const bad of ['oops', '', '   ', '1,000', '4_000', '1000abc', '1.5', '-500', '1e3', '99', '0', '10001', '50000']) {
       process.env[ENV_KEY] = bad;
-      expect(resolveStandardNSamples()).toBe(STANDARD_N_SAMPLES_DEFAULT); // 4000
+      expect(resolveStandardNSamples()).toBe(STANDARD_N_SAMPLES_DEFAULT); // 10000
     }
   });
 
@@ -72,9 +77,9 @@ describe('PR-E standard sample depth', () => {
     expect(h1000).not.toBe(h4000);
   });
 
-  it('flip probes do NOT inherit the new 4000 base depth (stay decoupled)', () => {
-    // Base default is now 4000; flip probes must remain at their independent depth.
-    expect(resolveFlipProbeNSamples(STANDARD_N_SAMPLES_DEFAULT)).toBe(1000);
-    expect(resolveFlipProbeNSamples(resolveStandardNSamples())).toBe(1000);
+  it('flip probes follow the base depth up to the 10k cap (Paul ruling 2026-07-17)', () => {
+    // Probes at base precision: base default 10000 → probes 10000 (== cap).
+    expect(resolveFlipProbeNSamples(STANDARD_N_SAMPLES_DEFAULT)).toBe(10_000);
+    expect(resolveFlipProbeNSamples(resolveStandardNSamples())).toBe(10_000);
   });
 });


### PR DESCRIPTION
## Ruling

Paul (17 Jul): raise latency limits to be much more lenient — he'd rather learn something is slow than have analysis cut off; prioritise analysis quality and scientific credibility.

Mid-build **SPEC AMENDMENT** applied: the A3 budget-scout's measured evidence (`acceptance-evidence/a3-verify-2026-07-16/budget-review.md`) superseded the lane's initial educated guesses — flip budgets set to the scout's measured values, base MC depth + complexity-mirror raises added, ISL-side items and the unflippable e-value drop left to their own lanes.

## Envelope derivation (read-only, at the bytes)

| Hop | Source | Value |
|---|---|---|
| **UI → PLoT /v2/run (LIVE analysis path)** | DecisionGuideAI staging `src/adapters/plot/v2/adapter.ts:1361` (`timeout = 120000`), wired from `useV2Run.ts:510`; `v5CanonicalAnalysis` default OFF | **120 s — BINDING** |
| UI → PLoT legacy v1 sync | `src/adapters/plot/v1/constants.ts` `SYNC_REQUEST_MS` | 150 s |
| CEE → PLoT /v2/run non-brief | CEE staging `src/config/timeouts.ts` `PLOT_RUN_TIMEOUT_MS` | 30 s (tightest caller — see CALLER ASKS) |
| CEE → PLoT /v2/run brief-bearing | same, `PLOT_RUN_BRIEF_TIMEOUT_MS` | 75 s |
| PLoT Fastify requestTimeout | `src/config/timeouts.ts` `FASTIFY_REQUEST_TIMEOUT_MS` | 180 s |
| Render platform | scout-verified primary source: **100-minute** max request duration | never binds |

CEE staging Render env overrides are not readable offline — CEE values are code defaults (flagged).

## Every raise, old → new

| Constant (file) | Old | New | Basis |
|---|---|---|---|
| `DEFAULT_FLIP_PROBE_N_SAMPLES` (flip-thresholds.ts) | 1,000 | **10,000** — `min(10000, base)` | probes at base precision (Paul ruling) |
| `DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS` (new named const, env `FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS`) | 5,000 | **10,000** | scout ruling table |
| `DEFAULT_FLIP_OVERALL_TIMEOUT_MS` (new named const, env `FLIP_SEARCH_OVERALL_TIMEOUT_MS`) | 10,000 | **30,000** | scout ruling table |
| `STANDARD_N_SAMPLES_DEFAULT` (sampling.ts) | 4,000 | **10,000** | amendment; scout task 2a: +0.7 s staging |
| `ISL_COMPLEXITY_BUDGET_DEFAULT` (sampling.ts) | 10 M | **30 M** | amendment; scout task 2e measured the silent clamp: requested K=10000 on 40n/120e → **4,873** under 10 M — without this raise the depth raise silently no-ops on any graph with nodes×edges > 1,000 (silent-cap class) |
| `ISL_TIMEOUT_MS` (timeouts.ts) | 30,000 | **60,000** | headroom for ISL's parallel internal-leniency raises + scout's 15-17 s staging worst-fit base call at K=10000/30M |
| `ISL_THRESHOLDS_TIMEOUT_MS_CAP` (timeouts.ts) | 10,000 | **30,000** | still `min()`-ed against remaining budget − 1 s at the call site |
| `REQUEST_BUDGET_MS` (timeouts.ts) | 60,000 | **70,000** | ≤58 % of the binding UI 120 s |

All new values are named constants with a `Paul-ruled lenient defaults 2026-07-17` doc comment and an exact **value-pinned test** (`tests/lenient-latency-values.pin.test.ts`) — a silent revert goes RED.

### Slowness made visible (disclosure machinery)
- `elapsed_ms` stamped on **every** flip diagnostics entry (timeout trips included) via a wrapper in `searchFlipForFactor`; block-level `elapsed_ms` + `flip_probe_n_samples` on `flip_thresholds_resolved`; `elapsed_ms` on `flip_thresholds_error`. Log-only — diagnostics never reach the wire.
- **New envelope guard**: the flip overall deadline is clamped to remaining `REQUEST_BUDGET_MS` − 1 s (pre-raise the composition could never exceed the budget; post-raise 60 s base + 30 s flip could). Clamp is logged (`flip_thresholds_budget_clamped`); exhaustion discloses per-entry `flip_reason:'timeout'` + elapsed_ms — never a silent cut.
- Each flip probe's ISL call is now capped at the per-factor budget (previously a single in-flight probe could add a full `ISL_TIMEOUT_MS` tail past the flip deadline).
- `config-validator.ts` stale mirrors (ISL 15000 / CEE 5000 vs real 30000 / 60000) now **derive** from `config/timeouts.ts`.

### Deliberately NOT raised (listed, no silent caps)
`FASTIFY_REQUEST_TIMEOUT_MS` 180 s (outermost) · `THRESHOLDS_MIN_REMAINING_BUDGET_MS` 5 s (floor-gate; raising it skips more work) · `CEE_*` proxy timeouts (CEE owns) · `ISL_HEALTH_CHECK_TIMEOUT_MS` 5 s (liveness) · `SSE_SLOT_MAX_MS` 120 s (v1 legacy) · circuit-breaker half-open + retry backoff (recovery, not cutoffs) · `ADAPTIVE_N_SAMPLES_FLOOR` 1000 (a floor).

## ⚠ Watch-item: probe depth × per-factor budget

Amendment items (1)+(2) combine so probes run at **10,000** (min(cap, base) with base now 10k) — ~2.5× the scout's depth-4000 probe timings (~2 s staging per probe at ×5). A factor needing a full bisection (3 step-0 + ≤7 sequential probes) may trip the 10 s per-factor budget on staging and **disclose** `flip_reason:'timeout'` + elapsed_ms. No-deploy mitigation knob: `FLIP_PROBE_N_SAMPLES=4000` (env).

## CALLER ASKS (for A1)

1. **CEE `PLOT_RUN_TIMEOUT_MS`** — olumi-assistants-service `src/config/timeouts.ts` (~line 182, `PLOT_RUN_TIMEOUT_MS` block): raise default 30_000 → **75_000** (matching the brief-bearing budget) *if/when* `v5CanonicalAnalysis` flips analysis onto the CEE path; until then CEE non-brief `run_analysis` calls cannot benefit from any PLoT-internal raise beyond 30 s. (Scout ruling table: NEED-ENVELOPE-WORK; also verify CEE's retry logic doesn't double-fire the raised-latency run.)
2. **ISL complexity budget — DEPLOY-ORDER COUPLING**: ISL enforces the same budget (`ISL_MAX_COMPUTE_COMPLEXITY`, ISL code default 10 M at tip `5745154e`, `src/api/robustness.py`). If PLoT's 30 M mirror deploys while ISL still enforces 10 M, PLoT under-reduces and dense graphs get a raw ISL **422** instead of today's disclosed adaptive reduction. **ISL's matching raise (separate ISL lane) or `ISL_MAX_COMPUTE_COMPLEXITY=30000000` set on BOTH services must land before or with this deploy.**

## Golden updates (value changes with reasoning — no strip-normaliser widening)

`tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json`, regenerated via `UPDATE_GOLDEN=1`. Before → after:
- all `n_samples` 4000 → 10000 (meta, decision_brief lineage, fact_objects lineage);
- `response_hash`/`graph_hash` `195f3c2552217c57` → `60e3ac213554be4f` — the canonical hash is **sample-aware by design** (`hash-sample-awareness.test.ts`), so the depth raise correctly mints a new analysis identity (post-deploy freshness re-runs instead of serving 4k-depth results as 10k);
- `_meta` `config_version` `2b3c700a4863` → `0c29e308b4b3` (derived from n_samples); `response_content_hash` `rch_v2:5c675374cdaeb9e3` → `rch_v2:96feaa2a2e028dfd`;
- `meta.flip_probe_n_samples` (was 1000) now **omitted** — the emitter (run.ts:2955) surfaces it only when probe depth *differs* from base; probes at base depth ⇒ omission is the designed semantics.

Pin updates in the same class, re-derived with reasoning in-file: `flip-probe-depth-decoupling` (Track-S 1000-pin is precisely what the ruling removed; cap + env override survive), `standard-n-samples-default` (PR-E 4000 pins), `adaptive-n-samples-complexity` (arithmetic re-derived at 30 M; env-override case changed to a LOWERED budget so it still discriminates), `cil-canonical-hash-v3`, `sample-depth-provenance`.

## Gates

- `npm run typecheck` (`tsc -p tsconfig.json --noEmit`): clean.
- Targeted suites: 122 tests / 8 files green; golden pin 4/4 after regen.
- **Full gate = pre-push hook (7 checks): PASSED** — full suite `5594 passed | 25 skipped (5630)`, no stale .js, file-dep policy, spectral lint.
- Spec files: **not touched** → Redocly problem-set diff N/A (no `contracts/openapi.yaml` change in this diff).
- Mutation checks (throwaway copy, deleted after): depth-cap revert → **8 RED** across 3 files (incl. behavioural); full revert of all raised values → **11 RED**. Every pin bites.

## r2 request wall-time (local, before/after)

Local no-ISL harness (createServer + inject, 8 timed runs after warmup, r2 capture request): base `35fdaf92` median **1.7 ms** vs branch median **1.6 ms** — identical within noise, as expected: budgets add no work on the no-ISL path. The meaningful latency deltas are the scout's live-ISL measurements (budget-review.md task 2c/2d): r2-class analyses ~2.6 s → ~6.5 s staging projected at the raised depths, all inside the 120 s binding envelope.

## Rebase order

Lane 4 (PR #228, `transformEdgeEValues` in run.ts) merges FIRST; this branch's run.ts hunks are at lines ~112 and ~5618-5710 (flip block) — disjoint from transformEdgeEValues (~430/2144/5110) — and will be rebased after lane 4 lands.

Evidence: `acceptance-evidence/a3-verify-2026-07-16/lane5-leniency-BUILD.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)