### PR TITLE
fix(isl-retry): bound optional-phase retries + deadline cancellation + honest backoff accounting (Codex F9/F3/F11) (A3)

### DIFF
--- a/acceptance-evidence/a3-verify-2026-07-16/codex-plot-r1-BUILD.md
+++ b/acceptance-evidence/a3-verify-2026-07-16/codex-plot-r1-BUILD.md
@@ -1,0 +1,85 @@
+# PLoT retry cluster — Codex F9 / F3 / F11 + ISL_MAX_RETRIES de-mirror (A3, r1 BUILD)
+
+Base: `origin/staging` = `b9f825afc0762b911edb2429cbab399a264dabbc` (#230). Built in a
+fresh shallow clone at that tip (the local working tree's `origin/staging` was stale
+at `e0293fe5` #224 with a hung fetch — the known iCloud-pack hazard; per CLAUDE.md
+verification trap #1 the clone is the authority). Node v20.19.5, npm 10.8.2, `npm ci` clean.
+
+Branch: `fix/isl-retry-bound-cancellation-a3`.
+
+## What changed (single source of truth: `src/config/timeouts.ts`)
+
+New exports in `config/timeouts.ts` (derive-don't-mirror):
+- `ISL_MAX_RETRIES_DEFAULT = 3` + `resolveIslMaxRetries()` — the `'3'` default was
+  hand-written in BOTH `isl/client.ts` and `config-validator.ts`; both now derive it.
+- `ISL_RETRY_BACKOFF_BASE_MS` / `ISL_RETRY_BACKOFF_CAP_MS` / `islRetryBackoffMs(attempt)`
+  — the client's backoff series, now one source (client uses it too).
+- `worstCaseMs(attempts, perAttemptTimeoutMs)` = `attempts × perAttempt + Σ backoff`
+  (the exact 1s+2s… series, capped 5s). The honest formula used by the clamp fitting,
+  the clamp telemetry, config-validator's budget warn, AND the tests.
+
+| Finding | Change |
+|---|---|
+| **F9** threshold call (`run.ts` `/api/v1/analysis/thresholds`) | pass `maxRetries = 1` (was omitted → inherited config default 3). Timeout stays clamped to remaining budget. |
+| **F3** flip probes | (a) pass `maxRetries = 1`; (b) thread an **AbortSignal** run.ts arrow → `createISLInferenceFn` → `callAnalysisEndpoint` → client fetch, combining it with the client's per-attempt timeout controller (folded via `controller.abort()`, preserving AbortError→ISLTimeoutError); (c) build a per-factor `AbortSignal.any([overall, factorTimeout])` in `searchFlipForFactorInner`, thread through the semaphore + grid fallback; (d) early-abort short-circuit in `createISLInferenceFn` so a probe dequeued past the deadline does no work (the "re-check deadline in acquire/release" requirement); (e) deadline-aware reclassification of a rejected/thrown probe to `flip_reason: 'timeout'` (else genuine `'error'`). |
+| **F11** base-call clamp | fitting loop + telemetry (`worst_case_total_ms`) + config-validator budget warn + the base-call-budget test now use `worstCaseMs` (backoff included). No runtime change at defaults (still 1 attempt @70s budget) — just honest accounting, centralised. |
+| **de-mirror** | `client.ts` `maxRetries` default and `config-validator.ts` `islMaxRetries` both derive `resolveIslMaxRetries()`; client backoff derives `islRetryBackoffMs`. |
+
+## Files touched
+- `src/config/timeouts.ts` (new helpers)
+- `src/integrations/isl/client.ts` (external signal fold; backoff + retries de-mirror)
+- `src/integrations/isl/index.ts` (`callAnalysisEndpoint` gains `signal?` arg #6; interface + impl)
+- `src/routes/v2/run.ts` (F9 threshold `maxRetries=1`; F3 flip arrow `maxRetries=1`+signal; F11 clamp/telemetry via `worstCaseMs`)
+- `src/analysis/flip-thresholds.ts` (F3 signal threading + cancellation + deadline-aware disclosure)
+- `src/config-validator.ts` (F11 honest budget warn + retries de-mirror)
+- `tests/plot-remediation.base-call-budget.route.test.ts` (F11 honest formula)
+- NEW `tests/isl-worst-case-accounting.test.ts` (F11 unit)
+- NEW `tests/isl-retry-bound.wallclock.test.ts` (F9/F3 wall-clock mechanism + positive control)
+- NEW `tests/flip-probe-cancellation.test.ts` (F3 cancellation + positive control)
+- NEW `tests/plot-remediation.optional-phase-retry.route.test.ts` (F9+F3 route capture)
+
+## Gate — typecheck
+`npx tsc --noEmit` → **0 errors** (TSC_EXIT=0). PLoT's authoritative Tier-1 typecheck
+(repo CLAUDE.md; PLoT has no openapi:generate step — that is the CEE gate).
+
+## GREEN run (new + regression)
+8 files / **92 tests passed**. Telemetry confirmed live in the run:
+- `base_isl_call_budget_clamped … worst_case_total_ms: 60000` (= `worstCaseMs(1, 60000)`, honest).
+- wall-clock positive control: `attempt: 3, max_retries: 3`, elapsed **3762ms** (~3× + 1s+2s backoff).
+- wall-clock fix: `attempt: 1, max_retries: 1`, elapsed **~252ms**.
+- flip probes ran (`probes_used: 3` per factor in the lane2 fixture) — F3 capture path is live.
+
+## Mutation checks (each fix hunk reverted in the committed tree; test → RED; `git checkout` restore, 0 dirty)
+
+| # | Fix hunk reverted | Test run | Result |
+|---|---|---|---|
+| 1 | `worstCaseMs` → `n × perAttempt` (drop backoff) | `isl-worst-case-accounting` | **RED** — `expected 180000 to be 183000` (+ 2 more) |
+| 2 | `run.ts` threshold call: remove `, 1` (maxRetries) | `optional-phase-retry` (F9) | **RED** — `expected undefined to be 1`; F3 case stayed green |
+| 3 | `run.ts` flip arrow: remove `, 1, signal` | `optional-phase-retry` (F3) | **RED** — `expected undefined to be 1`; F9 case stayed green |
+| 4 | `flip-thresholds.ts` Step-0 probes: drop `factorSignal` arg | `flip-probe-cancellation` | **RED** — `flip search did not cancel within 3s`; positive control stayed green |
+| 5 | `client.ts`: remove the external-signal fold | `isl-retry-bound.wallclock` (WIRING) | **RED** — `expected 5006 to be less than 1500` (ran full 5s per-attempt) |
+
+Each mutation was reverted with `git checkout -- <file>` (verified `git status` = 0 dirty) before the next.
+The de-mirror (single-source `ISL_MAX_RETRIES_DEFAULT` / `islRetryBackoffMs`) is a structural refactor
+with no dedicated behavioural test; it is exercised indirectly — the wall-clock positive control depends on
+`resolveIslMaxRetries()` returning 3 at default (it overran to attempt 3), and `tsc` proves both call sites bind.
+
+## Standing-red base-vs-branch check
+Files changed vs base `b9f825af`: **only** `src/*.ts` + `tests/*` + this evidence md. **No** `package.json`,
+`package-lock.json`, or `contracts/openapi.yaml` touched → the `audit` (dep advisories) and
+`validate-structure` (spectral/redocly) reds are IDENTICAL to base by construction; `gates (windows-latest)`
+is the pre-existing invalid-path red, unrelated. (Confirmed no new problem-set introduced.)
+
+## Full gate (`scripts/pre-push-validate.sh`) — PASSED, 0 failures
+```
+PASS [1/7] Branch guard (fix/isl-retry-bound-cancellation-a3)
+PASS [2/7] TypeScript compilation (tsc --noEmit)
+PASS [3/7] Full test suite —  Tests  5634 passed | 25 skipped (5670)
+PASS [4/7] No stale .js files tracked in src/
+PASS [5/7] file: dependency policy OK
+PASS [6/7] OpenAPI spec validation (spectral lint)
+Failures: 0 — Pre-push validation PASSED
+```
+(The local pre-push gate has no `npm audit` step; the CI `audit` / `gates (windows-latest)` /
+`validate-structure` jobs are the separate standing reds, unchanged — no deps/spec touched.)
+

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -43,7 +43,14 @@ export interface FlipInferenceResult {
  */
 export type ISLInferenceFn = (
   factorId: string,
-  overrideMean: number
+  overrideMean: number,
+  /**
+   * F3 (Codex): optional per-probe cancellation signal. When the factor/overall
+   * flip deadline trips, this aborts so an in-flight ISL probe cancels instead of
+   * running to completion. Implementations that ignore it still work (no
+   * cancellation, unchanged behaviour) — a 2-arg fn stays assignable to this type.
+   */
+  signal?: AbortSignal
 ) => Promise<FlipInferenceResult>;
 
 /**
@@ -271,10 +278,13 @@ function limitConcurrency(fn: ISLInferenceFn, max: number): ISLInferenceFn {
     const next = queue.shift();
     if (next) next();
   };
-  return async (factorId: string, overrideMean: number): Promise<FlipInferenceResult> => {
+  return async (factorId: string, overrideMean: number, signal?: AbortSignal): Promise<FlipInferenceResult> => {
     await acquire();
     try {
-      return await fn(factorId, overrideMean);
+      // Forward the deadline signal so a probe dequeued AFTER the deadline sees an
+      // already-aborted signal and short-circuits (see createISLInferenceFn) — this
+      // is how a queued probe past the deadline is prevented from starting real work.
+      return await fn(factorId, overrideMean, signal);
     } finally {
       release();
     }
@@ -310,6 +320,13 @@ export async function resolveFlipValues(
   }
 
   const overallDeadline = Date.now() + cfg.overallTimeoutMs;
+  // Cancellation (F3, Codex): a signal that aborts when the OVERALL flip deadline
+  // trips, threaded to every probe so in-flight ISL calls actually cancel. The
+  // `Date.now() >= deadline` guards below only fire BETWEEN probes — they cannot
+  // interrupt an awaited Promise.allSettled or cancel a queued/in-flight probe.
+  // AbortSignal.timeout's internal timer is unref'd, so it never keeps the event
+  // loop (or a test process) alive after the search settles.
+  const overallTimeoutSignal = AbortSignal.timeout(Math.max(0, cfg.overallTimeoutMs));
 
   // Cap TOTAL in-flight ISL calls at 2 across the whole flip search. Each factor
   // search issues up to 3 Step-0 probes in parallel (baseline + both bounds), so
@@ -323,7 +340,7 @@ export async function resolveFlipValues(
   const boundedInferenceFn = limitConcurrency(inferenceFn, FLIP_MAX_CONCURRENT_ISL_CALLS);
   const settled = await Promise.all(
     candidates.map((candidate) =>
-      searchFlipForFactor(candidate, boundedInferenceFn, originalWinnerId, cfg, overallDeadline)
+      searchFlipForFactor(candidate, boundedInferenceFn, originalWinnerId, cfg, overallDeadline, overallTimeoutSignal)
     )
   );
 
@@ -354,13 +371,14 @@ async function searchFlipForFactor(
   inferenceFn: ISLInferenceFn,
   originalWinnerId: string,
   config: FlipSearchConfig,
-  overallDeadline: number
+  overallDeadline: number,
+  overallSignal: AbortSignal
 ): Promise<{ result: FlipThresholdInputData; diagnostics: FlipDiagnostics }> {
   // Stamp elapsed_ms on every diagnostics entry (all exit paths return the
   // shared `diag` object). Paul-ruled lenient defaults 2026-07-17: slowness
   // must be visible, especially on 'timeout' trips.
   const searchStartedAt = Date.now();
-  const out = await searchFlipForFactorInner(candidate, inferenceFn, originalWinnerId, config, overallDeadline);
+  const out = await searchFlipForFactorInner(candidate, inferenceFn, originalWinnerId, config, overallDeadline, overallSignal);
   out.diagnostics.elapsed_ms = Date.now() - searchStartedAt;
   return out;
 }
@@ -370,9 +388,18 @@ async function searchFlipForFactorInner(
   inferenceFn: ISLInferenceFn,
   originalWinnerId: string,
   config: FlipSearchConfig,
-  overallDeadline: number
+  overallDeadline: number,
+  overallSignal: AbortSignal
 ): Promise<{ result: FlipThresholdInputData; diagnostics: FlipDiagnostics }> {
   const factorDeadline = Math.min(Date.now() + config.perFactorTimeoutMs, overallDeadline);
+  // Cancellation (F3): abort every probe of THIS factor when either the factor's
+  // own deadline or the overall flip deadline trips. Combined with the between-probe
+  // `Date.now() >= factorDeadline` guards below, this makes in-flight AND queued
+  // probes stop instead of running to completion past the deadline.
+  const factorSignal = AbortSignal.any([
+    overallSignal,
+    AbortSignal.timeout(Math.max(0, factorDeadline - Date.now())),
+  ]);
 
   const baseline = candidate.current_value;
 
@@ -433,19 +460,24 @@ async function searchFlipForFactorInner(
     // settles fulfilled or rejected); true in-flight bounding would require request
     // cancellation (AbortController), which is out of scope for this telemetry fix.
     const settled = await Promise.allSettled([
-      inferenceFn(candidate.factor_id, baseline),
-      inferenceFn(candidate.factor_id, 0),
-      inferenceFn(candidate.factor_id, 1),
+      inferenceFn(candidate.factor_id, baseline, factorSignal),
+      inferenceFn(candidate.factor_id, 0, factorSignal),
+      inferenceFn(candidate.factor_id, 1, factorSignal),
     ]);
     probes += settled.filter((s) => s.status === 'fulfilled').length;
 
     // Any Step-0 probe failing → error, with the honest count of probes that did
     // complete. (margin_sensitivity is intentionally omitted, as on the catch path.)
+    // Cancellation (F3): a rejection AFTER the deadline is a cancelled probe, not
+    // an ISL fault — disclose it as 'timeout' (the same status the between-probe
+    // guards use), else 'error'. Never relabel a genuine failure as a timeout.
     if (settled.some((s) => s.status === 'rejected')) {
-      diag.flip_reason = 'error';
+      const reason: 'timeout' | 'error' =
+        (Date.now() >= factorDeadline || factorSignal.aborted) ? 'timeout' : 'error';
+      diag.flip_reason = reason;
       diag.probes_used = probes;
       return {
-        result: { ...candidate, flip_value: null, flip_reason: 'error', iterations_used: 0, probes_used: probes, alternative_winner_id: null },
+        result: { ...candidate, flip_value: null, flip_reason: reason, iterations_used: 0, probes_used: probes, alternative_winner_id: null },
         diagnostics: diag,
       };
     }
@@ -560,7 +592,7 @@ async function searchFlipForFactorInner(
       }
 
       const mid = midpoint(searchLow, searchHigh);
-      const midResult = await inferenceFn(candidate.factor_id, mid);
+      const midResult = await inferenceFn(candidate.factor_id, mid, factorSignal);
       iterations++;
       probes++; // bisection midpoint probe completed
 
@@ -575,7 +607,7 @@ async function searchFlipForFactorInner(
       } else {
         // Non-monotonic: a third option became the winner. Fall back to grid scan.
         return await gridFallback(
-          candidate, inferenceFn, originalWinnerId, 0, 1, config, factorDeadline, iterations, probes, diag, marginSensitivity
+          candidate, inferenceFn, originalWinnerId, 0, 1, config, factorDeadline, iterations, probes, diag, marginSensitivity, factorSignal
         );
       }
     }
@@ -604,10 +636,15 @@ async function searchFlipForFactorInner(
       diagnostics: diag,
     };
   } catch (err) {
-    diag.flip_reason = 'error';
+    // Cancellation (F3): an error after the deadline is a cancelled probe →
+    // disclose 'timeout'; else a genuine ISL fault → 'error'. (Mirror of the
+    // Step-0 rejection branch above.)
+    const reason: 'timeout' | 'error' =
+      (Date.now() >= factorDeadline || factorSignal.aborted) ? 'timeout' : 'error';
+    diag.flip_reason = reason;
     diag.probes_used = probes;
     return {
-      result: { ...candidate, flip_value: null, flip_reason: 'error', iterations_used: 0, probes_used: probes, alternative_winner_id: null },
+      result: { ...candidate, flip_value: null, flip_reason: reason, iterations_used: 0, probes_used: probes, alternative_winner_id: null },
       diagnostics: diag,
     };
   }
@@ -632,7 +669,8 @@ async function gridFallback(
   iterationsSoFar: number,
   probesSoFar: number,
   diag: FlipDiagnostics,
-  marginSensitivity: MarginSensitivity
+  marginSensitivity: MarginSensitivity,
+  signal?: AbortSignal
 ): Promise<{ result: FlipThresholdInputData; diagnostics: FlipDiagnostics }> {
   // iterations_used stays bisection-only: grid probes count toward probes_used,
   // never toward iterations_used. `iterations` is fixed to the bisection-iteration
@@ -655,7 +693,7 @@ async function gridFallback(
     const probeValue = low + i * step;
 
     try {
-      const result = await inferenceFn(candidate.factor_id, probeValue);
+      const result = await inferenceFn(candidate.factor_id, probeValue, signal);
       probes++; // grid probe completed (counts toward probes_used, not iterations_used)
 
       const winner = getArgmaxOption(result);
@@ -768,7 +806,7 @@ function roundTo4(value: number): number {
  * @returns ISLInferenceFn callback
  */
 export function createISLInferenceFn(
-  callAnalysis: (endpoint: string, body: unknown, requestId: string) => Promise<{ data: any | null }>,
+  callAnalysis: (endpoint: string, body: unknown, requestId: string, signal?: AbortSignal) => Promise<{ data: any | null }>,
   originalRequest: {
     graph: { nodes: any[]; edges: any[] };
     options: any[];
@@ -785,7 +823,16 @@ export function createISLInferenceFn(
   // When omitted, probes fall back to the base request's n_samples (legacy behaviour).
   flipProbeNSamples?: number
 ): ISLInferenceFn {
-  return async (factorId: string, overrideMean: number): Promise<FlipInferenceResult> => {
+  return async (factorId: string, overrideMean: number, signal?: AbortSignal): Promise<FlipInferenceResult> => {
+    // F3 (Codex): a probe dequeued AFTER the deadline (semaphore release path)
+    // must not start real work — short-circuit before building the payload or
+    // calling ISL. This is the "re-check the deadline in the acquire/release path"
+    // guarantee, delivered via the threaded signal rather than by coupling the
+    // generic concurrency limiter to the flip deadline. An in-flight probe is
+    // separately cancelled inside the client (the signal aborts its fetch).
+    if (signal?.aborted) {
+      throw new DOMException('Flip probe aborted before ISL call (deadline elapsed)', 'AbortError');
+    }
     // Clone parameter_uncertainties with the target factor's mean overridden
     const basePU = originalRequest.parameter_uncertainties ?? [];
     const factorExists = basePU.some((pu) => pu.node_id === factorId);
@@ -860,7 +907,8 @@ export function createISLInferenceFn(
     const result = await callAnalysis(
       '/api/v1/robustness/analyze/v2',
       modifiedRequest,
-      `${requestId}__flip`
+      `${requestId}__flip`,
+      signal
     );
 
     if (!result.data) {

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -1,5 +1,5 @@
 import pino from 'pino';
-import { ISL_TIMEOUT_MS, CEE_TIMEOUT_MS } from './config/timeouts.js';
+import { ISL_TIMEOUT_MS, CEE_TIMEOUT_MS, worstCaseMs, resolveIslMaxRetries } from './config/timeouts.js';
 
 const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
@@ -154,12 +154,17 @@ export function validateEnv(): void {
   // 60000 CEE default), so this warn was doing its arithmetic on a codebase
   // that didn't exist.
   const islTimeoutMs = ISL_TIMEOUT_MS;
-  const islMaxRetries = Number(process.env.ISL_MAX_RETRIES || '3');
+  // De-mirrored 2026-07-18: the ISL_MAX_RETRIES default '3' now derives from the
+  // single source in config/timeouts.ts (was hand-written here AND in isl/client.ts).
+  const islMaxRetries = resolveIslMaxRetries();
   const ceeTimeoutMs = CEE_TIMEOUT_MS;
   const computeBudgetMs = Number(process.env.MAX_COMPUTE_MS || '10000');
 
-  // ISL worst-case: timeout × retries (sequential retries with exponential backoff)
-  const islWorstCaseMs = islTimeoutMs * islMaxRetries;
+  // ISL worst-case: attempts × per-attempt timeout PLUS the 1s+2s… backoff slept
+  // between them. The comment said "with exponential backoff" but the previous
+  // formula (islTimeoutMs × islMaxRetries) omitted it; worstCaseMs is now the
+  // single honest source shared with the /v2/run base-call clamp + telemetry.
+  const islWorstCaseMs = worstCaseMs(islMaxRetries, islTimeoutMs);
 
   // Total worst-case: max(ISL, CEE) + compute
   const totalWorstCaseMs = Math.max(islWorstCaseMs, ceeTimeoutMs) + computeBudgetMs;

--- a/src/config/timeouts.ts
+++ b/src/config/timeouts.ts
@@ -133,6 +133,61 @@ export function resolveRequestBudgetMs(): number {
 }
 
 // -----------------------------------------------------------------------------
+// ISL retry policy (single source of truth)
+// -----------------------------------------------------------------------------
+
+/**
+ * Default TOTAL ISL attempts (initial try + retries) — the `for (attempt = 1;
+ * attempt <= maxRetries; attempt++)` bound in isl/client.ts.
+ *
+ * De-mirrored 2026-07-18: this `3` was hand-written in BOTH isl/client.ts
+ * (`parseInt(process.env.ISL_MAX_RETRIES ?? '3', 10)`) and config-validator.ts
+ * (`Number(process.env.ISL_MAX_RETRIES || '3')`). A single constant so the two
+ * cannot silently drift. (The ISL timeouts were already de-mirrored here; this
+ * default was the one left behind.)
+ */
+export const ISL_MAX_RETRIES_DEFAULT = 3;
+
+/** Resolve the ISL attempt cap from `ISL_MAX_RETRIES` (default {@link ISL_MAX_RETRIES_DEFAULT}). */
+export function resolveIslMaxRetries(): number {
+  return parseInt(process.env.ISL_MAX_RETRIES ?? String(ISL_MAX_RETRIES_DEFAULT), 10);
+}
+
+/**
+ * Exponential-backoff constants for ISL retries. isl/client.ts sleeps
+ * `min(BASE · 2^(attempt-1), CAP)` AFTER each failed non-final attempt. Kept
+ * here as the single source shared with the worst-case accounting below.
+ */
+export const ISL_RETRY_BACKOFF_BASE_MS = 1_000;
+export const ISL_RETRY_BACKOFF_CAP_MS = 5_000;
+
+/** Backoff slept after attempt `attempt` (1-indexed) before the next try. */
+export function islRetryBackoffMs(attempt: number): number {
+  return Math.min(ISL_RETRY_BACKOFF_BASE_MS * Math.pow(2, attempt - 1), ISL_RETRY_BACKOFF_CAP_MS);
+}
+
+/**
+ * HONEST worst-case wall time for `attempts` sequential ISL attempts, each
+ * bounded by `perAttemptTimeoutMs`:
+ *
+ *   attempts × perAttemptTimeoutMs  +  Σ backoff slept BETWEEN them
+ *                                       (i = 1 .. attempts-1)
+ *
+ * The previous accounting (`attempts × perAttemptTimeoutMs`) OMITTED the 1s+2s…
+ * backoff the client actually sleeps — config-validator's comment even claimed
+ * "with exponential backoff" while its arithmetic did not include it, and the
+ * /v2/run base-call clamp + its telemetry + their test each repeated the same
+ * omission. Centralised here so every one of those sites DERIVES the same number
+ * instead of re-deriving (and re-omitting) it.
+ */
+export function worstCaseMs(attempts: number, perAttemptTimeoutMs: number): number {
+  const n = Math.max(0, Math.floor(attempts));
+  let backoff = 0;
+  for (let i = 1; i <= n - 1; i++) backoff += islRetryBackoffMs(i);
+  return n * perAttemptTimeoutMs + backoff;
+}
+
+// -----------------------------------------------------------------------------
 // Fastify server timeout
 // -----------------------------------------------------------------------------
 

--- a/src/integrations/isl/client.ts
+++ b/src/integrations/isl/client.ts
@@ -11,7 +11,7 @@
 import { ISLHttpError, ISLTimeoutError, ISLNetworkError, isRetryableError, type ISLError422 } from './errors.js';
 import { computeOlumiHash } from '../../util/canonical.js';
 import { recordDownstreamCall, sanitizePayloadForDebug, computePayloadDigest } from '../../util/downstream-tracker.js';
-import { ISL_TIMEOUT_MS, ISL_HEALTH_CHECK_TIMEOUT_MS } from '../../config/timeouts.js';
+import { ISL_TIMEOUT_MS, ISL_HEALTH_CHECK_TIMEOUT_MS, resolveIslMaxRetries, islRetryBackoffMs } from '../../config/timeouts.js';
 
 /**
  * ISL client configuration
@@ -39,6 +39,15 @@ export interface ISLRequestOptions {
   body: unknown;
   /** Request ID for tracing */
   requestId: string;
+  /**
+   * Optional external cancellation signal (e.g. a flip-search factor/overall
+   * deadline). Folded into THIS attempt's timeout AbortController so an in-flight
+   * fetch aborts the moment the caller's deadline trips. A deadline-cancel
+   * surfaces as an {@link ISLTimeoutError} — the same class as the per-attempt
+   * timeout — because the fold re-aborts via `controller.abort()` (name
+   * `AbortError`), preserving the existing AbortError→ISLTimeoutError mapping.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -82,7 +91,7 @@ export class ISLClient {
    * @throws ISLHttpError on non-2xx responses
    */
   async request<T>(options: ISLRequestOptions): Promise<ISLRequestResult<T>> {
-    const { endpoint, body, requestId } = options;
+    const { endpoint, body, requestId, signal: externalSignal } = options;
     // Pin response version via query param (in addition to header)
     const url = `${this.config.baseUrl}${endpoint}?response_version=2`;
 
@@ -109,12 +118,30 @@ export class ISLClient {
       // Track start time outside try block for catch access
       const startTime = Date.now();
 
+      // Per-attempt timeout controller. Hoisted (with the external-signal
+      // listener) so the `finally` below always clears the timer and detaches the
+      // listener — even on the throwing path — with no cross-attempt leak.
+      const controller = new AbortController();
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      let onExternalAbort: (() => void) | undefined;
+
       try {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(
+        timeoutId = setTimeout(
           () => controller.abort(),
           this.config.timeoutMs
         );
+        // Fold the caller's external cancellation signal into THIS attempt's
+        // controller: if it is (or becomes) aborted, abort the in-flight fetch.
+        // Re-aborted via controller.abort() (name 'AbortError') so a deadline
+        // cancel maps to ISLTimeoutError exactly like the per-attempt timeout.
+        if (externalSignal) {
+          if (externalSignal.aborted) {
+            controller.abort();
+          } else {
+            onExternalAbort = () => controller.abort();
+            externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+          }
+        }
 
         const response = await fetch(url, {
           method: 'POST',
@@ -131,8 +158,6 @@ export class ISLClient {
           body: requestBodyText,
           signal: controller.signal,
         });
-
-        clearTimeout(timeoutId);
 
         const duration = Date.now() - startTime;
 
@@ -265,9 +290,14 @@ export class ISLClient {
           break;
         }
 
-        // Exponential backoff: 1s, 2s, 4s (capped at 5s)
-        const backoffMs = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
+        // Exponential backoff (single source: islRetryBackoffMs) — 1s, 2s, 4s… capped at 5s.
+        const backoffMs = islRetryBackoffMs(attempt);
         await this.sleep(backoffMs);
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        if (onExternalAbort && externalSignal) {
+          externalSignal.removeEventListener('abort', onExternalAbort);
+        }
       }
     }
 
@@ -338,7 +368,7 @@ export function getISLClientConfig(): ISLClientConfig {
     baseUrl: String(process.env.ISL_BASE_URL ?? '').trim(),
     apiKey: String(process.env.ISL_API_KEY ?? '').trim(),
     timeoutMs: ISL_TIMEOUT_MS,
-    maxRetries: parseInt(process.env.ISL_MAX_RETRIES ?? '3', 10),
+    maxRetries: resolveIslMaxRetries(),
     healthCheckTimeoutMs: ISL_HEALTH_CHECK_TIMEOUT_MS,
   };
 }

--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -201,7 +201,8 @@ export interface ISLService {
     body: unknown,
     requestId: string,
     timeoutMs?: number,
-    maxRetries?: number
+    maxRetries?: number,
+    signal?: AbortSignal
   ): Promise<ISLAnalysisResult<T>>;
 }
 
@@ -619,7 +620,8 @@ export function createISLService(): ISLService {
       body: unknown,
       requestId: string,
       timeoutMs?: number,
-      maxRetries?: number
+      maxRetries?: number,
+      signal?: AbortSignal
     ): Promise<ISLAnalysisResult<T>> {
       const startMs = Date.now();
 
@@ -658,6 +660,7 @@ export function createISLService(): ISLService {
           endpoint,
           body,
           requestId,
+          signal,
         });
 
         return {

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -112,6 +112,7 @@ import {
   THRESHOLDS_MIN_REMAINING_BUDGET_MS,
   resolveRequestBudgetMs,
   ISL_TIMEOUT_MS,
+  worstCaseMs,
 } from '../../config/timeouts.js';
 import { getISLClientConfig } from '../../integrations/isl/client.js';
 import { createISLInferenceFn, resolveFlipValues, resolveFlipProbeNSamples, resolveFlipOverallTimeoutMs, resolveFlipPerFactorTimeoutMs } from '../../analysis/flip-thresholds.js';
@@ -4850,9 +4851,21 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             Math.max(BASE_CALL_MIN_TIMEOUT_MS, Math.floor(baseCallRemainingMs - baseCallSafetyMarginMs)),
           );
           const configuredMaxRetries = Math.max(1, getISLClientConfig().maxRetries);
-          // How many full per-attempt slices fit the remaining budget (≥ 1).
-          const fittingRetries = Math.max(1, Math.floor(baseCallRemainingMs / baseCallTimeoutMs));
-          const baseCallMaxRetries = Math.min(configuredMaxRetries, fittingRetries);
+          // Largest attempt count whose HONEST worst case (attempts × per-attempt
+          // + the 1s+2s… backoff the client sleeps between them) still fits the
+          // remaining budget — never < 1, never > the configured cap. The prior
+          // `floor(remaining / timeout)` counted bare timeout slices and omitted
+          // the backoff; worstCaseMs is the single source now shared with the
+          // telemetry below, the startup budget warn, and their tests. At the 70s
+          // default this still resolves to 1 attempt (no behaviour change) — it
+          // only stops the accounting from lying.
+          let baseCallMaxRetries = 1;
+          while (
+            baseCallMaxRetries < configuredMaxRetries &&
+            worstCaseMs(baseCallMaxRetries + 1, baseCallTimeoutMs) <= baseCallRemainingMs
+          ) {
+            baseCallMaxRetries++;
+          }
           if (baseCallTimeoutMs < ISL_TIMEOUT_MS || baseCallMaxRetries < configuredMaxRetries) {
             req.log.info({
               event: 'base_isl_call_budget_clamped',
@@ -4862,7 +4875,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               configured_max_retries: configuredMaxRetries,
               clamped_max_retries: baseCallMaxRetries,
               remaining_budget_ms: Math.round(baseCallRemainingMs),
-              worst_case_total_ms: baseCallMaxRetries * baseCallTimeoutMs,
+              worst_case_total_ms: worstCaseMs(baseCallMaxRetries, baseCallTimeoutMs),
             });
           }
           const response = await islService.callAnalysisEndpoint<any>(
@@ -5723,7 +5736,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                 // could add a full ISL_TIMEOUT_MS tail past the flip deadline.)
                 const flipProbeIslTimeoutMs = resolveFlipPerFactorTimeoutMs();
                 const flipInferenceFn = createISLInferenceFn(
-                  (endpoint, body, rid) => islService.callAnalysisEndpoint(endpoint, body, rid, flipProbeIslTimeoutMs),
+                  // F3 (Codex): maxRetries=1 — each probe is optional, so a
+                  // transient failure discloses per-factor instead of adding ~3×
+                  // per-attempt tails past the flip deadline. The 4th arg is the
+                  // per-probe AbortSignal threaded from the flip search: forwarding
+                  // it lets an in-flight probe cancel the moment the factor/overall
+                  // deadline trips (the client folds it into its per-attempt timeout).
+                  (endpoint, body, rid, signal) =>
+                    islService.callAnalysisEndpoint(endpoint, body, rid, flipProbeIslTimeoutMs, 1, signal),
                   islRequest,
                   requestId,
                   flipProbeNSamples
@@ -5870,11 +5890,21 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                 remaining_budget_ms: Math.round(remainingBudgetMs),
               });
 
+              // F9 (Codex): pass maxRetries=1 for this OPTIONAL phase. Omitting it
+              // inherited the config default (ISL_MAX_RETRIES=3), so a "30s cap"
+              // was really ~3× the per-attempt timeout + the 1s+2s backoff (~93s)
+              // — and this call is synchronously awaited AFTER the base science, so
+              // a retry storm here discards a completed base result. A transient
+              // failure now degrades-and-discloses (thresholds_status
+              // 'timeout'/'error') rather than retrying past the budget. The
+              // per-attempt timeout stays clamped to the remaining budget
+              // (thresholdsTimeoutMs above).
               const thresholdsResult = await islService.callAnalysisEndpoint<IslThresholdResponse>(
                 '/api/v1/analysis/thresholds',
                 thresholdsPayload,
                 requestId,
-                Math.round(thresholdsTimeoutMs)
+                Math.round(thresholdsTimeoutMs),
+                1
               );
 
               const thresholdsDurationMs = performance.now() - thresholdsStart;

--- a/tests/flip-probe-cancellation.test.ts
+++ b/tests/flip-probe-cancellation.test.ts
@@ -1,0 +1,106 @@
+/**
+ * F3 (Codex) — flip-search deadline actually CANCELS in-flight probes.
+ *
+ * Before this cluster the `Date.now() >= deadline` guards in searchFlipForFactor
+ * were checked only BETWEEN probes: they could not interrupt an awaited
+ * Promise.allSettled, nor cancel a queued/in-flight probe. A probe that started
+ * before the deadline ran to completion past it. The fix threads an AbortSignal
+ * (factor + overall deadline) through the inference fn → callAnalysisEndpoint →
+ * the client's fetch, so in-flight probes abort when the deadline trips.
+ *
+ * POSITIVE CONTROL (doctrine #13): the first test proves the harness can SEE the
+ * un-cancelled case — a probe that IGNORES the signal keeps the search running
+ * past the deadline (the deadline alone does NOT bound it). The second test then
+ * proves that when probes honour the signal, the search returns within the bound
+ * for 5 candidates and NO probe completes after the deadline.
+ *
+ * Mutation: revert the `factorSignal` threading in searchFlipForFactorInner (so
+ * probes receive `undefined`) and the second test hangs → the 3s race cap trips →
+ * RED. See the mutation transcript.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveFlipValues,
+  type ISLInferenceFn,
+  type FlipInferenceResult,
+} from '../src/analysis/flip-thresholds.js';
+import type { FlipThresholdInputData } from '../src/cee/validation/m1-review-types.js';
+
+function makeCandidate(id: string): FlipThresholdInputData {
+  return {
+    factor_id: id,
+    factor_label: id,
+    current_value: 0.5,
+    flip_value: null,
+    direction: 'decrease',
+    flip_reason: 'heuristic',
+    iterations_used: 0,
+  };
+}
+
+const FIVE = ['a', 'b', 'c', 'd', 'e'].map(makeCandidate);
+const DEADLINE_MS = 200;
+
+describe('flip-search cancellation on deadline (F3)', () => {
+  it('POSITIVE CONTROL — a probe that IGNORES the signal keeps the search running past the deadline', async () => {
+    // Never settles and never wires the abort listener → only real cancellation
+    // could end it. If the deadline alone bounded in-flight probes, this would
+    // return; it must not.
+    const ignoreSignalMock: ISLInferenceFn = () =>
+      new Promise<FlipInferenceResult>(() => { /* never settles, ignores signal */ });
+
+    const outcome = await Promise.race([
+      resolveFlipValues(FIVE, ignoreSignalMock, 'opt-a', {
+        overallTimeoutMs: DEADLINE_MS,
+        perFactorTimeoutMs: DEADLINE_MS,
+      }).then(() => 'returned' as const),
+      new Promise<'still-running'>((res) => setTimeout(() => res('still-running'), 600)),
+    ]);
+
+    expect(outcome).toBe('still-running');
+  });
+
+  it('FIX — honouring the signal cancels in-flight probes: returns within bound for 5 candidates, no late completion', async () => {
+    const deadlineRef = { t: Date.now() + DEADLINE_MS };
+    let lateCompletions = 0;
+
+    // Honours the signal (rejects on abort); otherwise would resolve only after
+    // 5s — far past the deadline. Any 5s resolution counts as a LATE completion.
+    const signalAwareMock: ISLInferenceFn = (_factorId, _mean, signal) =>
+      new Promise<FlipInferenceResult>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          if (Date.now() > deadlineRef.t) lateCompletions++;
+          resolve({
+            options: [
+              { option_id: 'opt-a', win_probability: 0.6 },
+              { option_id: 'opt-b', win_probability: 0.4 },
+            ],
+          });
+        }, 5_000);
+        const onAbort = () => { clearTimeout(timer); reject(new DOMException('aborted', 'AbortError')); };
+        if (signal?.aborted) { onAbort(); return; }
+        signal?.addEventListener('abort', onAbort, { once: true });
+      });
+
+    const start = Date.now();
+    // Hard 3s cap so a cancellation regression FAILS FAST instead of hanging 5s.
+    const { results } = (await Promise.race([
+      resolveFlipValues(FIVE, signalAwareMock, 'opt-a', {
+        overallTimeoutMs: DEADLINE_MS,
+        perFactorTimeoutMs: DEADLINE_MS,
+      }),
+      new Promise((_, rej) => setTimeout(() => rej(new Error('flip search did not cancel within 3s')), 3_000)),
+    ])) as { results: FlipThresholdInputData[] };
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(3_000);          // returned via cancellation, not the 5s stall
+    expect(results).toHaveLength(5);
+    // Deadline-tripped factors are unresolved (null threshold) and disclosed.
+    for (const r of results) {
+      expect(r.flip_value).toBeNull();
+      expect(r.flip_reason).toBe('timeout');
+    }
+    expect(lateCompletions).toBe(0);              // no probe completed AFTER the deadline
+  }, 10_000);
+});

--- a/tests/isl-retry-bound.wallclock.test.ts
+++ b/tests/isl-retry-bound.wallclock.test.ts
@@ -1,0 +1,99 @@
+/**
+ * F9 / F3 shared mechanism — WALL-CLOCK proof that a per-call `maxRetries` bounds
+ * the real ISL client's retry time, using PRODUCTION retry defaults.
+ *
+ * The defect both findings share: an optional-phase call (threshold F9, flip-probe
+ * F3) that omits `maxRetries` inherits the config default (ISL_MAX_RETRIES = 3),
+ * so a "cap" of one per-attempt timeout is really ~3× that timeout PLUS the 1s+2s
+ * backoff the client sleeps. The fix passes `maxRetries = 1`.
+ *
+ * This drives the REAL ISLClient (no mock) against a server that accepts the POST
+ * and never responds, so every attempt hits the per-attempt AbortController
+ * timeout and the client retries with real backoff sleeps.
+ *
+ * POSITIVE CONTROL (doctrine #13): the first case OMITS maxRetries (inherits the
+ * default 3) and asserts the call OVERRUNS to ~3× timeout + backoff — proving the
+ * harness can SEE the overrun the optional phases used to have. Only then does the
+ * second case assert `maxRetries = 1` bounds it to ~1× timeout.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createServer as createHttpServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { getISLService } from '../src/integrations/isl/index.js';
+
+const ROBUSTNESS_ENDPOINT = '/api/v1/robustness/analyze/v2';
+const PER_ATTEMPT_TIMEOUT_MS = 250;
+
+let server: Server;
+let port: number;
+
+describe('ISL client retry time is bounded by per-call maxRetries (F9/F3 mechanism)', () => {
+  beforeAll(async () => {
+    // A server that accepts the connection and NEVER responds → every attempt
+    // hits the client's per-attempt AbortController timeout.
+    server = createHttpServer(() => { /* intentionally hang */ });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    process.env.ISL_ENABLE = '1';
+    process.env.ISL_BASE_URL = `http://127.0.0.1:${port}`;
+    process.env.ISL_API_KEY = 'test-key';
+    // Production default: 3 total attempts. The positive control depends on this.
+    delete process.env.ISL_MAX_RETRIES;
+  });
+
+  it('POSITIVE CONTROL — omitting maxRetries inherits the default 3 and OVERRUNS (~3× + backoff)', async () => {
+    const svc = getISLService();
+    const t0 = Date.now();
+    const res = await svc.callAnalysisEndpoint(ROBUSTNESS_ENDPOINT, { probe: 1 }, 'rid-positive-control', PER_ATTEMPT_TIMEOUT_MS);
+    const elapsed = Date.now() - t0;
+
+    expect(res.data).toBeNull();
+    expect(res.error?.code).toBe('ISL_TIMEOUT');
+    // 3 attempts × 250ms + (1000 + 2000) backoff ≈ 3750ms. Anything > 3× the
+    // per-attempt timeout is impossible without the inherited extra attempts +
+    // backoff — this is the overrun the optional phases used to inherit.
+    expect(elapsed).toBeGreaterThan(3 * PER_ATTEMPT_TIMEOUT_MS + 2_000);
+    expect(elapsed).toBeLessThan(8_000);
+  }, 20_000);
+
+  it('FIX — maxRetries = 1 bounds the call to ~1× the per-attempt timeout (no retries, no backoff)', async () => {
+    const svc = getISLService();
+    const t0 = Date.now();
+    const res = await svc.callAnalysisEndpoint(ROBUSTNESS_ENDPOINT, { probe: 1 }, 'rid-bounded', PER_ATTEMPT_TIMEOUT_MS, 1);
+    const elapsed = Date.now() - t0;
+
+    expect(res.data).toBeNull();
+    expect(res.error?.code).toBe('ISL_TIMEOUT');
+    // One attempt only: ~250ms. No second attempt, no 1s/2s backoff sleeps.
+    expect(elapsed).toBeLessThan(1_500);
+  }, 10_000);
+
+  it('WIRING — an external AbortSignal cancels the in-flight fetch through the client (F3 end-to-end)', async () => {
+    // This is the load-bearing F3 path: the flip deadline's signal must reach the
+    // client's fetch, not just the flip-search bookkeeping. Per-attempt timeout is
+    // set FAR longer (5s) than when we abort (150ms), so if the abort did not reach
+    // the fetch the call would run the full 5s.
+    const svc = getISLService();
+    const ac = new AbortController();
+    const LONG_PER_ATTEMPT_MS = 5_000;
+    setTimeout(() => ac.abort(), 150);
+
+    const t0 = Date.now();
+    const res = await svc.callAnalysisEndpoint(ROBUSTNESS_ENDPOINT, { probe: 1 }, 'rid-external-abort', LONG_PER_ATTEMPT_MS, 1, ac.signal);
+    const elapsed = Date.now() - t0;
+
+    expect(res.data).toBeNull();
+    expect(res.error?.code).toBe('ISL_TIMEOUT'); // deadline-cancel folds to a timeout
+    // Cancelled at ~150ms, NOT after the 5s per-attempt timeout.
+    expect(elapsed).toBeLessThan(1_500);
+  }, 10_000);
+});

