### PR TITLE
fix(contract): canonicalise factor ids + finite-range guards + stability parse + real ISL warning shape (Codex F13/F14/F12/F4) (A3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "description": "",
   "type": "module",
   "engines": {
-    "node": ">=20 <21",
+    "node": ">=20.3.0 <21",
     "npm": ">=10 <11"
   },
   "dependencies": {

--- a/src/cee/decision-review-request.ts
+++ b/src/cee/decision-review-request.ts
@@ -13,6 +13,8 @@ import type { M1Coaching, EvidenceGap, Critique } from '../coaching/types.js';
 import {
   interventionTargetIdsFromOptions,
   isOptionControlledLever,
+  factorIdOf,
+  hasFactorIdConflict,
 } from '../lib/intervention-override.js';
 import type {
   DecisionReviewRequest,
@@ -269,13 +271,19 @@ export function extractFactorSensitivity(
   const factorSensitivity = islResult.factor_sensitivity ?? [];
 
   return factorSensitivity
-    .filter((f) => !isOptionControlledLever(f, structuralLeverIds))
-    .map((f) => ({
-      factor_id: f.factor_id,
-      factor_label: f.factor_label ?? f.factor_id,
-      elasticity: f.elasticity ?? 0,
-      confidence: f.confidence ?? 0.5,
-    }));
+    // F13: drop ambiguous twins (node_id/factor_id present and DIFFERENT) and
+    // option-controlled levers, both resolved through the ONE canonical
+    // precedence, so an unstamped union lever cannot escape to CEE.
+    .filter((f) => !hasFactorIdConflict(f) && !isOptionControlledLever(f, structuralLeverIds))
+    .map((f) => {
+      const factorId = factorIdOf(f) ?? f.factor_id;
+      return {
+        factor_id: factorId,
+        factor_label: f.factor_label ?? factorId,
+        elasticity: f.elasticity ?? 0,
+        confidence: f.confidence ?? 0.5,
+      };
+    });
 }
 
 /**

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -781,13 +781,36 @@ export interface ISLRobustnessAnalyzeV2Response {
   conditional_winners?: ISLConditionalWinner[];
 
   /**
-   * Inference warnings from ISL.
-   * Forwarded into PLoT's inference_warnings array in the response.
+   * Inference warnings from ISL, forwarded into PLoT's inference_warnings array.
+   *
+   * F4 (Codex deep review): the REAL ISL `InferenceWarning` wire shape (LIVE
+   * from ISL #79) is `{code, field, detail:{reason, elapsed_ms, message, ...},
+   * severity}` — `severity` is now producer-supplied (default 'info'; the four
+   * budget-degradation codes are 'warning'), and the human copy + timing live
+   * under `detail`. Top-level `message`/`severity`/`elapsed_ms`/`node_id` are
+   * kept OPTIONAL for back-compat with older fixtures/captures that used the
+   * flat shape; PLoT's merge reads detail-first, then the flat fallbacks.
    */
   inference_warnings?: Array<{
     code: string;
-    message: string;
+    /** Field path the warning is about (e.g. 'factor_evpi', 'path_decomposition'). */
+    field?: string;
     severity?: 'info' | 'warning';
+    /** Flat human copy (older captures); real shape carries it under `detail`. */
+    message?: string;
+    /** Flat timing (older captures); real shape carries it under `detail`. */
+    elapsed_ms?: number;
+    /** Flat node id (older per-node captures). */
+    node_id?: string;
+    /** The real nested payload. */
+    detail?: {
+      reason?: string;
+      message?: string;
+      elapsed_ms?: number;
+      node_id?: string;
+      field?: string;
+      [key: string]: unknown;
+    };
   }>;
 
   /**

--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -41,7 +41,7 @@ import type {
   ConfidenceFormulaVersion,
 } from '../types/engine-v3.js';
 import { ATTRIBUTION_STABILITY_BAND_SCORES } from '../review-pass/evidence-priority.js';
-import { isInterventionOverride, isOptionControlledLever } from './intervention-override.js';
+import { isInterventionOverride, isOptionControlledLever, factorIdOf, hasFactorIdConflict } from './intervention-override.js';
 
 /**
  * D-U lever suppression (ROADMAP 2.20/2.40): the public shape of a factor that
@@ -1138,7 +1138,13 @@ export function buildFactorStability(
       typeof f.stability_method !== 'string' || f.stability_method === ''
     ) continue;
 
-    const factorId = f.node_id ?? f.factor_id;
+    // F13: an ambiguous twin (both node_id and factor_id present and DIFFERENT)
+    // cannot be trusted to identify a single factor — drop it rather than
+    // publish a spread under a guessed identity. Disclosure of the drop rides
+    // the FACTOR_ID_CONFLICT wire warning (run.ts scans the same raw array).
+    if (hasFactorIdConflict(f)) continue;
+
+    const factorId = factorIdOf(f); // F13: one canonical precedence everywhere.
     if (!factorId) continue;
 
     // Deduplicate by factor key (first-wins)

--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -88,16 +88,28 @@ export function denormaliseFlipThresholds(
       ? denormaliseValue(flip.flip_value, factorContext.range)
       : null;
 
+    // F14 (defense-in-depth): the range-source finite guard (deriveRange) makes
+    // this unreachable for ranges built here, but a directly-supplied
+    // overflow-width range would denormalise a valid value to ±Infinity, which
+    // JSON.stringify emits as a fabricated `null`. Finite-check every public
+    // numeric after the map: emit the finite value, else null the flip_value AND
+    // DISCLOSE via flip_reason so the null is attributable, never silent.
+    const currentFinite = Number.isFinite(denormCurrent);
+    const flipFinite = denormFlip !== null && Number.isFinite(denormFlip);
+    const nonFiniteDenorm = !currentFinite || (denormFlip !== null && !flipFinite);
+
     return {
       factor_id: flip.factor_id,
       factor_label: flip.factor_label,
-      current_value: denormCurrent,
-      flip_value: denormFlip,
+      // Never emit a non-finite current_value — fall back to the pre-denorm
+      // (normalised) value, which the disclosed flip_reason flags as unmapped.
+      current_value: currentFinite ? denormCurrent : flip.current_value,
+      flip_value: flipFinite ? denormFlip : null,
       direction: flip.direction,
       unit: flip.unit,
       alternative_winner_id: flip.alternative_winner_id ?? null,
       alternative_winner_label: resolveLabel(flip.alternative_winner_id, options),
-      flip_reason: flip.flip_reason ?? 'heuristic',
+      flip_reason: nonFiniteDenorm ? 'non_finite_denormalisation' : (flip.flip_reason ?? 'heuristic'),
       iterations_used: flip.iterations_used,
       probes_used: flip.probes_used,
       ...(flip.margin_sensitivity

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -113,6 +113,26 @@ export interface NormalisationDiagnostic {
 // -----------------------------------------------------------------------------
 
 /**
+ * A range is usable for (de)normalisation ONLY when both endpoints are finite
+ * AND the width is finite and strictly positive (Codex F14). The half-open
+ * check `max > min` is NOT sufficient: `{min:-1e308,max:1e308}` satisfies it,
+ * yet `max - min === Infinity`, so denormalising a valid `0.5` returns
+ * `Infinity` — which `JSON.stringify` emits as a fabricated `null` on the wire,
+ * or (for edge current_mean/flip_mean) makes PLoT silently DROP the whole
+ * E-value. Every range source is gated through this so a non-finite-width range
+ * can never reach `denormaliseValue`; a rejected source falls through the
+ * priority chain to the safe `default [0,1]`.
+ */
+export function isFiniteRange(min: number, max: number): boolean {
+  return (
+    Number.isFinite(min) &&
+    Number.isFinite(max) &&
+    Number.isFinite(max - min) &&
+    max - min > 0
+  );
+}
+
+/**
  * Validate an extracted range from CE.
  * Returns true if the range is valid for normalisation.
  */
@@ -120,8 +140,9 @@ function isValidExtractedRange(range: [number, number] | undefined): range is [n
   if (!Array.isArray(range) || range.length !== 2) return false;
   const [min, max] = range;
   if (typeof min !== 'number' || typeof max !== 'number') return false;
-  if (!Number.isFinite(min) || !Number.isFinite(max)) return false;
-  if (min >= max) return false;
+  // F14: require finite endpoints AND a finite positive width (min<max alone
+  // admits {-1e308,1e308} whose width overflows to Infinity).
+  if (!isFiniteRange(min, max)) return false;
   return true;
 }
 
@@ -161,14 +182,17 @@ export function deriveRange(
   // Authoritative scale cap set by CEE (e.g., goal node with cap=1000 means value=200 → 0.2).
   // Takes precedence over state_space.range to ensure consistent normalisation
   // across both intervention (Phase 4a) and constraint (Phase 4b) paths.
-  if (typeof observedState?.cap === 'number' && observedState.cap > 0) {
+  // F14: require a finite positive width at every source (isFiniteRange) so an
+  // overflow-width range can never reach denormaliseValue — a rejected source
+  // falls through to the next priority (ultimately the safe default [0,1]).
+  if (typeof observedState?.cap === 'number' && observedState.cap > 0 && isFiniteRange(0, observedState.cap)) {
     return { min: 0, max: observedState.cap, source: 'explicit_cap' };
   }
 
   // Priority 1: Explicit state_space.range
   if (stateSpace?.range) {
     const { min, max } = stateSpace.range;
-    if (typeof min === 'number' && typeof max === 'number' && max > min) {
+    if (typeof min === 'number' && typeof max === 'number' && isFiniteRange(min, max)) {
       return { min, max, source: 'explicit' };
     }
   }
@@ -199,11 +223,12 @@ export function deriveRange(
         const padding = spread * 0.2;
         // Clamp lower bound to 0 when all intervention values are non-negative
         const paddedMin = minVal >= 0 ? Math.max(0, minVal - padding) : minVal - padding;
-        return {
-          min: paddedMin,
-          max: maxVal + padding,
-          source: 'inferred_spread',
-        };
+        const paddedMax = maxVal + padding;
+        // F14: skip an overflow-width spread (e.g. values near ±1e308) — fall
+        // through to baseline/value inference or the default.
+        if (isFiniteRange(paddedMin, paddedMax)) {
+          return { min: paddedMin, max: paddedMax, source: 'inferred_spread' };
+        }
       }
     }
   }
@@ -223,7 +248,8 @@ export function deriveRange(
 
     if (maxAbsValue > 0) {
       const max = 2 * maxAbsValue;
-      return { min: 0, max, source: 'inferred_baseline' };
+      // F14: skip an overflow-width inferred range; fall through to value / default.
+      if (isFiniteRange(0, max)) return { min: 0, max, source: 'inferred_baseline' };
     }
   }
 
@@ -231,7 +257,8 @@ export function deriveRange(
   if (currentValue !== undefined && typeof currentValue === 'number' && currentValue !== 0) {
     // Range: [0, 2 × |currentValue|]
     const max = 2 * Math.abs(currentValue);
-    return { min: 0, max, source: 'inferred_value' };
+    // F14: skip an overflow-width inferred range; fall through to the default.
+    if (isFiniteRange(0, max)) return { min: 0, max, source: 'inferred_value' };
   }
 
   // Priority 4: Default [0, 1]
@@ -440,21 +467,22 @@ function buildFallbackRanges(
           const padding = spread * 0.2;
           // Clamp lower bound to 0 when all values are non-negative
           const paddedMin = minVal >= 0 ? Math.max(0, minVal - padding) : minVal - padding;
-          fallbackRanges.set(factorId, {
-            min: paddedMin,
-            max: maxVal + padding,
-            source: 'inferred_spread',
-          });
-          continue;
+          const paddedMax = maxVal + padding;
+          // F14: skip an overflow-width spread; fall through to the [0, 2×max]
+          // fallback or the default [0,1] below.
+          if (isFiniteRange(paddedMin, paddedMax)) {
+            fallbackRanges.set(factorId, { min: paddedMin, max: paddedMax, source: 'inferred_spread' });
+            continue;
+          }
         }
-        // Fall through to default range on extreme outlier
+        // Fall through to default range on extreme outlier / overflow
       }
     }
 
     // Fallback for single value, zero spread, or extreme outlier: [0, 2 × max(|values|)]
     const maxAbsValue = Math.max(...values.map(Math.abs));
 
-    if (maxAbsValue > 0) {
+    if (maxAbsValue > 0 && isFiniteRange(0, 2 * maxAbsValue)) {
       // Range: [0, 2 × max(|values|)] - ensures all values fit with headroom
       fallbackRanges.set(factorId, {
         min: 0,
@@ -462,7 +490,7 @@ function buildFallbackRanges(
         source: 'default', // Still 'default' source but with meaningful range
       });
     } else {
-      // All values are zero - use [0, 1]
+      // All values are zero, or an overflow-width inference (F14) — use [0, 1]
       fallbackRanges.set(factorId, { min: 0, max: 1, source: 'default' });
     }
   }

--- a/src/lib/intervention-override.ts
+++ b/src/lib/intervention-override.ts
@@ -35,6 +35,46 @@ export function isInterventionOverride(f: { zero_reason?: string | null }): bool
 }
 
 /**
+ * Canonical identity of an ISL factor entry — ONE precedence, used EVERYWHERE
+ * (Codex F13). ISL's canonical key is `node_id` (the graph node id); PLoT's
+ * `factor_id` is the downstream alias. Precedence is **node_id-first**, matching
+ * the factor_sensitivity mapper (`mapIslFactorEntry`, `run.ts`) and the
+ * factor_stability publication (`buildFactorStability`, `factor-influence.ts`)
+ * which both already resolve `node_id ?? factor_id`. The D-U lever predicate
+ * (`isOptionControlledLever`) historically resolved the OPPOSITE way
+ * (`factor_id ?? node_id`), so a future/additive twin `{node_id:'lever',
+ * factor_id:'other'}` mapped/published as `lever` yet, resolving identity as
+ * `other`, escaped lever-suppression. Everything now resolves identity through
+ * this single helper.
+ *
+ * Returns `undefined` when neither id is a non-empty string.
+ */
+export function factorIdOf(
+  f: { factor_id?: string | null; node_id?: string | null },
+): string | undefined {
+  const nodeId = typeof f.node_id === 'string' && f.node_id !== '' ? f.node_id : undefined;
+  const factorId = typeof f.factor_id === 'string' && f.factor_id !== '' ? f.factor_id : undefined;
+  return nodeId ?? factorId;
+}
+
+/**
+ * True when an entry carries BOTH a non-empty `node_id` AND a non-empty
+ * `factor_id` that DIFFER — an ambiguous twin whose canonical identity cannot
+ * be trusted (Codex F13). Such an entry is dropped from lever-sensitive
+ * publication surfaces and the drop is DISCLOSED on the wire
+ * (`FACTOR_ID_CONFLICT`), never silently resolved to one of the two ids. The
+ * pinned ISL producer emits only `node_id` today, so this is schema-evolution
+ * hardening; it is additive and cannot fire on the current producer shape.
+ */
+export function hasFactorIdConflict(
+  f: { factor_id?: string | null; node_id?: string | null },
+): boolean {
+  const nodeId = typeof f.node_id === 'string' && f.node_id !== '' ? f.node_id : undefined;
+  const factorId = typeof f.factor_id === 'string' && f.factor_id !== '' ? f.factor_id : undefined;
+  return nodeId !== undefined && factorId !== undefined && nodeId !== factorId;
+}
+
+/**
  * The canonical structural lever union (D-U): every factor id that ANY
  * option's `interventions` map targets. Source of truth is the request-side
  * `options[i].interventions`, NOT raw ISL `zero_reason` — ISL's stamp is a
@@ -81,7 +121,9 @@ export function isOptionControlledLever(
   structuralLeverIds?: ReadonlySet<string>,
 ): boolean {
   if (isInterventionOverride(f)) return true;
-  const id = f.factor_id ?? f.node_id;
+  // F13: resolve identity through the ONE canonical precedence (node_id-first),
+  // identical to the factor_sensitivity mapper and factor_stability publication.
+  const id = factorIdOf(f);
   return id != null && (structuralLeverIds?.has(id) ?? false);
 }
 
@@ -104,7 +146,7 @@ export function interventionOverrideFactorIds(
   const ids = new Set<string>();
   for (const f of factors) {
     if (isInterventionOverride(f)) {
-      const id = f.factor_id ?? f.node_id;
+      const id = factorIdOf(f); // F13: one canonical precedence everywhere.
       if (id) ids.add(id);
     }
   }

--- a/src/routes/v2/enrichment-egress-guard.ts
+++ b/src/routes/v2/enrichment-egress-guard.ts
@@ -111,23 +111,118 @@ export interface EnrichmentContractAssessment {
 }
 
 /**
+ * F12 (Codex deep review, A3 r2) — PLoT-LOCAL refined validation of the nested
+ * `edge_e_values[].stability` band.
+ *
+ * The shared `EnrichmentEdgeEValueSchema` is `.passthrough()` and does NOT type
+ * the `stability` object, so the schema parse alone cannot see a malformed band.
+ * This is the FAIL-LOUD local interim (the canonical shared stability schema is
+ * a separate A1 schemas-PR): a band that violates any invariant below is
+ * reported as a contract issue so the response is NOT stamped valid.
+ *
+ * Invariants (per Codex F12 + ISLFlipStabilityBandV2 semantics):
+ * - finite ORDERED endpoints: band_min ≤ band_median ≤ band_max (each finite);
+ * - non-negative INTEGER counts: n_seeds ≥ 0, 0 ≤ n_seeds_flipped ≤ n_seeds;
+ * - count/list consistency: seed_flip_means length === n_seeds; each cell is a
+ *   finite number or null;
+ * - non-negative band_width (finite).
+ *
+ * Absent band (nothing to sweep) is valid — returns no issues. Codes are
+ * zod-flavoured strings ({path, code} only, no values — same PII discipline as
+ * the schema path).
+ */
+export function assessStabilityBands(body: unknown): EnrichmentContractIssue[] {
+  const issues: EnrichmentContractIssue[] = [];
+  if (!body || typeof body !== 'object') return issues;
+  const edges = (body as { edge_e_values?: unknown }).edge_e_values;
+  if (!Array.isArray(edges)) return issues;
+
+  const isNonNegInt = (v: unknown): v is number =>
+    typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v) && v >= 0;
+  const finiteOf = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+
+  edges.forEach((edge, i) => {
+    if (!edge || typeof edge !== 'object') return;
+    const stability = (edge as { stability?: unknown }).stability;
+    if (stability === undefined) return; // absent band — nothing to validate.
+    const base = `edge_e_values.${i}.stability`;
+    if (typeof stability !== 'object' || stability === null || Array.isArray(stability)) {
+      issues.push({ path: base, code: 'invalid_type' });
+      return;
+    }
+    const s = stability as Record<string, unknown>;
+
+    // Counts.
+    const nSeeds = s.n_seeds;
+    const nFlipped = s.n_seeds_flipped;
+    if (!isNonNegInt(nSeeds)) issues.push({ path: `${base}.n_seeds`, code: 'invalid_type' });
+    if (!isNonNegInt(nFlipped)) issues.push({ path: `${base}.n_seeds_flipped`, code: 'invalid_type' });
+    if (isNonNegInt(nSeeds) && isNonNegInt(nFlipped) && nFlipped > nSeeds) {
+      issues.push({ path: `${base}.n_seeds_flipped`, code: 'too_big' });
+    }
+
+    // Per-seed list: length matches n_seeds; each cell finite-or-null.
+    const means = s.seed_flip_means;
+    if (means !== undefined) {
+      if (!Array.isArray(means)) {
+        issues.push({ path: `${base}.seed_flip_means`, code: 'invalid_type' });
+      } else {
+        if (isNonNegInt(nSeeds) && means.length !== nSeeds) {
+          issues.push({ path: `${base}.seed_flip_means`, code: 'custom' }); // count/list mismatch
+        }
+        means.forEach((m, j) => {
+          if (m !== null && !(typeof m === 'number' && Number.isFinite(m))) {
+            issues.push({ path: `${base}.seed_flip_means.${j}`, code: 'invalid_type' });
+          }
+        });
+      }
+    }
+
+    // Endpoints + width: each finite when present.
+    for (const k of ['band_min', 'band_median', 'band_max', 'band_width'] as const) {
+      const v = s[k];
+      if (v !== undefined && finiteOf(v) === undefined) {
+        issues.push({ path: `${base}.${k}`, code: 'invalid_type' });
+      }
+    }
+    // Ordered endpoints (only when both sides are finite).
+    const bMin = finiteOf(s.band_min);
+    const bMed = finiteOf(s.band_median);
+    const bMax = finiteOf(s.band_max);
+    if (bMin !== undefined && bMed !== undefined && bMin > bMed) issues.push({ path: `${base}.band_median`, code: 'too_small' });
+    if (bMed !== undefined && bMax !== undefined && bMed > bMax) issues.push({ path: `${base}.band_max`, code: 'too_small' });
+    if (bMin !== undefined && bMax !== undefined && bMin > bMax) issues.push({ path: `${base}.band_max`, code: 'too_small' }); // reversed band
+    // Non-negative width.
+    const bW = finiteOf(s.band_width);
+    if (bW !== undefined && bW < 0) issues.push({ path: `${base}.band_width`, code: 'too_small' });
+  });
+
+  return issues;
+}
+
+/**
  * Assess an outgoing /v2/run success body against the typed enrichment
- * envelope. Pure and non-throwing over any JSON-serialisable input; callers
- * still wrap the call site (fail-open) so a schema-library failure can never
- * take down response delivery.
+ * envelope PLUS the PLoT-local refined stability-band parse (F12). Pure and
+ * non-throwing over any JSON-serialisable input; callers still wrap the call
+ * site (fail-open) so a schema-library failure can never take down response
+ * delivery.
  */
 export function assessEnrichmentContract(body: unknown): EnrichmentContractAssessment {
   const result = AnalysisEnrichmentSchema.safeParse(body);
-  if (result.success) {
+  const schemaIssues: EnrichmentContractIssue[] = result.success
+    ? []
+    : result.error.issues.map((issue) => ({ path: issue.path.join('.'), code: issue.code }));
+  // F12: the passthrough envelope cannot see the nested stability band — add the
+  // PLoT-local refinement so a malformed band is never stamped valid.
+  const stabilityIssues = assessStabilityBands(body);
+  const all = [...schemaIssues, ...stabilityIssues];
+  if (all.length === 0) {
     return { ok: true, issues: [], issue_count: 0 };
   }
-  const all = result.error.issues;
   return {
     ok: false,
-    issues: all.slice(0, ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES).map((issue) => ({
-      path: issue.path.join('.'),
-      code: issue.code,
-    })),
+    issues: all.slice(0, ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES),
     issue_count: all.length,
   };
 }

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -138,7 +138,7 @@ import { ReviewSkipReasons, type ReviewSkipReason } from '../../cee/validation/m
 import { getDownstreamCallsForLog, getDownstreamCalls } from '../../util/downstream-tracker.js';
 import { computeResponseContentHash } from '../../util/response-content-hash.js';
 import { computeFactorSensitivityFromGraph, buildFactorStability, mergeIslConfidenceIntoGraphFactors } from '../../lib/factor-influence.js';
-import { interventionTargetIdsFromOptions, isOptionControlledLever } from '../../lib/intervention-override.js';
+import { interventionTargetIdsFromOptions, isOptionControlledLever, factorIdOf, hasFactorIdConflict } from '../../lib/intervention-override.js';
 import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagMissingFromIsl } from '../../lib/auto-noise.js';
 import { sanitiseIslVoi, computeEvpiPercentagePoints } from '../../lib/evpi-emission.js';
 import {
@@ -472,12 +472,16 @@ export function transformEdgeEValues(
       // invariant: band values are ALWAYS in the same space as flip_mean on
       // the same entry. Counts (n_seeds/n_seeds_flipped) are space-invariant.
       if (stability !== undefined) {
+        // F14: finite-check every post-denormalisation band value. A non-finite
+        // denorm (an overflow-width range that slipped the source guard) would
+        // otherwise ride to the wire as a fabricated `null`; omit the field
+        // instead (honest absence), exactly as the sibling e_value filter does.
         const bandMin = typeof stability.band_min === 'number'
-          ? denormaliseValue(stability.band_min, goalRange) : undefined;
+          ? finiteNum(denormaliseValue(stability.band_min, goalRange)) : undefined;
         const bandMedian = typeof stability.band_median === 'number'
-          ? denormaliseValue(stability.band_median, goalRange) : undefined;
+          ? finiteNum(denormaliseValue(stability.band_median, goalRange)) : undefined;
         const bandMax = typeof stability.band_max === 'number'
-          ? denormaliseValue(stability.band_max, goalRange) : undefined;
+          ? finiteNum(denormaliseValue(stability.band_max, goalRange)) : undefined;
         stability = {
           // Spread first so any future additive ISL band field still rides
           // (the named-field-rebuild silent-drop trap this file's lane-3
@@ -497,8 +501,10 @@ export function transformEdgeEValues(
           // Per-seed means: map non-null cells, preserve nulls AS NULL (a
           // null means that seed's background admits no flip — not a value).
           ...(Array.isArray(stability.seed_flip_means) && {
+            // F14: a non-finite denorm cell becomes null (a "no value" seed),
+            // never a fabricated Infinity → null with lost provenance.
             seed_flip_means: stability.seed_flip_means.map((v) =>
-              typeof v === 'number' ? denormaliseValue(v, goalRange) : v),
+              typeof v === 'number' ? (finiteNum(denormaliseValue(v, goalRange)) ?? null) : v),
           }),
         };
       }
@@ -641,7 +647,7 @@ function mapIslFactorEntry(f: any, normContext?: NormalisationContext): FactorSe
     }));
   }
 
