### PR TITLE
refactor(plot): /simplify cleanups — dedup PU-recompute, consolidate finite guards, normIds, getHealthResponse (A3)

### DIFF
--- a/acceptance-evidence/a3-verify-2026-07-16/simplify-plot-BUILD.md
+++ b/acceptance-evidence/a3-verify-2026-07-16/simplify-plot-BUILD.md
@@ -1,0 +1,94 @@
+# /simplify — PLoT cleanup PR (BUILD evidence)
+
+Behavior-preserving mechanical cleanups from `SIMPLIFY-CONSOLIDATED-2026-07-19.md`
+(the PLoT cleanup PR). Refactors only — no defect fixes, no wire-shape changes.
+
+- Base: `staging` @ `ad255d3c` (fresh shallow clone; local tree stale/hung).
+- Branch: `refactor/a3-simplify-cleanups`.
+- Scope: `plot-lite-service` only. `contracts/openapi.yaml` NOT touched.
+
+## Items applied
+
+1. **[HIGH] Dedup the double PU-recompute per /v2/run.**
+   - Factor side: `buildParameterUncertaintiesV3(filteredGraph.nodes)` is now built
+     ONCE at the admission planner (`run.ts`), the node-id Set/count is derived from
+     it, and the SAME list is threaded into `toISLRobustnessRequest` via a new
+     optional `prebuiltParameterUncertainties` param (`translator-v3.ts`,
+     `parameter_uncertainties: prebuiltParameterUncertainties ?? buildParameterUncertaintiesV3(graph.nodes)`).
+     `filteredGraph.nodes` is `const` and not mutated between plan-time and
+     build-time (verified: no `filteredGraph =` / `.nodes =` / mutating array op),
+     and `buildParameterUncertaintiesV3` is a pure function of `nodes`, so the
+     request carries a byte-identical PU list while the pass runs once. Also closes
+     the lockstep-drift hazard (plan count can no longer diverge from what the
+     request sends).
+   - Constraint side: one id→node `Map` is built once in `run.ts` (only when
+     constraints exist — no-constraint fast path pays nothing) and threaded into
+     BOTH `selectConstraintInjectedPuNodeIds` (plan) and
+     `injectConstraintParameterUncertainties` (build) via a new optional
+     `sharedNodeMap` param on each. The map is identical to the one each function
+     built internally (same nodes, same construction, last-wins on dup ids), so the
+     classify decisions, `injected`/`skipped` outputs, and all log events are
+     byte-identical. The classify logic itself was already single-sourced
+     (`classifyConstraintPu`). Chose to share the nodeMap (the low-risk option the
+     doc offers) rather than re-plumb the injector's mean/skipped derivation.
+
+2. **Consolidate the finite-check predicates → new `src/util/numeric.ts`.**
+   Relocated the shared `typeof===number && Number.isFinite` family to a NEUTRAL
+   leaf util: `isFiniteNumber`, `isNonNegInt`, `finiteNum`, `nonNegInt`, plus
+   `allFiniteNumberFields` (item 4). Importers:
+   - `routes/v2/numeric-egress-guards.ts` imports `finiteNum`/`nonNegInt` from util
+     and RE-EXPORTS them (so `run.ts`'s existing import path is unchanged);
+     `prob01`/`nonNeg`/`hasAllRequiredOutcomeStats` kept local (not duplicated
+     across files) but now build on the imported `isFiniteNumber`.
+   - `routes/v2/enrichment-egress-guard.ts` — removed the local `isNonNegInt` /
+     `finiteOf` closures; imports `isNonNegInt` + `finiteNum` (`finiteOf`→`finiteNum`).
+   - `integrations/isl/compute-admission.ts` — removed local `isFiniteNumber`;
+     imports from util.
+   **Layering:** `src/util` is a leaf both `routes/v2` and `integrations/isl` import
+   from, so it avoids the `integrations/isl → routes/v2` inversion a shared home in
+   either dir would have created. Resolves cleanly (tsc green).
+
+3. **normIds extraction** (`lib/intervention-override.ts`) — `factorIdOf` and
+   `hasFactorIdConflict` now both call a private `normIds(f) => {nodeId, factorId}`
+   carrying the identical empty-string+type normalization.
+
+4. **Unify validWeights/validCaps** (`integrations/isl/compute-admission.ts`) —
+   both are now `allFiniteNumberFields(o, KEYS)` over `WEIGHT_KEYS`/`CAP_KEYS`.
+   Same boolean result (AND over the same field list; order-independent).
+
+5. **Extract getHealthResponse** (`integrations/isl/client.ts`) — `healthCheck()`
+   and `fetchHealth()` share a private `getHealthResponse()` (GET `/health` + auth
+   header + AbortController timeout, timeout cleared in `finally`); each caller reads
+   only its tail (`response.ok` vs parsed body). Return values unchanged.
+   Minor internal improvement: `healthCheck`'s timer is now always cleared
+   (`finally`), where the old inline version left it dangling on the fetch-reject
+   path — not observable in return value or wire output.
+
+6. **Name the optional-phase retry constant** — `OPTIONAL_PHASE_MAX_RETRIES = 1` in
+   `config/timeouts.ts` (next to `ISL_MAX_RETRIES_DEFAULT`), replacing the bare `1`
+   at the flip-probe and thresholds call sites in `run.ts`.
+
+## Gate result (authoritative, fresh clone with vendored schemas installed)
+
+- `tsc -p tsconfig.json --noEmit` — **0 errors**.
+- `npm run build` (all 3 steps: `tsc tsconfig.json` + `tsc tsconfig.tools.json` +
+  `check-no-stale-js.sh --clean`) — **exit 0**, "OK: No stale .js files in src/".
+- `scripts/pre-push-validate.sh` — **PASSED**, 6/7 checks run, 0 failures:
+  - 1/7 branch guard PASS · 2/7 tsc PASS · 3/7 full suite PASS
+    (**Tests 5701 passed | 25 skipped (5737)**) · 4/7 stale-js PASS ·
+    5/7 file-dep policy PASS · 6/7 OpenAPI spectral lint PASS.
+- No SSE-429 flake observed this run; `gates(windows)` checkout red is CI-only
+  (not run locally) and unrelated.
+
+## Byte-identical evidence (wire output unchanged)
+
+Existing goldens + boundary/PU tests all pass UNCHANGED (no golden edits):
+- `tests/golden/translator-fixtures.test.ts` (18), `tests/golden/constraint-pu-regression.test.ts` (5),
+  `tests/constraint-pu-injection.test.ts`, `tests/parameter-uncertainty-propagation.test.ts`,
+  `tests/boundary-plot-to-isl.contract.test.ts`, `tests/multi-constraint.test.ts` — 168 passed.
+- `tests/gates/numeric-egress-guards.test.ts`, `tests/enrichment-egress-guard.unit.test.ts`,
+  `tests/isl-compute-admission-handshake.test.ts` — 43 passed.
+- `tests/factor-id-canonicalisation.test.ts`, `tests/plot-remediation.optional-phase-retry.route.test.ts` — 10 passed.
+- Health/enrichment/timeout/intervention set — 181 passed.
+
+No `contracts/openapi.yaml` change → base-vs-branch standing-red set unchanged.

--- a/src/config/timeouts.ts
+++ b/src/config/timeouts.ts
@@ -148,6 +148,17 @@ export function resolveRequestBudgetMs(): number {
  */
 export const ISL_MAX_RETRIES_DEFAULT = 3;
 
+/**
+ * TOTAL ISL attempts (no retry) for an OPTIONAL, post-base-science phase —
+ * the flip-probe (Codex F3) and threshold (Codex F9) calls. These run AFTER a
+ * completed base result, so a retry storm would spend the request budget (and
+ * discard the base science) for a phase whose failure is safely
+ * degrade-and-disclose. `1` = one try, no retry; named here (rather than a bare
+ * literal at the two call sites) so the policy has one home next to
+ * {@link ISL_MAX_RETRIES_DEFAULT}.
+ */
+export const OPTIONAL_PHASE_MAX_RETRIES = 1;
+
 /** Resolve the ISL attempt cap from `ISL_MAX_RETRIES` (default {@link ISL_MAX_RETRIES_DEFAULT}). */
 export function resolveIslMaxRetries(): number {
   return parseInt(process.env.ISL_MAX_RETRIES ?? String(ISL_MAX_RETRIES_DEFAULT), 10);

--- a/src/integrations/isl/client.ts
+++ b/src/integrations/isl/client.ts
@@ -306,26 +306,34 @@ export class ISLClient {
   }
 
   /**
+   * GET `/health` with the shared auth header + short AbortController timeout.
+   * The common boilerplate behind {@link healthCheck} and {@link fetchHealth};
+   * each caller reads only the tail it needs (`response.ok` vs the parsed body).
+   * The timeout is always cleared (finally), even when `fetch` rejects.
+   */
+  private async getHealthResponse(): Promise<Response> {
+    const controller = new AbortController();
+    const healthCheckTimeout = this.config.healthCheckTimeoutMs ?? ISL_HEALTH_CHECK_TIMEOUT_MS;
+    const timeoutId = setTimeout(() => controller.abort(), healthCheckTimeout);
+    try {
+      return await fetch(`${this.config.baseUrl}/health`, {
+        method: 'GET',
+        headers: { 'X-API-Key': this.config.apiKey },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
    * Check ISL service health
    *
    * @returns true if ISL is healthy
    */
   async healthCheck(): Promise<boolean> {
     try {
-      const controller = new AbortController();
-      const healthCheckTimeout = this.config.healthCheckTimeoutMs ?? ISL_HEALTH_CHECK_TIMEOUT_MS;
-      const timeoutId = setTimeout(() => controller.abort(), healthCheckTimeout);
-
-      const response = await fetch(`${this.config.baseUrl}/health`, {
-        method: 'GET',
-        headers: {
-          'X-API-Key': this.config.apiKey,
-        },
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
+      const response = await this.getHealthResponse();
       return response.ok;
     } catch {
       return false;
@@ -343,21 +351,7 @@ export class ISLClient {
    */
   async fetchHealth(): Promise<ISLHealthResponse | null> {
     try {
-      const controller = new AbortController();
-      const healthCheckTimeout = this.config.healthCheckTimeoutMs ?? ISL_HEALTH_CHECK_TIMEOUT_MS;
-      const timeoutId = setTimeout(() => controller.abort(), healthCheckTimeout);
-
-      let response: Response;
-      try {
-        response = await fetch(`${this.config.baseUrl}/health`, {
-          method: 'GET',
-          headers: { 'X-API-Key': this.config.apiKey },
-          signal: controller.signal,
-        });
-      } finally {
-        clearTimeout(timeoutId);
-      }
-
+      const response = await this.getHealthResponse();
       if (!response.ok) return null;
       const body = (await response.json()) as ISLHealthResponse;
       return body && typeof body === 'object' ? body : null;

--- a/src/integrations/isl/compute-admission.ts
+++ b/src/integrations/isl/compute-admission.ts
@@ -23,6 +23,7 @@
 import { getISLClientConfig, isISLConfigured, ISLClient } from './client.js';
 import { KNOWN_COMPLEXITY_FORMULA_VERSIONS } from '../../config/sampling.js';
 import { recordIslAdmissionVersionSkew } from '../../metrics/registry.js';
+import { isFiniteNumber, allFiniteNumberFields } from '../../util/numeric.js';
 import type {
   ISLComputeAdmission,
   ISLComputeAdmissionWeights,
@@ -67,34 +68,27 @@ function isFresh(now: number): boolean {
   return _cache !== null && now - _cache.at < ADMISSION_CACHE_TTL_MS;
 }
 
-function isFiniteNumber(v: unknown): v is number {
-  return typeof v === 'number' && Number.isFinite(v);
-}
+/** Coefficients an advertised `weights` object must carry as finite numbers. */
+const WEIGHT_KEYS = [
+  'base_per_sample_per_option_per_struct',
+  'evpi_sample_cap',
+  'sensitivity_coef',
+  'evalue_coef',
+  'bands_coef',
+  'path_coef',
+  'max_decomposition_paths',
+] as const;
+
+/** Cap fields an advertised `caps` object must carry as finite numbers. */
+const CAP_KEYS = ['max_options', 'max_nodes', 'max_edges', 'max_parameter_uncertainties'] as const;
 
 /** Validate the advertised `weights` object — every coefficient must be finite. */
 function validWeights(w: unknown): w is ISLComputeAdmissionWeights {
-  if (!w || typeof w !== 'object') return false;
-  const o = w as Record<string, unknown>;
-  return (
-    isFiniteNumber(o.base_per_sample_per_option_per_struct) &&
-    isFiniteNumber(o.evpi_sample_cap) &&
-    isFiniteNumber(o.sensitivity_coef) &&
-    isFiniteNumber(o.evalue_coef) &&
-    isFiniteNumber(o.bands_coef) &&
-    isFiniteNumber(o.path_coef) &&
-    isFiniteNumber(o.max_decomposition_paths)
-  );
+  return allFiniteNumberFields(w, WEIGHT_KEYS);
 }
 
 function validCaps(c: unknown): c is ISLComputeAdmissionCaps {
-  if (!c || typeof c !== 'object') return false;
-  const o = c as Record<string, unknown>;
-  return (
-    isFiniteNumber(o.max_options) &&
-    isFiniteNumber(o.max_nodes) &&
-    isFiniteNumber(o.max_edges) &&
-    isFiniteNumber(o.max_parameter_uncertainties)
-  );
+  return allFiniteNumberFields(c, CAP_KEYS);
 }
 
 /**

--- a/src/integrations/isl/constraint-pu-injection.ts
+++ b/src/integrations/isl/constraint-pu-injection.ts
@@ -85,10 +85,14 @@ export function selectConstraintInjectedPuNodeIds(
   graphNodes: EngineNodeV3[],
   goalNodeId: string,
   existingPuNodeIds: ReadonlySet<string>,
+  // Optional prebuilt id→node map (built once by the caller and shared with the
+  // injector) so the plan-time selection and the build-time injection don't each
+  // reconstruct an identical map over the same nodes. Omitted callers build one.
+  sharedNodeMap?: ReadonlyMap<string, EngineNodeV3>,
 ): Set<string> {
   const injected = new Set<string>();
   if (!constraints || constraints.length === 0) return injected;
-  const nodeMap = new Map(graphNodes.map((n) => [n.id, n]));
+  const nodeMap = sharedNodeMap ?? new Map(graphNodes.map((n) => [n.id, n]));
   // Mirror the injector: a node accepted earlier becomes "existing" for later
   // duplicate constraints on the same node (so it is counted exactly once).
   const running = new Set(existingPuNodeIds);
@@ -124,6 +128,10 @@ export function injectConstraintParameterUncertainties(
   graphNodes: EngineNodeV3[],
   goalNodeId: string,
   logger?: FastifyBaseLogger,
+  // Optional prebuilt id→node map shared with the plan-time
+  // {@link selectConstraintInjectedPuNodeIds} so the map is built once, not twice.
+  // Omitted callers build one.
+  sharedNodeMap?: ReadonlyMap<string, EngineNodeV3>,
 ): { injected: InjectedPU[]; skipped: SkippedPU[] } {
   const injected: InjectedPU[] = [];
   const skipped: SkippedPU[] = [];
@@ -135,7 +143,7 @@ export function injectConstraintParameterUncertainties(
   const existingPuNodeIds = new Set(
     (islRequest.parameter_uncertainties ?? []).map((p) => p.node_id),
   );
-  const nodeMap = new Map(graphNodes.map((n) => [n.id, n]));
+  const nodeMap = sharedNodeMap ?? new Map(graphNodes.map((n) => [n.id, n]));
   const augmented = [...(islRequest.parameter_uncertainties ?? [])];
 
   for (const constraint of constraints) {

--- a/src/integrations/isl/translator-v3.ts
+++ b/src/integrations/isl/translator-v3.ts
@@ -412,7 +412,12 @@ export function toISLRobustnessRequest(
   goalConstraints?: GoalConstraint[],
   // CIL 0.1: forward seed to ISL for deterministic Monte Carlo runs
   seed?: string | number,
-  includePathDecomposition?: boolean
+  includePathDecomposition?: boolean,
+  // Optional: the factor PU list already built from `graph.nodes` by the caller
+  // (the /v2/run admission planner computes it to price EVPI). Threading it in
+  // avoids a second identical `buildParameterUncertaintiesV3` pass over the same
+  // nodes; byte-identical to recomputing here. Omitted callers recompute.
+  prebuiltParameterUncertainties?: ISLRobustnessRequestV3['parameter_uncertainties']
 ): ISLRobustnessRequestV3 {
   // Bidirected edges are trust-layer only (identifiability + warnings).
   // ISL operates on directed edges only. Phase 3A-inference will add inference semantics.
@@ -428,7 +433,7 @@ export function toISLRobustnessRequest(
     goal_node_id: goalNodeId,
     n_samples: nSamples,
     analysis_types: ['comparison', 'sensitivity', 'robustness'],
-    parameter_uncertainties: buildParameterUncertaintiesV3(graph.nodes),
+    parameter_uncertainties: prebuiltParameterUncertainties ?? buildParameterUncertaintiesV3(graph.nodes),
     include_e_values: true,
     include_voi: true,
   };

--- a/src/lib/intervention-override.ts
+++ b/src/lib/intervention-override.ts
@@ -35,6 +35,20 @@ export function isInterventionOverride(f: { zero_reason?: string | null }): bool
 }
 
 /**
+ * Normalise an entry's `node_id`/`factor_id` to `undefined` unless each is a
+ * non-empty string — the shared empty-string+type guard behind both
+ * {@link factorIdOf} (precedence resolution) and {@link hasFactorIdConflict}
+ * (twin detection), kept in one place so the two cannot drift.
+ */
+function normIds(
+  f: { factor_id?: string | null; node_id?: string | null },
+): { nodeId: string | undefined; factorId: string | undefined } {
+  const nodeId = typeof f.node_id === 'string' && f.node_id !== '' ? f.node_id : undefined;
+  const factorId = typeof f.factor_id === 'string' && f.factor_id !== '' ? f.factor_id : undefined;
+  return { nodeId, factorId };
+}
+
+/**
  * Canonical identity of an ISL factor entry — ONE precedence, used EVERYWHERE
  * (Codex F13). ISL's canonical key is `node_id` (the graph node id); PLoT's
  * `factor_id` is the downstream alias. Precedence is **node_id-first**, matching
@@ -52,8 +66,7 @@ export function isInterventionOverride(f: { zero_reason?: string | null }): bool
 export function factorIdOf(
   f: { factor_id?: string | null; node_id?: string | null },
 ): string | undefined {
-  const nodeId = typeof f.node_id === 'string' && f.node_id !== '' ? f.node_id : undefined;
-  const factorId = typeof f.factor_id === 'string' && f.factor_id !== '' ? f.factor_id : undefined;
+  const { nodeId, factorId } = normIds(f);
   return nodeId ?? factorId;
 }
 
@@ -69,8 +82,7 @@ export function factorIdOf(
 export function hasFactorIdConflict(
   f: { factor_id?: string | null; node_id?: string | null },
 ): boolean {
-  const nodeId = typeof f.node_id === 'string' && f.node_id !== '' ? f.node_id : undefined;
-  const factorId = typeof f.factor_id === 'string' && f.factor_id !== '' ? f.factor_id : undefined;
+  const { nodeId, factorId } = normIds(f);
   return nodeId !== undefined && factorId !== undefined && nodeId !== factorId;
 }
 

--- a/src/routes/v2/enrichment-egress-guard.ts
+++ b/src/routes/v2/enrichment-egress-guard.ts
@@ -36,6 +36,7 @@ import { AnalysisEnrichmentSchema } from '@talchain/schemas/boundary';
 import { INFERENCE_WARNING_CODES } from '../../types/engine-v3.js';
 import type { InferenceWarning } from '../../types/engine-v3.js';
 import { parseBoundedIntEnv } from '../../config/env-int.js';
+import { finiteNum, isNonNegInt } from '../../util/numeric.js';
 
 /**
  * Cap on reported issues (wire message + log event). A pathological body
@@ -137,11 +138,6 @@ export function assessStabilityBands(body: unknown): EnrichmentContractIssue[] {
   const edges = (body as { edge_e_values?: unknown }).edge_e_values;
   if (!Array.isArray(edges)) return issues;
 
-  const isNonNegInt = (v: unknown): v is number =>
-    typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v) && v >= 0;
-  const finiteOf = (v: unknown): number | undefined =>
-    typeof v === 'number' && Number.isFinite(v) ? v : undefined;
-
   edges.forEach((edge, i) => {
     if (!edge || typeof edge !== 'object') return;
     const stability = (edge as { stability?: unknown }).stability;
@@ -182,19 +178,19 @@ export function assessStabilityBands(body: unknown): EnrichmentContractIssue[] {
     // Endpoints + width: each finite when present.
     for (const k of ['band_min', 'band_median', 'band_max', 'band_width'] as const) {
       const v = s[k];
-      if (v !== undefined && finiteOf(v) === undefined) {
+      if (v !== undefined && finiteNum(v) === undefined) {
         issues.push({ path: `${base}.${k}`, code: 'invalid_type' });
       }
     }
     // Ordered endpoints (only when both sides are finite).
-    const bMin = finiteOf(s.band_min);
-    const bMed = finiteOf(s.band_median);
-    const bMax = finiteOf(s.band_max);
+    const bMin = finiteNum(s.band_min);
+    const bMed = finiteNum(s.band_median);
+    const bMax = finiteNum(s.band_max);
     if (bMin !== undefined && bMed !== undefined && bMin > bMed) issues.push({ path: `${base}.band_median`, code: 'too_small' });
     if (bMed !== undefined && bMax !== undefined && bMed > bMax) issues.push({ path: `${base}.band_max`, code: 'too_small' });
     if (bMin !== undefined && bMax !== undefined && bMin > bMax) issues.push({ path: `${base}.band_max`, code: 'too_small' }); // reversed band
     // Non-negative width.
-    const bW = finiteOf(s.band_width);
+    const bW = finiteNum(s.band_width);
     if (bW !== undefined && bW < 0) issues.push({ path: `${base}.band_width`, code: 'too_small' });
   });
 

--- a/src/routes/v2/numeric-egress-guards.ts
+++ b/src/routes/v2/numeric-egress-guards.ts
@@ -16,24 +16,21 @@
  * response-payload drift for the normal path).
  */
 
-/** Finite real number (any magnitude). Use for measurements: means, std, deltas. */
-export function finiteNum(v: unknown): number | undefined {
-  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
-}
+// `finiteNum` (measurements) and `nonNegInt` (sample counts) live in the
+// neutral numeric util so this guard, the enrichment-egress guard, and the
+// ISL compute-admission validator all share ONE definition. Re-exported here
+// so existing importers of this module keep their import path unchanged.
+import { finiteNum, nonNegInt, isFiniteNumber } from '../../util/numeric.js';
+export { finiteNum, nonNegInt };
 
 /** Finite probability/rate in [0,1]. Use for win_probability, prob_satisfied, rates. */
 export function prob01(v: unknown): number | undefined {
-  return typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 1 ? v : undefined;
+  return isFiniteNumber(v) && v >= 0 && v <= 1 ? v : undefined;
 }
 
 /** Finite non-negative real. Use for std, e_value, absolute margins. */
 export function nonNeg(v: unknown): number | undefined {
-  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : undefined;
-}
-
-/** Non-negative integer. Use for sample counts (n_samples, n_valid_samples). */
-export function nonNegInt(v: unknown): number | undefined {
-  return typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v) && v >= 0 ? v : undefined;
+  return isFiniteNumber(v) && v >= 0 ? v : undefined;
 }
 
 /**

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -113,6 +113,7 @@ import {
   resolveRequestBudgetMs,
   ISL_TIMEOUT_MS,
   worstCaseMs,
+  OPTIONAL_PHASE_MAX_RETRIES,
 } from '../../config/timeouts.js';
 import { getISLClientConfig } from '../../integrations/isl/client.js';
 import { createISLInferenceFn, resolveFlipValues, resolveFlipProbeNSamples, resolveFlipOverallTimeoutMs, resolveFlipPerFactorTimeoutMs } from '../../analysis/flip-thresholds.js';
@@ -4465,14 +4466,29 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // (one source of truth: selectConstraintInjectedPuNodeIds/classifyConstraintPu),
         // and activeGoalConstraints shares constraintsForISL's node-id set
         // (normalisation preserves node_ids), so the count is exact.
-        const factorPuNodeIds = new Set(
-          (buildParameterUncertaintiesV3(filteredGraph.nodes) ?? []).map((pu) => pu.node_id),
-        );
+        // Build the factor PU list ONCE here (the planner needs its node-id
+        // count to price EVPI) and thread the SAME list into
+        // toISLRobustnessRequest below — filteredGraph.nodes is not mutated
+        // between here and the request build, so the request sends byte-identical
+        // PUs while paying for the pass only once. This also closes the
+        // lockstep-drift hazard: the plan count can no longer diverge from what
+        // the request actually carries.
+        const factorParameterUncertainties = buildParameterUncertaintiesV3(filteredGraph.nodes) ?? [];
+        const factorPuNodeIds = new Set(factorParameterUncertainties.map((pu) => pu.node_id));
+        // One id→node map shared by the plan-time constraint-PU selection and the
+        // build-time injection (both classify the same constrained nodes against
+        // the same graph). Built only when there are constraints to classify, so
+        // the common no-constraint path pays nothing.
+        const constraintPuNodeMap =
+          activeGoalConstraints && activeGoalConstraints.length > 0
+            ? new Map(filteredGraph.nodes.map((n) => [n.id, n]))
+            : undefined;
         const constraintInjectedPuNodeIds = selectConstraintInjectedPuNodeIds(
           activeGoalConstraints,
           filteredGraph.nodes,
           body.goal_node_id,
           factorPuNodeIds,
+          constraintPuNodeMap,
         );
         const uniqueParamUncertainties = factorPuNodeIds.size + constraintInjectedPuNodeIds.size;
 
@@ -4929,7 +4945,8 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           effectiveGoalThreshold,  // Use effective threshold (undefined if multi-constraint)
           constraintsForISL,       // Normalised constraint values (undefined if not using multi-constraint)
           plotSeedUsed,  // Always forward PLoT's seed (PLoT is seed authority)
-          body.include_path_decomposition === true  // Lane PLoT-W4: request-gated opt-in, forwarded only on explicit true
+          body.include_path_decomposition === true,  // Lane PLoT-W4: request-gated opt-in, forwarded only on explicit true
+          factorParameterUncertainties  // Reuse the factor PUs already built for the admission plan (same nodes → byte-identical)
         );
 
         req.log.info(
@@ -4966,6 +4983,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           filteredGraph.nodes,
           body.goal_node_id,
           req.log,
+          constraintPuNodeMap,  // Reuse the id→node map built for the plan-time selection above.
         );
         for (const entry of puResult.injected) {
           repairs.push({
@@ -5965,7 +5983,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                   // it lets an in-flight probe cancel the moment the factor/overall
                   // deadline trips (the client folds it into its per-attempt timeout).
                   (endpoint, body, rid, signal) =>
-                    islService.callAnalysisEndpoint(endpoint, body, rid, flipProbeIslTimeoutMs, 1, signal),
+                    islService.callAnalysisEndpoint(endpoint, body, rid, flipProbeIslTimeoutMs, OPTIONAL_PHASE_MAX_RETRIES, signal),
                   islRequest,
                   requestId,
                   flipProbeNSamples
@@ -6126,7 +6144,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                 thresholdsPayload,
                 requestId,
                 Math.round(thresholdsTimeoutMs),
-                1
+                OPTIONAL_PHASE_MAX_RETRIES
               );
 
               const thresholdsDurationMs = performance.now() - thresholdsStart;

--- a/src/util/numeric.ts
+++ b/src/util/numeric.ts
@@ -1,0 +1,56 @@
+/**
+ * Neutral numeric predicates — the single source of truth for the
+ * `typeof === 'number' && Number.isFinite` family used across PLoT's boundary
+ * guards.
+ *
+ * Lives in `src/util` (a leaf) so both `routes/v2` (numeric-egress guards,
+ * enrichment-egress guard) and `integrations/isl` (compute-admission) can
+ * import from ONE place. A shared home in either of those dirs would force an
+ * `integrations/isl → routes/v2` (or the reverse) layering inversion; the
+ * neutral util avoids it.
+ *
+ * Two flavours, deliberately distinct:
+ *  - type-guard predicates (`isFiniteNumber` / `isNonNegInt`) narrow `unknown`
+ *    to `number` for boolean checks;
+ *  - egress accessors (`finiteNum` / `nonNegInt`) return the value verbatim
+ *    when valid else `undefined`, so a serialisation boundary can OMIT a field
+ *    (honest absence) rather than emit a fabricated `null`.
+ * Neither clamps nor coerces — a valid value passes through byte-identically.
+ */
+
+/** True iff `v` is a finite real number (not NaN / ±Infinity). */
+export function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+/** True iff `v` is a non-negative integer. */
+export function isNonNegInt(v: unknown): v is number {
+  return isFiniteNumber(v) && Number.isInteger(v) && v >= 0;
+}
+
+/**
+ * Finite real number (any magnitude), else `undefined`. Use for measurements:
+ * means, std, deltas, band endpoints.
+ */
+export function finiteNum(v: unknown): number | undefined {
+  return isFiniteNumber(v) ? v : undefined;
+}
+
+/**
+ * Non-negative integer, else `undefined`. Use for sample counts (n_samples,
+ * n_valid_samples, n_seeds).
+ */
+export function nonNegInt(v: unknown): number | undefined {
+  return isNonNegInt(v) ? v : undefined;
+}
+
+/**
+ * True iff `o` is a non-null object whose every field named in `keys` is a
+ * finite number. The shared shape behind compute-admission's weights/caps
+ * validation — one predicate over an explicit field list.
+ */
+export function allFiniteNumberFields(o: unknown, keys: readonly string[]): boolean {
+  if (!o || typeof o !== 'object') return false;
+  const rec = o as Record<string, unknown>;
+  return keys.every((k) => isFiniteNumber(rec[k]));
+}


### PR DESCRIPTION
**Behavior-preserving** mechanical cleanups from the `/simplify` wave
(`acceptance-evidence/a3-verify-2026-07-16/SIMPLIFY-CONSOLIDATED-2026-07-19.md`,
PLoT cleanup PR). Refactors only — no defect fixes, **no wire-shape changes**;
existing tests/goldens stay green (byte-identical output). Base = `staging` @ `ad255d3c`.

## What changed

1. **[HIGH] Dedup the double PU-recompute per `/v2/run`.** `buildParameterUncertaintiesV3(filteredGraph.nodes)` ran at the admission planner (only to count node-ids, then discarded) AND again inside `toISLRobustnessRequest`. Now built **once** at the planner and threaded into `toISLRobustnessRequest` via a new optional `prebuiltParameterUncertainties` param (`filteredGraph.nodes` is `const` and unmutated between plan and build, so byte-identical). The constraint side shares **one** id→node `Map` between `selectConstraintInjectedPuNodeIds` (plan) and `injectConstraintParameterUncertainties` (build) via a new optional `sharedNodeMap` param. Also closes the plan/build lockstep-drift hazard.
2. **Consolidate the finite-check predicates** into a neutral `src/util/numeric.ts` (`isFiniteNumber`/`isNonNegInt`/`finiteNum`/`nonNegInt`/`allFiniteNumberFields`), imported by `numeric-egress-guards`, `enrichment-egress-guard`, and `compute-admission`. `src/util` is a leaf → avoids the `integrations/isl → routes/v2` layering inversion.
3. **`normIds()`** private helper shared by `factorIdOf` + `hasFactorIdConflict`.
4. **`validWeights`/`validCaps`** → `allFiniteNumberFields(o, WEIGHT_KEYS/CAP_KEYS)`.
5. **Extract `getHealthResponse()`** shared by `healthCheck` + `fetchHealth`.
6. **Name the optional-phase retry constant** `OPTIONAL_PHASE_MAX_RETRIES = 1` in `config/timeouts.ts`.

## Gate (fresh clone, vendored schemas)

- `tsc -p tsconfig.json --noEmit` — **0 errors**
- `npm run build` (tsc + tsc tools + check-no-stale-js) — **exit 0**
- `scripts/pre-push-validate.sh` — **PASSED**, 0 failures, full suite **5701 passed | 25 skipped**
- `contracts/openapi.yaml` NOT touched → standing-red set unchanged.

Evidence: `acceptance-evidence/a3-verify-2026-07-16/simplify-plot-BUILD.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeXMQjxJeR2W7kLPtKnUSB
