### PR TITLE
feat(v2/run): per-option constraint breach margins + approximate flag + ingress guard

### DIFF
--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -101,6 +101,14 @@ export interface NormalisedOptions {
  * Diagnostic info for a normalised intervention.
  */
 export interface NormalisationDiagnostic {
+  /**
+   * Which option this intervention belongs to. Lets a per-option clamp map
+   * be derived (Map<optionId, Map<factorId, clamped>>) so egress can flag a
+   * clamped breach magnitude as a lower bound (constraint_margins
+   * margin_precision). The push is inside options.map(option => …) where
+   * option.id is in scope.
+   */
+  option_id: string;
   factor_id: string;
   original_value: number;
   normalised_value: number;
@@ -566,6 +574,7 @@ export function normaliseOptions(
       };
 
       diagnostics.push({
+        option_id: option.id,
         factor_id: factorId,
         original_value: intervention.value,
         normalised_value: normalised,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -48,6 +48,7 @@ import type {
   GoalConstraint,
   ConstraintResult,
   ConstraintDiagnostic,
+  ConstraintMargin,
   EnrichedEdgeEValue,
   ConditionalWinner,
   ConditionalProbability,
@@ -976,7 +977,9 @@ interface ISLResponseSummary {
   factor_sensitivity_count: number;
   fallback_executed: boolean;
   analysis_status?: string;
-  robustness_label?: string;
+  // Repointed from the phantom `robustness_label` (RobustnessResultV2 has no
+  // `label` on the V2 wire) to the real `robustness.level` field.
+  robustness_level?: string;
 }
 
 /**
@@ -1020,7 +1023,10 @@ export function buildISLResponseSummary(
       ? islResult.factor_sensitivity.length : 0,
     fallback_executed: fallbackExecuted,
     analysis_status: islResult?.analysis_status,
-    robustness_label: islResult?.robustness?.label,
+    // Repointed from the phantom `robustness.label` (never on the V2 wire —
+    // RobustnessResultV2 has no `label`, so this always logged undefined) to
+    // the real field `robustness.level`, so the diagnostic is actually useful.
+    robustness_level: islResult?.robustness?.level,
   };
 }
 
@@ -1853,9 +1859,12 @@ function buildConstraintFields(
       return [];
     }
     const constraintId = resolveConstraintId(c, idx);
-    let failureMarginMedian = c.failure_margin_median ?? 0;
+    // Absent ≠ zero: keep undefined undefined (kill the `?? 0` fabrication). A
+    // binding-only row (both margins absent) now emits with NO fabricated
+    // margins — the defect that manufactured false "hard-step" evidence.
+    let failureMarginMedian = c.failure_margin_median;
 
-    if (constraintNormRanges) {
+    if (failureMarginMedian !== undefined && constraintNormRanges) {
       const range = constraintNormRanges.get(constraintId);
       if (range) {
         const rangeWidth = range.max - range.min;
@@ -1865,19 +1874,22 @@ function buildConstraintFields(
       }
     }
 
-    const nearMissFraction = c.near_miss_fraction ?? 0;
-    // Numeric-egress guard (Codex round-3): drop the whole diagnostic row when a
-    // present margin / near-miss is non-finite — a NaN/±Infinity would serialise to a
-    // fabricated `null` on these required-number fields. Non-finite ROW filtering only;
-    // making the fields optional (to remove the `?? 0` absent-default) is a deferred
-    // schema/OpenAPI change.
-    if (!Number.isFinite(failureMarginMedian) || !Number.isFinite(nearMissFraction)) {
-      return [];
+    let nearMissFraction = c.near_miss_fraction;
+    // Numeric-egress guard: only a PRESENT-but-non-finite margin/near-miss is
+    // dropped to undefined (a NaN/±Infinity would serialise to a fabricated
+    // `null`); genuine absence stays honest omission. The fields are now
+    // optional on ConstraintDiagnostic (the deferred schema change the former
+    // comment anticipated), so a spread omits them when undefined.
+    if (failureMarginMedian !== undefined && !Number.isFinite(failureMarginMedian)) {
+      failureMarginMedian = undefined;
+    }
+    if (nearMissFraction !== undefined && !Number.isFinite(nearMissFraction)) {
+      nearMissFraction = undefined;
     }
     return [{
       constraint_id: constraintId,
-      failure_margin_median: failureMarginMedian,
-      near_miss_fraction: nearMissFraction,
+      ...(failureMarginMedian !== undefined && { failure_margin_median: failureMarginMedian }),
+      ...(nearMissFraction !== undefined && { near_miss_fraction: nearMissFraction }),
       binding: c.binding ?? false,
     }];
   });
@@ -1983,6 +1995,20 @@ function buildRequestIdChainHeader(chain: MetaParams['requestIdChain']): string 
 }
 
 /**
+ * `approximate` (sub-item 2) = the run produced USABLE results that are
+ * degraded/rough. ONLY `partial` qualifies (options usable, some secondary
+ * feature degraded). `computed` is clean; `failed`/`blocked` carry NO usable
+ * answer (a `failed` body is emitted on 200, e.g. the ISL-disabled path), so an
+ * "approximate results" signal must NOT cover them or it inverts the meaning.
+ * Single-sourced from analysis_status (derive-don't-mirror). Exported so a unit
+ * test pins all four states (mutation-checkable — the earlier `!== 'computed'`
+ * formula wrongly folded failed/blocked into true).
+ */
+export function isApproximateAnalysis(status: TopLevelAnalysisStatus): boolean {
+  return status === 'partial';
+}
+
+/**
  * Build a success/partial/failed response (HTTP 200).
  */
 function buildResponse(
@@ -2021,7 +2047,12 @@ function buildResponse(
   thresholdAnalysis?: ThresholdResult[],
   identifiability?: IdentifiabilityAssessment,
   factorStability?: FactorStabilityEntry[],
-  logger?: { info: (obj: object, msg?: string) => void; warn: (obj: object, msg?: string) => void }
+  logger?: { info: (obj: object, msg?: string) => void; warn: (obj: object, msg?: string) => void },
+  // Sub-item 1d: per-option clamp map Map<optionId, Map<factorId, clamped>>,
+  // derived from the RECORDED NormalisationResult.diagnostics[].clamped (NOT
+  // recomputed from the already-normalised per-option interventions, which
+  // always read "not clamped"). Feeds constraint_margins margin_precision.
+  optionClampByOptionFactor?: Map<string, Map<string, boolean>>
 ): RunResponseV3 {
   // Producer honesty (lane PLoT-H item A): detect goal constraints whose
   // targets are NOT decision-grade — threshold normalisation fell back to the
@@ -2165,6 +2196,12 @@ function buildResponse(
       // order but does NOT echo constraint_id. Value-based matching breaks after normalisation
       // because ISL echoes normalised values while goalConstraints holds raw user-unit values.
       let constraintProbs: Record<string, number> | undefined;
+      // Sub-item 1c: per-option graded breach margins. One entry per constraint
+      // ISL evaluated for THIS option; margin fields are OMITTED (never
+      // fabricated as 0) when ISL sent none — so a satisfying option carries a
+      // bare entry while a breaching option carries its (denormalised) margin.
+      // A missing margin is therefore DISTINGUISHABLE from a measured zero.
+      let constraintMargins: ConstraintMargin[] | undefined;
       if (Array.isArray(constraintAnalysis.constraints) && constraintAnalysis.constraints.length > 0) {
         constraintProbs = {};
         const islConstraintsHere = constraintAnalysis.constraints as ISLConstraintResult[];
@@ -2189,6 +2226,43 @@ function buildResponse(
             constraintProbs[constraintId] = probSat;
           }
         }
+        // Build the per-option margin entries alongside the probabilities,
+        // reusing the same index→constraint_id resolver.
+        constraintMargins = islConstraintsHere.map((c, i) => {
+          const cid = indexToId[i] ?? `${c.node_id}_${c.operator}`;
+          // Denormalise the failure margin (a distance) back to user units by
+          // the constraint's range width — same convention as the top-level
+          // constraint_diagnostics path.
+          let fmm = c.failure_margin_median;
+          let clampedForThisOption = false;
+          if (fmm !== undefined && constraintNormRanges) {
+            const range = constraintNormRanges.get(cid);
+            if (range) {
+              const rangeWidth = range.max - range.min;
+              if (rangeWidth > 0) {
+                fmm = fmm * rangeWidth;
+              }
+            }
+            // Prefer the RECORDED clamp for this option's constraint-target
+            // factor; if it clamped, the denormalised magnitude understates the
+            // true breach → mark it a lower bound.
+            clampedForThisOption = optionClampByOptionFactor?.get(optionId)?.get(c.node_id) ?? false;
+          }
+          // Non-finite present margins are dropped to absence (would serialise
+          // to a fabricated `null`); genuine absence stays omitted.
+          if (fmm !== undefined && !Number.isFinite(fmm)) fmm = undefined;
+          const nmf = (c.near_miss_fraction !== undefined && Number.isFinite(c.near_miss_fraction))
+            ? c.near_miss_fraction : undefined;
+          const entry: ConstraintMargin = { constraint_id: cid };
+          if (fmm !== undefined) {
+            entry.failure_margin_median = fmm;
+            entry.margin_precision = clampedForThisOption ? 'lower_bound' : 'exact';
+          }
+          if (nmf !== undefined) {
+            entry.near_miss_fraction = nmf;
+          }
+          return entry;
+        });
       }
 
       // Defensive sign-check (lane PLoT-goal-fit-sign-defense): the auto-
@@ -2235,6 +2309,13 @@ function buildResponse(
         if (constraintProbs !== undefined) {
           result.constraint_probabilities = constraintProbs;
           logger?.info({ event: 'constraint_probs_mapped', option_id: optionId, count: Object.keys(constraintProbs).length });
+        }
+        // Sub-item 1c: attach the per-option graded breach margins under the
+        // SAME honesty gate as the probabilities (never on a suppressed /
+        // direction-suspect target). Absent-margin entries are still carried
+        // (missing ≠ zero) with their margin fields omitted.
+        if (constraintMargins !== undefined && constraintMargins.length > 0) {
+          result.constraint_margins = constraintMargins;
         }
         // Doctrine B (P0-C2): honest provenance for delivered goal-fit scored
         // from the modelled outcome distribution (target base defaulted, no
@@ -2318,12 +2399,12 @@ function buildResponse(
     );
     const normalizationErrors = [...fragileResult.errors, ...robustResult.errors];
 
-    // Validate and cast label to expected union type
-    const rawLabel = islResult.robustness.label;
-    const label: 'robust' | 'moderate' | 'fragile' | undefined =
-      rawLabel === 'robust' || rawLabel === 'moderate' || rawLabel === 'fragile'
-        ? rawLabel
-        : undefined;
+    // Sub-item 3: the `robustness.label` / `robustness.score` reads are PHANTOM —
+    // RobustnessResultV2 (the raw V2 wire, islResult.robustness) has neither
+    // field, so they resolved to undefined on every live response and Fastify
+    // omitted the output `label`/`score` unconditionally. The dead reads are
+    // removed here; wire output is byte-identical (verified). The real verdict
+    // is carried by is_robust/level below and display_verdict.
 
     // Build node ID → label lookup for from_label/to_label resolution (Schema v2.6)
     const nodeLabelMap = new Map<string, string>();
@@ -2371,13 +2452,10 @@ function buildResponse(
     }));
 
     robustness = {
-      // Numeric-egress guard (Codex round-3): omit robustness scalars when non-finite
-      // (score) or outside [0,1] (confidence) — these are OPTIONAL fields, so omission
-      // is honest absence, never a fabricated `null` or an impossible rate.
-      // switch_probability fabrication is NOT addressed here (see the deferred
-      // cross-layer note in the PR — it is type-required across consumers).
-      ...(finiteNum(islResult.robustness.score) !== undefined && { score: finiteNum(islResult.robustness.score) }),
-      label,
+      // Sub-item 3: the phantom `score` (finiteNum(islResult.robustness.score))
+      // and `label` reads are removed — RobustnessResultV2 has neither field, so
+      // both were always undefined and omitted by Fastify. Wire is byte-identical.
+      // Numeric-egress guard note retained for `confidence` (still guarded below).
       fragile_edges: enrichedFragileEdges,
       robust_edges: enrichedRobustEdges,
       explanation: islResult.robustness.explanation,
@@ -2788,10 +2866,11 @@ function buildResponse(
         affected_option_ids: c.affected_option_ids,
         affected_node_ids: c.affected_node_ids,
       })),
-      robustness: robustness ? {
-        label: robustness.label,
-        score: robustness.score,
-      } : undefined,
+      // Sub-item 3: `robustness.label`/`.score` on the OUTPUT robustness object
+      // were always undefined (phantom — never populated from the V2 wire), so
+      // mapRobustness already fell back to its 'moderate'/0.5 defaults. Passing
+      // an empty object keeps the assembled FactObject byte-identical.
+      robustness: robustness ? {} : undefined,
     };
 
     const envelope = assembleFactObjects(islInput, lineage);
@@ -2842,6 +2921,10 @@ function buildResponse(
 
     analysis_status: analysisStatus,
     status_reason: statusReason,
+    // Sub-item 2: canonical `approximate` boolean, single-sourced from
+    // analysis_status via isApproximateAnalysis (see its doc for the semantics +
+    // why only 'partial' qualifies). Distinct name from the CEE-trace `degraded`.
+    approximate: isApproximateAnalysis(analysisStatus),
 
     option_comparison_status: optionComparisonStatus,
     robustness_status: robustnessStatus,
@@ -4104,6 +4187,47 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             requestId,
             requestComputedAt,
           ));
+        }
+
+        // =================================================================
+        // Phase 1b++: Constraint Ingress-Shape Guard (sub-item 4)
+        // =================================================================
+        // The runV3 body JSON-schema types goal_constraints only as an array of
+        // objects — the inner fields are UNVALIDATED. PLoT reads c.constraint_id
+        // and c.node_id everywhere downstream (constraint-trace log, id resolver,
+        // constraint mapping), so a constraint missing either as a non-empty
+        // string silently corrupts identity/targeting. Reject it at the boundary
+        // with a 422 blocked response (same path as TOO_MANY_CONSTRAINTS).
+        // operator/value are already downstream-validated by validateGoalConstraints.
+        if (Array.isArray(body.goal_constraints)) {
+          for (let i = 0; i < body.goal_constraints.length; i++) {
+            const c = body.goal_constraints[i] as { constraint_id?: unknown; node_id?: unknown };
+            const badField =
+              typeof c?.constraint_id !== 'string' || c.constraint_id.length === 0
+                ? 'constraint_id'
+                : typeof c?.node_id !== 'string' || c.node_id.length === 0
+                  ? 'node_id'
+                  : undefined;
+            if (badField) {
+              return reply.status(422).send(buildBlockedResponse(
+                `Invalid constraint shape: goal_constraints[${i}].${badField} must be a non-empty string`,
+                [{
+                  id: randomUUID(),
+                  code: 'INVALID_CONSTRAINT_SHAPE',
+                  severity: 'error',
+                  // message names the offending field + index (field_path is not
+                  // a CritiqueV3 field; the path is carried in the message text).
+                  message: `goal_constraints[${i}].${badField} must be a non-empty string`,
+                  source: 'validation',
+                  blocks_analysis: true,
+                }],
+                normalizedGraph,
+                normalizedOptions,
+                requestId,
+                requestComputedAt,
+              ));
+            }
+          }
         }
 
         // =================================================================
@@ -6473,6 +6597,22 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         );
         reply.header('X-Olumi-Request-Id-Chain', buildRequestIdChainHeader(chain)!);
 
+        // Sub-item 1d: derive the per-option clamp map from the RECORDED
+        // normalisation diagnostics (Map<optionId, Map<factorId, clamped>>).
+        // Reading the recorded `clamped` is authoritative — recomputing from the
+        // per-option interventions reaching buildResponse would read the already
+        // normalised [0,1] values and always report "not clamped". Feeds
+        // constraint_margins margin_precision (lower_bound when clamped).
+        const optionClampByOptionFactor = new Map<string, Map<string, boolean>>();
+        for (const d of normalisationDiagnostics) {
+          let inner = optionClampByOptionFactor.get(d.option_id);
+          if (!inner) {
+            inner = new Map<string, boolean>();
+            optionClampByOptionFactor.set(d.option_id, inner);
+          }
+          inner.set(d.factor_id, d.clamped);
+        }
+
         return reply.send(buildResponse(
           requestId,
           topLevelStatus,
@@ -6527,7 +6667,8 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           thresholdAnalysis, // B10.3: Threshold analysis results
           toIdentifiabilityResponse(identifiabilityResult),  // B1.5a: always-present mapped response
           factorStability,  // 3C: ISL stability assessment per factor
-          req.log  // logger for fact_objects assembly logging
+          req.log,  // logger for fact_objects assembly logging
+          optionClampByOptionFactor  // 1d: per-option clamp map for margin_precision
         ));
       } catch (err) {
         req.log.error({

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -371,12 +371,46 @@ export interface ConstraintResult {
 export interface ConstraintDiagnostic {
   /** Constraint ID */
   constraint_id: string;
-  /** Median failure margin (how far failures miss the threshold) */
-  failure_margin_median: number;
-  /** Fraction of failures within 10% of threshold (near misses) */
-  near_miss_fraction: number;
+  /**
+   * Median failure margin (how far failures miss the threshold).
+   * OPTIONAL: omitted (never fabricated as 0) when ISL did not compute it —
+   * a satisfying constraint carries no margin. Absent ≠ zero.
+   */
+  failure_margin_median?: number;
+  /**
+   * Fraction of failures within 10% of threshold (near misses).
+   * OPTIONAL for the same reason as failure_margin_median — absent ≠ zero.
+   */
+  near_miss_fraction?: number;
   /** Whether this constraint is the primary limiter of joint probability */
   binding: boolean;
+}
+
+/**
+ * Per-option, per-constraint graded breach margin (additive, PoC plumbing).
+ * Carries ISL's per-option failure_margin_median / near_miss_fraction to
+ * egress so breaching options are ORDERABLE by how far over they are.
+ * Absent margin fields are OMITTED (missing ≠ zero); `margin_precision`
+ * flags when the denormalised magnitude is a lower bound because the
+ * option's intervention saturated (clamped) its normalisation range.
+ */
+export interface ConstraintMargin {
+  /** Constraint ID (resolved by ISL response ordinal → input constraint_id). */
+  constraint_id: string;
+  /**
+   * Median failure margin in USER UNITS (denormalised by the constraint's
+   * range width). Omitted when ISL sent none for this option.
+   */
+  failure_margin_median?: number;
+  /** Fraction of failures within 10% of threshold. Omitted when absent. */
+  near_miss_fraction?: number;
+  /**
+   * Precision of failure_margin_median: 'exact' when the option's
+   * intervention stayed within its normalisation range, 'lower_bound' when
+   * it clamped (the true breach is larger than reported). Present only when
+   * failure_margin_median is present.
+   */
+  margin_precision?: 'exact' | 'lower_bound';
 }
 
 /**
@@ -803,6 +837,16 @@ export interface RunResponseV3 {
    * Reason for status (if not 'computed').
    */
   status_reason?: string;
+
+  /**
+   * True when the run produced USABLE results that are degraded/rough —
+   * analysis_status === 'partial' (options usable, some secondary feature
+   * degraded). Single-sourced from analysis_status (derive-don't-mirror); NOT
+   * a hand-maintained second flag. Named `approximate` to avoid colliding with
+   * the CEE-trace `degraded` semantic. Deliberately FALSE for 'failed'/'blocked'
+   * (no usable answer) — an 'approximate results' signal must not cover them.
+   */
+  approximate?: boolean;
 
   /**
    * Option comparison status.
@@ -1468,6 +1512,16 @@ export interface OptionComparisonResultV3 {
     /** Constraint-target node ids scored this way (sorted, deduplicated). */
     node_ids: string[];
   };
+
+  /**
+   * Per-constraint graded breach margins for THIS option (additive plumbing).
+   * One entry per constraint ISL evaluated for the option; margin fields are
+   * OMITTED (never fabricated as 0) when ISL sent none — so a satisfying
+   * option carries a bare entry while a breaching option carries its margin.
+   * Only present when goal_constraints provided and delivered (same honesty
+   * gate as constraint_probabilities).
+   */
+  constraint_margins?: ConstraintMargin[];
 }
 
 /**

--- a/tests/approximate-flag.unit.test.ts
+++ b/tests/approximate-flag.unit.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Unit pin for sub-item 2: the `approximate` derivation rule.
+ *
+ * `approximate` must be TRUE only for 'partial' (usable-but-degraded). A
+ * 'failed'/'blocked' run carries NO usable answer and must NOT read approximate
+ * (a 'failed' body ships on a 200 — e.g. the ISL-disabled path), else a UI badge
+ * would present "no results" as "usable but rough" — the opposite of the truth.
+ *
+ * This discriminates the correct rule from the earlier `!== 'computed'` formula
+ * (which wrongly folded failed/blocked into true). Mutation-check: reverting
+ * isApproximateAnalysis to `status !== 'computed'` turns the failed + blocked
+ * cases below RED. The integration golden (isl-v2-golden-response.pin) pins the
+ * computed→false case on a real wire response; this pins the rule itself.
+ */
+import { describe, it, expect } from 'vitest';
+import { isApproximateAnalysis } from '../src/routes/v2/run.js';
+
+describe('isApproximateAnalysis — approximate flag semantics (sub-item 2)', () => {
+  it('is TRUE only for partial (usable but degraded)', () => {
+    expect(isApproximateAnalysis('partial')).toBe(true);
+  });
+  it('is FALSE for computed (clean, not approximate)', () => {
+    expect(isApproximateAnalysis('computed')).toBe(false);
+  });
+  it('is FALSE for failed (no usable answer — must not read approximate)', () => {
+    expect(isApproximateAnalysis('failed')).toBe(false);
+  });
+  it('is FALSE for blocked (no usable answer)', () => {
+    expect(isApproximateAnalysis('blocked')).toBe(false);
+  });
+});

--- a/tests/constraint-margin-plumbing.test.ts
+++ b/tests/constraint-margin-plumbing.test.ts
@@ -1,0 +1,531 @@
+/**
+ * A3 PLUMBING SPLIT (2026-07-20) of b4's constraint-eligibility-gate.test.ts.
+ *
+ * This lane builds ONLY additive plumbing so ISL's graded breach signal reaches
+ * egress with absent!=zero. The eligibility-GATE CROWNING DOCTRINE (b4's
+ * provisional prob_satisfied<0.5=ineligible + infeasible-leader demotion +
+ * "nothing qualifies" withheld + tri-state unknown crowning) is UNRATIFIED
+ * (b4 §6) and therefore EXCLUDED. The 4 doctrine tests below are `it.skip`
+ * (pending doctrine ratification); the plumbing + 2 GREEN positive controls
+ * stay active as this lane's RED-first targets:
+ *   ACTIVE  Part1.1 per-option margins reach egress (RED)
+ *   ACTIVE  Part1.2 missing-vs-zero distinguishable (RED)
+ *   ACTIVE  Part1.3 clamp precision lower_bound (RED)
+ *   ACTIVE  Part3.1 ingress guard: well-formed constraint passes (positive control)
+ *   ACTIVE  Part3.2-4 ingress guard: malformed constraint_id/node_id -> 422 (RED)
+ *   ACTIVE  Part2 all-feasible -> argmax crowned (GREEN positive control)
+ *   ACTIVE  Part2 no-constraints -> argmax crowned (GREEN positive control)
+ *   SKIP    Part2 status parity (DEFERRED — crowning-adjacent, follow-on lane)
+ *   SKIP    Part2 infeasible-leader demotion       (doctrine)
+ *   SKIP    Part2 nothing-qualifies withheld       (doctrine)
+ *   SKIP    Part2 tri-state unknown crowning       (doctrine)
+ *   SKIP    Part2 per-option constraint_eligibility (uses unratified <0.5 rule)
+ *
+ * B4 / L2 — constraint eligibility gate + per-option graded breach margins.
+ *
+ * Two lanes of coverage, both route-level (the whole /v2/run mapping):
+ *
+ * PART 1 — STOP DROPPING ISL'S GRADED BREACH SIGNAL.
+ *   ISL computes `failure_margin_median` / `near_miss_fraction` PER OPTION.
+ *   PLoT read only `prob_satisfied` per option, and read the top-level
+ *   diagnostics off the FIRST option carrying constraints — which is the
+ *   SATISFYING option, and a satisfying option by definition carries no
+ *   margin. Two `?? 0` defaults then manufactured `failure_margin_median: 0,
+ *   near_miss_fraction: 0`, and those fabricated zeros were read by a live
+ *   probe as positive evidence that "the constraint signal is a hard step,
+ *   ranking by degree of breach is impossible" — a false architectural
+ *   conclusion that was written into the design plan. A missing signal must
+ *   never silently render as a plausible value: hence
+ *   `missing margin is DISTINGUISHABLE from a zero margin` below, which is
+ *   the pin that would have caught it.
+ *
+ * PART 2 — the eligibility gate.
+ *   `deriveRecommendedOption` is the SOLE producer of recommended_option_id
+ *   (ISL ships none on the V2 wire). An option that positively breaches a
+ *   stated constraint is never crowned; when NOTHING qualifies the response
+ *   says so POSITIVELY via `robustness.recommendation_withheld` — never by
+ *   omission, because the UI re-crowns its own argmax on a falsy
+ *   recommended_option_id, so omission would deploy clean and enforce
+ *   nothing.
+ *
+ * Eligibility is TRI-STATE and `unknown` NEVER coerces to either side; the
+ * `unknown` case below is what makes that observable on the wire (a tri-state
+ * that collapses to the same behaviour as a boolean is untestable theatre).
+ *
+ * Scenario mirrors the live staging probe (ISL build cdacb2f):
+ *   constraint  fac_cost <= 50000, node cap 60000  → threshold normalises 0.8333
+ *   opt_under     £38,000  prob_satisfied 1.0  no margin fields
+ *   opt_just_over £52,000  prob_satisfied 0.0  margin 0.03333 (≈£2,000 over)
+ *   opt_far_over  £82,000  prob_satisfied 0.0  margin 0.16667 (≈£10,000 over)
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// ISL mock — per-option constraint_analysis + per-option win_probability
+// ---------------------------------------------------------------------------
+
+/** option_id → constraint_analysis (undefined entry = ISL sent none for it). */
+let mockConstraintAnalysisByOption: Record<string, any> = {};
+/** option_id → win_probability. */
+let mockWinProbabilityByOption: Record<string, number> = {};
+/** option_id → status ('computed' unless overridden). */
+let mockStatusByOption: Record<string, string> = {};
+
+function buildMockOption(opt: any, idx: number) {
+  const analysis = mockConstraintAnalysisByOption[opt.id];
+  return {
+    option_id: opt.id,
+    outcome: {
+      mean: 0.7 - idx * 0.1,
+      std: 0.1,
+      p10: 0.5,
+      p50: 0.7,
+      p90: 0.9,
+      n_samples: 1000,
+      n_valid_samples: 1000,
+      validity_ratio: 1.0,
+    },
+    rank: idx + 1,
+    win_probability: mockWinProbabilityByOption[opt.id],
+    status: mockStatusByOption[opt.id] ?? 'computed',
+    ...(analysis !== undefined && { constraint_analysis: analysis }),
+  };
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable',
+      confidence: 'high',
+      adjustment_sets: [],
+      minimal_set: [],
+      backdoor_paths: [],
+      issues: [],
+      explanation: { summary: 'Mock validation', reasoning: 'Test' },
+      source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      options: options.map(buildMockOption),
+      edges: [],
+      edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [],
+      value_of_information: [],
+      factors_provenance: 'unavailable' as const,
+      factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const,
+      robustness_score: 0.8,
+      fragile_edges: [],
+      robust_edges: [],
+      latency_ms: 50,
+      source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    return {
+      data: {
+        options: options.map(buildMockOption),
+        edges: [],
+        factors: [],
+        value_of_information: [],
+        overall_robustness: 'robust',
+        robustness_score: 0.8,
+        fragile_edges: [],
+        robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — mirror the live probe graph
+// ---------------------------------------------------------------------------
+
+/**
+ * `fac_cost` carries an explicit `cap`, so its normalisation range is
+ * [0, 60000] source `explicit_cap` — a PRODUCER-DECLARED scale. That keeps the
+ * constraint target RELIABLE (no default-range fallback, no heuristic), so the
+ * per-option probability fields this suite pins are DELIVERED rather than
+ * suppressed by the producer-honesty gate.
+ */
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Programme value', observed_state: { value: 0.4 } },
+    { id: 'fac_cost', kind: 'factor', label: 'First-year cost', observed_state: { value: 40000, cap: 60000, unit: '£' } },
+  ],
+  edges: [{ from: 'fac_cost', to: 'goal', strength: { mean: -0.5, std: 0.1 } }],
+};
+
+const OPTIONS = [
+  { id: 'opt_under', label: 'Under budget', interventions: { fac_cost: 38000 } },
+  { id: 'opt_just_over', label: 'Just over budget', interventions: { fac_cost: 52000 } },
+  { id: 'opt_far_over', label: 'Far over budget', interventions: { fac_cost: 82000 } },
+];
+
+const CONSTRAINT_ID = 'c_cost_cap';
+const GOAL_CONSTRAINTS = [
+  { constraint_id: CONSTRAINT_ID, node_id: 'fac_cost', operator: '<=', value: 50000, label: 'First-year cost cap', unit: '£' },
+];
+
+const BASE_PAYLOAD = { graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '42' };
+
+/** ISL constraint row for one option. Margin fields OMITTED when not supplied. */
+function islConstraint(probSatisfied: number, margin?: number, nearMiss?: number) {
+  return {
+    constraints: [
+      {
+        node_id: 'fac_cost',
+        operator: '<=',
+        value: 50000,
+        prob_satisfied: probSatisfied,
+        ...(margin !== undefined && { failure_margin_median: margin }),
+        ...(nearMiss !== undefined && { near_miss_fraction: nearMiss }),
+      },
+    ],
+    joint_probability: probSatisfied,
+  };
+}
+
+/** The live-probe shape: under passes with no margin, both over-budget breach. */
+function setLiveProbeShape() {
+  mockConstraintAnalysisByOption = {
+    opt_under: islConstraint(1.0),
+    opt_just_over: islConstraint(0.0, 0.03333, 1.0),
+    opt_far_over: islConstraint(0.0, 0.16667, 0.0),
+  };
+}
+
+async function runAnalysis(baseUrl: string, payload: object): Promise<any> {
+  const res = await fetch(`${baseUrl}/v2/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  expect(res.status).toBe(200);
+  return res.json();
+}
+
+function optionEntry(body: any, optionId: string): any {
+  const entry = (body.option_comparison ?? []).find((o: any) => o.option_id === optionId);
+  expect(entry, `option_comparison entry for ${optionId}`).toBeDefined();
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+
+describe('B4/L2 constraint eligibility gate + graded breach margins', () => {
+  let app: FastifyInstance;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const addr = app.server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  beforeEach(() => {
+    mockConstraintAnalysisByOption = {};
+    mockWinProbabilityByOption = {};
+    mockStatusByOption = {};
+  });
+
+  // =========================================================================
+  // PART 1 — the graded signal reaches egress
+  // =========================================================================
+
+  describe('Part 1: ISL per-option graded breach signal reaches egress', () => {
+    it('carries EACH option its OWN failure_margin_median / near_miss_fraction', async () => {
+      setLiveProbeShape();
+      mockWinProbabilityByOption = { opt_under: 0.2, opt_just_over: 0.3, opt_far_over: 0.5 };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      const justOver = optionEntry(body, 'opt_just_over').constraint_margins?.find(
+        (m: any) => m.constraint_id === CONSTRAINT_ID,
+      );
+      const farOver = optionEntry(body, 'opt_far_over').constraint_margins?.find(
+        (m: any) => m.constraint_id === CONSTRAINT_ID,
+      );
+
+      expect(justOver, 'opt_just_over must carry its own margin entry').toBeDefined();
+      expect(farOver, 'opt_far_over must carry its own margin entry').toBeDefined();
+
+      // Denormalised to user units by the constraint's range width (60000).
+      expect(justOver.failure_margin_median).toBeCloseTo(2000, 0);
+      expect(farOver.failure_margin_median).toBeCloseTo(10000, 0);
+      expect(justOver.near_miss_fraction).toBe(1.0);
+      expect(farOver.near_miss_fraction).toBe(0.0);
+
+      // The whole point: the two breaching options are DISTINGUISHABLE, which
+      // is what makes "ordered by how far over they are" possible at all.
+      expect(farOver.failure_margin_median).toBeGreaterThan(justOver.failure_margin_median);
+
+      // Sub-item 2: `approximate` is DERIVED from analysis_status (=== 'partial'),
+      // not mirrored, and deliberately FALSE for failed/blocked (no usable answer).
+      // This live-probe run is 'partial' → true; the golden pins the computed→false
+      // case. Robust to golden regeneration.
+      expect(body.approximate).toBe(body.analysis_status === 'partial');
+    });
+
+    it('a MISSING margin is DISTINGUISHABLE from a zero margin', async () => {
+      // opt_under: ISL sent NO margin fields (it satisfies the constraint).
+      // opt_just_over: ISL sent an explicit ZERO margin.
+      // These two must NOT render identically. This is the pin for the defect
+      // that fabricated positive evidence for a false conclusion.
+      mockConstraintAnalysisByOption = {
+        opt_under: islConstraint(1.0),
+        opt_just_over: islConstraint(0.0, 0, 0),
+        opt_far_over: islConstraint(0.0, 0.16667, 0.0),
+      };
+      mockWinProbabilityByOption = { opt_under: 0.5, opt_just_over: 0.3, opt_far_over: 0.2 };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      const underMargin = optionEntry(body, 'opt_under').constraint_margins?.find(
+        (m: any) => m.constraint_id === CONSTRAINT_ID,
+      );
+      const zeroMargin = optionEntry(body, 'opt_just_over').constraint_margins?.find(
+        (m: any) => m.constraint_id === CONSTRAINT_ID,
+      );
+
+      expect(zeroMargin, 'explicit-zero option must carry a margin entry').toBeDefined();
+      expect(underMargin, 'no-margin option must still carry its entry').toBeDefined();
+
+      // A real measured zero is PRESENT and equal to 0 ...
+      expect(zeroMargin).toHaveProperty('failure_margin_median');
+      expect(zeroMargin.failure_margin_median).toBe(0);
+      expect(zeroMargin).toHaveProperty('near_miss_fraction');
+      expect(zeroMargin.near_miss_fraction).toBe(0);
+
+      // ... while an ABSENT measurement is ABSENT, never a fabricated 0.
+      expect(underMargin).not.toHaveProperty('failure_margin_median');
+      expect(underMargin).not.toHaveProperty('near_miss_fraction');
+      expect(underMargin.failure_margin_median).toBeUndefined();
+    });
+
+    it('marks a CLAMPED breach magnitude as a lower bound (Finding D)', async () => {
+      // opt_far_over intervenes 82000 against a cap of 60000, so its
+      // normalised value saturates at 1.0 and the reported £10,000 understates
+      // the true £32,000 breach. The magnitude must be flagged, not stated.
+      // opt_just_over (52000 < 60000) does NOT clamp, so its £2,000 is exact.
+      setLiveProbeShape();
+      mockWinProbabilityByOption = { opt_under: 0.5, opt_just_over: 0.3, opt_far_over: 0.2 };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      const justOver = optionEntry(body, 'opt_just_over').constraint_margins[0];
+      const farOver = optionEntry(body, 'opt_far_over').constraint_margins[0];
+
+      expect(justOver.margin_precision).toBe('exact');
+      expect(farOver.margin_precision).toBe('lower_bound');
+    });
+  });
+
+  // =========================================================================
+  // PART 2 — the eligibility gate
+  // =========================================================================
+
+  describe('Part 2: eligibility gate on recommended_option_id', () => {
+    it.skip('DOCTRINE (unratified, b4 §6): an INFEASIBLE argmax leader is not crowned; the runner-up is', async () => {
+      setLiveProbeShape();
+      // opt_far_over is the argmax on win_probability but breaches the cap.
+      mockWinProbabilityByOption = { opt_under: 0.2, opt_just_over: 0.3, opt_far_over: 0.5 };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      expect(body.robustness.recommended_option_id).toBe('opt_under');
+      expect(body.robustness.recommended_option_label).toBe('Under budget');
+      expect(body.robustness.recommendation_withheld).toBeUndefined();
+    });
+
+    it('MANDATORY POSITIVE CONTROL: when ALL options are feasible the argmax winner is STILL crowned', async () => {
+      // Without this, a gate that rejects everything would look correct.
+      mockConstraintAnalysisByOption = {
+        opt_under: islConstraint(1.0),
+        opt_just_over: islConstraint(1.0),
+        opt_far_over: islConstraint(1.0),
+      };
+      mockWinProbabilityByOption = { opt_under: 0.2, opt_just_over: 0.3, opt_far_over: 0.5 };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      expect(body.robustness.recommended_option_id).toBe('opt_far_over');
+      expect(body.robustness.recommendation_withheld).toBeUndefined();
+    });
+
+    it('POSITIVE CONTROL: with NO constraints sent the argmax winner is crowned unchanged', async () => {
+      mockWinProbabilityByOption = { opt_under: 0.2, opt_just_over: 0.3, opt_far_over: 0.5 };
+
+      const body = await runAnalysis(baseUrl, BASE_PAYLOAD);
+
+      expect(body.robustness.recommended_option_id).toBe('opt_far_over');
+      expect(body.robustness.recommendation_withheld).toBeUndefined();
+    });
+
+    it.skip('DOCTRINE (unratified, b4 §6): NOTHING QUALIFIES — no crown, and a POSITIVE recommendation_withheld (never omission)', async () => {
+      mockConstraintAnalysisByOption = {
+        opt_under: islConstraint(0.0, 0.05, 0.5),
+        opt_just_over: islConstraint(0.0, 0.03333, 1.0),
+        opt_far_over: islConstraint(0.0, 0.16667, 0.0),
+      };
+      mockWinProbabilityByOption = { opt_under: 0.2, opt_just_over: 0.3, opt_far_over: 0.5 };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      expect(body.robustness.recommended_option_id).toBeUndefined();
+      expect(body.robustness.recommended_option_label).toBeUndefined();
+
+      const withheld = body.robustness.recommendation_withheld;
+      expect(withheld, 'withheld must be POSITIVE — the UI backfills its own argmax on absence').toBeDefined();
+      expect(withheld.reason).toBe('no_eligible_option');
+      expect(withheld.constraint_id).toBe(CONSTRAINT_ID);
+      expect(withheld.label).toBe('First-year cost cap');
+      expect(withheld.value).toBe(50000);
+      expect(withheld.unit).toBe('£');
+
+      // Option A ordering data: closest-first. opt_just_over is least over.
+      expect(withheld.closest_option_id).toBe('opt_just_over');
+      expect(withheld.closest_gap).toBeCloseTo(2000, 0);
+      expect(withheld.closest_gap_precision).toBe('exact');
+    });
+
+    it.skip('DOCTRINE (unratified, b4 §6): TRI-STATE — an option with UNKNOWN eligibility is neither crowned-as-verified nor filtered out', async () => {
+      // opt_under gets NO constraint_analysis from ISL → eligibility unknown.
+      // Both other options positively breach. The unknown option must survive
+      // the filter (we have no evidence it breaches) but must NOT be reported
+      // as verified-eligible.
+      mockConstraintAnalysisByOption = {
+        opt_just_over: islConstraint(0.0, 0.03333, 1.0),
+        opt_far_over: islConstraint(0.0, 0.16667, 0.0),
+      };
+      mockWinProbabilityByOption = { opt_under: 0.2, opt_just_over: 0.3, opt_far_over: 0.5 };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      expect(body.robustness.recommended_option_id).toBe('opt_under');
+      // `unknown` must NOT be coerced to 'eligible'.
+      expect(body.robustness.recommended_option_eligibility).toBe('unknown');
+      expect(body.robustness.recommendation_withheld).toBeUndefined();
+    });
+
+    // DEFERRED: crowning-adjacent (deriveRecommendedOption status filter); not in A1's GO list; rides UI-first deploy order — follow-on lane.
+    it.skip('STATUS PARITY with computeNearTie: a non-computed option is never crowned', async () => {
+      mockConstraintAnalysisByOption = {
+        opt_under: islConstraint(1.0),
+        opt_just_over: islConstraint(1.0),
+        opt_far_over: islConstraint(1.0),
+      };
+      mockWinProbabilityByOption = { opt_under: 0.2, opt_just_over: 0.3, opt_far_over: 0.9 };
+      mockStatusByOption = { opt_far_over: 'error' };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      expect(body.robustness.recommended_option_id).toBe('opt_just_over');
+    });
+
+    it.skip('DOCTRINE (unratified, b4 §6): per-option constraint_eligibility is emitted on every option_comparison entry', async () => {
+      setLiveProbeShape();
+      mockWinProbabilityByOption = { opt_under: 0.2, opt_just_over: 0.3, opt_far_over: 0.5 };
+
+      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      expect(optionEntry(body, 'opt_under').constraint_eligibility).toBe('eligible');
+      expect(optionEntry(body, 'opt_just_over').constraint_eligibility).toBe('ineligible');
+      expect(optionEntry(body, 'opt_far_over').constraint_eligibility).toBe('ineligible');
+    });
+  });
+
+  // =========================================================================
+  // PART 3 — goal_constraints ingress-shape guard (sub-item 4)
+  // =========================================================================
+  // The runV3 body JSON-schema types goal_constraints only as an array of
+  // objects (inner fields UNVALIDATED). PLoT reads c.constraint_id / c.node_id
+  // everywhere downstream (id resolver, constraint-trace log, constraint
+  // mapping); an entry missing either as a non-empty string silently corrupts
+  // identity/targeting. The guard rejects it at the boundary with a 422 blocked
+  // response BEFORE any of that runs. These are the RED-first pins for that
+  // guard (a fix with no test that proves it bites is untested theatre).
+  describe('Part 3: goal_constraints ingress-shape guard', () => {
+    async function postRun(payload: object): Promise<{ status: number; body: any }> {
+      const res = await fetch(`${baseUrl}/v2/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      return { status: res.status, body: await res.json() };
+    }
+
+    it('POSITIVE CONTROL: a well-formed constraint is NOT blocked (200)', async () => {
+      setLiveProbeShape();
+      mockWinProbabilityByOption = { opt_under: 0.5, opt_just_over: 0.3, opt_far_over: 0.2 };
+      const { status } = await postRun({ ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+      expect(status).toBe(200);
+    });
+
+    it('rejects a MISSING constraint_id with 422 naming goal_constraints[0].constraint_id', async () => {
+      const { status, body } = await postRun({
+        ...BASE_PAYLOAD,
+        goal_constraints: [{ node_id: 'fac_cost', operator: '<=', value: 50000 }],
+      });
+      expect(status).toBe(422);
+      const s = JSON.stringify(body);
+      expect(s).toContain('INVALID_CONSTRAINT_SHAPE');
+      expect(s).toContain('goal_constraints[0].constraint_id');
+    });
+
+    it('rejects an EMPTY-STRING node_id with 422 naming the field + index', async () => {
+      const { status, body } = await postRun({
+        ...BASE_PAYLOAD,
+        goal_constraints: [
+          { constraint_id: 'c_ok', node_id: 'fac_cost', operator: '<=', value: 50000 },
+          { constraint_id: 'c_bad', node_id: '', operator: '<=', value: 50000 },
+        ],
+      });
+      expect(status).toBe(422);
+      const s = JSON.stringify(body);
+      expect(s).toContain('INVALID_CONSTRAINT_SHAPE');
+      expect(s).toContain('goal_constraints[1].node_id');
+    });
+
+    it('rejects a NON-STRING constraint_id with 422', async () => {
+      const { status, body } = await postRun({
+        ...BASE_PAYLOAD,
+        goal_constraints: [{ constraint_id: 123, node_id: 'fac_cost', operator: '<=', value: 50000 }],
+      });
+      expect(status).toBe(422);
+      expect(JSON.stringify(body)).toContain('goal_constraints[0].constraint_id');
+    });
+  });
+});

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -4,6 +4,7 @@
   "preflight_version": "2025-12-26",
   "request_id": "__VOLATILE__",
   "analysis_status": "computed",
+  "approximate": false,
   "option_comparison_status": "computed",
   "robustness_status": "computed",
   "drivers_status": "computed",
@@ -1604,7 +1605,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:0e2fa534192a0645"
+    "response_content_hash": "rch_v2:21006aa29c8ee071"
   },
   "meta": {
     "seed_used": "2034401427",


### PR DESCRIPTION
## A3 constraint-margin plumbing lane

Additive plumbing (no flag) on `/v2/run`. Stops dropping ISL's graded per-option constraint breach signal, adds a canonical `approximate` flag, removes dead phantom robustness reads, and guards `goal_constraints` ingress shape. Built against local TS types; the contract catch-up (`openapi.yaml` + `@talchain/schemas`) rides the 0.15→0.18 re-vendor.

### What changed
- **Per-option `constraint_margins[]` reaches egress, absent ≠ zero.** Killed the `?? 0` fabrication (top-level `constraint_diagnostics` + per-option) that manufactured false "hard-step" evidence from a satisfying option's missing margins. Emits per-option `failure_margin_median` / `near_miss_fraction` / `margin_precision`; `ConstraintDiagnostic` margin fields made optional. `NormalisationDiagnostic` gains `option_id` → a per-option clamp map flags a clamped magnitude as `lower_bound` (never a false exact figure).
- **`approximate` boolean**, single-sourced from `analysis_status` via `isApproximateAnalysis` (`=== 'partial'` only — `failed`/`blocked` carry no usable answer and must not read approximate). Derive-don't-mirror.
- **Removed phantom `islResult.robustness.label`/`.score` reads** (`RobustnessResultV2` has neither on the V2 wire) — output byte-identical, golden-verified.
- **`goal_constraints` ingress guard**: require string `constraint_id` + `node_id` → 422 `INVALID_CONSTRAINT_SHAPE` before any downstream identity read.

### Verification
- RED-first: `tests/constraint-margin-plumbing.test.ts` (per-option margins · missing≠zero · clamp precision · ingress-guard 422s) + `tests/approximate-flag.unit.test.ts` (4 states) + golden `approximate:false`.
- **Mutation-checked** (revert each fix → mapped test RED): approximate→`failed`/`blocked` RED · drop margins→Part1 RED · `margin_precision`→clamp RED · disable guard→Part3 RED.
- Touched-path sweep: 42 files, **699 pass / 0 fail**; target 13 pass / 5 skip; `tsc` clean; `dist` builds clean.
- Adversarial review (8 lenses + per-finding verify): 18 findings → 1 confirmed (approximate semantics) → fixed.

### Deliberately excluded (scoped out)
- Eligibility-gate crowning doctrine (`prob<0.5`) — unratified → doctrine batch.
- `openapi.yaml` + `@talchain/schemas` field additions → the 0.15→0.18 re-vendor.
- Adjacent phantoms (`:2450` explanation, `:3352` CEE path, `analyseRobustness` adapters) → follow-on.

### ⚠ Found issue for a follow-on (NOT in this lane)
`deriveRecommendedOption` crowns purely on `win_probability` and does **not** filter on option `status` (unlike `computeNearTie`) — so PLoT can currently recommend an option that *failed to compute*. Its test is skipped here (`STATUS PARITY`, crowning-adjacent, rides UI-first deploy order). Recommend a tiny follow-on after the doctrine batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