-  const factorId: string = f.node_id ?? f.factor_id;
+  const factorId: string = factorIdOf(f) ?? ''; // F13: one canonical precedence everywhere.
 
   // Denormalise sensitivity_score and elasticity_std when normalisation was active.
   // sensitivity_score is an elasticity-like measure (Δoutcome / Δfactor); scale by
@@ -1223,6 +1229,14 @@ interface MetaParams {
    * they ride `flip_reason` on each flip_thresholds entry.
    */
   flipThresholdsFailedErrorName?: string;
+  /**
+   * F14 (Codex deep review): count of edge E-value entries dropped from the
+   * public array because a required numeric (e_value/current_mean/flip_mean)
+   * was non-finite after transformation. Presence (>0) drives the
+   * EDGE_E_VALUE_NON_FINITE_DROPPED inference warning so the drop is
+   * attributable on the wire, not only in the server log. Absent/0 = no drop.
+   */
+  edgeEValuesDroppedNonFinite?: number;
   detailLevel: string;
   latencyMs: number;
   normalizationMs?: number;
@@ -2355,6 +2369,40 @@ function buildResponse(
     }
   }
 
+  // F13 (Codex deep review): DISCLOSE ambiguous-identity factor entries. An ISL
+  // entry carrying BOTH a node_id AND a factor_id that DIFFER cannot be resolved
+  // to a single trusted id, so the publication builders DROP it (factor_stability
+  // buildFactorStability, CEE-review extractFactorSensitivity, and the D-U lever
+  // predicate resolve identity through the one canonical factorIdOf precedence).
+  // The pinned ISL producer emits only node_id, so this cannot fire today — it is
+  // schema-evolution hardening that fails LOUD (never silent) if a future
+  // producer adds a conflicting factor_id.
+  {
+    const rawFactors = Array.isArray(islResult?.factor_sensitivity)
+      ? islResult.factor_sensitivity
+      : [];
+    const conflictIds = new Set<string>();
+    for (const f of rawFactors) {
+      if (hasFactorIdConflict(f)) {
+        const id = factorIdOf(f);
+        if (id) conflictIds.add(id);
+      }
+    }
+    if (conflictIds.size > 0) {
+      inferenceWarnings.push({
+        code: INFERENCE_WARNING_CODES.FACTOR_ID_CONFLICT,
+        // provisional_doctrine_v0 — wording surface (diagnostic disclosure). Names
+        // only structural graph ids (never user values); count disambiguates.
+        message:
+          `${conflictIds.size} factor entr${conflictIds.size === 1 ? 'y' : 'ies'} carried a ` +
+          `conflicting node_id/factor_id and ${conflictIds.size === 1 ? 'was' : 'were'} dropped from ` +
+          `factor_sensitivity, factor_stability and decision-review derivation (ambiguous identity): ` +
+          `${[...conflictIds].sort().join(', ')}. All other analyses are unaffected.`,
+        severity: 'warning',
+      });
+    }
+  }
+
   // Liveness honesty: edge-level sensitivity is requested on every ISL call
   // (analysis_types always includes 'sensitivity'). ISL builds 9a22a1a+ emit
   // it nested at robustness.edge_sensitivity (consumed above — lane PLoT-W4);
