### PR TITLE
feat(admission): complete the /health handshake — check advertised caps (esp. max_parameter_uncertainties) to prevent raw-ISL-422 passthrough (A3)

### DIFF
--- a/acceptance-evidence/a3-verify-2026-07-16/caps-gate-BUILD.md
+++ b/acceptance-evidence/a3-verify-2026-07-16/caps-gate-BUILD.md
@@ -1,0 +1,114 @@
+# PLoT admission CAPS gate — completing the /health capability handshake (A3 BUILD)
+
+Base: `origin/staging` = `ad255d3c90a9b0fe5a28f3cfdf40a486ca10d38b` (#233, the COST half of the
+handshake). Built in a FRESH shallow clone at that tip (local working tree stale/hung-fetch — per
+CLAUDE.md verification trap #1 the clone is the authority). Node v20.19.5, npm 10.8.2, `npm ci` clean.
+
+Branch: `feat/admission-caps-handshake-a3`.
+
+Completes finding **A1** of `SIMPLIFY-CONSOLIDATED-2026-07-19.md`: #233 shipped the COST half
+(`planSampleDepth` vs advertised `max_cost_units`); this ships the **CAPS half**.
+
+## Problem (verified) — the passthrough gap the handshake exists to prevent
+
+ISL advertises structural caps on `/health` (`compute_admission.caps`:
+`max_nodes` / `max_edges` / `max_options` / `max_parameter_uncertainties`) SPECIFICALLY so PLoT can
+pre-check them and refuse BEFORE calling ISL. But the admission-planning path
+(`planWeighted`/`planSampleDepth`, `src/config/sampling.ts`, called at `run.ts` ~4499) read ONLY
+`max_cost_units` + `weights` — it never consulted `caps`.
+
+Consequence: a request UNDER the cost ceiling but OVER a structural cap was forwarded and came back a
+**raw Pydantic 422** ("List should have at most 50 items"), the exact PLoT-passes-ISL-422 passthrough
+the handshake is meant to prevent. The genuinely un-checkable dimension is **`max_parameter_uncertainties=50`**:
+`grep` confirms ZERO PU-count check anywhere in PLoT `src/`. PLoT enforces node/edge/option from its OWN
+`LIMITS` mirror (which can skew from ISL's pin) but has NO check for `parameter_uncertainties` at all.
+
+**Live-verified ISL advertisement** (isl-staging `/health`, 2026-07-18, carried from #233 evidence) —
+`compute_admission.caps`: `{ max_options 10, max_nodes 50, max_edges 200, max_parameter_uncertainties 50 }`.
+PLoT LIMITS (schemas 0.15.0): `MAX_NODES 50 / MAX_EDGES 100 / MAX_OPTIONS 10`.
+
+## What changed (scoped to the admission-planning path only)
+
+| File | Change |
+|---|---|
+| `src/config/sampling.ts` | NEW `checkAdmissionCaps(input, admission, limits)` + `AdmissionCapsInput` / `AdmissionCapsDecision` / `AdmissionCapDimension` / `StructuralSafetyLimits`. Pure function; no change to `planSampleDepth`/`planWeighted` (the shipped cost path is untouched). |
+| `src/routes/v2/run.ts` | Calls `checkAdmissionCaps` at the plan call site — right after `getIslComputeAdmission()`, BEFORE `planSampleDepth` — using the counts ALREADY assembled for the cost formula (`causalNodeCount`, `causalDirectedEdgeCount`, `causalOptionCount`, `uniqueParamUncertainties`). On breach → the SAME structured `GRAPH_TOO_COMPLEX` blocked response (422 via `buildBlockedResponse`) the cost ceiling produces, naming the cap + observed/limit; plus a `graph_exceeds_admission_cap` warn log. NEW helper `capsRefusalMessage`. |
+| `tests/isl-admission-caps-gate.test.ts` | NEW — 10 tests (RED-first + positive control + derive-not-mirror + no-regression + skew fallback). |
+
+`contracts/openapi.yaml` NOT touched. PLoT's preflight LIMITS checks elsewhere NOT touched.
+
+## Design decisions (matching the task spec)
+
+- **PU (the must-add, genuinely un-checkable):** `uniqueParamUncertainties > caps.max_parameter_uncertainties`
+  → refusal. No PLoT LIMITS twin exists, so the advertised cap is the sole gate. Checked FIRST.
+- **Node/edge/option:** enforced at **`min(PLoT LIMITS, advertised caps.max_*)`** — the derive-not-mirror
+  completion. An ISL-tightened cap (below PLoT's LIMITS) now bites here; PLoT's LIMITS stay the
+  belt-and-braces LOWER bound so a garbage-high advertised cap can never WIDEN what PLoT admits.
+  In normal operation (caps ≥ LIMITS) the min is LIMITS, which preflight already enforces → no new
+  refusals; the only NEW refusals are (a) ISL-tightened caps and (b) requests ISL would 422 anyway.
+- **Skew / no-caps fallback:** the caps check is gated on `admission !== null` — EXACTLY like the cost
+  gate. When `/health` caps are absent (version skew / ISL unconfigured / cold warm-up) the resolver
+  returns `admission: null` and `checkAdmissionCaps` returns `{ kind: 'ok' }` → NO spurious refusal;
+  the conservative cost-gate fallback governs, byte-identical to today.
+- **Handled response, not a throw:** structured `GRAPH_TOO_COMPLEX` via `buildBlockedResponse` (422),
+  matching how the cost ceiling refuses — the caller gets the same handled shape.
+
+## RED-first + positive control + mutation (throwaway-safe, isolated single-owner clone)
+
+Test file `tests/isl-admission-caps-gate.test.ts`, 10 tests.
+
+**Positive control (the passthrough gap):** a `10n/10e/1opt/51-PU @10000s` graph (weighted cost ≈ 2.36M
+≪ 24M ceiling) → `planSampleDepth(...)` returns `kind: 'unchanged'` — the COST gate admits it at full
+depth, i.e. PLoT WOULD forward it to ISL, which 422s it. This assertion PASSES both before and after the
+fix, documenting the seam the caps gate closes.
+
+**THE FIX (GREEN post-fix):** `checkAdmissionCaps` on the SAME input → `exceeded`, `dimension:
+'parameter_uncertainties'`, `observed 51`, `limit 50`, `source 'isl_cap'`.
+
+**Mutation-check:** neutered the caps logic (short-circuit `return { kind: 'ok' }` right after the null
+guard) and re-ran →
+
+```
+❯ tests/isl-admission-caps-gate.test.ts (10 tests | 6 failed)
+  ✓ POSITIVE CONTROL (passthrough gap) ...unchanged...        (control — stays green)
+  × THE FIX: refuses the >50-PU graph naming the cap
+  ✓ exactly AT the cap (50) admits                             (control — stays green)
+  × DERIVE-NOT-MIRROR: tightened PU cap (5) bites at 10 PUs
+  × 120 edges breach min(100,200)=100 via plot_limit
+  × tightened caps.max_nodes 20 refuses 30 nodes via isl_cap
+  × options over min(10,10) breach
+  × PU checked FIRST (PU + edges → names parameter_uncertainties)
+  ✓ WITHIN every cap admits (no regression)                    (control — stays green)
+  ✓ SKEW / no-caps (admission null) does NOT refuse            (control — stays green)
+```
+
+Reverting the check turns the 6 over-cap tests RED while the 4 controls (positive-control passthrough,
+at-cap=50 admits, within-caps admits, skew-null admits) stay GREEN. File restored (`0` MUTATION lines,
+`git diff` shows only the intended `+121` insertions) and re-run → 10/10 GREEN.
+
+## Controls confirmed
+
+- **Within-caps still admits (no regression):** `50n/100e/10opt/50-PU` with a live block → `{ kind: 'ok' }`.
+- **Skew / no-caps does NOT spuriously refuse:** `admission: null` with a wildly over-cap input
+  (`999/999/999/999`) → `{ kind: 'ok' }`.
+- **`min(LIMITS, cap)` used for node/edge/option:** YES — 120 edges breach the PLoT floor `min(100,200)=100`
+  (`source plot_limit`); a tightened `caps.max_nodes 20` breaches at 30 nodes (`source isl_cap`).
+
+## Gate results
+
+| Gate | Result |
+|---|---|
+| `tsc -p tsconfig.json --noEmit` | PASS (0 errors) |
+| `npm run build` (tsc app + tsc tools + `check-no-stale-js`) — all 3 steps | PASS (`OK: No stale .js files in src/`) |
+| New test `tests/isl-admission-caps-gate.test.ts` | 10/10 PASS |
+| Sibling regression (`isl-compute-admission-handshake` + `adaptive-n-samples-complexity` + `sampling-engine` + new) | 109/109 PASS |
+| `scripts/pre-push-validate.sh` (7 checks) | PASS — branch guard, tsc, **full suite 5711 passed / 25 skipped**, stale-.js, file-dep policy, OpenAPI spectral lint. 0 failures |
+
+Standing CI reds `gates (windows-latest)` + `audit` are tolerated (pre-existing, per CLAUDE.md).
+
+## Merge-sequence note (for the orchestrator)
+
+This branch is off `ad255d3c` and touches `src/config/sampling.ts` + `src/routes/v2/run.ts`, which the
+HELD cleanup PR **#235** (`refactor/a3-simplify-cleanups`) also touches. Expected sequence: **merge #235
+first, then rebase this caps PR onto it.** (The additions here are self-contained — a new function +
+a new call-site block — so the rebase should be low-conflict, but sequence deliberately.)

--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -533,3 +533,124 @@ function planLegacyFallback(input: DepthPlanInput, conservative: boolean): Depth
   }
   return { kind: 'unchanged', nSamples: scalar.nSamples, cost: scalar.complexity, ceiling: budget, mode: 'legacy_fallback' };
 }
+
+// ---------------------------------------------------------------------------
+// Codex F8 handshake — STRUCTURAL CAPS gate (the CAPS half of the handshake)
+// ---------------------------------------------------------------------------
+//
+// ISL advertises structural caps on /health (`compute_admission.caps`:
+// max_nodes / max_edges / max_options / max_parameter_uncertainties) SPECIFICALLY
+// so PLoT can pre-check them and refuse BEFORE calling ISL — rather than forward
+// a request ISL is guaranteed to reject with a raw Pydantic 422. #233 completed
+// the COST half (planSampleDepth against max_cost_units); THIS is the CAPS half.
+//
+// DERIVE-DON'T-MIRROR (programme trap #12):
+//   - parameter_uncertainties is the genuinely un-mirrored dimension — PLoT has
+//     NO LIMITS twin and NO other check for it — so the advertised cap is the
+//     sole gate. Before this, a >cap-PU graph passed PLoT and 422'd at ISL.
+//   - nodes / edges / options are checked against min(PLoT LIMITS, advertised
+//     cap): the advertised cap RETIRES the drift between PLoT's LIMITS mirror
+//     and ISL's pin (a cap ISL tightened BELOW PLoT's LIMITS now bites here),
+//     while PLoT's own LIMITS stay as the belt-and-braces LOWER bound (a
+//     garbage-high advertised cap can never WIDEN what PLoT admits). PLoT's
+//     preflight LIMITS checks elsewhere are untouched — this is scoped to the
+//     admission-planning path only.
+
+/** PLoT-side structural safety LIMITS — the belt-and-braces lower bound. */
+export interface StructuralSafetyLimits {
+  maxNodes: number;
+  maxEdges: number;
+  maxOptions: number;
+}
+
+/** The structural counts a request will send to ISL, for the caps gate. */
+export interface AdmissionCapsInput {
+  /** N — causal node count ISL will receive. */
+  nodeCount: number;
+  /** E — causal (directed) edge count ISL will receive. */
+  edgeCount: number;
+  /** O — option count ISL will receive. */
+  optionCount: number;
+  /** U — number of UNIQUE parameter uncertainties (factor + injected constraint). */
+  uniqueParamUncertainties: number;
+}
+
+/** Which structural dimension breached its admission cap. */
+export type AdmissionCapDimension = 'parameter_uncertainties' | 'nodes' | 'edges' | 'options';
+
+/** Outcome of the structural caps gate. */
+export type AdmissionCapsDecision =
+  | { kind: 'ok' }
+  | {
+      kind: 'exceeded';
+      /** The dimension that breached (named in the refusal message). */
+      dimension: AdmissionCapDimension;
+      /** Observed count in the request. */
+      observed: number;
+      /** Enforced limit: the advertised cap (PU) or min(LIMITS, cap) (structural). */
+      limit: number;
+      /** Which side produced the binding limit — for logging/telemetry. */
+      source: 'isl_cap' | 'plot_limit';
+    };
+
+/**
+ * Check a request's structural counts against ISL's advertised caps BEFORE the
+ * ISL call — the CAPS half of the /health handshake.
+ *
+ * Applies ONLY when caps are advertised-and-valid (`admission` non-null; the
+ * resolver has already version-checked the block and validated `caps`). When
+ * `admission` is null (genuine skew, ISL unconfigured, or the cold warm-up
+ * before the first /health read) this returns `{ kind: 'ok' }` — NO spurious
+ * caps refusal; the conservative cost-gate fallback governs exactly as before,
+ * mirroring planSampleDepth's skew posture so the two halves stay consistent.
+ *
+ * First breach wins; parameter_uncertainties is checked FIRST because it is the
+ * dimension PLoT has no other means to catch.
+ */
+export function checkAdmissionCaps(
+  input: AdmissionCapsInput,
+  admission: ISLComputeAdmission | null,
+  limits: StructuralSafetyLimits,
+): AdmissionCapsDecision {
+  if (admission === null) return { kind: 'ok' };
+  const caps = admission.caps;
+
+  // U — the genuinely un-checkable dimension: no PLoT LIMITS twin, so the
+  // advertised cap is the sole gate.
+  if (input.uniqueParamUncertainties > caps.max_parameter_uncertainties) {
+    return {
+      kind: 'exceeded',
+      dimension: 'parameter_uncertainties',
+      observed: input.uniqueParamUncertainties,
+      limit: caps.max_parameter_uncertainties,
+      source: 'isl_cap',
+    };
+  }
+
+  // Structural dimensions — enforce min(PLoT LIMITS, advertised cap).
+  const structural: ReadonlyArray<{
+    dimension: AdmissionCapDimension;
+    observed: number;
+    plotLimit: number;
+    islCap: number;
+  }> = [
+    { dimension: 'nodes', observed: input.nodeCount, plotLimit: limits.maxNodes, islCap: caps.max_nodes },
+    { dimension: 'edges', observed: input.edgeCount, plotLimit: limits.maxEdges, islCap: caps.max_edges },
+    { dimension: 'options', observed: input.optionCount, plotLimit: limits.maxOptions, islCap: caps.max_options },
+  ];
+  for (const { dimension, observed, plotLimit, islCap } of structural) {
+    const limit = Math.min(plotLimit, islCap);
+    if (observed > limit) {
+      return {
+        kind: 'exceeded',
+        dimension,
+        observed,
+        limit,
+        // The advertised cap binds iff it is the (strictly) tighter of the two.
+        source: islCap < plotLimit ? 'isl_cap' : 'plot_limit',
+      };
+    }
+  }
+
+  return { kind: 'ok' };
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -130,7 +130,8 @@ import type { SeedSourceType } from '@talchain/schemas';
 import { factorReviewV2, type CEESchemaV2Config } from '../../cee/client.js';
 import { FLAGS } from '../../config/flags.js';
 import { getAllFeatureFlags } from '../../config/feature-flags.js';
-import { resolveStandardNSamples, ADAPTIVE_N_SAMPLES_FLOOR, planSampleDepth, type DepthPlanInput } from '../../config/sampling.js';
+import { resolveStandardNSamples, ADAPTIVE_N_SAMPLES_FLOOR, planSampleDepth, checkAdmissionCaps, type DepthPlanInput, type AdmissionCapsDecision, type AdmissionCapDimension } from '../../config/sampling.js';
+import { LIMITS_MAX_NODES, LIMITS_MAX_EDGES, LIMITS_MAX_OPTIONS } from '../../config/constants.js';
 import { getIslComputeAdmission } from '../../integrations/isl/compute-admission.js';
 import { generateM1Coaching } from '../../coaching/m1-coaching.js';
 import { filterInterventionOverrides } from '../../coaching/sensitivity-filter.js';
@@ -1440,6 +1441,25 @@ function buildBlockedResponse(
     computedAt,
     critiques: addUserMessages(critiques, graph, options),
   });
+}
+
+/**
+ * User-facing GRAPH_TOO_COMPLEX message for a structural admission-cap breach
+ * (the CAPS half of the /health handshake — checkAdmissionCaps). Names the
+ * breached dimension plus the observed count and enforced limit so the caller
+ * knows exactly what to reduce, matching the tone of the cost-ceiling refusal.
+ */
+function capsRefusalMessage(
+  decision: Extract<AdmissionCapsDecision, { kind: 'exceeded' }>,
+): string {
+  const noun: Record<AdmissionCapDimension, string> = {
+    parameter_uncertainties: 'factors with parameter uncertainty',
+    nodes: 'causal nodes',
+    edges: 'causal edges',
+    options: 'options',
+  };
+  const what = noun[decision.dimension];
+  return `This graph is too complex to analyse: it has ${decision.observed} ${what}, but the analysis engine admits at most ${decision.limit}. Reduce the number of ${what} — e.g. remove weaker or duplicate influences — and re-run.`;
 }
 
 /**
@@ -4493,6 +4513,63 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         const uniqueParamUncertainties = factorPuNodeIds.size + constraintInjectedPuNodeIds.size;
 
         const admissionResolution = getIslComputeAdmission();
+
+        // -----------------------------------------------------------------
+        // CAPS half of the /health handshake (checkAdmissionCaps).
+        // -----------------------------------------------------------------
+        // #233 fitted the depth to ISL's advertised COST ceiling. ISL ALSO
+        // advertises structural caps (compute_admission.caps) specifically so
+        // PLoT can pre-check them: a request over a cap — most importantly
+        // max_parameter_uncertainties, for which PLoT has NO other check — is
+        // otherwise forwarded and comes back a raw Pydantic 422 (the exact
+        // passthrough the handshake exists to prevent). Refuse it here with the
+        // SAME structured GRAPH_TOO_COMPLEX blocker the cost ceiling produces,
+        // BEFORE the ISL call. nodes/edges/options are checked against
+        // min(PLoT LIMITS, advertised cap) — derive-not-mirror, PLoT's LIMITS
+        // stay the belt-and-braces floor. Gated on a valid advertised block
+        // (admission non-null) exactly like the cost gate: on skew / no caps /
+        // cold warm-up this does NOT fire (no spurious refusal).
+        const capsDecision = checkAdmissionCaps(
+          {
+            nodeCount: causalNodeCount,
+            edgeCount: causalDirectedEdgeCount,
+            optionCount: causalOptionCount,
+            uniqueParamUncertainties,
+          },
+          admissionResolution.admission,
+          { maxNodes: LIMITS_MAX_NODES, maxEdges: LIMITS_MAX_EDGES, maxOptions: LIMITS_MAX_OPTIONS },
+        );
+        if (capsDecision.kind === 'exceeded') {
+          req.log.warn({
+            event: 'graph_exceeds_admission_cap',
+            request_id: requestId,
+            dimension: capsDecision.dimension,
+            observed: capsDecision.observed,
+            limit: capsDecision.limit,
+            limit_source: capsDecision.source,
+            node_count: causalNodeCount,
+            edge_count: causalDirectedEdgeCount,
+            option_count: causalOptionCount,
+            unique_parameter_uncertainties: uniqueParamUncertainties,
+            admission_status: admissionResolution.status,
+          });
+          return reply.status(422).send(buildBlockedResponse(
+            'Graph too complex to analyse',
+            [{
+              id: randomUUID(),
+              code: 'GRAPH_TOO_COMPLEX',
+              severity: 'blocker' as const,
+              message: capsRefusalMessage(capsDecision),
+              source: 'validation' as const,
+              blocks_analysis: true,
+            }],
+            filteredGraph,
+            normalizedOptions,
+            requestId,
+            requestComputedAt,
+          ));
+        }
+
         const depthPlanInput: DepthPlanInput = {
           nSamples: requestedNSamples,
           nSamplesExplicit: body.n_samples !== undefined,

--- a/tests/isl-admission-caps-gate.test.ts
+++ b/tests/isl-admission-caps-gate.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Codex F8 handshake — the CAPS half. Completes the /health capability handshake
+ * that #233 opened (which fitted sample depth to the advertised COST ceiling).
+ *
+ * ISL advertises structural caps on /health (`compute_admission.caps`:
+ * max_nodes / max_edges / max_options / max_parameter_uncertainties) SPECIFICALLY
+ * so PLoT can pre-check them and refuse BEFORE calling ISL. Before this gate a
+ * request UNDER the cost ceiling but OVER a structural cap — most importantly
+ * `max_parameter_uncertainties=50`, for which PLoT has NO other check — was
+ * forwarded and came back a raw Pydantic 422 ("List should have at most 50
+ * items"), the exact passthrough the handshake exists to prevent.
+ *
+ * DERIVE-DON'T-MIRROR (trap #12): parameter_uncertainties has no PLoT LIMITS
+ * twin (advertised cap is the sole gate); nodes/edges/options are checked
+ * against min(PLoT LIMITS, advertised cap) so an ISL-tightened cap bites here
+ * while PLoT's LIMITS stay the belt-and-braces lower bound.
+ *
+ * Live-verified advertisement (isl-staging /health, 2026-07-18):
+ *   caps { max_options 10, max_nodes 50, max_edges 200, max_parameter_uncertainties 50 }
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  checkAdmissionCaps,
+  planSampleDepth,
+  type AdmissionCapsInput,
+  type StructuralSafetyLimits,
+  type DepthPlanInput,
+  type WeightedCostRequest,
+} from '../src/config/sampling.js';
+import type {
+  ISLComputeAdmission,
+  ISLComputeAdmissionWeights,
+} from '../src/integrations/isl/types/isl-types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — the LIVE advertised weights/caps (v2-weighted-2026-07) + PLoT LIMITS.
+// ---------------------------------------------------------------------------
+
+const LIVE_WEIGHTS: ISLComputeAdmissionWeights = {
+  base_per_sample_per_option_per_struct: 1,
+  evpi_sample_cap: 2000,
+  sensitivity_coef: 4,
+  evalue_coef: 20,
+  bands_coef: 200,
+  path_coef: 1,
+  max_decomposition_paths: 20000,
+};
+
+function v2Admission(overrides: Partial<ISLComputeAdmission> = {}): ISLComputeAdmission {
+  return {
+    max_cost_units: 24_000_000,
+    complexity_formula_version: 'v2-weighted-2026-07',
+    weights: { ...LIVE_WEIGHTS },
+    caps: { max_options: 10, max_nodes: 50, max_edges: 200, max_parameter_uncertainties: 50 },
+    ...overrides,
+  };
+}
+
+/** PLoT's production LIMITS (schemas 0.15.0): nodes 50 / edges 100 / options 10. */
+const PLOT_LIMITS: StructuralSafetyLimits = { maxNodes: 50, maxEdges: 100, maxOptions: 10 };
+
+function capsInput(o: Partial<AdmissionCapsInput> = {}): AdmissionCapsInput {
+  return { nodeCount: 10, edgeCount: 10, optionCount: 1, uniqueParamUncertainties: 0, ...o };
+}
+
+function baseReq(o: Partial<WeightedCostRequest> = {}): WeightedCostRequest {
+  return {
+    nSamples: 10_000,
+    nodeCount: 10,
+    edgeCount: 10,
+    optionCount: 1,
+    uniqueParamUncertainties: 0,
+    includeVoi: true,
+    includeSensitivity: true,
+    includeEValues: true,
+    includePathDecomposition: false,
+    ...o,
+  };
+}
+
+function planInput(o: Partial<DepthPlanInput> = {}): DepthPlanInput {
+  return { ...baseReq(o), nSamplesExplicit: false, ...o } as DepthPlanInput;
+}
+
+// ===========================================================================
+// A. The un-checkable dimension — max_parameter_uncertainties (the core gap)
+// ===========================================================================
+
+describe('checkAdmissionCaps — parameter_uncertainties (the genuinely un-checkable cap)', () => {
+  it('POSITIVE CONTROL (the passthrough gap): a >50-PU graph UNDER the cost ceiling PASSES the depth planner — it would reach ISL and 422', () => {
+    // 10n/10e/1opt/51-PU @10000s: cost ≈ 2.36M ≪ 24M ceiling → the COST gate
+    // admits it at full depth (never refuses/reduces), i.e. PLoT would forward
+    // it to ISL, which rejects it with a raw Pydantic 422 (>50 PUs). This is the
+    // exact seam the caps half closes.
+    const plan = planSampleDepth(planInput({ uniqueParamUncertainties: 51 }), v2Admission());
+    expect(plan.mode).toBe('weighted');
+    expect(plan.kind).toBe('unchanged'); // NOT refused/reduced — the cost gate lets it through
+  });
+
+  it('THE FIX: the caps gate refuses the SAME >50-PU graph, naming the cap + observed/limit (no ISL call)', () => {
+    const d = checkAdmissionCaps(capsInput({ uniqueParamUncertainties: 51 }), v2Admission(), PLOT_LIMITS);
+    expect(d.kind).toBe('exceeded');
+    if (d.kind === 'exceeded') {
+      expect(d.dimension).toBe('parameter_uncertainties');
+      expect(d.observed).toBe(51);
+      expect(d.limit).toBe(50);
+      expect(d.source).toBe('isl_cap');
+    }
+  });
+
+  it('exactly AT the cap (50) admits — strictly-greater-than, matching ISL "at most 50"', () => {
+    const d = checkAdmissionCaps(capsInput({ uniqueParamUncertainties: 50 }), v2Admission(), PLOT_LIMITS);
+    expect(d.kind).toBe('ok');
+  });
+
+  it('DERIVE-NOT-MIRROR: an ISL-tightened PU cap (5) bites even at 10 PUs — PLoT reads the advertised value', () => {
+    const tightened = v2Admission({
+      caps: { max_options: 10, max_nodes: 50, max_edges: 200, max_parameter_uncertainties: 5 },
+    });
+    const d = checkAdmissionCaps(capsInput({ uniqueParamUncertainties: 10 }), tightened, PLOT_LIMITS);
+    expect(d.kind).toBe('exceeded');
+    if (d.kind === 'exceeded') {
+      expect(d.dimension).toBe('parameter_uncertainties');
+      expect(d.limit).toBe(5);
+    }
+  });
+});
+
+// ===========================================================================
+// B. Structural dimensions — enforced at min(PLoT LIMITS, advertised cap)
+// ===========================================================================
+
+describe('checkAdmissionCaps — nodes/edges/options at min(LIMITS, advertised cap)', () => {
+  it('PLoT LIMITS is the belt-and-braces floor: 120 edges breach min(100, 200)=100 via plot_limit', () => {
+    // ISL advertises max_edges 200, but PLoT LIMITS is 100 → the min (100) binds.
+    const d = checkAdmissionCaps(capsInput({ edgeCount: 120 }), v2Admission(), PLOT_LIMITS);
+    expect(d.kind).toBe('exceeded');
+    if (d.kind === 'exceeded') {
+      expect(d.dimension).toBe('edges');
+      expect(d.limit).toBe(100);
+      expect(d.source).toBe('plot_limit');
+    }
+  });
+
+  it('an ISL-tightened cap BELOW PLoT LIMITS bites: caps.max_nodes 20 refuses 30 nodes via isl_cap', () => {
+    const tightened = v2Admission({
+      caps: { max_options: 10, max_nodes: 20, max_edges: 200, max_parameter_uncertainties: 50 },
+    });
+    const d = checkAdmissionCaps(capsInput({ nodeCount: 30 }), tightened, PLOT_LIMITS);
+    expect(d.kind).toBe('exceeded');
+    if (d.kind === 'exceeded') {
+      expect(d.dimension).toBe('nodes');
+      expect(d.limit).toBe(20);
+      expect(d.source).toBe('isl_cap');
+    }
+  });
+
+  it('options over min(LIMITS 10, cap 10) breach', () => {
+    const d = checkAdmissionCaps(capsInput({ optionCount: 11 }), v2Admission(), PLOT_LIMITS);
+    expect(d.kind).toBe('exceeded');
+    if (d.kind === 'exceeded') expect(d.dimension).toBe('options');
+  });
+
+  it('PU is checked FIRST: a graph over BOTH PU and edges names parameter_uncertainties', () => {
+    const d = checkAdmissionCaps(
+      capsInput({ uniqueParamUncertainties: 51, edgeCount: 999 }),
+      v2Admission(),
+      PLOT_LIMITS,
+    );
+    expect(d.kind).toBe('exceeded');
+    if (d.kind === 'exceeded') expect(d.dimension).toBe('parameter_uncertainties');
+  });
+});
+
+// ===========================================================================
+// C. No regression + no spurious refusal (skew / no-caps fallback)
+// ===========================================================================
+
+describe('checkAdmissionCaps — within-caps admits; skew/no-caps does NOT spuriously refuse', () => {
+  it('a graph WITHIN every cap admits (no regression)', () => {
+    const d = checkAdmissionCaps(
+      capsInput({ nodeCount: 50, edgeCount: 100, optionCount: 10, uniqueParamUncertainties: 50 }),
+      v2Admission(),
+      PLOT_LIMITS,
+    );
+    expect(d.kind).toBe('ok');
+  });
+
+  it('SKEW / no-caps (admission null) does NOT refuse — even a wildly over-cap graph passes the caps gate', () => {
+    // Version skew, ISL unconfigured, or the cold warm-up all resolve admission
+    // to null. The caps gate must NOT invent a refusal there (the cost-gate
+    // conservative fallback governs instead) — matching planSampleDepth.
+    const d = checkAdmissionCaps(
+      capsInput({ nodeCount: 999, edgeCount: 999, optionCount: 999, uniqueParamUncertainties: 999 }),
+      null,
+      PLOT_LIMITS,
+    );
+    expect(d.kind).toBe('ok');
+  });
+});


### PR DESCRIPTION
Completes the ISL `/health` capability handshake. #233 shipped the **COST** half (`planSampleDepth` vs advertised `max_cost_units`); this adds the **CAPS** half. Base = `staging` @ `ad255d3c`. Implements finding **A1** of `SIMPLIFY-CONSOLIDATED-2026-07-19.md`.

## The gap
ISL advertises `compute_admission.caps` (`max_nodes`/`max_edges`/`max_options`/`max_parameter_uncertainties`) on `/health` specifically so PLoT can pre-check them, but the admission-planning path (`planWeighted`/`planSampleDepth`) read ONLY `max_cost_units` + `weights`. A request UNDER the cost ceiling but OVER a structural cap — most importantly **`max_parameter_uncertainties=50`, for which PLoT had ZERO check** (grep-confirmed) — was forwarded and came back a **raw Pydantic 422** ("List should have at most 50 items"), the exact PLoT-passes-ISL-422 passthrough the handshake exists to prevent.

## The fix
New `checkAdmissionCaps()` (`src/config/sampling.ts`), called at the plan call site in `run.ts` **before** `planSampleDepth`, using the counts already assembled for the cost formula. On breach it returns the **same** structured `GRAPH_TOO_COMPLEX` blocked response (422) the cost ceiling produces, naming the cap + observed/limit — not a throw.

- **parameter_uncertainties** (the must-add, genuinely un-checkable): `> caps.max_parameter_uncertainties` → refuse. No PLoT LIMITS twin, so the advertised cap is the sole gate. Checked first.
- **nodes/edges/options**: enforced at `min(PLoT LIMITS, advertised cap)` — the derive-not-mirror completion (retires the drift between PLoT's `LIMITS` mirror and ISL's pin) while keeping `LIMITS` as the belt-and-braces lower bound. PLoT's preflight `LIMITS` checks elsewhere untouched.
- **skew / no-caps fallback**: gated on `admission != null` exactly like the cost gate — on version skew / ISL unconfigured / cold warm-up it does **not** fire (no spurious refusal).

`planSampleDepth` untouched. `contracts/openapi.yaml` untouched.

## Discipline (RED-first + positive control + mutation)
- **Positive control (passthrough gap):** a `10n/10e/1opt/51-PU @10000s` graph (cost ≈ 2.36M ≪ 24M) → `planSampleDepth` returns `unchanged` — the cost gate admits it, i.e. it would reach ISL and 422.
- **Fix (GREEN):** `checkAdmissionCaps` on the same input → `exceeded`, `parameter_uncertainties`, `observed 51 / limit 50 / source isl_cap`.
- **Mutation:** neutering the caps logic turns 6 over-cap tests RED while the 4 controls (positive-control passthrough, at-cap=50 admits, within-caps admits, skew-null admits) stay GREEN; restored → 10/10 GREEN.
- **Controls:** within-all-caps still admits (no regression); `admission=null` with a wildly over-cap input does NOT refuse.

## Gates
- `tsc -p tsconfig.json --noEmit` — 0 errors
- `npm run build` (tsc app + tsc tools + `check-no-stale-js`) — all 3 steps PASS
- `scripts/pre-push-validate.sh` — PASS (full suite 5711 passed / 25 skipped). Standing `gates (windows-latest)` + `audit` reds tolerated per CLAUDE.md.

Evidence: `acceptance-evidence/a3-verify-2026-07-16/caps-gate-BUILD.md`.

## ⚠ Merge-sequence note (orchestrator)
Off `ad255d3c`, touches `src/config/sampling.ts` + `src/routes/v2/run.ts`, which the HELD cleanup PR **#235** (`refactor/a3-simplify-cleanups`) also touches. **Merge #235 first, then rebase this PR onto it.** Additions here are self-contained (new function + new call-site block), so the rebase should be low-conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeXMQjxJeR2W7kLPtKnUSB
