### PR TITLE
fix(robustness): NaN-safe budgets + base-call clamp + degrade disclosures + contract-doc + cleanups (A3 remediation)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4058,9 +4058,9 @@ paths:
           entry via `flip_reason` ('timeout'/'error'/...). Non-blocking: all other analyses are
           unaffected.
         - `edge_e_values[].stability` (additive, A3 lane 3): seed-sweep flip-threshold
-          stability band carried from ISL (ISL PR #71). Present ONLY when ISL runs
-          with `ISL_FLIP_STABILITY_BANDS` enabled (default OFF — absent from every entry on
-          today's live wire); when ISL omits it the key is absent, never null. Shape:
+          stability band carried from ISL (ISL PR #71). DEFAULT-ON since ISL PR #76
+          — present when ISL computed a band for the entry; when ISL omits it (nothing
+          to sweep, or an older pre-#76 build) the key is absent, never null. Shape:
           `{ n_seeds, n_seeds_flipped, band_min?, band_median?, band_max?, band_width?,
           seed_flip_means[] }` — the four `band_*` keys are omitted when `n_seeds_flipped`
           is 0; `seed_flip_means` entries are null where that seed's background admits no

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -18,7 +18,6 @@
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
 import { computeMarginSensitivity, type MarginSensitivity } from './margin-sensitivity.js';
 import { resolveBoundedIntEnvOrWarn, MIN_N_SAMPLES, MAX_N_SAMPLES } from '../config/env-int.js';
-import { STANDARD_N_SAMPLES_DEFAULT } from '../config/sampling.js';
 
 // =============================================================================
 // Types
@@ -88,14 +87,39 @@ export interface FlipSearchConfig {
 export const DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS = 10_000;
 export const DEFAULT_FLIP_OVERALL_TIMEOUT_MS = 30_000;
 
+/**
+ * Bounds for the flip-search time-budget env overrides (ms).
+ *
+ * A budget must be a non-negative integer. `0` is PERMITTED and means an
+ * immediate timeout on every factor — the deterministic "disable flip search
+ * but keep the per-factor 'timeout' disclosure" knob (used by the disclosure
+ * tests). The upper bound is generous (10 min) because the OVERALL budget is
+ * additionally clamped to the remaining request budget at the call site — this
+ * bound only exists to reject garbage. Routing these through the strict
+ * {@link resolveBoundedIntEnvOrWarn} (rather than `parseInt`) closes the
+ * NaN/misparse hole: `parseInt('' ?? default)` on an EMPTY env string is `NaN`,
+ * and `parseInt('30_000')`/`parseInt('30000abc')` silently return `30`/`30000`.
+ * A `NaN` deadline (`Date.now() + NaN`) makes every `Date.now() >= deadline`
+ * guard false — defeating every timeout. (`?? DEFAULT` preserves a valid `0`
+ * because `0` is non-nullish.)
+ */
+export const MIN_FLIP_TIMEOUT_MS = 0;
+export const MAX_FLIP_TIMEOUT_MS = 600_000;
+
 /** Env-or-default overall flip-search budget (before call-site budget clamping). */
 export function resolveFlipOverallTimeoutMs(): number {
-  return parseInt(process.env.FLIP_SEARCH_OVERALL_TIMEOUT_MS ?? String(DEFAULT_FLIP_OVERALL_TIMEOUT_MS), 10);
+  return (
+    resolveBoundedIntEnvOrWarn('FLIP_SEARCH_OVERALL_TIMEOUT_MS', MIN_FLIP_TIMEOUT_MS, MAX_FLIP_TIMEOUT_MS) ??
+    DEFAULT_FLIP_OVERALL_TIMEOUT_MS
+  );
 }
 
 /** Env-or-default per-factor flip-search budget. Also caps each probe's ISL call. */
 export function resolveFlipPerFactorTimeoutMs(): number {
-  return parseInt(process.env.FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS ?? String(DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS), 10);
+  return (
+    resolveBoundedIntEnvOrWarn('FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS', MIN_FLIP_TIMEOUT_MS, MAX_FLIP_TIMEOUT_MS) ??
+    DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS
+  );
 }
 
 function getDefaultConfig(): FlipSearchConfig {
@@ -124,8 +148,25 @@ function getDefaultConfig(): FlipSearchConfig {
  * (flip_reason 'timeout' + elapsed_ms) instead of silently shipping
  * low-precision values. Track-S decoupling survives as the cap + the
  * FLIP_PROBE_N_SAMPLES env override, no longer as a hard 1,000 floor-pin.
+ *
+ * The cap DERIVES from `MAX_N_SAMPLES` (the /v2/run schema ceiling) rather than
+ * mirroring the `10_000` literal, so the two can never silently diverge.
  */
-export const DEFAULT_FLIP_PROBE_N_SAMPLES = 10_000;
+export const DEFAULT_FLIP_PROBE_N_SAMPLES = MAX_N_SAMPLES;
+
+/**
+ * Fallback base depth used ONLY when the caller's base `n_samples` is unknown.
+ *
+ * An EXPLICIT 4,000 floor — deliberately NOT `STANDARD_N_SAMPLES_DEFAULT`.
+ * `STANDARD_N_SAMPLES_DEFAULT` was raised to `MAX_N_SAMPLES` (10,000) on
+ * 2026-07-17, so `min(DEFAULT_FLIP_PROBE_N_SAMPLES, STANDARD_N_SAMPLES_DEFAULT)`
+ * collapsed to `min(10k, 10k) = 10k` — the exact 10k CAP the docstring below
+ * promises to avoid. "Base precision" means matching a typical base depth, not
+ * maxing out the probe depth when the base is unknown. On the live route the
+ * base depth is always known (resolveStandardNSamples), so this branch is a
+ * defensive fallback for direct callers/tests only.
+ */
+export const FLIP_PROBE_UNKNOWN_BASE_N_SAMPLES = 4_000;
 
 /**
  * Resolve the sample depth to use for flip probes.
@@ -140,11 +181,11 @@ export const DEFAULT_FLIP_PROBE_N_SAMPLES = 10_000;
 export function resolveFlipProbeNSamples(baseNSamples?: number): number {
   const envOverride = resolveBoundedIntEnvOrWarn('FLIP_PROBE_N_SAMPLES', MIN_N_SAMPLES, MAX_N_SAMPLES);
   if (envOverride !== null) return envOverride;
-  // Unknown base depth → assume the standard base default (4,000), never the
-  // 10k cap: "base precision" means matching the base, not maxing out.
+  // Unknown base depth → the explicit 4,000 floor, never the 10k cap:
+  // "base precision" means matching a typical base, not maxing out.
   const base = typeof baseNSamples === 'number' && Number.isFinite(baseNSamples) && baseNSamples > 0
     ? baseNSamples
-    : STANDARD_N_SAMPLES_DEFAULT;
+    : FLIP_PROBE_UNKNOWN_BASE_N_SAMPLES;
   return Math.min(DEFAULT_FLIP_PROBE_N_SAMPLES, base);
 }
 
@@ -194,6 +235,53 @@ export interface FlipDiagnostics {
 }
 
 // =============================================================================
+// Concurrency bound
+// =============================================================================
+
+/**
+ * Max ISL inference calls in flight at once across a single flip search.
+ * Bounds ISL load so a many-candidate / deep-probe search cannot saturate the
+ * engine (→ 429s). Pinned; see the concurrency comment in resolveFlipValues.
+ */
+export const FLIP_MAX_CONCURRENT_ISL_CALLS = 2;
+
+/**
+ * Wrap an {@link ISLInferenceFn} so at most `max` invocations run concurrently;
+ * excess calls queue FIFO and start as earlier ones settle. A minimal
+ * counting-semaphore — no external dependency, order-preserving, and it applies
+ * uniformly to every probe of every factor because it wraps the single shared fn.
+ */
+function limitConcurrency(fn: ISLInferenceFn, max: number): ISLInferenceFn {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const acquire = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      if (active < max) {
+        active++;
+        resolve();
+      } else {
+        queue.push(() => {
+          active++;
+          resolve();
+        });
+      }
+    });
+  const release = (): void => {
+    active--;
+    const next = queue.shift();
+    if (next) next();
+  };
+  return async (factorId: string, overrideMean: number): Promise<FlipInferenceResult> => {
+    await acquire();
+    try {
+      return await fn(factorId, overrideMean);
+    } finally {
+      release();
+    }
+  };
+}
+
+// =============================================================================
 // Main Function
 // =============================================================================
 
@@ -223,10 +311,19 @@ export async function resolveFlipValues(
 
   const overallDeadline = Date.now() + cfg.overallTimeoutMs;
 
-  // Process factors with max 2 concurrency (spec: max 2 parallel ISL calls)
+  // Cap TOTAL in-flight ISL calls at 2 across the whole flip search. Each factor
+  // search issues up to 3 Step-0 probes in parallel (baseline + both bounds), so
+  // an unbounded `Promise.all` over N candidates would peak at N×3 concurrent ISL
+  // calls — at the raised 10k probe depth that amplifies into ISL saturation/429s.
+  // A shared semaphore around inferenceFn bounds the REAL ISL fan-out to
+  // FLIP_MAX_CONCURRENT_ISL_CALLS, independent of candidate count or per-factor
+  // probe parallelism. (Prior comment claimed "max 2 concurrency" but nothing
+  // enforced it — the candidate-level Promise.all was unbounded and each factor
+  // fanned out 3-wide underneath.)
+  const boundedInferenceFn = limitConcurrency(inferenceFn, FLIP_MAX_CONCURRENT_ISL_CALLS);
   const settled = await Promise.all(
     candidates.map((candidate) =>
-      searchFlipForFactor(candidate, inferenceFn, originalWinnerId, cfg, overallDeadline)
+      searchFlipForFactor(candidate, boundedInferenceFn, originalWinnerId, cfg, overallDeadline)
     )
   );
 

--- a/src/config/timeouts.ts
+++ b/src/config/timeouts.ts
@@ -115,6 +115,23 @@ export const THRESHOLDS_MIN_REMAINING_BUDGET_MS =
 export const REQUEST_BUDGET_MS =
   Number(process.env.REQUEST_BUDGET_MS) || 70_000;
 
+/**
+ * Resolve the request budget at CALL TIME, honouring a runtime `REQUEST_BUDGET_MS`
+ * env override.
+ *
+ * `REQUEST_BUDGET_MS` above is evaluated ONCE at module load (used for startup
+ * logging and the value-pin tests). The /v2/run call sites need the LIVE env
+ * value so an override set after import — e.g. a test forcing budget exhaustion
+ * with `process.env.REQUEST_BUDGET_MS = '1'` — actually takes effect. This
+ * consolidates the two identical `Number(process.env.REQUEST_BUDGET_MS) ||
+ * REQUEST_BUDGET_MS` expressions that previously sat inline in run.ts (a
+ * one-liner shared here rather than "just REQUEST_BUDGET_MS", which would
+ * silently drop the documented runtime-override capability).
+ */
+export function resolveRequestBudgetMs(): number {
+  return Number(process.env.REQUEST_BUDGET_MS) || REQUEST_BUDGET_MS;
+}
+
 // -----------------------------------------------------------------------------
 // Fastify server timeout
 // -----------------------------------------------------------------------------

--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -160,9 +160,9 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     'path_decomposition',                // Request-gated structural pathway decomposition (opt-in; not a causal claim).
     // A3 lane 3 (ISL PR #71): seed-sweep flip-stability band — additive
     // passthrough on edge_e_values entries, NOT an enrichment.
-    // Present only when ISL runs with ISL_FLIP_STABILITY_BANDS enabled
-    // (default OFF — absent on today's live wire); key absent, never null,
-    // when ISL omits it. Lever edges: e-values (now incl. stability) are
+    // DEFAULT-ON since ISL PR #76 — present when ISL computed a band for the
+    // entry; key absent (never null) when ISL omits it (nothing to sweep, or
+    // an older pre-#76 build). Lever edges: e-values (now incl. stability) are
     // currently PUBLISHED for levers — same surface as the open R2 doctrine
     // bullet on lever flip_thresholds/e-values; this lane invents no new
     // suppression pending that ruling.

--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -200,7 +200,8 @@ export interface ISLService {
     endpoint: string,
     body: unknown,
     requestId: string,
-    timeoutMs?: number
+    timeoutMs?: number,
+    maxRetries?: number
   ): Promise<ISLAnalysisResult<T>>;
 }
 
@@ -617,7 +618,8 @@ export function createISLService(): ISLService {
       endpoint: string,
       body: unknown,
       requestId: string,
-      timeoutMs?: number
+      timeoutMs?: number,
+      maxRetries?: number
     ): Promise<ISLAnalysisResult<T>> {
       const startMs = Date.now();
 
@@ -642,6 +644,12 @@ export function createISLService(): ISLService {
       // Apply per-call timeout override if provided (e.g., budget-aware threshold calls)
       if (timeoutMs !== undefined) {
         currentConfig.timeoutMs = timeoutMs;
+      }
+      // Per-call retry cap (A3 remediation item 4): the base /v2/run robustness
+      // call passes this so its retries × per-attempt timeout cannot outlive the
+      // request budget. Omitted → the config default (ISL_MAX_RETRIES, 3).
+      if (maxRetries !== undefined) {
+        currentConfig.maxRetries = Math.max(1, Math.floor(maxRetries));
       }
       const currentClient = new ISLClient(currentConfig);
 

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -327,11 +327,12 @@ export interface ISLPathDecompositionV2 {
 
 /**
  * Seed-sweep stability band for one edge's flip threshold (ISL Track S
- * Phase 1, ISL PR #71). Flag-gated in ISL by `ISL_FLIP_STABILITY_BANDS`
- * (default OFF): the field is simply ABSENT from every edge_e_values entry
- * until the flag is enabled — PLoT carries it through when present and emits
- * nothing when absent (dark carry-through, A3 lane 3; units alignment, A3
- * lane 4 — see the UNITS invariant below).
+ * Phase 1, ISL PR #71). DEFAULT-ON in ISL since PR #76 (the
+ * `ISL_FLIP_STABILITY_BANDS` env gate was removed) — present on every
+ * edge_e_values entry ISL computed a band for. PLoT carries it through when
+ * present and emits nothing when absent (an entry ISL had nothing to sweep,
+ * or an older pre-#76 ISL build) — dark carry-through, A3 lane 3; units
+ * alignment, A3 lane 4 — see the UNITS invariant below.
  *
  * Shape derived from ISL `FlipStabilityBandV2`
  * (src/models/response_v2.py:368-415 at ISL tip 5745154e) serialised with
@@ -366,7 +367,11 @@ export interface ISLPathDecompositionV2 {
  * this invariant guarantees internal consistency, not that semantics.
  */
 export interface ISLFlipStabilityBandV2 {
-  /** Number of child seeds swept (ISL default 5, clamped [2, 20]) */
+  /**
+   * Number of child seeds swept — ISL constant `FLIP_STABILITY_N_SEEDS`
+   * (10 since ISL PR #76; the former env-select + [2, 20] clamp was removed
+   * when bands went default-on).
+   */
   n_seeds: number;
   /** Seeds whose sampled background admits a flip within [-1, 1]. When 0, the band_* fields are omitted. */
   n_seeds_flipped: number;
@@ -423,12 +428,13 @@ export interface ISLEdgeEValue {
    */
   is_unflippable?: boolean;
   /**
-   * Seed-sweep flip-threshold stability band (ISL PR #71). Present ONLY when
-   * ISL runs with `ISL_FLIP_STABILITY_BANDS` enabled (default OFF — absent on
-   * the live wire today). Carried through to the /v2/run response in the SAME
-   * space as the entry's flip_mean (A3 lane 3 carry-through + lane 4 units
-   * alignment); see ISLFlipStabilityBandV2 for the band_width/n_seeds_flipped
-   * interpretation trap and the units invariant.
+   * Seed-sweep flip-threshold stability band (ISL PR #71). DEFAULT-ON since ISL
+   * PR #76 — present when ISL computed a band for this entry; absent (key
+   * omitted, never null) when it had nothing to sweep or on older pre-#76 ISL
+   * builds. Carried through to the /v2/run response in the SAME space as the
+   * entry's flip_mean (A3 lane 3 carry-through + lane 4 units alignment); see
+   * ISLFlipStabilityBandV2 for the band_width/n_seeds_flipped interpretation
+   * trap and the units invariant.
    */
   stability?: ISLFlipStabilityBandV2;
 }

--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -1108,8 +1108,17 @@ export function buildFactorStability(
    * factor_id rides the factor_sensitivity entry. The domain-validity gate
    * below still applies to the RAW value first (an invalid raw std skips the
    * entry, never zero-launders it).
+   *
+   * REQUIRED (A3 remediation 2026-07-18): the sole production caller (run.ts)
+   * passes the D-U union; making the param non-optional turns a future
+   * refactor that drops it into a COMPILE error instead of a silent
+   * re-introduction of the #226 elasticity_std leak. Callers with no levers
+   * pass an empty set. (The zeroing keeps its own ternary rather than spreading
+   * LEVER_SUPPRESSION_FIELDS — a FactorStabilityEntry has only elasticity_std,
+   * so the full suppression shape does not apply here; the divergence is
+   * intentional. This change is about ENFORCING the param, not sharing the set.)
    */
-  structuralLeverIds?: ReadonlySet<string>,
+  structuralLeverIds: ReadonlySet<string>,
 ): FactorStabilityEntry[] {
   if (!Array.isArray(islFactorSensitivity) || islFactorSensitivity.length === 0) return [];
 

--- a/src/routes/v2/enrichment-egress-guard.ts
+++ b/src/routes/v2/enrichment-egress-guard.ts
@@ -35,6 +35,7 @@
 import { AnalysisEnrichmentSchema } from '@talchain/schemas/boundary';
 import { INFERENCE_WARNING_CODES } from '../../types/engine-v3.js';
 import type { InferenceWarning } from '../../types/engine-v3.js';
+import { parseBoundedIntEnv } from '../../config/env-int.js';
 
 /**
  * Cap on reported issues (wire message + log event). A pathological body
@@ -42,6 +43,54 @@ import type { InferenceWarning } from '../../types/engine-v3.js';
  * defect and `issue_count` carries the true total.
  */
 export const ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES = 10;
+
+// ----------------------------------------------------------------------------
+// Sampling (A3 remediation item 8, efficiency)
+// ----------------------------------------------------------------------------
+
+/**
+ * Production default sample rate: assess 1 in N outgoing bodies.
+ *
+ * The full-body `AnalysisEnrichmentSchema.safeParse` on EVERY /v2/run duplicates
+ * CEE's shadow parse of the same envelope. A real contract regression is
+ * DETERMINISTIC — it breaks the same field on EVERY response — so a 1-in-N
+ * sample still surfaces it within N requests, while cutting the per-request
+ * schema-parse cost by ~(N-1)/N. Outside production the guard runs on EVERY
+ * request (staging + tests want the immediate, complete signal). Ops override:
+ * `ENRICHMENT_GUARD_SAMPLE_N` (integer ≥ 1; 1 = every request).
+ */
+export const DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD = 16;
+
+/** Round-robin request counter for the 1-in-N sampler (per process). */
+let enrichmentGuardCounter = 0;
+
+/** Test-only: reset the sampler so 1-in-N sequences are deterministic per test. */
+export function __resetEnrichmentGuardSampler(): void {
+  enrichmentGuardCounter = 0;
+}
+
+/**
+ * Resolve the sample denominator. `ENRICHMENT_GUARD_SAMPLE_N` (strict, ≥1)
+ * overrides; otherwise every request outside production, 1-in-N in production.
+ */
+export function resolveEnrichmentGuardSampleN(): number {
+  const parsed = parseBoundedIntEnv(process.env.ENRICHMENT_GUARD_SAMPLE_N, 1, 1_000_000);
+  if (parsed !== null) return parsed;
+  return process.env.NODE_ENV === 'production' ? DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD : 1;
+}
+
+/**
+ * True when THIS request should run the egress guard. Deterministic round-robin
+ * (assess request 1, N+1, 2N+1, …) so a deterministic envelope break surfaces
+ * within N. `N <= 1` ⇒ always true (every request).
+ */
+export function shouldAssessEnrichmentContract(): boolean {
+  const n = resolveEnrichmentGuardSampleN();
+  if (n <= 1) return true;
+  const shouldAssess = enrichmentGuardCounter % n === 0;
+  enrichmentGuardCounter = (enrichmentGuardCounter + 1) % n;
+  return shouldAssess;
+}
 
 /** One schema violation, reduced to non-sensitive coordinates. */
 export interface EnrichmentContractIssue {

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -110,8 +110,10 @@ import {
   CEE_DECISION_REVIEW_TIMEOUT_MS,
   ISL_THRESHOLDS_TIMEOUT_MS_CAP,
   THRESHOLDS_MIN_REMAINING_BUDGET_MS,
-  REQUEST_BUDGET_MS,
+  resolveRequestBudgetMs,
+  ISL_TIMEOUT_MS,
 } from '../../config/timeouts.js';
+import { getISLClientConfig } from '../../integrations/isl/client.js';
 import { createISLInferenceFn, resolveFlipValues, resolveFlipProbeNSamples, resolveFlipOverallTimeoutMs, resolveFlipPerFactorTimeoutMs } from '../../analysis/flip-thresholds.js';
 import { computeFlipThresholdData, getFactorsOverriddenByAllOptions } from '../../coaching/flip-thresholds.js';
 import { denormaliseFlipThresholds, type DenormalisedFlipThreshold } from '../../lib/flip-threshold-denormaliser.js';
@@ -174,6 +176,7 @@ import type { FactObjectV1, FactLineage } from '../../facts/types.js';
 import { finiteNum, prob01, nonNeg, nonNegInt, hasAllRequiredOutcomeStats } from './numeric-egress-guards.js';
 import {
   assessEnrichmentContract,
+  shouldAssessEnrichmentContract,
   buildEnrichmentContractWarning,
   logEnrichmentContractMismatch,
 } from './enrichment-egress-guard.js';
@@ -514,8 +517,8 @@ export function transformEdgeEValues(
       current_mean: currentMean,
       flip_mean: flipMean,
       // A3 lane 3 + lane 4: seed-sweep flip-stability band (ISL PR #71,
-      // flag-gated ISL_FLIP_STABILITY_BANDS — absent on the live wire until
-      // the flag flips). Key absent (never null) when ISL omits it: this
+      // DEFAULT-ON since ISL PR #76). Key absent (never null) when ISL omits
+      // it (nothing to sweep, or an older pre-#76 build): this
       // field-by-field rebuild used to silently DROP it. UNITS-COHERENCE
       // INVARIANT (Paul's 17 Jul ruling): band values are ALWAYS in the same
       // space as flip_mean on the same entry — mapped above via the same
@@ -2496,10 +2499,19 @@ function buildResponse(
       const nodeId = w?.detail?.node_id ?? w?.node_id ?? '';
       const dedupKey = `${w?.code}:${nodeId}`;
       if (w && typeof w.code === 'string' && typeof message === 'string' && !existingKeys.has(dedupKey)) {
+        // Carry a finite elapsed_ms through when the ISL warning supplies one —
+        // the budget-degradation family (STABILITY_BANDS_UNAVAILABLE /
+        // E_VALUES_UNAVAILABLE / EVPI_UNAVAILABLE / PATH_DECOMPOSITION_UNAVAILABLE)
+        // stamps how long the phase ran before degrading, so a slow degrade is
+        // diagnosable on the wire, not only in the ISL log. Additive + numeric
+        // only (no PII); the egress envelope's warning element is passthrough.
+        const rawElapsed = w?.elapsed_ms ?? w?.detail?.elapsed_ms;
+        const elapsedMs = typeof rawElapsed === 'number' && Number.isFinite(rawElapsed) ? rawElapsed : undefined;
         inferenceWarnings.push({
           code: w.code,
           message,
           severity: w.severity === 'warning' ? 'warning' : 'info',
+          ...(elapsedMs !== undefined && { elapsed_ms: elapsedMs }),
         });
         existingKeys.add(dedupKey);
       }
@@ -3029,17 +3041,24 @@ function buildResponse(
   // The appended warning `{code, message, severity}` conforms to the
   // envelope's inference_warnings element schema by construction, so the
   // disclosure can never itself create a contract violation.
+  // A3 remediation item 8: sample the guard (1-in-N in production, every
+  // request otherwise). A skipped request leaves enrichment_contract_ok ABSENT
+  // (= unassessed — the same honest non-claim as the guard-error path below),
+  // never a fabricated `true`. A deterministic envelope break still surfaces
+  // within N, and CEE's shadow parse remains the independent backstop.
   try {
-    const enrichmentAssessment = assessEnrichmentContract(response);
-    if (response._meta?.evidence) {
-      response._meta.evidence.enrichment_contract_ok = enrichmentAssessment.ok;
-    }
-    if (!enrichmentAssessment.ok) {
-      response.inference_warnings = [
-        ...(response.inference_warnings ?? []),
-        buildEnrichmentContractWarning(enrichmentAssessment),
-      ];
-      if (logger) logEnrichmentContractMismatch(logger, enrichmentAssessment, requestId);
+    if (shouldAssessEnrichmentContract()) {
+      const enrichmentAssessment = assessEnrichmentContract(response);
+      if (response._meta?.evidence) {
+        response._meta.evidence.enrichment_contract_ok = enrichmentAssessment.ok;
+      }
+      if (!enrichmentAssessment.ok) {
+        response.inference_warnings = [
+          ...(response.inference_warnings ?? []),
+          buildEnrichmentContractWarning(enrichmentAssessment),
+        ];
+        if (logger) logEnrichmentContractMismatch(logger, enrichmentAssessment, requestId);
+      }
     }
   } catch (err) {
     // A guard bug is NOT a contract mismatch: stamp NOTHING (absence =
@@ -4812,10 +4831,46 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         let islResponseRetryable: boolean | undefined;
 
         try {
+          // A3 remediation item 4: clamp the base ISL robustness call to the
+          // REMAINING request budget so its retries cannot outlive the caller.
+          // Unclamped this call is ISL_TIMEOUT_MS per attempt × ISL_MAX_RETRIES
+          // (default 60s × 3 ≈ 180s worst case) — past the UI's 120s client
+          // timeout, which loses the WHOLE analysis. Mirror of the flip block's
+          // remaining-budget clamp (below): allow ONE generous attempt up to the
+          // remaining budget, then cap the retry COUNT to what still fits — so a
+          // slow-but-successful call is NOT truncated (per-attempt stays near
+          // ISL_TIMEOUT_MS), yet the total is bounded by the budget. The base
+          // call runs early, so remaining ≈ REQUEST_BUDGET_MS (70s) → one 60s
+          // attempt; the clamp only bites the pathological retry storm.
+          const baseCallRemainingMs = resolveRequestBudgetMs() - (performance.now() - startTime);
+          const baseCallSafetyMarginMs = 1_000;
+          const BASE_CALL_MIN_TIMEOUT_MS = 1_000;
+          const baseCallTimeoutMs = Math.min(
+            ISL_TIMEOUT_MS,
+            Math.max(BASE_CALL_MIN_TIMEOUT_MS, Math.floor(baseCallRemainingMs - baseCallSafetyMarginMs)),
+          );
+          const configuredMaxRetries = Math.max(1, getISLClientConfig().maxRetries);
+          // How many full per-attempt slices fit the remaining budget (≥ 1).
+          const fittingRetries = Math.max(1, Math.floor(baseCallRemainingMs / baseCallTimeoutMs));
+          const baseCallMaxRetries = Math.min(configuredMaxRetries, fittingRetries);
+          if (baseCallTimeoutMs < ISL_TIMEOUT_MS || baseCallMaxRetries < configuredMaxRetries) {
+            req.log.info({
+              event: 'base_isl_call_budget_clamped',
+              request_id: requestId,
+              isl_timeout_ms: ISL_TIMEOUT_MS,
+              clamped_timeout_ms: baseCallTimeoutMs,
+              configured_max_retries: configuredMaxRetries,
+              clamped_max_retries: baseCallMaxRetries,
+              remaining_budget_ms: Math.round(baseCallRemainingMs),
+              worst_case_total_ms: baseCallMaxRetries * baseCallTimeoutMs,
+            });
+          }
           const response = await islService.callAnalysisEndpoint<any>(
             '/api/v1/robustness/analyze/v2',
             islRequest,
-            requestId
+            requestId,
+            baseCallTimeoutMs,
+            baseCallMaxRetries
           );
 
           if (response.data) {
@@ -5652,9 +5707,15 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               const winnerId = topWinnerOption?.option_id ?? topWinnerOption?.id ?? '';
 
               if (winnerId) {
-                // Track S: flip probes use a depth decoupled from the base analysis
-                // (`nSamples`), so raising base depth cannot silently push probes into
-                // timeout. See resolveFlipProbeNSamples / FLIP_PROBE_N_SAMPLES.
+                // Track S (revised 2026-07-17): flip probes now INHERIT the base
+                // analysis depth up to the 10k cap (resolveFlipProbeNSamples =
+                // min(cap, nSamples)), so flip values carry the precision of the
+                // probabilities displayed beside them. Raising the base therefore
+                // DOES deepen probes (toward the flip timeout) — which is why the
+                // flip time budgets were raised in step and a slow search now
+                // DISCLOSES a per-factor 'timeout' rather than silently shipping
+                // low-precision values. The FLIP_PROBE_N_SAMPLES env override still
+                // decouples probe depth from the base on demand.
                 flipProbeNSamples = resolveFlipProbeNSamples(nSamples);
                 // Paul-ruled lenient defaults 2026-07-17: each probe's ISL call is
                 // capped at the per-factor budget — a probe has no use for time its
@@ -5678,7 +5739,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                 // itself is logged below.
                 const flipStartMs = performance.now();
                 const flipConfiguredOverallMs = resolveFlipOverallTimeoutMs();
-                const flipRequestBudgetMs = Number(process.env.REQUEST_BUDGET_MS) || REQUEST_BUDGET_MS;
+                const flipRequestBudgetMs = resolveRequestBudgetMs();
                 const flipRemainingBudgetMs = flipRequestBudgetMs - (flipStartMs - startTime);
                 const flipSafetyMarginMs = 1_000;
                 const flipOverallTimeoutMs = Math.min(
@@ -5759,7 +5820,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         if (body.include_thresholds) {
           const elapsedMs = performance.now() - startTime;
           // Read budget dynamically to support test-time env overrides
-          const requestBudgetMs = Number(process.env.REQUEST_BUDGET_MS) || REQUEST_BUDGET_MS;
+          const requestBudgetMs = resolveRequestBudgetMs();
           const remainingBudgetMs = requestBudgetMs - elapsedMs;
 
           if (remainingBudgetMs < THRESHOLDS_MIN_REMAINING_BUDGET_MS) {

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1529,8 +1529,9 @@ export interface EnrichedEdgeEValue {
   /**
    * Seed-sweep flip-threshold stability band, carried VERBATIM from ISL
    * (ISL PR #71; single ISL type, no mirrored shape — trap-12 discipline).
-   * Present ONLY when ISL runs with `ISL_FLIP_STABILITY_BANDS` enabled
-   * (default OFF — the key is absent, never null, on today's live wire).
+   * DEFAULT-ON since ISL PR #76 — present when ISL computed a band for this
+   * entry; the key is absent (never null) when it had nothing to sweep or on
+   * older pre-#76 ISL builds.
    * ⚠ band_width is 0.0 BY CONSTRUCTION when n_seeds_flipped == 1 (single
    * flipped seed has zero range) — consumers must condition any width-based
    * confidence rubric on n_seeds_flipped. ⚠ Band values stay in ISL
@@ -2081,6 +2082,48 @@ export const INFERENCE_WARNING_CODES = {
    * Severity: warning.
    */
   FLIP_THRESHOLDS_UNAVAILABLE: 'FLIP_THRESHOLDS_UNAVAILABLE',
+  /**
+   * A3 remediation (ALTITUDE Hunt 2, 2026-07-18): ISL-ORIGINATED degrade
+   * disclosure. ISL computes seed-sweep flip-stability bands under a wall-clock
+   * budget; on a budget trip it degrades all-or-nothing (no bands attached to
+   * ANY edge_e_values entry) and — post ISL-lane — emits this code in its
+   * `inference_warnings` so the absence is attributable on the wire instead of
+   * ISL-log-only. PLoT forwards it verbatim through the ISL-warning merge (the
+   * same passthrough ROOT_NODE_DEFAULT_VALUE rides), exactly mirroring how
+   * FLIP_THRESHOLDS_UNAVAILABLE discloses PLoT's own whole-block flip failure.
+   * Bands are additive enrichment — non-blocking; all other analyses unaffected.
+   * Severity: warning.
+   */
+  STABILITY_BANDS_UNAVAILABLE: 'STABILITY_BANDS_UNAVAILABLE',
+  /**
+   * A3 remediation (ALTITUDE Hunt 2, 2026-07-18): ISL-ORIGINATED degrade
+   * disclosure, sibling of STABILITY_BANDS_UNAVAILABLE. ISL computes edge
+   * E-values under their own budget; on a trip the E-value phase degrades and
+   * ISL emits this code in `inference_warnings` so the empty/partial
+   * edge_e_values are attributable on the wire, not ISL-log-only. PLoT forwards
+   * it verbatim. Non-blocking; other analyses unaffected. Severity: warning.
+   */
+  E_VALUES_UNAVAILABLE: 'E_VALUES_UNAVAILABLE',
+  /**
+   * A3 remediation (ALTITUDE Hunt 2, 2026-07-18): ISL-ORIGINATED degrade
+   * disclosure, sibling of STABILITY_BANDS_UNAVAILABLE / E_VALUES_UNAVAILABLE.
+   * ISL's per-factor EVPI (value-of-information) phase runs under its own
+   * wall-clock budget; on a trip it degrades and ISL emits this code (with
+   * elapsed_ms) in `inference_warnings` so the absent/partial EVPI is
+   * attributable on the wire, not ISL-log-only. PLoT forwards it verbatim.
+   * Non-blocking; other analyses unaffected. Severity: warning.
+   */
+  EVPI_UNAVAILABLE: 'EVPI_UNAVAILABLE',
+  /**
+   * A3 remediation (ALTITUDE Hunt 2, 2026-07-18): ISL-ORIGINATED degrade
+   * disclosure, sibling of the budget-degradation family. ISL's structural
+   * path decomposition (request-gated) runs under its own budget; on a trip it
+   * degrades and ISL emits this code (with elapsed_ms) in `inference_warnings`
+   * so the absent path_decomposition is attributable on the wire, not
+   * ISL-log-only. PLoT forwards it verbatim. Non-blocking; other analyses
+   * unaffected. Severity: warning.
+   */
+  PATH_DECOMPOSITION_UNAVAILABLE: 'PATH_DECOMPOSITION_UNAVAILABLE',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];
@@ -2093,6 +2136,16 @@ export interface InferenceWarning {
   code: InferenceWarningCode | string;
   message: string;
   severity: 'info' | 'warning';
+  /**
+   * Optional wall-clock ms the underlying phase ran before degrading. Carried
+   * through from ISL's budget-degradation disclosures (STABILITY_BANDS_UNAVAILABLE,
+   * E_VALUES_UNAVAILABLE, EVPI_UNAVAILABLE, PATH_DECOMPOSITION_UNAVAILABLE) so a
+   * slow degrade is diagnosable on the wire, not only in the ISL log. Present
+   * only when the source warning carried a finite elapsed_ms. The egress
+   * enrichment envelope's inference_warnings element is passthrough, so this
+   * additive field never fails the contract.
+   */
+  elapsed_ms?: number;
 }
 
 /**

--- a/tests/3c-factor-sensitivity-enrichment.test.ts
+++ b/tests/3c-factor-sensitivity-enrichment.test.ts
@@ -534,7 +534,7 @@ describe('3C: factor_stability (buildFactorStability)', () => {
   ];
 
   it('FS1: populated from ISL when all four 3C fields present', () => {
-    const result = buildFactorStability(ISL_WITH_3C, GRAPH);
+    const result = buildFactorStability(ISL_WITH_3C, GRAPH, new Set());
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
@@ -556,7 +556,7 @@ describe('3C: factor_stability (buildFactorStability)', () => {
   });
 
   it('FS2: empty array when ISL omits 3C fields', () => {
-    const result = buildFactorStability(ISL_WITHOUT_3C, GRAPH);
+    const result = buildFactorStability(ISL_WITHOUT_3C, GRAPH, new Set());
     expect(result).toEqual([]);
   });
 
@@ -574,7 +574,7 @@ describe('3C: factor_stability (buildFactorStability)', () => {
       },
     ];
 
-    const result = buildFactorStability(partial, GRAPH);
+    const result = buildFactorStability(partial, GRAPH, new Set());
 
     // Only factor-b has all four fields
     expect(result).toHaveLength(1);
@@ -590,7 +590,7 @@ describe('3C: factor_stability (buildFactorStability)', () => {
       { node_id: 'f5', elasticity_std: 0.1, attribution_stability: 'high', rank_flip_rate: 0.03, stability_method: 'bootstrap_1000' }, // valid
     ];
 
-    const result = buildFactorStability(invalid, GRAPH);
+    const result = buildFactorStability(invalid, GRAPH, new Set());
     expect(result).toHaveLength(1);
     expect(result[0].factor_id).toBe('f5');
   });
@@ -601,7 +601,7 @@ describe('3C: factor_stability (buildFactorStability)', () => {
       { node_id: 'factor-a', elasticity_std: 0.99, attribution_stability: 'low', rank_flip_rate: 0.5, stability_method: 'bootstrap_500' },
     ];
 
-    const result = buildFactorStability(dupes, GRAPH);
+    const result = buildFactorStability(dupes, GRAPH, new Set());
     expect(result).toHaveLength(1);
     expect(result[0].elasticity_std).toBe(0.042); // first-wins
   });
@@ -610,7 +610,7 @@ describe('3C: factor_stability (buildFactorStability)', () => {
     // buildFactorStability reads from the raw ISL array (not the transformed factor_sensitivity)
     // Verify the ISL input array is not mutated
     const islCopy = JSON.parse(JSON.stringify(ISL_WITH_3C));
-    buildFactorStability(islCopy, GRAPH);
+    buildFactorStability(islCopy, GRAPH, new Set());
 
     // Input array is unchanged
     expect(islCopy).toEqual(ISL_WITH_3C);

--- a/tests/lane2-lever-elasticity-std-suppression.test.ts
+++ b/tests/lane2-lever-elasticity-std-suppression.test.ts
@@ -318,6 +318,7 @@ describe('buildFactorStability: lever elasticity_std suppressed on the stability
     const out = buildFactorStability(
       [rawIsl('fac_stamped', { sensitivity: 0, zero_reason: 'intervention_override', elasticity_std: 0.005 })],
       GRAPH_MIN,
+      new Set(), // no union — suppression here rides the ISL zero_reason stamp
     );
     expect(out).toHaveLength(1);
     expect(out[0].factor_id).toBe('fac_stamped');
@@ -325,7 +326,7 @@ describe('buildFactorStability: lever elasticity_std suppressed on the stability
   });
 
   it('suppression keys ONLY on the lever predicate: unstamped + no union set → raw value preserved', () => {
-    const out = buildFactorStability([rawIsl('fac_plain', { elasticity_std: 0.00750934 })], GRAPH_MIN);
+    const out = buildFactorStability([rawIsl('fac_plain', { elasticity_std: 0.00750934 })], GRAPH_MIN, new Set());
     expect(out[0].elasticity_std).toBe(0.00750934);
   });
 

--- a/tests/lenient-latency-values.pin.test.ts
+++ b/tests/lenient-latency-values.pin.test.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_FLIP_PROBE_N_SAMPLES,
   DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS,
   DEFAULT_FLIP_OVERALL_TIMEOUT_MS,
+  FLIP_PROBE_UNKNOWN_BASE_N_SAMPLES,
   resolveFlipProbeNSamples,
   resolveFlipPerFactorTimeoutMs,
   resolveFlipOverallTimeoutMs,
@@ -103,8 +104,14 @@ describe('flip probes run at base precision (behavioural, not just the constant)
     expect(resolveFlipProbeNSamples(20_000)).toBe(10_000);
   });
 
-  it('unknown base depth falls back to the standard base default (now 10k)', () => {
-    expect(resolveFlipProbeNSamples(undefined)).toBe(STANDARD_N_SAMPLES_DEFAULT);
+  it('unknown base depth falls back to the explicit 4,000 floor, NOT the 10k cap', () => {
+    // A3 remediation item 2 (2026-07-18): the fallback was STANDARD_N_SAMPLES_DEFAULT,
+    // which was raised 4000 → 10_000 (the cap) on 2026-07-17 — so min(10k, 10k) = 10k
+    // silently contradicted resolveFlipProbeNSamples's "assume 4000 floor, never the
+    // 10k cap" contract. Now the fallback is the explicit FLIP_PROBE_UNKNOWN_BASE_N_SAMPLES.
+    expect(resolveFlipProbeNSamples(undefined)).toBe(FLIP_PROBE_UNKNOWN_BASE_N_SAMPLES);
+    expect(resolveFlipProbeNSamples(undefined)).toBe(4_000);
+    expect(resolveFlipProbeNSamples(undefined)).not.toBe(STANDARD_N_SAMPLES_DEFAULT);
   });
 });
 

--- a/tests/plot-remediation.base-call-budget.route.test.ts
+++ b/tests/plot-remediation.base-call-budget.route.test.ts
@@ -1,0 +1,135 @@
+/**
+ * A3 remediation item 4 (2026-07-18) — the base /v2/run ISL robustness call is
+ * clamped to the remaining request budget so its retries cannot outlive the
+ * caller. Unclamped it was ISL_TIMEOUT_MS (60s) per attempt × ISL_MAX_RETRIES
+ * (3) ≈ 180s worst case, past the UI's 120s client timeout — losing the WHOLE
+ * analysis. This test captures the (timeoutMs, maxRetries) the route passes to
+ * callAnalysisEndpoint for the base robustness endpoint and asserts the
+ * worst-case total (maxRetries × per-attempt timeout) is bounded.
+ *
+ * RED against the pre-fix code: the base call passed NO timeoutMs/maxRetries
+ * (undefined → config default 60s × 3 = 180s worst case). See mutation transcript.
+ *
+ * Harness modelled on tests/lane3-stability-bands-carrythrough.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { ISL_TIMEOUT_MS } from '../src/config/timeouts.js';
+
+const BASE_ROBUSTNESS_ENDPOINT = '/api/v1/robustness/analyze/v2';
+const UI_CLIENT_TIMEOUT_MS = 120_000; // the binding caller hop
+
+// Records the per-call (timeoutMs, maxRetries) for the base robustness call.
+const captured: Array<{ endpoint: string; timeoutMs?: number; maxRetries?: number }> = [];
+
+const ISL_DATA = {
+  options: [
+    { option_id: 'opt1', outcome: { mean: 0.8, std: 0.1, p10: 0.6, p50: 0.8, p90: 0.95, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 1, win_probability: 0.7, probability_of_goal: 0.65 },
+    { option_id: 'opt2', outcome: { mean: 0.7, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 2, win_probability: 0.3, probability_of_goal: 0.55 },
+  ],
+  factor_sensitivity: [],
+  robustness: { score: 0.82, label: 'robust', fragile_edges: [], robust_edges: [], edge_e_values: [] },
+};
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return { status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl' };
+  },
+  async analyseSensitivity() { return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' }; },
+  async analyseRobustness() { return { ...ISL_DATA, source: 'isl' as const, latency_ms: 42 }; },
+  async analyseFactorSensitivity() { return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.82, latency_ms: 0, source: 'unavailable' as const }; },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(endpoint: string, _body: unknown, _requestId: string, timeoutMs?: number, maxRetries?: number): Promise<{ data: T | null; error: string | null }> {
+    captured.push({ endpoint, timeoutMs, maxRetries });
+    return { data: ISL_DATA as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, get islService() { return mockISLService; } };
+});
+
+import { createServer } from '../src/createServer.js';
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'factor-a', kind: 'factor', label: 'Marketing', observed_state: { value: 0.6 } },
+  ],
+  edges: [{ from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+};
+const OPTIONS = [
+  { id: 'opt1', label: 'A', interventions: { 'factor-a': 0.8 } },
+  { id: 'opt2', label: 'B', interventions: { 'factor-a': 0.3 } },
+];
+
+describe('item 4 — base ISL robustness call clamped to the request budget', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    delete process.env.REQUEST_BUDGET_MS;
+  });
+  beforeEach(() => { captured.length = 0; });
+
+  async function run() {
+    const res = await app.inject({
+      method: 'POST', url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: 'item4' }),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  function baseCall() {
+    const c = captured.find((x) => x.endpoint === BASE_ROBUSTNESS_ENDPOINT);
+    expect(c, 'base robustness call was made').toBeDefined();
+    return c!;
+  }
+
+  it('passes a finite per-attempt timeout AND a retry cap (not the unclamped defaults)', async () => {
+    delete process.env.REQUEST_BUDGET_MS; // default 70s
+    await run();
+    const c = baseCall();
+    expect(typeof c.timeoutMs).toBe('number');
+    expect(Number.isFinite(c.timeoutMs)).toBe(true);
+    expect(typeof c.maxRetries).toBe('number');
+    expect(c.timeoutMs!).toBeLessThanOrEqual(ISL_TIMEOUT_MS);
+    expect(c.maxRetries!).toBeGreaterThanOrEqual(1);
+  });
+
+  it('worst-case total (maxRetries × per-attempt) is under the UI 120s timeout at the default budget', async () => {
+    delete process.env.REQUEST_BUDGET_MS; // default 70s
+    await run();
+    const c = baseCall();
+    const worstCase = c.maxRetries! * c.timeoutMs!;
+    // Pre-fix worst case was 60_000 × 3 = 180_000 (> 120_000). Now bounded.
+    expect(worstCase).toBeLessThan(UI_CLIENT_TIMEOUT_MS);
+    // …and within the request budget envelope (70s default).
+    expect(worstCase).toBeLessThanOrEqual(70_000);
+  });
+
+  it('a tighter runtime budget clamps harder (mirror of the flip-block clamp)', async () => {
+    process.env.REQUEST_BUDGET_MS = '30000';
+    await run();
+    const c = baseCall();
+    const worstCase = c.maxRetries! * c.timeoutMs!;
+    expect(c.timeoutMs!).toBeLessThanOrEqual(30_000);
+    expect(worstCase).toBeLessThanOrEqual(30_000);
+    expect(worstCase).toBeLessThan(UI_CLIENT_TIMEOUT_MS);
+    delete process.env.REQUEST_BUDGET_MS;
+  });
+});

--- a/tests/plot-remediation.cross-repo-complexity-pin.test.ts
+++ b/tests/plot-remediation.cross-repo-complexity-pin.test.ts
@@ -1,0 +1,35 @@
+/**
+ * A3 remediation item 12 (2026-07-18) — CROSS-REPO complexity-budget drift guard.
+ *
+ * PLoT mirrors ISL's request-complexity budget (`ISL_MAX_COMPUTE_COMPLEXITY`) in
+ * `ISL_COMPLEXITY_BUDGET_DEFAULT` so it can ADAPT n_samples BEFORE calling ISL
+ * (avoiding a raw ISL 422). The two values MUST match: if PLoT's mirror exceeds
+ * ISL's enforced budget, PLoT under-reduces and dense graphs get a raw ISL 422
+ * instead of PLoT's disclosed adaptive reduction.
+ *
+ * The per-repo "lenient limits" value pins (PLoT tests/lenient-latency-values.pin,
+ * ISL tests/unit/test_lenient_limits.py) each pin their OWN side INDEPENDENTLY —
+ * that is exactly the hand-maintained mirror that drifts silently (CLAUDE.md
+ * trap #12). This test is the explicit cross-repo contract: it names ISL's
+ * enforced value and goes RED the moment PLoT's mirror moves away from it, so a
+ * change on either side forces a conscious update here + a deploy-order check.
+ *
+ * ⚠ DEPLOY-ORDER COUPLING: a change to this number must land on ISL (or be set
+ * via `ISL_MAX_COMPUTE_COMPLEXITY` on BOTH services) BEFORE/with the PLoT deploy.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ISL_COMPLEXITY_BUDGET_DEFAULT } from '../src/config/sampling.js';
+
+/**
+ * The value ISL enforces as its complexity cap (`_DEFAULT_MAX_COMPLEXITY` /
+ * env `ISL_MAX_COMPUTE_COMPLEXITY`), raised 10M → 30M in the ISL lenient-limits
+ * lane (ISL PR #77). Update BOTH repos + this constant together.
+ */
+const ISL_ENFORCED_COMPLEXITY_BUDGET = 30_000_000;
+
+describe('item 12 — PLoT complexity mirror equals ISL enforced budget', () => {
+  it('ISL_COMPLEXITY_BUDGET_DEFAULT === the value ISL enforces (30M)', () => {
+    expect(ISL_COMPLEXITY_BUDGET_DEFAULT).toBe(ISL_ENFORCED_COMPLEXITY_BUDGET);
+  });
+});

--- a/tests/plot-remediation.enrichment-sampling.test.ts
+++ b/tests/plot-remediation.enrichment-sampling.test.ts
@@ -1,0 +1,75 @@
+/**
+ * A3 remediation item 8 (2026-07-18) — env-configurable 1-in-N sampling for the
+ * producer-side enrichment egress guard. Every request outside production; 1-in-N
+ * in production; `ENRICHMENT_GUARD_SAMPLE_N` overrides. A deterministic envelope
+ * break still surfaces within N (round-robin, not random).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  shouldAssessEnrichmentContract,
+  resolveEnrichmentGuardSampleN,
+  __resetEnrichmentGuardSampler,
+  DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD,
+} from '../src/routes/v2/enrichment-egress-guard.js';
+
+const ENV = 'ENRICHMENT_GUARD_SAMPLE_N';
+let savedNodeEnv: string | undefined;
+
+beforeEach(() => {
+  savedNodeEnv = process.env.NODE_ENV;
+  delete process.env[ENV];
+  __resetEnrichmentGuardSampler();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  delete process.env[ENV];
+  if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = savedNodeEnv;
+  __resetEnrichmentGuardSampler();
+  vi.restoreAllMocks();
+});
+
+function sequence(n: number): boolean[] {
+  return Array.from({ length: n }, () => shouldAssessEnrichmentContract());
+}
+
+describe('item 8 — enrichment guard sampling', () => {
+  it('default outside production: assess EVERY request (N = 1)', () => {
+    process.env.NODE_ENV = 'test';
+    expect(resolveEnrichmentGuardSampleN()).toBe(1);
+    expect(sequence(5)).toEqual([true, true, true, true, true]);
+  });
+
+  it('default in production: 1-in-N (N = DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD)', () => {
+    process.env.NODE_ENV = 'production';
+    expect(resolveEnrichmentGuardSampleN()).toBe(DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD);
+    const seq = sequence(DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD * 2);
+    // Exactly one assessment per window of N, at the window start.
+    expect(seq.filter(Boolean)).toHaveLength(2);
+    expect(seq[0]).toBe(true);
+    expect(seq[DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD]).toBe(true);
+  });
+
+  it('ENRICHMENT_GUARD_SAMPLE_N overrides — deterministic 1-in-3 round-robin', () => {
+    process.env.NODE_ENV = 'production';
+    process.env[ENV] = '3';
+    expect(resolveEnrichmentGuardSampleN()).toBe(3);
+    // Round-robin: request 1, 4, 7 assessed — a deterministic break surfaces within 3.
+    expect(sequence(7)).toEqual([true, false, false, true, false, false, true]);
+  });
+
+  it('ENRICHMENT_GUARD_SAMPLE_N=1 forces every-request even in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env[ENV] = '1';
+    expect(sequence(4)).toEqual([true, true, true, true]);
+  });
+
+  it('malformed ENRICHMENT_GUARD_SAMPLE_N falls back to the env default (never misparsed)', () => {
+    process.env.NODE_ENV = 'production';
+    for (const bad of ['', '3.5', '1_0', '10abc', '-2', '0']) {
+      process.env[ENV] = bad;
+      expect(resolveEnrichmentGuardSampleN()).toBe(DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD);
+    }
+  });
+});

--- a/tests/plot-remediation.isl-degrade-disclosure.route.test.ts
+++ b/tests/plot-remediation.isl-degrade-disclosure.route.test.ts
@@ -1,0 +1,190 @@
+/**
+ * A3 remediation item 5 (ALTITUDE Hunt 2, 2026-07-18; expanded per coordinator
+ * — ISL PR #78 emits FOUR budget-degradation codes) — PLoT carries ISL's
+ * degrade disclosures STABILITY_BANDS_UNAVAILABLE, E_VALUES_UNAVAILABLE,
+ * EVPI_UNAVAILABLE, PATH_DECOMPOSITION_UNAVAILABLE through to the /v2/run wire
+ * as inference_warnings, exactly the way FLIP_THRESHOLDS_UNAVAILABLE rides. Each
+ * carries elapsed_ms (how long the phase ran before degrading), which PLoT
+ * preserves on the wire. PLoT's generic ISL-warning merge (run.ts) forwards any
+ * {code, message, severity, elapsed_ms?} entry, and the egress enrichment
+ * guard's inference_warnings element is passthrough with an open
+ * `code: z.string().min(1)`, so enrichment_contract_ok stays true.
+ *
+ * Harness modelled on tests/lane3-stability-bands-carrythrough.test.ts (single
+ * vi.mock of the ISL service so the mocked envelope reaches the route).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const ISL_INFERENCE_WARNINGS = [
+  {
+    code: 'STABILITY_BANDS_UNAVAILABLE',
+    message:
+      'Seed-sweep flip-stability bands were attempted but the band computation ' +
+      'exceeded its budget for this analysis — bands are omitted; all other analyses are unaffected.',
+    severity: 'warning',
+    elapsed_ms: 2013,
+  },
+  {
+    code: 'E_VALUES_UNAVAILABLE',
+    message:
+      'Edge E-values were attempted but the E-value computation exceeded its ' +
+      'budget for this analysis — edge_e_values are omitted; all other analyses are unaffected.',
+    severity: 'warning',
+    elapsed_ms: 8041,
+  },
+  {
+    code: 'EVPI_UNAVAILABLE',
+    message:
+      'Per-factor EVPI (value of information) was attempted but exceeded its ' +
+      'budget for this analysis — EVPI is omitted; all other analyses are unaffected.',
+    severity: 'warning',
+    elapsed_ms: 1502,
+  },
+  {
+    code: 'PATH_DECOMPOSITION_UNAVAILABLE',
+    message:
+      'Structural path decomposition was attempted but exceeded its budget for ' +
+      'this analysis — path_decomposition is omitted; all other analyses are unaffected.',
+    severity: 'warning',
+    elapsed_ms: 3300,
+  },
+];
+
+const EXPECTED_CODES = [
+  'STABILITY_BANDS_UNAVAILABLE',
+  'E_VALUES_UNAVAILABLE',
+  'EVPI_UNAVAILABLE',
+  'PATH_DECOMPOSITION_UNAVAILABLE',
+] as const;
+
+const ISL_DATA = {
+  options: [
+    { option_id: 'opt1', outcome: { mean: 0.8, std: 0.1, p10: 0.6, p50: 0.8, p90: 0.95, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 1, win_probability: 0.7, probability_of_goal: 0.65 },
+    { option_id: 'opt2', outcome: { mean: 0.7, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 2, win_probability: 0.3, probability_of_goal: 0.55 },
+  ],
+  factor_sensitivity: [],
+  robustness: {
+    score: 0.82,
+    label: 'robust',
+    fragile_edges: [],
+    robust_edges: ['factor-a::goal'],
+    edge_e_values: [],
+  },
+  // ISL-originated degrade disclosures (the ISL lane emits these on budget trip).
+  inference_warnings: ISL_INFERENCE_WARNINGS,
+};
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness() {
+    return { ...ISL_DATA, source: 'isl' as const, latency_ms: 42 };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.82, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, _body: unknown): Promise<{ data: T | null; error: string | null }> {
+    return { data: ISL_DATA as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../src/integrations/isl/index.ts');
+  return {
+    ...actual,
+    getISLService: () => mockISLService,
+    get islService() { return mockISLService; },
+  };
+});
+
+import { createServer } from '../src/createServer.js';
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+    { id: 'factor-b', kind: 'factor', label: 'Churn Rate', observed_state: { value: 0.4 } },
+  ],
+  edges: [
+    { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'factor-b', to: 'goal', strength: { mean: 0.3, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 0.8 } },
+  { id: 'opt2', label: 'Reduce Spend', interventions: { 'factor-a': 0.3 } },
+];
+
+describe('item 5 — ISL degrade disclosures carried through to the wire', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  async function run() {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: 'item5-degrade' }),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  it('all FOUR ISL degrade codes appear on inference_warnings, severity + elapsed_ms preserved', async () => {
+    const body = await run();
+    const warnings = body.inference_warnings ?? [];
+    const byCode = new Map<string, { code: string; message: string; severity: string; elapsed_ms?: number }>(
+      warnings.map((w: { code: string }) => [w.code, w]),
+    );
+
+    for (const source of ISL_INFERENCE_WARNINGS) {
+      const got = byCode.get(source.code);
+      expect(got, `wire warning for ${source.code}`).toBeDefined();
+      expect(got!.severity).toBe('warning');
+      // elapsed_ms is carried through verbatim (a slow degrade stays diagnosable).
+      expect(got!.elapsed_ms).toBe(source.elapsed_ms);
+    }
+    // spot-check the message routing survives too
+    expect(byCode.get('STABILITY_BANDS_UNAVAILABLE')!.message).toContain('bands are omitted');
+    expect(byCode.get('PATH_DECOMPOSITION_UNAVAILABLE')!.message).toContain('path_decomposition is omitted');
+  });
+
+  it('carrying the four codes keeps enrichment_contract_ok true (open, passthrough schema)', async () => {
+    const body = await run();
+    // Non-vacuous: the codes are genuinely on this wire…
+    const codes = (body.inference_warnings ?? []).map((w: { code: string }) => w.code);
+    for (const code of EXPECTED_CODES) {
+      expect(codes).toContain(code);
+    }
+    // …and the egress guard still assesses the envelope as conformant, even with
+    // the additive elapsed_ms field on each forwarded warning.
+    expect(body._meta?.evidence?.enrichment_contract_ok).toBe(true);
+    expect(codes).not.toContain('ENRICHMENT_CONTRACT_MISMATCH');
+  });
+});

--- a/tests/plot-remediation.robustness.test.ts
+++ b/tests/plot-remediation.robustness.test.ts
@@ -1,0 +1,173 @@
+/**
+ * A3 PLoT remediation (2026-07-18) — robustness/correctness fixes.
+ *
+ * Covers spec items 1-3 (flip-thresholds.ts):
+ *  1. NaN-safe env parse for the flip-search time budgets (was `parseInt`).
+ *  2. Unknown-base probe-depth fallback = explicit 4,000 floor (not the 10k cap).
+ *  3. resolveFlipValues bounds ISL fan-out to FLIP_MAX_CONCURRENT_ISL_CALLS.
+ *
+ * @see acceptance-evidence/a3-verify-2026-07-16/REMEDIATION-SPEC.md (PLoT LANE)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  resolveFlipOverallTimeoutMs,
+  resolveFlipPerFactorTimeoutMs,
+  resolveFlipProbeNSamples,
+  resolveFlipValues,
+  DEFAULT_FLIP_OVERALL_TIMEOUT_MS,
+  DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS,
+  DEFAULT_FLIP_PROBE_N_SAMPLES,
+  FLIP_PROBE_UNKNOWN_BASE_N_SAMPLES,
+  FLIP_MAX_CONCURRENT_ISL_CALLS,
+  type ISLInferenceFn,
+} from '../src/analysis/flip-thresholds.js';
+import { MAX_N_SAMPLES } from '../src/config/env-int.js';
+import type { FlipThresholdInputData } from '../src/cee/validation/m1-review-types.js';
+
+const OVERALL_ENV = 'FLIP_SEARCH_OVERALL_TIMEOUT_MS';
+const PERFACTOR_ENV = 'FLIP_SEARCH_PER_FACTOR_TIMEOUT_MS';
+
+beforeEach(() => {
+  delete process.env[OVERALL_ENV];
+  delete process.env[PERFACTOR_ENV];
+  // Invalid-env cases trip a once-per-process operator warning; silence it.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  delete process.env[OVERALL_ENV];
+  delete process.env[PERFACTOR_ENV];
+  vi.restoreAllMocks();
+});
+
+// -----------------------------------------------------------------------------
+// Item 1 — NaN-safe env parse
+// -----------------------------------------------------------------------------
+describe('item 1 — flip-timeout env parsing is NaN-safe (strict, bounded)', () => {
+  it('unset env → the raised defaults (positive control)', () => {
+    expect(resolveFlipOverallTimeoutMs()).toBe(DEFAULT_FLIP_OVERALL_TIMEOUT_MS); // 30_000
+    expect(resolveFlipPerFactorTimeoutMs()).toBe(DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS); // 10_000
+  });
+
+  it('a valid integer env override wins', () => {
+    process.env[OVERALL_ENV] = '25000';
+    process.env[PERFACTOR_ENV] = '8000';
+    expect(resolveFlipOverallTimeoutMs()).toBe(25000);
+    expect(resolveFlipPerFactorTimeoutMs()).toBe(8000);
+  });
+
+  it.each(['', '30_000', '30000abc', '1.5', '-5', 'nan'])(
+    'malformed/empty env %o falls back to the default (never NaN/garbage — old parseInt bug)',
+    (bad) => {
+      process.env[OVERALL_ENV] = bad;
+      process.env[PERFACTOR_ENV] = bad;
+      const overall = resolveFlipOverallTimeoutMs();
+      const perFactor = resolveFlipPerFactorTimeoutMs();
+      // The core of the bug: a NaN deadline (Date.now() + NaN) disables every
+      // `Date.now() >= deadline` guard. Assert finiteness explicitly.
+      expect(Number.isFinite(overall)).toBe(true);
+      expect(Number.isFinite(perFactor)).toBe(true);
+      expect(overall).toBe(DEFAULT_FLIP_OVERALL_TIMEOUT_MS);
+      expect(perFactor).toBe(DEFAULT_FLIP_PER_FACTOR_TIMEOUT_MS);
+      // parseInt('30_000') === 30 and parseInt('30000abc') === 30000 — prove we
+      // did NOT silently accept those truncations. (perFactor default is 10_000,
+      // which discriminates the 30000-truncation; overall default is 30_000 so it
+      // cannot, hence the truncation check rides perFactor.)
+      expect(overall).not.toBe(30);
+      expect(perFactor).not.toBe(30);
+      expect(perFactor).not.toBe(30000);
+    },
+  );
+});
+
+// -----------------------------------------------------------------------------
+// Item 2 — unknown-base fallback floor + cap derives from MAX_N_SAMPLES
+// -----------------------------------------------------------------------------
+describe('item 2 — probe-depth cap + unknown-base fallback floor', () => {
+  it('the cap constant DERIVES from MAX_N_SAMPLES (value-pin, no drift)', () => {
+    expect(DEFAULT_FLIP_PROBE_N_SAMPLES).toBe(MAX_N_SAMPLES);
+    expect(DEFAULT_FLIP_PROBE_N_SAMPLES).toBe(10_000);
+  });
+
+  it('the unknown-base fallback is the explicit 4,000 floor (value-pin)', () => {
+    expect(FLIP_PROBE_UNKNOWN_BASE_N_SAMPLES).toBe(4_000);
+  });
+
+  it('unknown base depth → 4,000 floor, NEVER the 10k cap (the item-2 fix)', () => {
+    // Pre-fix this returned min(10k, STANDARD_N_SAMPLES_DEFAULT=10k) = 10k,
+    // contradicting the "assume 4000 floor, never the 10k cap" contract.
+    expect(resolveFlipProbeNSamples(undefined)).toBe(4_000);
+    expect(resolveFlipProbeNSamples(undefined)).not.toBe(DEFAULT_FLIP_PROBE_N_SAMPLES);
+    expect(resolveFlipProbeNSamples(NaN)).toBe(4_000);
+    expect(resolveFlipProbeNSamples(0)).toBe(4_000);
+    expect(resolveFlipProbeNSamples(-1)).toBe(4_000);
+  });
+
+  it('known base depth still matches the base up to the cap (unchanged)', () => {
+    expect(resolveFlipProbeNSamples(4000)).toBe(4000);
+    expect(resolveFlipProbeNSamples(8000)).toBe(8000);
+    expect(resolveFlipProbeNSamples(20_000)).toBe(10_000);
+    expect(resolveFlipProbeNSamples(500)).toBe(500);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Item 3 — concurrency cap on ISL fan-out
+// -----------------------------------------------------------------------------
+describe('item 3 — resolveFlipValues bounds ISL fan-out to max 2', () => {
+  const candidate = (id: string): FlipThresholdInputData => ({
+    factor_id: id,
+    factor_label: id,
+    current_value: 0.5,
+    flip_value: null,
+    direction: 'increase',
+  });
+
+  /**
+   * Mock inferenceFn that (a) tracks concurrent in-flight calls and records the
+   * peak, and (b) forces a strict flip at both bounds so each factor runs the
+   * full 3-probe Step-0 fan-out + bisection (maximal ISL calls per factor).
+   */
+  function makeTracker() {
+    let active = 0;
+    let peak = 0;
+    const fn: ISLInferenceFn = async (_factorId, overrideMean) => {
+      active++;
+      peak = Math.max(peak, active);
+      // Yield so overlapping calls actually coexist in-flight.
+      await new Promise((r) => setTimeout(r, 2));
+      active--;
+      // winner flips away from 'opt1' at both bounds (0 and 1), toward 'opt2'
+      const opt1Wins = overrideMean === 0.5;
+      return {
+        options: [
+          { option_id: 'opt1', win_probability: opt1Wins ? 0.7 : 0.3 },
+          { option_id: 'opt2', win_probability: opt1Wins ? 0.3 : 0.7 },
+        ],
+      };
+    };
+    return { fn, peak: () => peak };
+  }
+
+  it('positive control: the tracker CAN observe >2 concurrency when unbounded', async () => {
+    const { fn, peak } = makeTracker();
+    // Fire 5 raw calls in parallel, bypassing the semaphore.
+    await Promise.all([0, 0, 0, 0, 0].map((v) => fn('x', v)));
+    expect(peak()).toBeGreaterThan(FLIP_MAX_CONCURRENT_ISL_CALLS);
+    expect(peak()).toBe(5);
+  });
+
+  it('caps in-flight ISL calls at 2 across 4 candidates (each fans out 3-wide)', async () => {
+    const { fn, peak } = makeTracker();
+    const candidates = [candidate('a'), candidate('b'), candidate('c'), candidate('d')];
+    const { results } = await resolveFlipValues(candidates, fn, 'opt1', {
+      // generous budgets so the cap — not a timeout — governs concurrency
+      overallTimeoutMs: 60_000,
+      perFactorTimeoutMs: 60_000,
+    });
+    expect(results).toHaveLength(4);
+    // Without the cap, peak would be up to 4×3 = 12 (or ≥3 for a single factor).
+    expect(peak()).toBeLessThanOrEqual(FLIP_MAX_CONCURRENT_ISL_CALLS);
+    expect(peak()).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
A3 PLoT remediation lane. Base = staging tip `139150c`. Spec:
`acceptance-evidence/a3-verify-2026-07-16/REMEDIATION-SPEC.md` (PLoT LANE + ALTITUDE-FINALIZED).
Full build evidence + mutation transcripts: `acceptance-evidence/a3-verify-2026-07-16/plot-remediation-BUILD.md`.

**DRAFT — do not merge.** Deploy-order note: item 5 (four ISL degrade codes) pairs with ISL PR #78; item 12 pins the 30M complexity budget ISL must also enforce (ISL PR #77) before/with this deploy.

## Fixes (spec item → change → RED→GREEN)
1. **[P2] NaN-safe flip-timeout env parse** — `resolveFlip{Overall,PerFactor}TimeoutMs` now route through the strict `resolveBoundedIntEnvOrWarn` (was `parseInt(env ?? default)` → NaN on empty, 30 on `30_000`, 30000 on `30000abc` — a NaN deadline disables every guard). ms bounds `[0, 600_000]`; MIN=0 preserves the `=0` immediate-timeout test knob. _RED: parseInt revert → 4 misparse tests fail._
2. **[P2] Unknown-base probe floor** — fallback = explicit `FLIP_PROBE_UNKNOWN_BASE_N_SAMPLES=4000` (was `STANDARD_N_SAMPLES_DEFAULT`, now 10k → `min(10k,10k)` collapsed the cap, contradicting the docstring). `DEFAULT_FLIP_PROBE_N_SAMPLES` derives from `MAX_N_SAMPLES`. Updated the pre-existing pin test that asserted the buggy value. _RED: floor→10k → 2 tests fail._
3. **[P2] Concurrency cap** — `resolveFlipValues` bounds real ISL fan-out to 2 via a shared semaphore (was unbounded `Promise.all`, each factor 3-wide → up to N×3, vs a stale "max 2" comment). _RED: bypass semaphore → peak 12; positive control sees 5-wide._
4. **[P1] Base-call budget clamp** — the base `/v2/run` robustness call is clamped to the remaining request budget + a per-call retry cap (new backward-compatible `maxRetries?` on `callAnalysisEndpoint`) → worst case 60s at default 70s budget (was 60s×3 ≈ 180s > UI 120s). One generous attempt, not truncated. _RED: drop args → NaN worst-case._
5. **[P1] Carry FOUR ISL degrade codes + elapsed_ms** — `STABILITY_BANDS_/E_VALUES_/EVPI_/PATH_DECOMPOSITION_UNAVAILABLE` registered + forwarded through the ISL-warning merge with elapsed_ms preserved; egress schema is open+passthrough so `enrichment_contract_ok` stays true. _RED: drop elapsed_ms → assertion fails; codes still ride (pre-existing merge)._
6. **[P1] Contract-doc corrections** — bands are DEFAULT-ON (ISL #76), n_seeds fixed at 10; deleted the false "default OFF / default 5 clamped [2,20]" flag-state across 5 sites (isl-types ×3, engine-v3, isl-to-ui.contract) + a 5th spec-unlisted site (run.ts transformEdgeEValues). Kept shape + interpretation traps. Zero band flag-state remains in src.
7. **[robustness] Lever suppression** — `structuralLeverIds` REQUIRED on `buildFactorStability` (compile-guard against a silent #226 re-leak). Kept the ternary (divergence justified). 8 test call sites pass explicit `new Set()`.
8. **[efficiency] Enrichment guard sampling** — env-configurable 1-in-N (`ENRICHMENT_GUARD_SAMPLE_N`); every request outside prod, 1-in-16 in prod. Deterministic round-robin so a deterministic break surfaces within N; a skipped request leaves `enrichment_contract_ok` absent (unassessed, never fabricated true).
9. **[cleanup] `resolveRequestBudgetMs()` helper** — replaces two inline `Number(process.env.REQUEST_BUDGET_MS) || REQUEST_BUDGET_MS` re-reads. **Deviated from the literal "→ just REQUEST_BUDGET_MS"**: that would drop the runtime override `threshold-analysis.test.ts` relies on; the helper keeps it while removing the duplication.
10. **[cleanup] Inverted comment** — corrected the flip-probe "decoupled from base depth" comment (the #229 PR reversed it — probes now inherit base depth).

## Dropped / skipped
- **11 (DROPPED)** — the `enrichment-egress-guard.ts` comment cites `wire-generation.ts`, which **exists** at this tip and is used by run.ts. The reference is accurate; correcting it would be wrong.
- **13 (SKIPPED)** — the optional band-denorm `dn` closure: marginal readability gain in a byte-sensitive units-coherence path built across lanes #227/#228; not worth touching (values unchanged either way).

## Gates
- `tsc --noEmit` clean; full `npm test` **5621 passed / 25 skipped / 0 failed** (+ fixtures + loadcheck) — this ran again as the pre-push gate (6/6 PASS).
- **Golden byte-pin** `isl-v2-golden-response.pin.test.ts` PASS → `/v2/run` byte-identical; no value change, golden NOT regenerated, strip NOT widened.
- All five correctness fixes mutation-checked (revert → targeted RED → restore); tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
## Review follow-up (2026-07-18) — head `6af4b72`
Adversarial review found one real item-6 miss: `contracts/openapi.yaml:4062` carried the identical
false band flag-state ("Present ONLY when ISL_FLIP_STABILITY_BANDS enabled (default OFF)"). Corrected
to DEFAULT-ON (ISL #76) to match the 5 src sites — **item 6 now covers all 6 sites**; the
band_width==0/single-flip + units interpretation notes are kept (producer-invariant). Grep confirms
zero band flag-state remains in `contracts/openapi.yaml`.

Spec-touching → ran the exact Redocly CI command (`npx @redocly/cli lint contracts/openapi.yaml
--skip-rule=no-unused-components`) on base `139150c` vs branch: both **37 errors / 39 warnings**;
normalized problem-set diff (JSON-pointer + rule breakdown, line-number-independent) is **EMPTY** —
109 pointers identical both sides, no new problems added.