@@ -2482,10 +2530,37 @@ function buildResponse(
     });
   }
 
+  // F14 (Codex deep review): DISCLOSE edge E-values dropped for non-finiteness.
+  // The transform drops entries whose e_value/current_mean/flip_mean are
+  // non-finite (a fabricated `null` would otherwise ship). Without this marker
+  // the drop was server-log-only — a short/empty edge_e_values was
+  // indistinguishable from a genuinely computed-empty result. Non-blocking.
+  if (meta.edgeEValuesDroppedNonFinite && meta.edgeEValuesDroppedNonFinite > 0) {
+    const n = meta.edgeEValuesDroppedNonFinite;
+    inferenceWarnings.push({
+      code: INFERENCE_WARNING_CODES.EDGE_E_VALUE_NON_FINITE_DROPPED,
+      // provisional_doctrine_v0 — wording surface (diagnostic disclosure). Count only.
+      message: `${n} edge E-value entr${n === 1 ? 'y was' : 'ies were'} omitted from edge_e_values because a required numeric was non-finite after transformation — edge_e_values is shorter because those entries could not be represented, not because they were computed empty. All other analyses are unaffected.`,
+      // info, not warning: ISL routinely emits null e_value for UNFLIPPABLE edges
+      // (current_mean == flip_mean → no finite evidence ratio), so this is an
+      // expected non-representability disclosure, not an alarm — matching the
+      // sibling EDGE_E_VALUES_UNAVAILABLE_V2_WIRE severity. Still fully on the
+      // wire (+ _meta warning_codes), just below the prominent warning strip.
+      severity: 'info',
+    });
+  }
+
   // Merge ISL-originated inference_warnings into the PLoT array.
   // ISL may return warnings like ROOT_NODE_DEFAULT_VALUE that PLoT forwards as-is.
   // Deduplicate by code to prevent equivalent warnings from both sources.