--- a/tests/isl-worst-case-accounting.test.ts
+++ b/tests/isl-worst-case-accounting.test.ts
@@ -1,0 +1,59 @@
+/**
+ * F11 (Codex) — honest worst-case retry-time accounting.
+ *
+ * The base-call clamp, its telemetry, config-validator's startup budget warn, and
+ * the base-call-budget test each computed `attempts × perAttemptTimeout` and
+ * OMITTED the 1s+2s… exponential backoff the ISL client actually sleeps between
+ * attempts — config-validator's comment even said "with exponential backoff"
+ * while the arithmetic didn't. `worstCaseMs` centralises the HONEST formula so
+ * none of them can re-omit it.
+ *
+ * RED-first / positive control: the first assertion (183_000, not 180_000) FAILS
+ * against the old `attempts × perAttemptTimeout` formula. Reverting worstCaseMs to
+ * `n * perAttemptTimeoutMs` turns this file RED — see the mutation transcript.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  worstCaseMs,
+  islRetryBackoffMs,
+  ISL_RETRY_BACKOFF_BASE_MS,
+  ISL_RETRY_BACKOFF_CAP_MS,
+} from '../src/config/timeouts.js';
+
+describe('worstCaseMs — honest retry-time accounting (F11)', () => {
+  it('includes the backoff slept BETWEEN attempts (not just attempts × timeout)', () => {
+    // 3 attempts at 60s each = 180s of per-attempt budget PLUS the 1s + 2s backoff
+    // slept between them = 183s. The OLD `attempts × timeout` returned 180s.
+    expect(worstCaseMs(3, 60_000)).toBe(3 * 60_000 + 1_000 + 2_000);
+    expect(worstCaseMs(3, 60_000)).toBe(183_000);
+    // The exact omission this cluster removes — guards against a silent revert.
+    expect(worstCaseMs(3, 60_000)).not.toBe(3 * 60_000);
+  });
+
+  it('a single attempt has zero backoff', () => {
+    expect(worstCaseMs(1, 42_000)).toBe(42_000);
+  });
+
+  it('two attempts add exactly one 1s backoff', () => {
+    expect(worstCaseMs(2, 5_000)).toBe(2 * 5_000 + 1_000);
+  });
+
+  it('backoff is capped at ISL_RETRY_BACKOFF_CAP_MS (5s), not unbounded doubling', () => {
+    // 5 attempts → 4 inter-attempt backoffs: 1s, 2s, 4s, 5s(capped) = 12s
+    // (NOT 1+2+4+8 = 15s). perAttempt=0 isolates the backoff sum.
+    expect(worstCaseMs(5, 0)).toBe(1_000 + 2_000 + 4_000 + 5_000);
+  });
+
+  it('islRetryBackoffMs matches the client series and its cap', () => {
+    expect(islRetryBackoffMs(1)).toBe(ISL_RETRY_BACKOFF_BASE_MS); // 1000
+    expect(islRetryBackoffMs(2)).toBe(2_000);
+    expect(islRetryBackoffMs(3)).toBe(4_000);
+    expect(islRetryBackoffMs(4)).toBe(ISL_RETRY_BACKOFF_CAP_MS); // 8000 → capped 5000
+    expect(islRetryBackoffMs(10)).toBe(ISL_RETRY_BACKOFF_CAP_MS);
+  });
+
+  it('degenerate attempt counts are safe (0 → 0)', () => {
+    expect(worstCaseMs(0, 60_000)).toBe(0);
+  });
+});

--- a/tests/plot-remediation.base-call-budget.route.test.ts
+++ b/tests/plot-remediation.base-call-budget.route.test.ts
@@ -15,7 +15,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
-import { ISL_TIMEOUT_MS } from '../src/config/timeouts.js';
+import { ISL_TIMEOUT_MS, worstCaseMs } from '../src/config/timeouts.js';
 
 const BASE_ROBUSTNESS_ENDPOINT = '/api/v1/robustness/analyze/v2';
 const UI_CLIENT_TIMEOUT_MS = 120_000; // the binding caller hop
@@ -115,7 +115,10 @@ describe('item 4 — base ISL robustness call clamped to the request budget', ()
     delete process.env.REQUEST_BUDGET_MS; // default 70s
     await run();
     const c = baseCall();
-    const worstCase = c.maxRetries! * c.timeoutMs!;
+    // Honest accounting (F11): include the 1s+2s… backoff the client sleeps
+    // between attempts — the previous `maxRetries × timeoutMs` omitted it and so
+    // could not see the very omission this cluster fixes.
+    const worstCase = worstCaseMs(c.maxRetries!, c.timeoutMs!);
     // Pre-fix worst case was 60_000 × 3 = 180_000 (> 120_000). Now bounded.
     expect(worstCase).toBeLessThan(UI_CLIENT_TIMEOUT_MS);
     // …and within the request budget envelope (70s default).
@@ -126,7 +129,7 @@ describe('item 4 — base ISL robustness call clamped to the request budget', ()
     process.env.REQUEST_BUDGET_MS = '30000';
     await run();
     const c = baseCall();
-    const worstCase = c.maxRetries! * c.timeoutMs!;
+    const worstCase = worstCaseMs(c.maxRetries!, c.timeoutMs!);
     expect(c.timeoutMs!).toBeLessThanOrEqual(30_000);
     expect(worstCase).toBeLessThanOrEqual(30_000);
     expect(worstCase).toBeLessThan(UI_CLIENT_TIMEOUT_MS);

--- a/tests/plot-remediation.optional-phase-retry.route.test.ts
+++ b/tests/plot-remediation.optional-phase-retry.route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * F9 + F3 (Codex) — the OPTIONAL ISL phases pass maxRetries = 1 at the route.
+ *
+ * Structural capture (mirror of tests/plot-remediation.base-call-budget.route.test.ts):
+ * a mock islService records the per-call (endpoint, requestId, timeoutMs,
+ * maxRetries) for every callAnalysisEndpoint. We then assert:
+ *   • F9 — the threshold call (/api/v1/analysis/thresholds) passes maxRetries = 1.
+ *   • F3 — every flip-probe call (requestId contains '__flip') passes maxRetries = 1.
+ *
+ * RED against the pre-fix code: both call sites OMITTED maxRetries (undefined →
+ * config default 3). See the mutation transcript. The flip-triggering graph is
+ * taken from tests/lane2-flip-block-disclosure.test.ts (two factors, each
+ * intervened by a different option → both stay flip candidates → probes run).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const THRESHOLDS_ENDPOINT = '/api/v1/analysis/thresholds';
+
+interface Capture { endpoint: string; requestId: string; timeoutMs?: number; maxRetries?: number }
+const captured: Capture[] = [];
+
+function optionComparison(options: any[]) {
+  return (options ?? []).map((opt: any, idx: number) => ({
+    option_id: opt.id ?? opt.option_id,
+    win_probability: 0.6 - idx * 0.2,
+    outcome: { mean: 0.65 + idx * 0.12, std: 0.08, p10: 0.45, p50: 0.65, p90: 0.85, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+    rank: idx + 1,
+  }));
+}
+
+function robustnessData(options: any[]) {
+  return {
+    options: optionComparison(options),
+    edges: [
+      { from: 'factor-a', to: 'goal', sensitivity: 0.5, confidence: 0.8, direction: 'positive' },
+      { from: 'factor-b', to: 'goal', sensitivity: -0.3, confidence: 0.7, direction: 'negative' },
+    ],
+    factors: [
+      { node_id: 'factor-a', sensitivity: 0.5, confidence: 0.8, direction: 'positive' },
+      { node_id: 'factor-b', sensitivity: -0.3, confidence: 0.7, direction: 'negative' },
+    ],
+    value_of_information: [],
+    overall_robustness: 'robust', robustness_score: 0.82,
+    fragile_edges: [], robust_edges: [],
+  };
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return { status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl' };
+  },
+  async analyseSensitivity() { return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' }; },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return { ...robustnessData(options), edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const, edge_sensitivity_status: 'available' as const, factors_provenance: 'isl:/api/v1/robustness/analyze/v2' as const, factor_sensitivity_status: 'available' as const, latency_ms: 42, source: 'isl' as const };
+  },
+  async analyseFactorSensitivity() { return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.82, latency_ms: 0, source: 'unavailable' as const }; },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(endpoint: string, body: any, requestId: string, timeoutMs?: number, maxRetries?: number, _signal?: AbortSignal): Promise<{ data: T | null; error: string | null }> {
+    captured.push({ endpoint, requestId, timeoutMs, maxRetries });
+    if (endpoint === THRESHOLDS_ENDPOINT) {
+      return { data: { thresholds: [] } as T, error: null };
+    }
+    return { data: robustnessData(body?.options ?? []) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, get islService() { return mockISLService; } };
+});
+
+import { createServer } from '../src/createServer.js';
+
+const PAYLOAD = {
+  graph: {
+    nodes: [
+      { id: 'goal', kind: 'goal', label: 'Revenue' },
+      { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+      { id: 'factor-b', kind: 'factor', label: 'Customer Churn', observed_state: { value: 0.5 } },
+    ],
+    edges: [
+      { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+      { from: 'factor-b', to: 'goal', strength: { mean: -0.3, std: 0.1 } },
+    ],
+  },
+  options: [
+    { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 0.8 } },
+    { id: 'opt2', label: 'Reduce Churn', interventions: { 'factor-b': 0.3 } },
+  ],
+  goal_node_id: 'goal',
+  seed: '424242',
+  include_thresholds: true,
+};
+
+describe('optional ISL phases pass maxRetries = 1 (F9 threshold, F3 flip probes)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+  beforeEach(() => { captured.length = 0; });
+
+  async function run() {
+    const res = await app.inject({
+      method: 'POST', url: '/v2/run',
+      headers: { 'content-type': 'application/json' },
+      payload: PAYLOAD,
+    });
+    expect(res.statusCode).toBe(200);
+    return res.json();
+  }
+
+  it('F9 — the threshold call passes maxRetries = 1 (was undefined → default 3)', async () => {
+    await run();
+    const thresholdCall = captured.find((c) => c.endpoint === THRESHOLDS_ENDPOINT);
+    expect(thresholdCall, 'threshold call was made').toBeDefined();
+    expect(thresholdCall!.maxRetries).toBe(1);
+    expect(typeof thresholdCall!.timeoutMs).toBe('number'); // still clamped to remaining budget
+  });
+
+  it('F3 — every flip-probe call passes maxRetries = 1 (was undefined → default 3)', async () => {
+    await run();
+    const flipProbes = captured.filter((c) => c.requestId.includes('__flip'));
+    expect(flipProbes.length, 'flip probes ran').toBeGreaterThan(0);
+    for (const probe of flipProbes) {
+      expect(probe.maxRetries).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary — PLoT ISL retry cluster (Codex **F9 / F3 / F11**) + `ISL_MAX_RETRIES` de-mirror (A3)

**DRAFT — do NOT merge/deploy before the ISL PRs deploy.** Base `staging` @ `b9f825af` (#230).

Optional ISL phases were inheriting the full `ISL_MAX_RETRIES` default (3) because they passed only a
per-attempt timeout, so a "cap" of one timeout was really ~3× that timeout **plus** the 1s+2s backoff the
client sleeps — and the flip deadline could not cancel an in-flight or queued probe. The base-call clamp's
worst-case accounting omitted that same backoff.

### F9 — threshold call bounded
`/api/v1/analysis/thresholds` now passes `maxRetries = 1`. It is an optional phase awaited **after** the base
science, so a retry storm there discarded a completed base result; a transient failure now
degrades-and-discloses (`thresholds_status` `timeout`/`error`). Per-attempt timeout stays clamped to the
remaining request budget.

### F3 — flip probes bounded **and** cancellable
- Probes pass `maxRetries = 1`.
- An **AbortSignal** is threaded end-to-end: `run.ts` arrow → `createISLInferenceFn` → `callAnalysisEndpoint`
  → the client's `fetch`, folded into the client's per-attempt timeout controller (via `controller.abort()`,
  so a deadline-cancel keeps the existing `AbortError → ISLTimeoutError` mapping).
- `searchFlipForFactorInner` builds a per-factor `AbortSignal.any([overall, factorTimeout])`, threaded through
  the concurrency semaphore and the grid fallback. In-flight probes now cancel when the factor/overall
  deadline trips; a probe dequeued past the deadline short-circuits before doing work. A deadline-tripped
  probe discloses `flip_reason: 'timeout'` (a genuine ISL fault stays `'error'`). This brings into scope the
  cancellation the author's comment (`flip-thresholds.ts`) had explicitly deferred.

### F11 — honest, centralised worst-case accounting
One shared `worstCaseMs(attempts, perAttemptTimeoutMs)` = `attempts × perAttempt + Σ backoff (1s,2s,… cap 5s)`
now drives the base-call clamp fitting, its telemetry (`worst_case_total_ms`), `config-validator`'s startup
budget warn (whose comment already claimed "with exponential backoff"), and the base-call-budget test — each
previously recomputed and re-omitted the backoff. **No runtime change at defaults** (still 1 attempt at the
70s budget); the accounting is just honest and single-sourced.

### De-mirror
`ISL_MAX_RETRIES` default `'3'` (hand-written in `client.ts` **and** `config-validator.ts`) and the retry
backoff series now derive from single sources in `config/timeouts.ts`.

## Verification
- `npx tsc --noEmit`: **0 errors**.
- New tests are RED-first with positive controls; **all 5 fix hunks mutation-checked** (revert → RED):
  worstCaseMs backoff, F9 maxRetries, F3 maxRetries, F3 cancellation-signal threading, client external-signal fold.
- Wall-clock proof (real client + stalling server): default-3 overran to ~3.8s (attempt 3); `maxRetries=1`
  bounded to ~0.25s; external abort cancelled the in-flight fetch at ~150ms (not the 5s per-attempt timeout).
- No `package.json` / lockfile / OpenAPI changes → `audit` / `validate-structure` / `gates (windows-latest)`
  reds are the standing pre-existing ones, unchanged.

Evidence: `acceptance-evidence/a3-verify-2026-07-16/codex-plot-r1-BUILD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeXMQjxJeR2W7kLPtKnUSB