-  // ISL warnings may have top-level `message` OR `detail.message` — check both.
+  //
+  // F4 (Codex deep review): map ISL's REAL `InferenceWarning` shape
+  // `{code, field, detail:{reason, elapsed_ms, message}, severity}` (LIVE from
+  // ISL #79) faithfully — read `detail.message` (falling back to `detail.reason`),
+  // `detail.elapsed_ms`, preserve `field`, and map `severity` THROUGH (ISL now
+  // supplies it: the 4 budget-degradation codes are 'warning', benign codes
+  // 'info'/absent → 'info'). Top-level `message`/`elapsed_ms`/`node_id` are still
+  // read first for back-compat with older fixtures/captures.
   if (Array.isArray(islResult?.inference_warnings)) {
     // Deduplicate by code+node_id composite key to allow per-node warnings
     // (e.g., multiple ROOT_NODE_DEFAULT_VALUE for different root nodes).
@@ -2496,7 +2571,9 @@ function buildResponse(
         ? w.message
         : typeof w?.detail?.message === 'string'
           ? w.detail.message
-          : undefined;
+          : typeof w?.detail?.reason === 'string'
+            ? w.detail.reason
+            : undefined;
       const nodeId = w?.detail?.node_id ?? w?.node_id ?? '';
       const dedupKey = `${w?.code}:${nodeId}`;
       if (w && typeof w.code === 'string' && typeof message === 'string' && !existingKeys.has(dedupKey)) {
@@ -2508,10 +2585,14 @@ function buildResponse(
         // only (no PII); the egress envelope's warning element is passthrough.
         const rawElapsed = w?.elapsed_ms ?? w?.detail?.elapsed_ms;
         const elapsedMs = typeof rawElapsed === 'number' && Number.isFinite(rawElapsed) ? rawElapsed : undefined;
+        // F4: preserve `field` from the real ISL shape (top-level, or detail-nested).
+        const rawField = w?.field ?? w?.detail?.field;
+        const field = typeof rawField === 'string' && rawField !== '' ? rawField : undefined;
         inferenceWarnings.push({
           code: w.code,
           message,
           severity: w.severity === 'warning' ? 'warning' : 'info',
+          ...(field !== undefined && { field }),
           ...(elapsedMs !== undefined && { elapsed_ms: elapsedMs }),
         });
         existingKeys.add(dedupKey);
@@ -5213,6 +5294,8 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // robustness.edge_e_values on the V2 wire (the former top-level read
         // was structurally dead — every live response came back "empty").
         const islEdgeEValuesRaw = getIslEdgeEValues(islResult);
+        // F14: threaded to buildResponse's meta so a non-finite drop is disclosed on the wire.
+        let edgeEValuesDroppedNonFinite: number | undefined;
         const edgeEValues = transformEdgeEValues(islEdgeEValuesRaw, earlyNodeLabelMap, normalisationContext);
 
         // Transform ISL conditional_winners (when present) with label enrichment
@@ -5229,6 +5312,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // hiding the upstream defect. (Counts only — no payload.)
         const eValuesDropped = (islEdgeEValuesRaw?.length ?? 0) - edgeEValues.length;
         if (eValuesDropped > 0) {
+          edgeEValuesDroppedNonFinite = eValuesDropped; // F14: wire disclosure via meta.
           req.log.warn({ event: 'edge_e_values_dropped_nonfinite', request_id: requestId, dropped: eValuesDropped, kept: edgeEValues.length });
         }
         const condWinnersDropped = (islResult.conditional_winners?.length ?? 0) - conditionalWinners.length;
@@ -6171,6 +6255,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             originalNSamples,
             flipProbeNSamples,
             flipThresholdsFailedErrorName,
+            edgeEValuesDroppedNonFinite,
             detailLevel,
             latencyMs: finalTotalMs,
             normalizationMs,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -425,21 +425,73 @@ export function transformEdgeSensitivity(
 }
 
 /**
+ * NIT 1 (post-#232 review): edge E-value drops have TWO distinct causes and the
+ * disclosure must attribute them accurately (never claim a transformation
+ * overflow for a benign input null):
+ * - `inputNull`: a required numeric was ALREADY non-finite in the ISL INPUT —
+ *   the common UNFLIPPABLE case (ISL emits e_value:null when current==flip, so
+ *   there is no evidence ratio). Not a defect, not an overflow.
+ * - `overflow`: every raw input numeric was finite yet a value became non-finite
+ *   AFTER range denormalisation (the pathological F14 case).
+ */
+export interface EdgeEValueDropSink {
+  inputNull: number;
+  overflow: number;
+}
+
+/**
+ * Build the accurate, cause-attributing wire disclosure for dropped edge
+ * E-values (NIT 1). Returns undefined when nothing was dropped. Names only the
+ * cause(s) actually present — the unflippable/input-null case is NEVER described
+ * as an overflow. Severity: info (see EDGE_E_VALUE_NON_FINITE_DROPPED doc).
+ */
+export function describeEdgeEValueDrop(
+  inputNull: number,
+  overflow: number,
+): InferenceWarning | undefined {
+  const total = inputNull + overflow;
+  if (total <= 0) return undefined;
+  const causes: string[] = [];
+  if (inputNull > 0) {
+    causes.push(
+      `${inputNull} carried no finite E-value from the analysis engine (an unflippable edge, whose current and flip means coincide, has no evidence ratio)`,
+    );
+  }
+  if (overflow > 0) {
+    causes.push(`${overflow} became non-finite after range denormalisation`);
+  }
+  return {
+    code: INFERENCE_WARNING_CODES.EDGE_E_VALUE_NON_FINITE_DROPPED,
+    // provisional_doctrine_v0 — wording surface (diagnostic disclosure). Count only.
+    message:
+      `${total} edge E-value ${total === 1 ? 'entry was' : 'entries were'} omitted from ` +
+      `edge_e_values: ${causes.join('; ')}. edge_e_values is shorter because those entries ` +
+      `could not be represented, not because they were computed empty. All other analyses are unaffected.`,
+    severity: 'info',
+  };
+}
+
+/**
  * Transform ISL edge_e_values to enriched response format with labels.
  * Returns [] when input is empty/absent so consumers see "computed, empty"
  * rather than "not computed".
  * Edge IDs are normalised to double-colon format.
+ *
+ * `dropSink` (optional, NIT 1): when supplied, entries dropped for
+ * non-finiteness are classified by cause (input-null vs post-transform overflow)
+ * so the wire disclosure can attribute them accurately.
  */
 /** @internal Exported for numeric-egress-guard unit tests. */
 export function transformEdgeEValues(
   islEdgeEValues: ISLEdgeEValue[] | undefined,
   nodeLabelMap?: Map<string, string>,
   normContext?: NormalisationContext,
+  dropSink?: EdgeEValueDropSink,
 ): EnrichedEdgeEValue[] {
   if (!islEdgeEValues || islEdgeEValues.length === 0) return [];
   const goalRange = normContext?.goal_context?.range;
 
-  return islEdgeEValues.map(e => {
+  const mapped = islEdgeEValues.map(e => {
     // Parse ISL edge_id ("from->to" or "from::to") to get node IDs.
     // Fallback: if neither separator found, use entire edge_id as both from and to
     // (matches parseEdgeId pattern in robustness-analysis.ts).
@@ -537,14 +589,40 @@ export function transformEdgeEValues(
       ...(stability !== undefined && { stability }),
       ...(eValueNormalised !== undefined && { _normalised: eValueNormalised }),
     };
-    // Numeric-egress guard (Codex round-2): e_value/current_mean/flip_mean are
-    // required numbers; drop entries with any non-finite value rather than emit a
-    // fabricated `null`.
-  }).filter((e) =>
-    finiteNum(e.e_value) !== undefined &&
-    finiteNum(e.current_mean) !== undefined &&
-    finiteNum(e.flip_mean) !== undefined
-  );
+  });
+
+  // Numeric-egress guard (Codex round-2): e_value/current_mean/flip_mean are
+  // required numbers; drop entries with any non-finite value rather than emit a
+  // fabricated `null`. NIT 1: classify each drop by cause (input-null vs
+  // post-transform overflow) so the disclosure attributes it accurately. `mapped`
+  // is 1:1 with `islEdgeEValues` (map preserves order), so index i pairs the
+  // transformed entry with its raw ISL input.
+  const kept: EnrichedEdgeEValue[] = [];
+  for (let i = 0; i < mapped.length; i++) {
+    const out = mapped[i];
+    const keep =
+      finiteNum(out.e_value) !== undefined &&
+      finiteNum(out.current_mean) !== undefined &&
+      finiteNum(out.flip_mean) !== undefined;
+    if (keep) {
+      kept.push(out);
+      continue;
+    }
+    if (dropSink) {
+      const raw = islEdgeEValues[i];
+      // If any RAW input numeric was already non-finite, the drop is due to the
+      // INPUT (unflippable edge: e_value=null) — NOT a transform overflow. Only
+      // when every raw input was finite yet a transformed value is non-finite is
+      // the cause a range-denormalisation overflow.
+      const rawAllFinite =
+        finiteNum(raw.e_value) !== undefined &&
+        finiteNum(raw.current_mean) !== undefined &&
+        finiteNum(raw.flip_mean) !== undefined;
+      if (rawAllFinite) dropSink.overflow++;
+      else dropSink.inputNull++;
+    }
+  }
+  return kept;
 }
 
 /**
@@ -1230,13 +1308,15 @@ interface MetaParams {
    */
   flipThresholdsFailedErrorName?: string;
   /**
-   * F14 (Codex deep review): count of edge E-value entries dropped from the
-   * public array because a required numeric (e_value/current_mean/flip_mean)
-   * was non-finite after transformation. Presence (>0) drives the
-   * EDGE_E_VALUE_NON_FINITE_DROPPED inference warning so the drop is
-   * attributable on the wire, not only in the server log. Absent/0 = no drop.
+   * F14 (Codex deep review) + NIT 1: edge E-value entries dropped from the public
+   * array because a required numeric was non-finite, split by CAUSE — `inputNull`
+   * (already non-finite in the ISL input, e.g. an unflippable edge) vs `overflow`
+   * (finite input that became non-finite after range denormalisation). A non-zero
+   * total drives the cause-accurate EDGE_E_VALUE_NON_FINITE_DROPPED inference
+   * warning so the drop is attributable on the wire, not only in the server log.
+   * Absent = no drop.
    */
-  edgeEValuesDroppedNonFinite?: number;
+  edgeEValuesDropped?: EdgeEValueDropSink;
   detailLevel: string;
   latencyMs: number;
   normalizationMs?: number;
@@ -2530,24 +2610,22 @@ function buildResponse(
     });
   }
 
-  // F14 (Codex deep review): DISCLOSE edge E-values dropped for non-finiteness.
-  // The transform drops entries whose e_value/current_mean/flip_mean are
-  // non-finite (a fabricated `null` would otherwise ship). Without this marker
-  // the drop was server-log-only — a short/empty edge_e_values was
-  // indistinguishable from a genuinely computed-empty result. Non-blocking.
-  if (meta.edgeEValuesDroppedNonFinite && meta.edgeEValuesDroppedNonFinite > 0) {
-    const n = meta.edgeEValuesDroppedNonFinite;
-    inferenceWarnings.push({
-      code: INFERENCE_WARNING_CODES.EDGE_E_VALUE_NON_FINITE_DROPPED,
-      // provisional_doctrine_v0 — wording surface (diagnostic disclosure). Count only.
-      message: `${n} edge E-value entr${n === 1 ? 'y was' : 'ies were'} omitted from edge_e_values because a required numeric was non-finite after transformation — edge_e_values is shorter because those entries could not be represented, not because they were computed empty. All other analyses are unaffected.`,
-      // info, not warning: ISL routinely emits null e_value for UNFLIPPABLE edges
-      // (current_mean == flip_mean → no finite evidence ratio), so this is an
-      // expected non-representability disclosure, not an alarm — matching the
-      // sibling EDGE_E_VALUES_UNAVAILABLE_V2_WIRE severity. Still fully on the
-      // wire (+ _meta warning_codes), just below the prominent warning strip.
-      severity: 'info',
-    });
+  // F14 (Codex deep review) + NIT 1: DISCLOSE edge E-values dropped for
+  // non-finiteness, attributing the CAUSE accurately. The transform drops
+  // entries whose e_value/current_mean/flip_mean are non-finite (a fabricated
+  // `null` would otherwise ship). Without this marker the drop was
+  // server-log-only — a short/empty edge_e_values was indistinguishable from a
+  // genuinely computed-empty result. describeEdgeEValueDrop names the
+  // unflippable/input-null cause and the overflow cause separately, never
+  // claiming an overflow for the common benign input-null case. Severity: info
+  // (ISL routinely emits null e_value for unflippable edges — expected
+  // non-representability, not an alarm; still on the wire + _meta warning_codes).
+  if (meta.edgeEValuesDropped) {
+    const disclosure = describeEdgeEValueDrop(
+      meta.edgeEValuesDropped.inputNull,
+      meta.edgeEValuesDropped.overflow,
+    );
+    if (disclosure) inferenceWarnings.push(disclosure);
   }
 
   // Merge ISL-originated inference_warnings into the PLoT array.
@@ -2591,7 +2669,12 @@ function buildResponse(
         inferenceWarnings.push({
           code: w.code,
           message,
-          severity: w.severity === 'warning' ? 'warning' : 'info',
+          // NIT 2: map severity defensively. 'info' (and absent — the F4 benign
+          // default) stays 'info'; 'warning' stays 'warning'; anything MORE severe
+          // than 'warning' (e.g. 'error') or any unknown value escalates to
+          // 'warning' — the most severe level PLoT's InferenceWarning supports —
+          // and is NEVER collapsed DOWN to 'info' (which would HIDE it).
+          severity: (w.severity == null || w.severity === 'info') ? 'info' : 'warning',
           ...(field !== undefined && { field }),
           ...(elapsedMs !== undefined && { elapsed_ms: elapsedMs }),
         });
@@ -5294,9 +5377,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // robustness.edge_e_values on the V2 wire (the former top-level read
         // was structurally dead — every live response came back "empty").
         const islEdgeEValuesRaw = getIslEdgeEValues(islResult);
-        // F14: threaded to buildResponse's meta so a non-finite drop is disclosed on the wire.
-        let edgeEValuesDroppedNonFinite: number | undefined;
-        const edgeEValues = transformEdgeEValues(islEdgeEValuesRaw, earlyNodeLabelMap, normalisationContext);
+        // F14 + NIT 1: classify drops by cause (input-null vs overflow) and thread
+        // to buildResponse's meta so the wire disclosure attributes them accurately.
+        let edgeEValuesDropped: EdgeEValueDropSink | undefined;
+        const edgeEValueDropSink: EdgeEValueDropSink = { inputNull: 0, overflow: 0 };
+        const edgeEValues = transformEdgeEValues(islEdgeEValuesRaw, earlyNodeLabelMap, normalisationContext, edgeEValueDropSink);
 
         // Transform ISL conditional_winners (when present) with label enrichment
         const conditionalWinners = transformConditionalWinners(
@@ -5310,10 +5395,10 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // non-finite / out-of-range numerics. These surfaces have no per-feature status
         // to degrade, so emit a warning when entries are silently removed rather than
         // hiding the upstream defect. (Counts only — no payload.)
-        const eValuesDropped = (islEdgeEValuesRaw?.length ?? 0) - edgeEValues.length;
+        const eValuesDropped = edgeEValueDropSink.inputNull + edgeEValueDropSink.overflow;
         if (eValuesDropped > 0) {
-          edgeEValuesDroppedNonFinite = eValuesDropped; // F14: wire disclosure via meta.
-          req.log.warn({ event: 'edge_e_values_dropped_nonfinite', request_id: requestId, dropped: eValuesDropped, kept: edgeEValues.length });
+          edgeEValuesDropped = edgeEValueDropSink; // F14 + NIT 1: cause-attributed wire disclosure via meta.
+          req.log.warn({ event: 'edge_e_values_dropped_nonfinite', request_id: requestId, dropped: eValuesDropped, input_null: edgeEValueDropSink.inputNull, overflow: edgeEValueDropSink.overflow, kept: edgeEValues.length });
         }
         const condWinnersDropped = (islResult.conditional_winners?.length ?? 0) - conditionalWinners.length;
         if (condWinnersDropped > 0) {
@@ -6255,7 +6340,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             originalNSamples,
             flipProbeNSamples,
             flipThresholdsFailedErrorName,
-            edgeEValuesDroppedNonFinite,
+            edgeEValuesDropped,
             detailLevel,
             latencyMs: finalTotalMs,
             normalizationMs,

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2124,6 +2124,33 @@ export const INFERENCE_WARNING_CODES = {
    * unaffected. Severity: warning.
    */
   PATH_DECOMPOSITION_UNAVAILABLE: 'PATH_DECOMPOSITION_UNAVAILABLE',
+  /**
+   * F13 (Codex deep review, A3 r2): one or more ISL factor-sensitivity entries
+   * carried BOTH a `node_id` AND a `factor_id` that DIFFER — an ambiguous twin
+   * whose canonical identity cannot be trusted. Rather than resolve it to a
+   * guessed id (and risk mapping it as a lever on one surface while it escapes
+   * lever-suppression on another), PLoT DROPS such entries from the public
+   * factor_sensitivity / factor_stability / CEE-review surfaces and discloses
+   * the drop here. The pinned ISL producer emits only canonical `node_id`, so
+   * this cannot fire on the current wire — it is schema-evolution hardening.
+   * Non-blocking; all other analyses unaffected. Severity: warning.
+   * @see src/lib/intervention-override.ts factorIdOf / hasFactorIdConflict
+   */
+  FACTOR_ID_CONFLICT: 'FACTOR_ID_CONFLICT',
+  /**
+   * F14 (Codex deep review, A3 r2): one or more edge E-value entries were
+   * dropped from the public `edge_e_values` array because a required numeric
+   * (e_value / current_mean / flip_mean) was non-finite after transformation
+   * (e.g. a range-width overflow denormalised a valid value to ±Infinity, which
+   * would serialise to a fabricated `null`). Without this marker the drop was
+   * SILENT — an empty/short `edge_e_values` was indistinguishable from a
+   * genuinely computed-empty result. Non-blocking; other analyses unaffected.
+   * Severity: info (ISL routinely emits null e_value for unflippable edges —
+   * expected non-representability, not an alarm; mirrors
+   * EDGE_E_VALUES_UNAVAILABLE_V2_WIRE).
+   * @see src/routes/v2/run.ts transformEdgeEValues
+   */
+  EDGE_E_VALUE_NON_FINITE_DROPPED: 'EDGE_E_VALUE_NON_FINITE_DROPPED',
 } as const;
 
 export type InferenceWarningCode = (typeof INFERENCE_WARNING_CODES)[keyof typeof INFERENCE_WARNING_CODES];
@@ -2136,6 +2163,14 @@ export interface InferenceWarning {
   code: InferenceWarningCode | string;
   message: string;
   severity: 'info' | 'warning';
+  /**
+   * F4 (Codex deep review): the field path the warning is about, preserved
+   * verbatim from ISL's real `InferenceWarning.field` (e.g. `factor_evpi`,
+   * `path_decomposition`). Present only when the source warning carried one.
+   * The egress enrichment envelope's inference_warnings element is passthrough,
+   * so this additive field never fails the contract.
+   */
+  field?: string;
   /**
    * Optional wall-clock ms the underlying phase ran before degrading. Carried
    * through from ISL's budget-degradation disclosures (STABILITY_BANDS_UNAVAILABLE,

--- a/src/util/structural-keys.generated.ts
+++ b/src/util/structural-keys.generated.ts
@@ -97,6 +97,7 @@ export const STRUCTURAL_KEYS: ReadonlySet<string> = new Set([
   "deduplicated_options",
   "degraded",
   "description",
+  "detail",
   "detail_level",
   "details",
   "details_truncated",

--- a/tests/edge-e-value-drop-cause.test.ts
+++ b/tests/edge-e-value-drop-cause.test.ts
@@ -1,0 +1,124 @@
+/**
+ * NIT 1 (post-#232 review) — EDGE_E_VALUE_NON_FINITE_DROPPED must attribute the
+ * drop CAUSE accurately.
+ *
+ * Two distinct causes share the code:
+ *  (a) UNFLIPPABLE / input-null: ISL sends e_value:null (current_mean==flip_mean,
+ *      no evidence ratio) — a NORMAL, common case. It must NOT be described as a
+ *      transformation overflow.
+ *  (b) OVERFLOW: a finite value became non-finite AFTER range denormalisation
+ *      (the pathological F14 case) — covered by the unit test in
+ *      finite-range-overflow-guard.test.ts (unreachable via the route now that the
+ *      range-source guard rejects overflow-width ranges).
+ *
+ * RED-first (this file, route level): an unflippable-null edge is dropped and the
+ * wire disclosure names the INPUT/unflippable cause — it must NOT claim
+ * "after transformation" / overflow. Pre-fix the single message misattributes it.
+ * The dropped edge SET and drop BEHAVIOUR are unchanged — only the wording.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const ISL_DATA = {
+  options: [
+    { option_id: 'opt1', outcome: { mean: 0.8, std: 0.1, p10: 0.6, p50: 0.8, p90: 0.95, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 1, win_probability: 0.7, probability_of_goal: 0.65 },
+    { option_id: 'opt2', outcome: { mean: 0.7, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 2, win_probability: 0.3, probability_of_goal: 0.55 },
+  ],
+  factor_sensitivity: [],
+  robustness: {
+    score: 0.82,
+    label: 'robust',
+    fragile_edges: [],
+    robust_edges: [],
+    edge_e_values: [
+      // UNFLIPPABLE: ISL sends e_value:null with current_mean == flip_mean.
+      { edge_id: 'factor-a->goal', e_value: null, current_mean: 0.5, flip_mean: 0.5, flip_direction: 'increase' },
+      // NORMAL: kept.
+      { edge_id: 'factor-b->goal', e_value: 1.4, current_mean: 0.3, flip_mean: 0.5, flip_direction: 'increase' },
+    ],
+  },
+};
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return { status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl' };
+  },
+  async analyseSensitivity() { return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' }; },
+  async analyseRobustness() { return { ...ISL_DATA, source: 'isl' as const, latency_ms: 42 }; },
+  async analyseFactorSensitivity() { return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.82, latency_ms: 0, source: 'unavailable' as const }; },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, _body: unknown): Promise<{ data: T | null; error: string | null }> { return { data: ISL_DATA as T, error: null }; },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, get islService() { return mockISLService; } };
+});
+
+import { createServer } from '../src/createServer.js';
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+    { id: 'factor-b', kind: 'factor', label: 'Churn Rate', observed_state: { value: 0.4 } },
+  ],
+  edges: [
+    { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'factor-b', to: 'goal', strength: { mean: 0.3, std: 0.1 } },
+  ],
+};
+const OPTIONS = [
+  { id: 'opt1', label: 'Increase Marketing', interventions: { 'factor-a': 0.8 } },
+  { id: 'opt2', label: 'Reduce Spend', interventions: { 'factor-a': 0.3 } },
+];
+
+describe('NIT 1 — edge E-value drop cause attribution (unflippable input-null)', () => {
+  let app: FastifyInstance;
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  async function run() {
+    const res = await app.inject({
+      method: 'POST', url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: 'nit1-drop-cause' }),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  it('drops only the unflippable edge (behaviour unchanged) and discloses it', async () => {
+    const body = await run();
+    // The normal edge is kept; the unflippable one is dropped — SET unchanged.
+    expect(body.edge_e_values.length).toBe(1);
+    const w = (body.inference_warnings ?? []).find((x: { code: string }) => x.code === 'EDGE_E_VALUE_NON_FINITE_DROPPED');
+    expect(w, 'drop disclosure present').toBeDefined();
+    expect(w.severity).toBe('info');
+  });
+
+  it('names the UNFLIPPABLE/input cause, never a transformation overflow', async () => {
+    const body = await run();
+    const w = (body.inference_warnings ?? []).find((x: { code: string }) => x.code === 'EDGE_E_VALUE_NON_FINITE_DROPPED');
+    const msg: string = w.message;
+    // RED-first: pre-fix the single message says "non-finite after transformation".
+    expect(msg.toLowerCase()).not.toContain('after transformation');
+    expect(msg.toLowerCase()).not.toContain('denormalisation');
+    expect(msg.toLowerCase()).not.toContain('overflow');
+    // Accurate: the value simply had no finite E-value from the engine.
+    expect(msg.toLowerCase()).toContain('unflippable');
+    expect(msg).toContain('no finite E-value');
+  });
+});

--- a/tests/enrichment-stability-band-refinement.test.ts
+++ b/tests/enrichment-stability-band-refinement.test.ts
@@ -1,0 +1,101 @@
+/**
+ * F12 (Codex deep review, A3 r2) — refined stability-band parse in the egress
+ * guard (PLoT-LOCAL interim; the canonical SHARED stability schema is a
+ * separate A1 schemas-PR).
+ *
+ * The shared `EnrichmentEdgeEValueSchema` is `.passthrough()` and does NOT type
+ * `edge_e_values[].stability`, so a malformed band (reversed endpoints, negative
+ * / non-integer counts, n_seeds_flipped > n_seeds, seed_flip_means length
+ * mismatch, negative width) survives `assessEnrichmentContract` and is stamped
+ * `enrichment_contract_ok: true`.
+ *
+ * RED-first: every malformed-band body below asserts `ok === false`; on the
+ * current (passthrough-only) code they return `ok === true` (the false-pass) —
+ * so each assertion FAILS pre-fix and PASSES post-fix. The valid-band and
+ * no-band cases are positive controls that must STILL pass (`ok === true`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assessEnrichmentContract } from '../src/routes/v2/enrichment-egress-guard.js';
+
+// A minimal body the shared schema otherwise accepts (edge outer fields valid);
+// only the nested `stability` object varies.
+function bodyWithBand(stability: unknown) {
+  return {
+    edge_e_values: [
+      {
+        edge_id: 'a::b', from_id: 'a', to_id: 'b',
+        e_value: 1.4, flip_direction: 'increase',
+        current_mean: 0.5, flip_mean: 0.7,
+        stability,
+      },
+    ],
+  };
+}
+
+const VALID_BAND = {
+  n_seeds: 10,
+  n_seeds_flipped: 3,
+  band_min: 0.2,
+  band_median: 0.5,
+  band_max: 0.8,
+  band_width: 0.6,
+  seed_flip_means: [0.2, null, 0.5, null, 0.8, null, null, null, null, null],
+};
+
+describe('F12 — egress guard refines the nested stability band (positive controls)', () => {
+  it('a well-formed band still passes (ok:true)', () => {
+    expect(assessEnrichmentContract(bodyWithBand(VALID_BAND)).ok).toBe(true);
+  });
+
+  it('an absent band still passes (nothing to sweep)', () => {
+    const body = { edge_e_values: [{ edge_id: 'a::b', from_id: 'a', to_id: 'b', e_value: 1.4, flip_direction: 'increase', current_mean: 0.5, flip_mean: 0.7 }] };
+    expect(assessEnrichmentContract(body).ok).toBe(true);
+  });
+
+  it('an n_seeds_flipped==0 band with omitted endpoints still passes', () => {
+    expect(assessEnrichmentContract(bodyWithBand({ n_seeds: 10, n_seeds_flipped: 0, seed_flip_means: new Array(10).fill(null) })).ok).toBe(true);
+  });
+});
+
+describe('F12 — malformed bands are REJECTED (RED-first: ok:true pre-fix)', () => {
+  it('reversed band (band_min > band_max)', () => {
+    expect(assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, band_min: 0.9, band_max: 0.1 })).ok).toBe(false);
+  });
+
+  it('unordered median (band_median outside [min,max])', () => {
+    expect(assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, band_median: 0.95 })).ok).toBe(false);
+  });
+
+  it('negative count (n_seeds < 0)', () => {
+    expect(assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, n_seeds: -1 })).ok).toBe(false);
+  });
+
+  it('non-integer count (n_seeds not an integer)', () => {
+    expect(assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, n_seeds: 10.5 })).ok).toBe(false);
+  });
+
+  it('n_seeds_flipped > n_seeds', () => {
+    expect(assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, n_seeds: 3, n_seeds_flipped: 5, seed_flip_means: [0.2, 0.5, 0.8] })).ok).toBe(false);
+  });
+
+  it('seed_flip_means length mismatch (count/list inconsistency)', () => {
+    expect(assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, seed_flip_means: [0.2, 0.5] })).ok).toBe(false);
+  });
+
+  it('negative band_width', () => {
+    expect(assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, band_width: -0.1 })).ok).toBe(false);
+  });
+
+  it('non-finite endpoint (band_max = Infinity via null in JSON is not number)', () => {
+    // A band_max that is not a finite number (e.g. a stringified overflow).
+    expect(assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, band_max: 'NaN' as unknown as number })).ok).toBe(false);
+  });
+
+  it('reports a stability path + keeps issue_count', () => {
+    const a = assessEnrichmentContract(bodyWithBand({ ...VALID_BAND, band_min: 0.9, band_max: 0.1 }));
+    expect(a.ok).toBe(false);
+    expect(a.issue_count).toBeGreaterThan(0);
+    expect(a.issues.some((i) => i.path.startsWith('edge_e_values.0.stability'))).toBe(true);
+  });
+});

--- a/tests/factor-id-canonicalisation.test.ts
+++ b/tests/factor-id-canonicalisation.test.ts
@@ -1,0 +1,131 @@
+/**
+ * F13 (Codex deep review, A3 r2) — canonicalise node_id/factor_id to ONE
+ * precedence used everywhere, so a `{node_id:'lever', factor_id:'other'}` twin
+ * cannot map/publish as `lever` while escaping lever-suppression via the
+ * opposite-precedence D-U predicate.
+ *
+ * RED-first: the two DEFECT assertions below use ONLY pre-existing exports
+ * (`isOptionControlledLever`, `buildFactorStability`) and FAIL on the current
+ * (opposite-precedence) code — they see the leak at BOTH the raw-ISL predicate
+ * boundary and the post-mapping publication boundary. `factorIdOf` /
+ * `hasFactorIdConflict` are pure additive helpers (no behaviour of their own).
+ *
+ * NOTE: the pinned ISL producer emits only canonical `node_id` today, so no
+ * live leak exists — this is schema-evolution hardening, kept additive/safe.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isOptionControlledLever,
+  factorIdOf,
+  hasFactorIdConflict,
+} from '../src/lib/intervention-override.js';
+import { buildFactorStability } from '../src/lib/factor-influence.js';
+import { extractFactorSensitivity } from '../src/cee/decision-review-request.js';
+import type { EngineGraphV3 } from '../src/types/engine-v3.js';
+
+const GRAPH: EngineGraphV3 = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'lever', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
+    { id: 'other', kind: 'factor', label: 'Brand Awareness', observed_state: { value: 0.5 } },
+  ],
+  edges: [
+    { from: 'lever', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
+  ],
+} as unknown as EngineGraphV3;
+
+// A future/additive ISL entry: identifies node `lever` (canonical) but ALSO
+// carries a conflicting `factor_id: 'other'`. The structural lever set is
+// {'lever'}. Valid 3C stability fields so the publication path would emit it.
+const TWIN = {
+  node_id: 'lever',
+  factor_id: 'other',
+  label: 'Marketing Spend',
+  elasticity_std: 0.2,
+  attribution_stability: 'high',
+  rank_flip_rate: 0.1,
+  stability_method: 'bootstrap_1000',
+  zero_reason: null,
+} as const;
+
+describe('F13 — factor-id canonicalisation (raw-ISL boundary)', () => {
+  it('DEFECT: option-controlled-lever predicate suppresses the unequal twin (canonical id = node_id)', () => {
+    // Pre-fix this returns FALSE: the predicate checked factor_id ('other') first,
+    // which is NOT in the structural lever set {'lever'} → escapes suppression.
+    expect(isOptionControlledLever(TWIN, new Set(['lever']))).toBe(true);
+  });
+
+  it('positive control: a NON-lever twin (node/factor both outside the set) is NOT falsely suppressed', () => {
+    expect(isOptionControlledLever(
+      { node_id: 'freefactor', factor_id: 'alsofree' },
+      new Set(['lever']),
+    )).toBe(false);
+  });
+});
+
+describe('F13 — factor-id canonicalisation (post-mapping publication boundary)', () => {
+  it('DEFECT: factor_stability does not publish the unequal twin\'s non-zero spread', () => {
+    const result = buildFactorStability([TWIN], GRAPH, new Set(['lever']));
+    // Pre-fix: one entry with elasticity_std 0.2 leaks (identified as `lever`,
+    // suppression missed because the D-U predicate resolved `other`).
+    // Post-fix: the conflicting twin is DROPPED (ambiguous identity), so it is
+    // absent from the published spread.
+    const leaked = result.find((e) => e.elasticity_std === 0.2);
+    expect(leaked, 'unequal twin must not leak a non-zero spread').toBeUndefined();
+    expect(result).toHaveLength(0);
+  });
+
+  it('positive control: a CLEAN lever (node_id only, in the set) still publishes with spread suppressed to 0', () => {
+    const cleanLever = { ...TWIN, factor_id: undefined };
+    const result = buildFactorStability([cleanLever], GRAPH, new Set(['lever']));
+    expect(result).toHaveLength(1);
+    expect(result[0].factor_id).toBe('lever');
+    expect(result[0].elasticity_std).toBe(0);
+  });
+
+  it('positive control: a genuine non-lever (node_id only, NOT in the set) keeps its spread verbatim', () => {
+    const nonLever = {
+      node_id: 'other', label: 'Brand Awareness', elasticity_std: 0.11,
+      attribution_stability: 'moderate', rank_flip_rate: 0.15, stability_method: 'bootstrap_1000',
+    };
+    const result = buildFactorStability([nonLever], GRAPH, new Set(['lever']));
+    expect(result).toHaveLength(1);
+    expect(result[0].elasticity_std).toBe(0.11);
+  });
+});
+
+describe('F13 — CEE review-request derivation uses the canonical predicate', () => {
+  it('DEFECT: an unequal-twin lever is filtered out of the CEE review factor list', () => {
+    const islResult = {
+      factor_sensitivity: [
+        { ...TWIN, factor_label: 'Marketing Spend', elasticity: 0.3, confidence: 0.7 },
+        { node_id: 'other', factor_id: 'other', factor_label: 'Brand', elasticity: 0.1, confidence: 0.6 },
+      ],
+    };
+    // Structural lever set = {'lever'}. Pre-fix the twin resolves 'other' and
+    // survives the filter → its elasticity egresses to CEE. Post-fix it is
+    // recognised as the lever and dropped.
+    const out = extractFactorSensitivity(islResult as never, new Set(['lever']));
+    expect(out.some((f) => f.factor_id === 'lever')).toBe(false);
+    expect(out.map((f) => f.factor_id)).toEqual(['other']);
+  });
+});
+
+describe('F13 — factorIdOf / hasFactorIdConflict helpers (positive controls)', () => {
+  it('factorIdOf resolves node_id first, falls back to factor_id, ignores empties', () => {
+    expect(factorIdOf({ node_id: 'n', factor_id: 'f' })).toBe('n');
+    expect(factorIdOf({ factor_id: 'f' })).toBe('f');
+    expect(factorIdOf({ node_id: '', factor_id: 'f' })).toBe('f');
+    expect(factorIdOf({})).toBeUndefined();
+    expect(factorIdOf({ node_id: '', factor_id: '' })).toBeUndefined();
+  });
+
+  it('hasFactorIdConflict is true only when both non-empty ids differ', () => {
+    expect(hasFactorIdConflict({ node_id: 'a', factor_id: 'b' })).toBe(true);
+    expect(hasFactorIdConflict({ node_id: 'a', factor_id: 'a' })).toBe(false);
+    expect(hasFactorIdConflict({ node_id: 'a' })).toBe(false);
+    expect(hasFactorIdConflict({ factor_id: 'b' })).toBe(false);
+    expect(hasFactorIdConflict({ node_id: 'a', factor_id: '' })).toBe(false);
+  });
+});

--- a/tests/finite-range-overflow-guard.test.ts
+++ b/tests/finite-range-overflow-guard.test.ts
@@ -21,7 +21,7 @@ import {
   type NormalisationContext,
 } from '../src/lib/intervention-normaliser.js';
 import { denormaliseFlipThresholds } from '../src/lib/flip-threshold-denormaliser.js';
-import { transformEdgeEValues } from '../src/routes/v2/run.js';
+import { transformEdgeEValues, describeEdgeEValueDrop, type EdgeEValueDropSink } from '../src/routes/v2/run.js';
 import type { EngineNodeV3 } from '../src/types/engine-v3.js';
 
 const INSANE = { min: -1e308, max: 1e308 };
@@ -118,5 +118,58 @@ describe('F14 — edge E-values: overflow no longer silently drops the entry', (
 
   it('positive control: denormaliseValue on a safe range is exact', () => {
     expect(denormaliseValue(0.5, { min: 10, max: 60, source: 'explicit' })).toBe(35);
+  });
+});
+
+describe('NIT 1 — edge E-value drop cause is classified + described accurately', () => {
+  it('transformEdgeEValues classifies an UNFLIPPABLE input-null drop as inputNull', () => {
+    const sink: EdgeEValueDropSink = { inputNull: 0, overflow: 0 };
+    // e_value:null in the ISL INPUT (finite means) — unflippable. No normContext.
+    const isl = [{ edge_id: 'a->b', e_value: null, current_mean: 0.5, flip_mean: 0.5, flip_direction: 'increase' }];
+    const out = transformEdgeEValues(isl as never, undefined, undefined, sink);
+    expect(out).toHaveLength(0);
+    expect(sink).toEqual({ inputNull: 1, overflow: 0 });
+  });
+
+  it('transformEdgeEValues classifies a post-transform OVERFLOW drop as overflow', () => {
+    const sink: EdgeEValueDropSink = { inputNull: 0, overflow: 0 };
+    // All raw inputs FINITE, but a directly non-finite goal range denormalises
+    // current/flip to Infinity → dropped → cause is the transform, not the input.
+    const context: NormalisationContext = {
+      factors: new Map(),
+      goal_node_id: 'goal',
+      goal_context: { factor_id: 'goal', range: { min: -1e308, max: 1e308, source: 'explicit' }, baseline: 0 },
+    };
+    const isl = [{ edge_id: 'a->b', e_value: 1.4, current_mean: 0.5, flip_mean: 0.7, flip_direction: 'increase' }];
+    const out = transformEdgeEValues(isl as never, undefined, context, sink);
+    expect(out).toHaveLength(0);
+    expect(sink).toEqual({ inputNull: 0, overflow: 1 });
+  });
+
+  it('describeEdgeEValueDrop names the unflippable cause WITHOUT overflow wording', () => {
+    const d = describeEdgeEValueDrop(1, 0)!;
+    expect(d.severity).toBe('info');
+    expect(d.code).toBe('EDGE_E_VALUE_NON_FINITE_DROPPED');
+    expect(d.message.toLowerCase()).toContain('unflippable');
+    expect(d.message).toContain('no finite E-value');
+    expect(d.message.toLowerCase()).not.toContain('denormalisation');
+    expect(d.message.toLowerCase()).not.toContain('after transformation');
+  });
+
+  it('describeEdgeEValueDrop names the overflow cause WITHOUT unflippable wording', () => {
+    const d = describeEdgeEValueDrop(0, 1)!;
+    expect(d.message.toLowerCase()).toContain('denormalisation');
+    expect(d.message.toLowerCase()).not.toContain('unflippable');
+  });
+
+  it('describeEdgeEValueDrop names BOTH causes when both present', () => {
+    const d = describeEdgeEValueDrop(2, 3)!;
+    expect(d.message).toContain('no finite E-value');
+    expect(d.message.toLowerCase()).toContain('denormalisation');
+    expect(d.message).toContain('5 edge E-value entries'); // total
+  });
+
+  it('describeEdgeEValueDrop returns undefined when nothing dropped', () => {
+    expect(describeEdgeEValueDrop(0, 0)).toBeUndefined();
   });
 });

--- a/tests/finite-range-overflow-guard.test.ts
+++ b/tests/finite-range-overflow-guard.test.ts
@@ -1,0 +1,122 @@
+/**
+ * F14 (Codex deep review, A3 r2) — finite-range overflow guards.
+ *
+ * An accepted explicit range `{min:-1e308, max:1e308}` has `max > min` but
+ * `max - min === Infinity`. Denormalising a valid `0.5` through it returns
+ * `Infinity`, which `JSON.stringify` emits as a fabricated `null` on the wire
+ * (flip_value), or makes PLoT silently DROP the whole edge E-value
+ * (current_mean/flip_mean). These tests SERIALIZE the final bytes (per the
+ * Codex requirement) rather than only inspecting JS objects.
+ *
+ * RED-first: each byte assertion FAILS on the current code — the insane range
+ * survives `deriveRange` (only `max > min` is checked) and overflows.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildNormalisationContext,
+  deriveRange,
+  denormaliseValue,
+  isFiniteRange,
+  type NormalisationContext,
+} from '../src/lib/intervention-normaliser.js';
+import { denormaliseFlipThresholds } from '../src/lib/flip-threshold-denormaliser.js';
+import { transformEdgeEValues } from '../src/routes/v2/run.js';
+import type { EngineNodeV3 } from '../src/types/engine-v3.js';
+
+const INSANE = { min: -1e308, max: 1e308 };
+
+// Goal + factor nodes carrying the overflow-width explicit range. Normalisation
+// context is built through deriveRange (Priority 1: explicit state_space.range),
+// exactly as the live route does — so the range-source finite guard is exercised.
+const NODES: EngineNodeV3[] = [
+  { id: 'goal', kind: 'goal', label: 'Revenue', state_space: { range: { ...INSANE } } },
+  { id: 'f', kind: 'factor', label: 'Spend', state_space: { range: { ...INSANE } }, observed_state: { value: 0.6 } },
+];
+
+function ctx(): NormalisationContext {
+  return buildNormalisationContext(NODES, 'goal');
+}
+
+describe('F14 — deriveRange rejects overflow-width ranges (range-source fix)', () => {
+  it('DEFECT: an explicit {min:-1e308,max:1e308} range is NOT accepted verbatim', () => {
+    const r = deriveRange(NODES[1]);
+    // Pre-fix: source 'explicit' with the insane endpoints (width Infinity).
+    // Post-fix: rejected → falls through the chain to a finite range.
+    expect(Number.isFinite(r.max - r.min)).toBe(true);
+    expect(r.max - r.min).toBeGreaterThan(0);
+  });
+
+  it('positive control: a NORMAL explicit range is preserved verbatim (no regression)', () => {
+    const node: EngineNodeV3 = { id: 'n', kind: 'factor', label: 'n', state_space: { range: { min: 10, max: 60 } } };
+    const r = deriveRange(node);
+    expect(r).toEqual({ min: 10, max: 60, source: 'explicit' });
+  });
+
+  it('isFiniteRange: positive control', () => {
+    expect(isFiniteRange(0, 1)).toBe(true);
+    expect(isFiniteRange(10, 60)).toBe(true);
+    expect(isFiniteRange(-1e308, 1e308)).toBe(false); // width overflows
+    expect(isFiniteRange(5, 5)).toBe(false); // zero width
+    expect(isFiniteRange(5, 4)).toBe(false); // negative width
+    expect(isFiniteRange(Infinity, 0)).toBe(false);
+    expect(isFiniteRange(NaN, 1)).toBe(false);
+  });
+});
+
+describe('F14 — flip thresholds: no fabricated null on the SERIALIZED wire', () => {
+  it('DEFECT: a valid normalised flip_value denormalises to a FINITE number, not null', () => {
+    const out = denormaliseFlipThresholds(
+      [{ factor_id: 'f', factor_label: 'Spend', current_value: 0.5, flip_value: 0.5, direction: 'increase', flip_reason: 'found' }],
+      ctx(),
+      [],
+    );
+    const json = JSON.stringify(out);
+    // Pre-fix: 0.5 → Infinity → serialised "flip_value":null (fabricated).
+    // Post-fix: the goal/factor range is a safe default → finite flip_value.
+    expect(json).not.toContain('"flip_value":null');
+    expect(Number.isFinite(out[0].flip_value)).toBe(true);
+    expect(Number.isFinite(out[0].current_value)).toBe(true);
+  });
+
+  it('defense + disclosure: a directly non-finite range nulls flip_value AND discloses via flip_reason', () => {
+    // Bypass deriveRange — hand a context whose range already overflows, to
+    // prove the post-denormalisation finite guard (defense-in-depth) discloses
+    // rather than emitting a silent fabricated null.
+    const context: NormalisationContext = {
+      factors: new Map([['f', { factor_id: 'f', range: { min: -1e308, max: 1e308, source: 'explicit' }, baseline: 0 }]]),
+      goal_node_id: 'goal',
+    };
+    const out = denormaliseFlipThresholds(
+      [{ factor_id: 'f', factor_label: 'Spend', current_value: 0.5, flip_value: 0.5, direction: 'increase', flip_reason: 'found' }],
+      context,
+      [],
+    );
+    const json = JSON.stringify(out);
+    expect(json).not.toContain('Infinity'); // never a non-finite token
+    expect(out[0].flip_reason).toBe('non_finite_denormalisation');
+    expect(Number.isFinite(out[0].current_value)).toBe(true);
+  });
+});
+
+describe('F14 — edge E-values: overflow no longer silently drops the entry', () => {
+  it('DEFECT: an edge E-value survives (not dropped) and serialises with finite means', () => {
+    const isl = [{
+      edge_id: 'f->goal', e_value: 1.4, flip_direction: 'increase',
+      current_mean: 0.5, flip_mean: 0.7,
+    }];
+    const out = transformEdgeEValues(isl as never, new Map([['f', 'Spend'], ['goal', 'Revenue']]), ctx());
+    const json = JSON.stringify(out);
+    // Pre-fix: current_mean/flip_mean → Infinity → filtered out → out is [].
+    // Post-fix: safe goal range → finite means → entry retained.
+    expect(out).toHaveLength(1);
+    expect(json).not.toContain('"current_mean":null');
+    expect(json).not.toContain('"flip_mean":null');
+    expect(Number.isFinite(out[0].current_mean)).toBe(true);
+    expect(Number.isFinite(out[0].flip_mean)).toBe(true);
+  });
+
+  it('positive control: denormaliseValue on a safe range is exact', () => {
+    expect(denormaliseValue(0.5, { min: 10, max: 60, source: 'explicit' })).toBe(35);
+  });
+});

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -654,7 +654,13 @@
     "version": "v1.0-operational-defaults",
     "provisional": true
   },
-  "inference_warnings": [],
+  "inference_warnings": [
+    {
+      "code": "EDGE_E_VALUE_NON_FINITE_DROPPED",
+      "message": "4 edge E-value entries were omitted from edge_e_values because a required numeric was non-finite after transformation — edge_e_values is shorter because those entries could not be represented, not because they were computed empty. All other analyses are unaffected.",
+      "severity": "info"
+    }
+  ],
   "m1_coaching": {
     "story_headlines": {
       "opt_tech_lead": "Hire One Tech Lead leads, but Technical Quality and Architecture → Increase Team Productivity could swing the outcome to Hire Two Developers",
@@ -1598,7 +1604,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:96feaa2a2e028dfd"
+    "response_content_hash": "rch_v2:fa0104979707a391"
   },
   "meta": {
     "seed_used": "2034401427",

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -657,7 +657,7 @@
   "inference_warnings": [
     {
       "code": "EDGE_E_VALUE_NON_FINITE_DROPPED",
-      "message": "4 edge E-value entries were omitted from edge_e_values because a required numeric was non-finite after transformation — edge_e_values is shorter because those entries could not be represented, not because they were computed empty. All other analyses are unaffected.",
+      "message": "4 edge E-value entries were omitted from edge_e_values: 4 carried no finite E-value from the analysis engine (an unflippable edge, whose current and flip means coincide, has no evidence ratio). edge_e_values is shorter because those entries could not be represented, not because they were computed empty. All other analyses are unaffected.",
       "severity": "info"
     }
   ],
@@ -1604,7 +1604,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:fa0104979707a391"
+    "response_content_hash": "rch_v2:0e2fa534192a0645"
   },
   "meta": {
     "seed_used": "2034401427",

--- a/tests/isl-v2-liveness.fixture.test.ts
+++ b/tests/isl-v2-liveness.fixture.test.ts
@@ -427,7 +427,11 @@ describe('CONSTRAINT_SAMPLES_UNNOISED warning tolerance', () => {
     }
   }, 60_000);
 
-  it('unknown severity values degrade to info, never crash', async () => {
+  it('unknown severity values ESCALATE to warning (never hidden as info), never crash', async () => {
+    // NIT 2 (post-#232 review): an unrecognised/severe ISL severity must surface
+    // as 'warning' — the most severe level PLoT supports — never be collapsed
+    // DOWN to 'info' (which would hide a potentially-severe condition). Only an
+    // explicit 'info' (or absent) severity stays 'info'.
     injectWarning = {
       code: 'CONSTRAINT_SAMPLES_UNNOISED',
       message: 'Constraint node samples were not auto-noised for this run',
@@ -446,7 +450,7 @@ describe('CONSTRAINT_SAMPLES_UNNOISED warning tolerance', () => {
         (w: any) => w.code === 'CONSTRAINT_SAMPLES_UNNOISED',
       );
       expect(forwarded).toHaveLength(1);
-      expect(forwarded[0].severity).toBe('info');
+      expect(forwarded[0].severity).toBe('warning');
     } finally {
       injectWarning = null;
     }

--- a/tests/plot-remediation.isl-degrade-disclosure.route.test.ts
+++ b/tests/plot-remediation.isl-degrade-disclosure.route.test.ts
@@ -17,40 +17,75 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 
+// F4 (Codex deep review): the REAL ISL InferenceWarning wire shape (LIVE from
+// ISL #79) — `{code, field, detail:{reason, elapsed_ms, message}, severity}`.
+// NOT the old idealised flat `{message, severity, elapsed_ms}` mock. The four
+// budget-degradation codes carry severity:'warning'; the human copy + timing
+// live under `detail`; `field` names the affected wire location.
 const ISL_INFERENCE_WARNINGS = [
   {
     code: 'STABILITY_BANDS_UNAVAILABLE',
-    message:
-      'Seed-sweep flip-stability bands were attempted but the band computation ' +
-      'exceeded its budget for this analysis — bands are omitted; all other analyses are unaffected.',
+    field: 'edge_e_values',
     severity: 'warning',
-    elapsed_ms: 2013,
+    detail: {
+      reason: 'budget_exceeded',
+      elapsed_ms: 2013,
+      message:
+        'Seed-sweep flip-stability bands were attempted but the band computation ' +
+        'exceeded its budget for this analysis — bands are omitted; all other analyses are unaffected.',
+    },
   },
   {
     code: 'E_VALUES_UNAVAILABLE',
-    message:
-      'Edge E-values were attempted but the E-value computation exceeded its ' +
-      'budget for this analysis — edge_e_values are omitted; all other analyses are unaffected.',
+    field: 'edge_e_values',
     severity: 'warning',
-    elapsed_ms: 8041,
+    detail: {
+      reason: 'budget_exceeded',
+      elapsed_ms: 8041,
+      message:
+        'Edge E-values were attempted but the E-value computation exceeded its ' +
+        'budget for this analysis — edge_e_values are omitted; all other analyses are unaffected.',
+    },
   },
   {
     code: 'EVPI_UNAVAILABLE',
-    message:
-      'Per-factor EVPI (value of information) was attempted but exceeded its ' +
-      'budget for this analysis — EVPI is omitted; all other analyses are unaffected.',
+    field: 'factor_evpi',
     severity: 'warning',
-    elapsed_ms: 1502,
+    detail: {
+      reason: 'budget_exceeded',
+      elapsed_ms: 1502,
+      message:
+        'Per-factor EVPI (value of information) was attempted but exceeded its ' +
+        'budget for this analysis — EVPI is omitted; all other analyses are unaffected.',
+    },
   },
   {
     code: 'PATH_DECOMPOSITION_UNAVAILABLE',
-    message:
-      'Structural path decomposition was attempted but exceeded its budget for ' +
-      'this analysis — path_decomposition is omitted; all other analyses are unaffected.',
+    field: 'path_decomposition',
     severity: 'warning',
-    elapsed_ms: 3300,
+    detail: {
+      reason: 'budget_exceeded',
+      elapsed_ms: 3300,
+      message:
+        'Structural path decomposition was attempted but exceeded its budget for ' +
+        'this analysis — path_decomposition is omitted; all other analyses are unaffected.',
+    },
   },
 ];
+
+// A benign, non-degradation warning — severity 'info' (the ISL default) must
+// stay 'info' through the map (proves severity is mapped THROUGH faithfully,
+// not blanket-forced to either value).
+const ISL_INFO_WARNING = {
+  code: 'ROOT_NODE_DEFAULT_VALUE',
+  field: 'goal',
+  severity: 'info',
+  detail: {
+    reason: 'no_observed_value',
+    node_id: 'goal',
+    message: 'A root node had no observed value; a default base was used. This is informational.',
+  },
+};
 
 const EXPECTED_CODES = [
   'STABILITY_BANDS_UNAVAILABLE',
@@ -72,8 +107,9 @@ const ISL_DATA = {
     robust_edges: ['factor-a::goal'],
     edge_e_values: [],
   },
-  // ISL-originated degrade disclosures (the ISL lane emits these on budget trip).
-  inference_warnings: ISL_INFERENCE_WARNINGS,
+  // ISL-originated degrade disclosures (the ISL lane emits these on budget trip),
+  // plus one benign info-severity warning — all in the REAL detail-nested shape.
+  inference_warnings: [...ISL_INFERENCE_WARNINGS, ISL_INFO_WARNING],
 };
 
 const mockISLService = {
@@ -156,20 +192,31 @@ describe('item 5 — ISL degrade disclosures carried through to the wire', () =>
     return JSON.parse(res.body);
   }
 
-  it('all FOUR ISL degrade codes appear on inference_warnings, severity + elapsed_ms preserved', async () => {
+  it('real detail-nested ISL warnings ride to the wire: severity + elapsed_ms + field + message preserved', async () => {
     const body = await run();
     const warnings = body.inference_warnings ?? [];
-    const byCode = new Map<string, { code: string; message: string; severity: string; elapsed_ms?: number }>(
+    const byCode = new Map<string, { code: string; message: string; severity: string; elapsed_ms?: number; field?: string }>(
       warnings.map((w: { code: string }) => [w.code, w]),
     );
 
     for (const source of ISL_INFERENCE_WARNINGS) {
       const got = byCode.get(source.code);
       expect(got, `wire warning for ${source.code}`).toBeDefined();
+      // severity mapped THROUGH (ISL supplied 'warning').
       expect(got!.severity).toBe('warning');
-      // elapsed_ms is carried through verbatim (a slow degrade stays diagnosable).
-      expect(got!.elapsed_ms).toBe(source.elapsed_ms);
+      // elapsed_ms read from detail.elapsed_ms and carried through verbatim.
+      expect(got!.elapsed_ms).toBe(source.detail.elapsed_ms);
+      // message read from detail.message.
+      expect(got!.message).toBe(source.detail.message);
+      // field preserved from the real ISL shape (RED pre-fix: field was dropped).
+      expect(got!.field).toBe(source.field);
     }
+    // benign info-severity warning stays 'info' (severity mapped through, not forced).
+    const info = byCode.get('ROOT_NODE_DEFAULT_VALUE');
+    expect(info, 'benign info warning present').toBeDefined();
+    expect(info!.severity).toBe('info');
+    expect(info!.field).toBe('goal');
+    expect(info!.message).toBe(ISL_INFO_WARNING.detail.message);
     // spot-check the message routing survives too
     expect(byCode.get('STABILITY_BANDS_UNAVAILABLE')!.message).toContain('bands are omitted');
     expect(byCode.get('PATH_DECOMPOSITION_UNAVAILABLE')!.message).toContain('path_decomposition is omitted');

--- a/tests/plot-remediation.isl-degrade-disclosure.route.test.ts
+++ b/tests/plot-remediation.isl-degrade-disclosure.route.test.ts
@@ -87,6 +87,20 @@ const ISL_INFO_WARNING = {
   },
 };
 
+// NIT 2 (post-#232 review): a hypothetical ISL severity MORE severe than
+// 'warning' (e.g. 'error') must surface as 'warning' — the most severe level
+// PLoT's InferenceWarning supports — NEVER be collapsed DOWN to 'info' (which
+// would hide it). ISL emits no 'error' today; this maps defensively.
+const ISL_ERROR_WARNING = {
+  code: 'SOME_SEVERE_CONDITION',
+  field: 'robustness',
+  severity: 'error',
+  detail: {
+    reason: 'severe',
+    message: 'A severe condition ISL might one day emit — must NOT be downgraded to info.',
+  },
+};
+
 const EXPECTED_CODES = [
   'STABILITY_BANDS_UNAVAILABLE',
   'E_VALUES_UNAVAILABLE',
@@ -108,8 +122,9 @@ const ISL_DATA = {
     edge_e_values: [],
   },
   // ISL-originated degrade disclosures (the ISL lane emits these on budget trip),
-  // plus one benign info-severity warning — all in the REAL detail-nested shape.
-  inference_warnings: [...ISL_INFERENCE_WARNINGS, ISL_INFO_WARNING],
+  // plus one benign info-severity warning and one hypothetical error-severity
+  // warning — all in the REAL detail-nested shape.
+  inference_warnings: [...ISL_INFERENCE_WARNINGS, ISL_INFO_WARNING, ISL_ERROR_WARNING],
 };
 
 const mockISLService = {
@@ -217,6 +232,10 @@ describe('item 5 — ISL degrade disclosures carried through to the wire', () =>
     expect(info!.severity).toBe('info');
     expect(info!.field).toBe('goal');
     expect(info!.message).toBe(ISL_INFO_WARNING.detail.message);
+    // NIT 2: an 'error'-severity ISL warning escalates to 'warning', never 'info'.
+    const severe = byCode.get('SOME_SEVERE_CONDITION');
+    expect(severe, 'severe warning present').toBeDefined();
+    expect(severe!.severity).toBe('warning');
     // spot-check the message routing survives too
     expect(byCode.get('STABILITY_BANDS_UNAVAILABLE')!.message).toContain('bands are omitted');
     expect(byCode.get('PATH_DECOMPOSITION_UNAVAILABLE')!.message).toContain('path_decomposition is omitted');


### PR DESCRIPTION
## Summary

A3 r2 build of four Codex deep-review findings (PLoT-only) + one nit. Base `staging` @ `020858f5` (#231). **DRAFT — do not merge; orchestrator reviews.**

Each finding is **RED-first with positive controls**, and each fix hunk was **mutation-checked** (reverted in a throwaway worktree → its test goes RED). F14 tests **serialize response bytes** (`JSON.stringify`), not JS objects.

### F13 — canonicalise `node_id`/`factor_id`, ONE precedence everywhere
Opposite-precedence twins: `isOptionControlledLever` resolved `factor_id ?? node_id` (factor-first) while the factor_sensitivity mapper and factor_stability publication resolve `node_id ?? factor_id` (node-first), so a future twin `{node_id:'lever', factor_id:'other'}` maps as `lever` yet escapes lever-suppression. Introduce one `factorIdOf()` (node-first) + `hasFactorIdConflict()` used at **all** sites (D-U predicate, `mapIslFactorEntry`, `buildFactorStability`, `extractFactorSensitivity`, `interventionOverrideFactorIds`). Ambiguous twins are dropped + disclosed (`FACTOR_ID_CONFLICT`). Additive/safe hardening — the pinned ISL producer emits only `node_id` today.

### F14 — finite-range overflow guards
`{min:-1e308,max:1e308}` has `max>min` but `max-min===Infinity` → denorm → `Infinity` → wire `null` / silent E-value drop. New `isFiniteRange` gates every range source (`deriveRange`, `buildFallbackRanges`, `isValidExtractedRange`); post-denorm finite-checks on flip thresholds (disclose via `flip_reason`), stability band values, and edge E-values; dropped edge E-values now disclosed on the wire (`EDGE_E_VALUE_NON_FINITE_DROPPED`, info).

### F12 — refined stability-band parse in the egress guard (PLoT-LOCAL interim)
The shared `EnrichmentEdgeEValueSchema` is `.passthrough()` and doesn't type `stability`, so a malformed band was stamped `enrichment_contract_ok:true`. New `assessStabilityBands` enforces finite ordered endpoints, non-negative integer counts (`n_seeds_flipped ≤ n_seeds`), `seed_flip_means` length/finiteness, non-negative width. (Canonical shared schema = separate A1 schemas-PR.)

### F4-PLoT — map the REAL ISL warning shape (LIVE from ISL #79)
ISL now emits `{code, field, detail:{reason, elapsed_ms, message}, severity}`. Preserve `field`, read `detail.reason` fallback, map severity through; update the TS mirror (`isl-types`) + replace the idealised test mock with the real detail-nested shape.

### nit
`engines.node` `>=20` → `>=20.3.0` (retry cluster uses `AbortSignal.any`, Node 20.3+).

## Gate
- `tsc -p tsconfig.json --noEmit` → 0 errors.
- Full `scripts/pre-push-validate.sh` → **PASSED**, 5661 passed / 25 skipped, 0 failures (also re-run on push).
- Base-vs-branch problem set unchanged: only the pre-existing `gates (windows-latest)` checkout red is tolerated; `validate-structure` not touched (no `contracts/openapi.yaml` change).

## Golden update (fully understood, not blind regen)
The real ISL capture carries **4 unflippable edges** (`e_value:null`, current_mean==flip_mean) that the pre-existing finite filter already dropped silently (13→9). F14 now **discloses** that pre-existing drop on the wire (info) — a genuine non-vacuous positive control. `structural-keys.generated.ts` regenerated (derive-don't-mirror) for the new isl-types `detail` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeXMQjxJeR2W7kLPtKnUSB