### PR TITLE
fix(v2/run): unify constraint-threshold and intervention normalisation ranges (P0 probability inversion + margin scale)

### DIFF
--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -1049,33 +1049,44 @@ export function normaliseGoalConstraints(
 
     // The scale this node's INTERVENTIONS were normalised against (Phase 4a).
     const interventionScale = extras?.interventionScaleByNodeId?.get(node_id);
+    // An IDENTITY [0,1] intervention scale is the route's marker for "this node
+    // was intervened while Phase 4a was SKIPPED" (all interventions already in
+    // [0,1]) — it is an ASSUMPTION, not a measured spread. A NON-identity scale
+    // is a measured ground-truth spread. The two rank very differently below.
+    const interventionScaleIsIdentity =
+      interventionScale !== undefined && interventionScale.min === 0 && interventionScale.max === 1;
     // Default TRUE so every existing caller (unit tests, code paths that omit
     // the flag) keeps the pre-fix chain behaviour for scale-less constraints.
     const applyChainWithoutScale = extras?.normaliseWithoutScale ?? true;
 
-    // Derive range. Priority:
-    //   -1  interventionScale — the constraint threshold MUST share the exact
-    //       scale its node's samples occupy (A3 range-unify fix).
-    //  FWD  forward-raw — gate FALSE + no intervention scale ⇒ value already in
-    //       [0,1] ⇒ leave it untouched (HEAD parity, F1). MUST outrank the
-    //       producer branches below.
-    //    0  goal_threshold_cap  (producer-declared)
-    //    1  unit_percent        (producer-declared)
-    //    2+ deriveRange(node)   (existing chain: explicit_cap → … → default)
+    // Derive range. Priority ladder (F4, Codex-confirmed reorder):
+    //   1  interventionScale, NON-identity — a MEASURED spread is ground truth;
+    //      the threshold MUST share the exact scale its samples occupy
+    //      (A3 range-unify). Wins even over a producer cap (DOCTRINE-PENDING).
+    //   2  forward-raw — gate FALSE + no intervention scale ⇒ value already in
+    //      [0,1] ⇒ leave it untouched (HEAD parity, F1). MUST outrank producers.
+    //   3  goal_threshold_cap  (producer-declared)   ]  a producer DECLARATION
+    //   4  unit_percent        (producer-declared)   ]  outranks an ASSUMED
+    //                                                    identity scale (F4).
+    //   5  interventionScale, IDENTITY — the Phase-4a-skipped assumption; ranks
+    //      BELOW producer declarations, ABOVE the node heuristic, so the
+    //      core no-producer-metadata combos stay unchanged.
+    //   6  deriveRange(node)   (existing chain: explicit_cap → … → default)
     // If node not found and no declared scale, use default [0,1].
     let range: NormalisationRange;
     // Forwarded-raw ⇒ value is already in [0,1] (the global gate was FALSE) and
     // this node has no intervention scale: leave it untouched, emit no repair.
     let forwardedRawUnchanged = false;
-    if (interventionScale) {
-      // DOCTRINE-PENDING: when a node carries BOTH an intervention spread scale
-      // and a producer-declared cap (goal_threshold_cap / '%' / explicit_cap /
-      // state_space.range) and the two DISAGREE, this fix picks the
+    if (interventionScale && !interventionScaleIsIdentity) {
+      // DOCTRINE-PENDING: when a node carries BOTH a MEASURED intervention spread
+      // scale and a producer-declared cap (goal_threshold_cap / '%' / explicit_cap
+      // / state_space.range) and the two DISAGREE, this fix picks the
       // intervention-side range — it is the scale the ISL samples actually live
       // on, so it is the only choice that keeps threshold and samples
       // comparable. WHICH of the two should be authoritative when they diverge
       // is an unratified doctrine call (owner: A3 lead). Sameness is the
-      // invariant here; the pick is provisional.
+      // invariant here; the pick is provisional. (F4: this branch is now gated on
+      // NON-identity — an identity scale is an assumption, demoted to branch 5.)
       range = interventionScale;
     } else if (!applyChainWithoutScale) {
       // F1 (adversarial review): the global gate did NOT fire and this node has
@@ -1095,6 +1106,13 @@ export function normaliseGoalConstraints(
       range = { min: 0, max: nodeCap, source: 'goal_threshold_cap' };
     } else if (isPercentUnit(unit)) {
       range = { min: 0, max: 100, source: 'unit_percent' };
+    } else if (interventionScale) {
+      // F4 branch 5: an IDENTITY [0,1] intervention scale (Phase 4a skipped for
+      // this intervened node). Reached only when no producer '%'/cap declared it
+      // (those are handled above). Keeps the threshold on the SAME raw sample
+      // scale the interventions occupy, rather than independently re-deriving a
+      // node heuristic. (interventionScaleIsIdentity is necessarily true here.)
+      range = interventionScale;
     } else {
       range = targetNode
         ? deriveRange(targetNode)

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -914,6 +914,33 @@ export interface ConstraintNormalisationExtras {
   unitsByConstraintId?: Map<string, string>;
   /** Raw-node goal-threshold metadata per node_id */
   goalThresholdMetaByNodeId?: Map<string, GoalThresholdNodeMeta>;
+  /**
+   * The EXACT normalisation range each node's INTERVENTIONS were scaled against
+   * in Phase 4a (keyed by node_id). This is the scale the ISL samples for that
+   * node actually occupy, so the constraint threshold on the same node MUST be
+   * normalised against the identical range — otherwise ISL compares a threshold
+   * and samples that live on two different scales (the A3 range-split defect:
+   * a violated cap scored probability 1; margins were on a phantom width).
+   *
+   * When present for a node, this range OVERRIDES the constraint-side derivation
+   * chain (including producer-declared caps) — see the DOCTRINE-PENDING note in
+   * normaliseGoalConstraints. A node whose interventions were forwarded raw
+   * ([0,1] gate skipped) is carried here as an identity [0,1] range so the
+   * threshold stays on the same raw sample scale rather than being independently
+   * re-normalised via a node heuristic.
+   */
+  interventionScaleByNodeId?: Map<string, NormalisationRange>;
+  /**
+   * Whether the caller's global `constraintsNeedNormalisation` gate fired. When
+   * TRUE (or unset — the default preserves every direct-unit-test caller), a
+   * constraint on a node WITHOUT an intervention scale is normalised through the
+   * existing derivation chain, exactly as before. When explicitly FALSE, that
+   * same constraint is forwarded raw (its value is already in [0,1] by
+   * definition of the gate), so only constraints on intervened nodes with a
+   * NON-identity scale are transformed. This keeps behaviour byte-identical for
+   * constraints on non-intervened nodes across every gate combination.
+   */
+  normaliseWithoutScale?: boolean;
 }
 
 /**
@@ -1011,19 +1038,47 @@ export function normaliseGoalConstraints(
     const unit = extras?.unitsByConstraintId?.get(constraint_id);
     const nodeCap = nodeMeta?.goal_threshold_cap;
 
-    // Derive range. Producer-declared constraint scales outrank the
-    // node-derived chain; deriveRange() handles observed_state.cap as
-    // priority 0 (explicit_cap), then state_space.range → heuristics → [0,1].
+    // The scale this node's INTERVENTIONS were normalised against (Phase 4a).
+    const interventionScale = extras?.interventionScaleByNodeId?.get(node_id);
+    // Default TRUE so every existing caller (unit tests, code paths that omit
+    // the flag) keeps the pre-fix chain behaviour for scale-less constraints.
+    const applyChainWithoutScale = extras?.normaliseWithoutScale ?? true;
+
+    // Derive range. Priority:
+    //   -1  interventionScale — the constraint threshold MUST share the exact
+    //       scale its node's samples occupy (A3 range-unify fix).
+    //    0  goal_threshold_cap  (producer-declared)
+    //    1  unit_percent        (producer-declared)
+    //    2+ deriveRange(node)   (existing chain: explicit_cap → … → default)
     // If node not found and no declared scale, use default [0,1].
     let range: NormalisationRange;
-    if (typeof nodeCap === 'number' && Number.isFinite(nodeCap) && nodeCap > 0) {
+    // Forwarded-raw ⇒ value is already in [0,1] (the global gate was FALSE) and
+    // this node has no intervention scale: leave it untouched, emit no repair.
+    let forwardedRawUnchanged = false;
+    if (interventionScale) {
+      // DOCTRINE-PENDING: when a node carries BOTH an intervention spread scale
+      // and a producer-declared cap (goal_threshold_cap / '%' / explicit_cap /
+      // state_space.range) and the two DISAGREE, this fix picks the
+      // intervention-side range — it is the scale the ISL samples actually live
+      // on, so it is the only choice that keeps threshold and samples
+      // comparable. WHICH of the two should be authoritative when they diverge
+      // is an unratified doctrine call (owner: A3 lead). Sameness is the
+      // invariant here; the pick is provisional.
+      range = interventionScale;
+    } else if (typeof nodeCap === 'number' && Number.isFinite(nodeCap) && nodeCap > 0) {
       range = { min: 0, max: nodeCap, source: 'goal_threshold_cap' };
     } else if (isPercentUnit(unit)) {
       range = { min: 0, max: 100, source: 'unit_percent' };
-    } else {
+    } else if (applyChainWithoutScale) {
       range = targetNode
         ? deriveRange(targetNode)
         : { min: 0, max: 1, source: 'default' };
+    } else {
+      // Global gate did not fire and this node has no intervention scale ⇒ the
+      // value is already in [0,1]; forward it verbatim (identity), matching the
+      // pre-fix "gate false ⇒ constraints forwarded raw" behaviour exactly.
+      range = { min: 0, max: 1, source: 'default' };
+      forwardedRawUnchanged = true;
     }
 
     // Normalise value
@@ -1063,25 +1118,39 @@ export function normaliseGoalConstraints(
     };
     normalisedConstraints.push(normalisedConstraint);
 
-    // Add repair record
-    repairs.push({
-      field: `constraint.value.${constraint_id}`,
-      action: 'normalised',
-      from_value: value,
-      to_value: normalised,
-      reason: `normalised range=[${range.min},${range.max}] source=${range.source}${clamped ? ' (clamped)' : ''}${usedNodeGoalThreshold ? ' (node goal_threshold preferred)' : ''}`,
-    });
+    // Add repair record. A forwarded-raw constraint (gate FALSE, no intervention
+    // scale) is an identity no-op — emit no repair, so repairs_applied stays
+    // byte-identical to the pre-fix "gate false ⇒ no constraint normalisation"
+    // path.
+    if (!forwardedRawUnchanged) {
+      repairs.push({
+        field: `constraint.value.${constraint_id}`,
+        action: 'normalised',
+        from_value: value,
+        to_value: normalised,
+        reason: `normalised range=[${range.min},${range.max}] source=${range.source}${clamped ? ' (clamped)' : ''}${usedNodeGoalThreshold ? ' (node goal_threshold preferred)' : ''}`,
+      });
+    }
 
-    // Add diagnostic
-    diagnostics.push({
-      constraint_id,
-      node_id,
-      original_value: value,
-      normalised_value: normalised,
-      range,
-      used_heuristic: usedHeuristic,
-      ...(usedNodeGoalThreshold && { used_node_goal_threshold: true }),
-    });
+    // Add diagnostic. A forwarded-raw constraint underwent NO transform, so it
+    // contributes no normalisation range — emitting a synthetic 'default' range
+    // here would make the callers treat it as identical to the pre-fix
+    // "gate false ⇒ function not called" state. Crucially, that synthetic
+    // 'default' range would trip constraint-reliability.ts
+    // (threshold_normalisation_defaulted) and SUPPRESS a constraint that HEAD
+    // delivered. So skip it: no diagnostic ⇒ no constraintNormalisationRanges
+    // entry ⇒ the reliability gate and margin denorm behave exactly as before.
+    if (!forwardedRawUnchanged) {
+      diagnostics.push({
+        constraint_id,
+        node_id,
+        original_value: value,
+        normalised_value: normalised,
+        range,
+        used_heuristic: usedHeuristic,
+        ...(usedNodeGoalThreshold && { used_node_goal_threshold: true }),
+      });
+    }
 
     // Heuristic use is captured in diagnostics[].used_heuristic and repair records.
   }

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -1047,6 +1047,9 @@ export function normaliseGoalConstraints(
     // Derive range. Priority:
     //   -1  interventionScale — the constraint threshold MUST share the exact
     //       scale its node's samples occupy (A3 range-unify fix).
+    //  FWD  forward-raw — gate FALSE + no intervention scale ⇒ value already in
+    //       [0,1] ⇒ leave it untouched (HEAD parity, F1). MUST outrank the
+    //       producer branches below.
     //    0  goal_threshold_cap  (producer-declared)
     //    1  unit_percent        (producer-declared)
     //    2+ deriveRange(node)   (existing chain: explicit_cap → … → default)
@@ -1065,20 +1068,28 @@ export function normaliseGoalConstraints(
       // is an unratified doctrine call (owner: A3 lead). Sameness is the
       // invariant here; the pick is provisional.
       range = interventionScale;
+    } else if (!applyChainWithoutScale) {
+      // F1 (adversarial review): the global gate did NOT fire and this node has
+      // NO intervention scale ⇒ the value is already in [0,1] by definition of
+      // the gate; forward it verbatim (identity). This decision MUST precede the
+      // producer goal_threshold_cap / '%' branches below: at HEAD the function
+      // was NOT called for a constraint on a non-intervened node when the gate
+      // was false, so a producer cap or '%' unit on such a node must NOT drag the
+      // value through a normalisation HEAD never applied (e.g. '%' value 0.5 →
+      // 0.005, a new repair, margin denorm ×100). Restores exact HEAD parity for
+      // non-intervened nodes in the gate-false + some-other-node-has-a-scale
+      // combo. When the gate IS true (or unset — every direct-unit-test caller),
+      // this branch is skipped and the producer/chain branches apply as before.
+      range = { min: 0, max: 1, source: 'default' };
+      forwardedRawUnchanged = true;
     } else if (typeof nodeCap === 'number' && Number.isFinite(nodeCap) && nodeCap > 0) {
       range = { min: 0, max: nodeCap, source: 'goal_threshold_cap' };
     } else if (isPercentUnit(unit)) {
       range = { min: 0, max: 100, source: 'unit_percent' };
-    } else if (applyChainWithoutScale) {
+    } else {
       range = targetNode
         ? deriveRange(targetNode)
         : { min: 0, max: 1, source: 'default' };
-    } else {
-      // Global gate did not fire and this node has no intervention scale ⇒ the
-      // value is already in [0,1]; forward it verbatim (identity), matching the
-      // pre-fix "gate false ⇒ constraints forwarded raw" behaviour exactly.
-      range = { min: 0, max: 1, source: 'default' };
-      forwardedRawUnchanged = true;
     }
 
     // Normalise value

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -978,6 +978,15 @@ export interface ConstraintNormalisationResult {
     normalised_value: number;
     range: NormalisationRange;
     used_heuristic: boolean;
+    /**
+     * True when the raw threshold fell OUTSIDE the normalisation range and was
+     * clamped onto [0,1] (Codex F2a). The clamp DIRECTION is read from
+     * normalised_value at egress (0 ⇒ clamped at the range floor, 1 ⇒ at the
+     * ceiling). A clamped threshold makes the emitted failure_margin a strict
+     * bound, not an exact distance — the margin egress consults this so it never
+     * labels an understated margin 'exact'.
+     */
+    clamped: boolean;
     /** True when the node's CEE-stamped goal_threshold was preferred (P0-C1) */
     used_node_goal_threshold?: boolean;
   }>;
@@ -1159,6 +1168,10 @@ export function normaliseGoalConstraints(
         normalised_value: normalised,
         range,
         used_heuristic: usedHeuristic,
+        // F2a: carry whether the threshold clamped. When the CEE goal_threshold
+        // stamp was preferred, `clamped` was reset to false above (the stamp is
+        // an exact in-[0,1] value, no clamp), so this is correct in that branch too.
+        clamped,
         ...(usedNodeGoalThreshold && { used_node_goal_threshold: true }),
       });
     }

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -2076,7 +2076,14 @@ function buildResponse(
   // all, per option. The direction map alone cannot distinguish "diagnosed
   // and not clamped" (margin is exact) from "never diagnosed" (clamp state
   // unknown → no precision claim may be made).
-  optionDiagnosedFactors?: Map<string, Set<string>>
+  optionDiagnosedFactors?: Map<string, Set<string>>,
+  // Codex F2a: per-constraint THRESHOLD clamp direction ('low' = clamped at the
+  // range floor, 'high' = at the ceiling). Present ONLY when the constraint
+  // threshold itself clamped during normalisation. Independent of the per-option
+  // intervention clamp above — a threshold can clamp while every intervention
+  // sits inside the range (the response-1 defect: cap below the intervention
+  // floor). Feeds constraint_margins margin_precision.
+  constraintThresholdClampByConstraintId?: Map<string, 'low' | 'high'>
 ): RunResponseV3 {
   // Producer honesty (lane PLoT-H item A): detect goal constraints whose
   // targets are NOT decision-grade — threshold normalisation fell back to the
@@ -2279,28 +2286,56 @@ function buildResponse(
           const entry: ConstraintMargin = { constraint_id: cid };
           if (fmm !== undefined) {
             entry.failure_margin_median = fmm;
-            // Codex F1 (b)+(c): consult the RECORDED clamp state independently
-            // of constraintNormRanges, and only claim what the evidence
-            // supports:
-            //   - 'lower_bound' ONLY when the clamp direction is
-            //     operator-compatible (high-clamp understates a '<=' breach,
-            //     low-clamp understates a '>=' breach);
-            //   - 'exact' ONLY when this option HAS a normalisation
-            //     diagnostic for the target factor and it did NOT clamp;
-            //   - OMITTED when clamped in a direction that says nothing about
-            //     this operator's breach, or when the target factor carries
-            //     no diagnostic at all (clamp state unknown — e.g. the
-            //     constraint targets a non-intervened node).
+            // Codex F1 (b)+(c) + F2a: consult BOTH recorded clamp states — the
+            // per-option INTERVENTION clamp (a clamped sample) and the
+            // constraint THRESHOLD clamp (a threshold pushed outside the shared
+            // range) — independently of constraintNormRanges, and only claim
+            // what the evidence supports.
+            //
+            // Case analysis (why each clamp/operator pairing is understatement
+            // vs overstatement of the emitted breach margin):
+            //   INTERVENTION clamp (the SAMPLE moves):
+            //     - high-clamp ('<='): true sample ≥ emitted ⇒ true breach ≥
+            //       emitted ⇒ understates → lower_bound.
+            //     - low-clamp  ('>='): true sample ≤ emitted ⇒ understates.
+            //     - the two opposite pairings could OVERSTATE ⇒ no claim.
+            //   THRESHOLD clamp (the THRESHOLD moves — the MIRROR direction):
+            //     - '<=' threshold clamped LOW (to the floor, normalised 0): the
+            //       true threshold is below 0, so the true breach (sample −
+            //       threshold) is LARGER ⇒ emitted understates → lower_bound.
+            //     - '>=' threshold clamped HIGH (to the ceiling, normalised 1):
+            //       true threshold above 1, true breach (threshold − sample)
+            //       LARGER ⇒ understates → lower_bound.
+            //     - '<=' clamped HIGH / '>=' clamped LOW: the emitted breach
+            //       could OVERSTATE the true breach ⇒ NEVER claim a bound.
+            // Precedence: ANY possible overstatement ⇒ OMIT (cannot prove a
+            // lower bound, and it is not exact). Otherwise ANY understatement ⇒
+            // 'lower_bound'. Otherwise (no clamp on either side) 'exact' — but
+            // ONLY when the target factor is diagnosed (else clamp state is
+            // unknown, e.g. a non-intervened target, and no claim is made).
             const clampDir = optionClampDirectionByFactor?.get(optionId)?.get(c.node_id);
             const hasDiagnostic = optionDiagnosedFactors?.get(optionId)?.has(c.node_id) ?? false;
-            if (clampDir !== undefined) {
-              const operatorCompatible =
-                (clampDir === 'high' && c.operator === '<=') ||
-                (clampDir === 'low' && c.operator === '>=');
-              if (operatorCompatible) {
-                entry.margin_precision = 'lower_bound';
-              }
+            const thresholdClamp = constraintThresholdClampByConstraintId?.get(cid);
+
+            const interventionUnderstates =
+              (clampDir === 'high' && c.operator === '<=') ||
+              (clampDir === 'low' && c.operator === '>=');
+            const interventionOverstates = clampDir !== undefined && !interventionUnderstates;
+
+            const thresholdUnderstates =
+              (thresholdClamp === 'low' && c.operator === '<=') ||
+              (thresholdClamp === 'high' && c.operator === '>=');
+            const thresholdOverstates = thresholdClamp !== undefined && !thresholdUnderstates;
+
+            if (interventionOverstates || thresholdOverstates) {
+              // At least one clamp may inflate the emitted margin above the true
+              // breach ⇒ we cannot honestly claim 'lower_bound', and it is not
+              // 'exact'. OMIT.
+            } else if (interventionUnderstates || thresholdUnderstates) {
+              entry.margin_precision = 'lower_bound';
             } else if (hasDiagnostic) {
+              // Neither side clamped in any direction and the target factor is
+              // diagnosed (thresholdClamp is necessarily undefined here) ⇒ exact.
               entry.margin_precision = 'exact';
             }
           }
@@ -4996,6 +5031,12 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         let normalisationContext: NormalisationContext | undefined;
         let normalisationDiagnostics: NormalisationDiagnostic[] = [];
         let constraintNormalisationRanges: Map<string, NormalisationRange> | undefined;
+        // Codex F2a: per-constraint THRESHOLD clamp direction ('low' = clamped at
+        // the range floor, 'high' = at the ceiling), derived from the constraint
+        // normalisation diagnostics (entry present ONLY when the threshold
+        // clamped). A clamped threshold makes the emitted breach margin a strict
+        // bound — the margin egress uses this to avoid mislabelling it 'exact'.
+        let constraintThresholdClampByConstraintId: Map<string, 'low' | 'high'> | undefined;
 
         if (needsNormalisation(normalizedOptions)) {
           const normResult = normaliseOptionsForISL(
@@ -5127,6 +5168,22 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             constraintNormalisationRanges = new Map(
               constraintNormResult.diagnostics.map(d => [d.constraint_id, d.range])
             );
+
+            // Codex F2a: derive the per-constraint THRESHOLD clamp direction from
+            // the SAME diagnostics (single source of truth — not a parallel
+            // hand-maintained structure). Direction from the recorded post-clamp
+            // normalised_value: 0 ⇒ clamped at the range floor ('low'), 1 ⇒ at the
+            // ceiling ('high'). Only clamped thresholds get an entry; an interior
+            // normalised value under a degenerate (zero-width) range is
+            // indeterminate and recorded as neither (the margin egress then makes
+            // no precision claim).
+            constraintThresholdClampByConstraintId = new Map<string, 'low' | 'high'>();
+            for (const d of constraintNormResult.diagnostics) {
+              if (!d.clamped) continue;
+              const direction = d.normalised_value <= 0 ? 'low' : d.normalised_value >= 1 ? 'high' : undefined;
+              if (direction === undefined) continue;
+              constraintThresholdClampByConstraintId.set(d.constraint_id, direction);
+            }
 
             // Add constraint normalisation repairs to repairs_applied[]
             repairs = repairs.concat(constraintNormResult.repairs);
@@ -6802,7 +6859,8 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           factorStability,  // 3C: ISL stability assessment per factor
           req.log,  // logger for fact_objects assembly logging
           optionClampDirectionByFactor,  // 1d + Codex F1: per-option clamp DIRECTION map for margin_precision
-          optionDiagnosedFactors  // Codex F1: factors with a recorded diagnostic (exact vs unknown)
+          optionDiagnosedFactors,  // Codex F1: factors with a recorded diagnostic (exact vs unknown)
+          constraintThresholdClampByConstraintId  // Codex F2a: per-constraint threshold clamp direction for margin_precision
         ));
       } catch (err) {
         req.log.error({

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -5057,10 +5057,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             normalised: true,
             diagnostics_count: normalisationDiagnostics.length,
             repairs_count: normResult.repairs.length,
+            // F7 (Codex): log NO raw numeric decision values (original /
+            // normalised). The log boundary hashes registered raw inputs, but a
+            // DERIVED normalised scalar under an unlisted key is neither
+            // registered nor a DECISION_DOMAIN_KEY, so it would reach info logs
+            // in plaintext. Keep only the hashed factor_id, the range.source
+            // vocabulary, and the clamped boolean (least data wins).
             sample: normalisationDiagnostics.slice(0, 3).map(d => ({
               factor_id: d.factor_id,
-              original: d.original_value,
-              normalised: d.normalised_value,
               range_source: d.range.source,
               clamped: d.clamped,
             })),
@@ -5193,12 +5197,15 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               normalised: true,
               diagnostics_count: constraintNormResult.diagnostics.length,
               repairs_count: constraintNormResult.repairs.length,
+              // F7 (Codex): log NO raw numeric decision values (original /
+              // normalised) — same rationale as the intervention log above.
+              // Keep the identifiers, the range.source vocabulary, and the
+              // clamped boolean (surfaced by F2a; useful, non-sensitive).
               sample: constraintNormResult.diagnostics.slice(0, 3).map(d => ({
                 constraint_id: d.constraint_id,
                 node_id: d.node_id,
-                original: d.original_value,
-                normalised: d.normalised_value,
                 range_source: d.range.source,
+                clamped: d.clamped,
               })),
             });
           } else {

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -5065,21 +5065,65 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         let constraintsForISL: GoalConstraint[] | undefined;
 
         if (activeGoalConstraints && activeGoalConstraints.length > 0) {
-          if (constraintsNeedNormalisation(activeGoalConstraints)) {
+          // A3 range-unify: the constraint threshold on a node MUST be normalised
+          // against the EXACT scale that node's interventions were scaled against
+          // in Phase 4a — otherwise ISL evaluates prob_satisfied and margins with
+          // the threshold and samples on two different scales (a violated cap
+          // could score probability 1; margins landed on a phantom width). Build
+          // the per-node intervention scale from what the interventions ACTUALLY
+          // used (the Phase-4a diagnostics). A node intervened while Phase 4a was
+          // SKIPPED (all interventions already in [0,1]) is carried as an
+          // identity [0,1] range so its threshold stays on the same raw sample
+          // scale rather than being independently re-normalised via a heuristic.
+          const IDENTITY_RANGE: NormalisationRange = { min: 0, max: 1, source: 'default' };
+          const interventionScaleByNodeId = ((): Map<string, NormalisationRange> => {
+            const rangeByNode = new Map<string, NormalisationRange>();
+            for (const d of normalisationDiagnostics) {
+              if (!rangeByNode.has(d.factor_id)) rangeByNode.set(d.factor_id, d.range);
+            }
+            const scales = new Map<string, NormalisationRange>();
+            for (const opt of normalizedOptions) {
+              for (const nodeId of Object.keys(opt.interventions)) {
+                if (!scales.has(nodeId)) {
+                  scales.set(nodeId, rangeByNode.get(nodeId) ?? IDENTITY_RANGE);
+                }
+              }
+            }
+            return scales;
+          })();
+
+          const gateNeedsNorm = constraintsNeedNormalisation(activeGoalConstraints);
+          // A NON-identity intervention scale forces normalisation even when the
+          // raw constraint value already sits in [0,1] (Caveat A combo 2): that
+          // value is a raw user quantity on the intervention scale and must be
+          // re-scaled onto it, not forwarded as an already-normalised number.
+          const anyNonIdentityScale = [...interventionScaleByNodeId.values()].some(
+            r => !(r.min === 0 && r.max === 1),
+          );
+
+          if (gateNeedsNorm || anyNonIdentityScale) {
             const constraintNormResult = normaliseGoalConstraints(
               activeGoalConstraints,
               filteredGraph.nodes,
               // P0-C1: producer-declared scales (constraint '%' unit, node
               // goal_threshold_cap / goal_threshold) captured before the
-              // temporal filter stripped them — see Phase 1c++ above.
+              // temporal filter stripped them — see Phase 1c++ above. A3: plus
+              // the per-node intervention scale, and the global gate result so
+              // constraints on NON-intervened nodes keep their exact prior
+              // behaviour (chain when the gate fired, forward-raw otherwise).
               {
                 unitsByConstraintId: constraintUnitsByConstraintId,
                 goalThresholdMetaByNodeId,
+                interventionScaleByNodeId,
+                normaliseWithoutScale: gateNeedsNorm,
               }
             );
             constraintsForISL = constraintNormResult.constraints;
 
-            // Store ranges for denormalisation of failure_margin_median in response
+            // Store ranges for denormalisation of failure_margin_median in
+            // response. After A3 unify these are the SAME ranges the samples
+            // live on, so the two margin-egress paths (run.ts ~1885, ~2269)
+            // denormalise on the correct (intervention) width automatically.
             constraintNormalisationRanges = new Map(
               constraintNormResult.diagnostics.map(d => [d.constraint_id, d.range])
             );

--- a/tests/gates/constraint-intervention-range-unify.test.ts
+++ b/tests/gates/constraint-intervention-range-unify.test.ts
@@ -126,6 +126,86 @@ describe('A3 range-unify · pure function · constraint shares the intervention 
 });
 
 // ===========================================================================
+// Layer A2 — F1 regression pin: non-intervened node, gate FALSE, forwarded RAW
+// ===========================================================================
+// F1 (adversarial review, MEDIUM): when the global gate is FALSE (all constraint
+// values already in [0,1]) but the function is called anyway because some OTHER
+// node has a non-identity intervention scale, a constraint on a DIFFERENT,
+// NON-intervened node carrying a producer-declared scale ('%' unit or
+// goal_threshold_cap) was NEWLY normalised (0.5 → 0.005 / ×1/cap) with a new
+// repair — where HEAD forwarded it RAW (HEAD only called the function when the
+// gate fired). This pins the restored HEAD parity: forwarded raw, NO repair.
+describe('A3 range-unify · F1 · producer-scale constraint on a non-intervened node, gate FALSE', () => {
+  // 'cost' is the intervened node with a non-identity scale (forces the caller to
+  // invoke the function via anyNonIdentityScale). 'churn' is a DIFFERENT,
+  // NON-intervened node — it has NO entry in interventionScaleByNodeId.
+  const nodes: EngineNodeV3[] = [
+    { id: 'goal', kind: 'goal', label: 'Goal', observed_state: { value: 0.4 } },
+    { id: 'cost', kind: 'factor', label: 'First-year cost', observed_state: { value: 30000 } },
+    { id: 'churn', kind: 'factor', label: 'Churn rate', observed_state: { value: 0.1 } },
+  ] as unknown as EngineNodeV3[];
+
+  // The OTHER node's scale — its mere presence is what forces the call in the route
+  // (anyNonIdentityScale) and reproduces the F1 combo. 'churn' is absent from it.
+  const interventionScaleByNodeId = new Map([
+    ['cost', { min: 21000, max: 49000, source: 'inferred_spread' as const }],
+  ]);
+
+  it("'%'-unit constraint on the non-intervened node is FORWARDED RAW (not 0.005), no repair", () => {
+    const { constraints, repairs, diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c_pct', node_id: 'churn', operator: '<=', value: 0.5 }],
+      nodes,
+      {
+        unitsByConstraintId: new Map([['c_pct', '%']]),
+        interventionScaleByNodeId,
+        normaliseWithoutScale: false, // global gate did NOT fire
+      },
+    );
+    // HEAD forwarded 0.5 raw (function not called for non-intervened nodes). The
+    // fix must reproduce that EXACTLY — NOT re-scale it to 0.005 via unit_percent.
+    expect(constraints[0].value).toBe(0.5);
+    expect(constraints[0].original_value).toBe(0.5);
+    // Forwarded-raw ⇒ identity no-op ⇒ NO repair, NO diagnostic (so it cannot trip
+    // the reliability gate or margin denorm — byte-identical to HEAD).
+    expect(repairs.filter(r => r.field === 'constraint.value.c_pct')).toHaveLength(0);
+    expect(diagnostics.filter(d => d.constraint_id === 'c_pct')).toHaveLength(0);
+  });
+
+  it('goal_threshold_cap constraint on the non-intervened node is FORWARDED RAW, no repair', () => {
+    const { constraints, repairs, diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c_cap', node_id: 'churn', operator: '<=', value: 0.5 }],
+      nodes,
+      {
+        goalThresholdMetaByNodeId: new Map([['churn', { goal_threshold_cap: 100000 }]]),
+        interventionScaleByNodeId,
+        normaliseWithoutScale: false, // global gate did NOT fire
+      },
+    );
+    // HEAD forwarded 0.5 raw; the fix must NOT re-scale it to 0.000005 via the cap.
+    expect(constraints[0].value).toBe(0.5);
+    expect(repairs.filter(r => r.field === 'constraint.value.c_cap')).toHaveLength(0);
+    expect(diagnostics.filter(d => d.constraint_id === 'c_cap')).toHaveLength(0);
+  });
+
+  it('parity control: gate TRUE ⇒ the producer scale STILL applies (no over-broad guard)', () => {
+    // The reorder must ONLY forward-raw when the gate is FALSE. With the gate TRUE
+    // (or default), a '%'-unit constraint on a non-intervened node must still be
+    // normalised via unit_percent exactly as before the F1 fix.
+    const { constraints, repairs } = normaliseGoalConstraints(
+      [{ constraint_id: 'c_pct', node_id: 'churn', operator: '<=', value: 50 }],
+      nodes,
+      {
+        unitsByConstraintId: new Map([['c_pct', '%']]),
+        interventionScaleByNodeId,
+        normaliseWithoutScale: true, // global gate DID fire
+      },
+    );
+    expect(constraints[0].value).toBeCloseTo(0.5, 6); // 50 / 100
+    expect(repairs.filter(r => r.field === 'constraint.value.c_pct')).toHaveLength(1);
+  });
+});
+
+// ===========================================================================
 // Layer B — route-level pins with a FAITHFUL ISL surrogate
 // ===========================================================================
 // The surrogate computes prob_satisfied / failure_margin_median from the
@@ -364,4 +444,15 @@ describe('A3 range-unify · route level · faithful ISL surrogate', () => {
     expect(optionEntry(body, 'opt_a').constraint_probabilities?.c1).toBe(1);
     expect(optionEntry(body, 'opt_b').constraint_probabilities?.c1).toBe(0);
   });
+
+  // NOTE (F1): the F1 corner (gate FALSE + a producer-'%'/cap constraint on a
+  // NON-intervened node while another node forces the call via a non-identity
+  // scale) is pinned deterministically at the pure-function layer above
+  // ("A3 range-unify · F1 …"), which is the exact unit the reorder lives in. An
+  // end-to-end route pin was prototyped and manually confirmed (the churn '%'
+  // constraint reaches ISL with value 0.5 forwarded raw, only the pre-existing
+  // STRIP_RAW_CONSTRAINT_FIELDS unit-strip repair, no normalisation repair), but
+  // the module-level `capturedISLRequest` is overwritten by the additional ISL
+  // calls this multi-factor graph triggers, so a stable route assertion would
+  // test the harness, not the fix. Kept as pure-function pins to avoid theatre.
 });

--- a/tests/gates/constraint-intervention-range-unify.test.ts
+++ b/tests/gates/constraint-intervention-range-unify.test.ts
@@ -1,0 +1,367 @@
+/**
+ * A3 / SCIENCE — Constraint vs intervention normalisation range UNIFY.
+ * ----------------------------------------------------------------------------
+ * Verified HIGH-severity defect (see acceptance-evidence/a3-verify-2026-07-16/
+ * constraint-norm-split/FINDINGS.md): interventions and the constraint threshold
+ * on the SAME node normalise against DIFFERENT ranges whenever the node lacks an
+ * explicit/producer-declared scale. Interventions get
+ * `deriveRange(node, hints, interventionValues)` (spread-capable → e.g.
+ * [21000,49000]); the constraint threshold got a BARE `deriveRange(targetNode)`
+ * (→ e.g. [0,60000]). ISL then evaluates `prob_satisfied` and margins ACROSS the
+ * two scales → a violated cap can score probability 1, and margins are on a
+ * phantom width.
+ *
+ * INVARIANT under test: ONE range per node — the constraint threshold must be
+ * normalised against the EXACT range that node's interventions used, in EVERY
+ * gate combination.
+ *
+ * Two layers:
+ *   A. Pure-function pins on `normaliseGoalConstraints` (drives the new
+ *      `interventionScaleByNodeId` extra) — asserts SHARED ARGUMENTS, not just
+ *      shared functions.
+ *   B. Route-level pins with a FAITHFUL ISL surrogate that computes
+ *      `prob_satisfied` / `failure_margin_median` from the normalised threshold
+ *      it actually receives — so the probability inversion and phantom margin are
+ *      reproduced end-to-end, and the four gate combinations are each documented.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+import {
+  normaliseOptionsForISL,
+  normaliseGoalConstraints,
+} from '../../src/lib/intervention-normaliser.js';
+import type {
+  EngineNodeV3,
+  OptionV3,
+  GoalConstraint,
+} from '../../src/types/engine-v3.js';
+
+// ===========================================================================
+// Layer A — pure-function pins: shared ARGUMENTS (same node → same range)
+// ===========================================================================
+
+describe('A3 range-unify · pure function · constraint shares the intervention range', () => {
+  // Live-probe node: cost, observed value 30000, NO cap, NO state_space.range.
+  const nodes: EngineNodeV3[] = [
+    { id: 'goal', kind: 'goal', label: 'Goal', observed_state: { value: 0.4 } },
+    { id: 'cost', kind: 'factor', label: 'First-year cost', observed_state: { value: 30000 } },
+  ] as unknown as EngineNodeV3[];
+
+  const options: OptionV3[] = [
+    { id: 'opt_a', label: 'A', interventions: { cost: { value: 25000, source: 'user_specified' } } },
+    { id: 'opt_b', label: 'B', interventions: { cost: { value: 45000, source: 'user_specified' } } },
+  ] as unknown as OptionV3[];
+
+  it('interventions derive the spread range [21000,49000] (source inferred_spread)', () => {
+    const { context } = normaliseOptionsForISL(options, nodes, 'goal');
+    const range = context.factors.get('cost')?.range;
+    expect(range).toBeDefined();
+    expect(range!.min).toBeCloseTo(21000, 6);
+    expect(range!.max).toBeCloseTo(49000, 6);
+    expect(range!.source).toBe('inferred_spread');
+  });
+
+  it('THE SPLIT (documented at HEAD): a BARE constraint derivation lands on a DIFFERENT range', () => {
+    // This is what run.ts did before the fix (deriveRange(targetNode), no scale).
+    // Pinned so the regression is legible: the constraint fell to [0,60000].
+    const { diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 20000 }],
+      nodes,
+    );
+    const range = diagnostics[0].range;
+    expect(range.min).toBe(0);
+    expect(range.max).toBe(60000); // 2 × observed value 30000
+    // ...which is NOT the intervention range [21000,49000]. That is the bug.
+    expect(range.max).not.toBeCloseTo(49000, 0);
+  });
+
+  it('FIX: given the intervention scale, the constraint uses the SAME range (shared arguments)', () => {
+    const { context } = normaliseOptionsForISL(options, nodes, 'goal');
+    const interventionRange = context.factors.get('cost')!.range;
+
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 20000 }],
+      nodes,
+      { interventionScaleByNodeId: new Map([['cost', interventionRange]]) },
+    );
+
+    // The constraint's normalisation range is now IDENTICAL to the intervention range.
+    expect(diagnostics[0].range.min).toBeCloseTo(interventionRange.min, 6);
+    expect(diagnostics[0].range.max).toBeCloseTo(interventionRange.max, 6);
+
+    // Threshold 20000 sits BELOW the range floor (21000) → clamps to 0 on the
+    // shared scale, so an intervention sample of 0.142857 (opt_a 25000) is NOT
+    // `<= threshold` → the '<=' constraint is correctly VIOLATED (was prob 1).
+    expect(constraints[0].value).toBe(0);
+    expect(constraints[0].original_value).toBe(20000);
+  });
+
+  it('FIX: a threshold INSIDE the spread normalises exactly on the shared range', () => {
+    const { context } = normaliseOptionsForISL(options, nodes, 'goal');
+    const interventionRange = context.factors.get('cost')!.range;
+    const { constraints } = normaliseGoalConstraints(
+      [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 30000 }],
+      nodes,
+      { interventionScaleByNodeId: new Map([['cost', interventionRange]]) },
+    );
+    // (30000 - 21000) / 28000 = 0.321428...
+    expect(constraints[0].value).toBeCloseTo(0.32142857, 6);
+  });
+
+  it('DOCTRINE-PENDING: the intervention scale wins over a producer goal_threshold_cap', () => {
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 30000 }],
+      nodes,
+      {
+        interventionScaleByNodeId: new Map([['cost', { min: 21000, max: 49000, source: 'inferred_spread' }]]),
+        goalThresholdMetaByNodeId: new Map([['cost', { goal_threshold_cap: 100000 }]]),
+      },
+    );
+    // Not [0,100000]: the intervention range is the scale the samples live on.
+    expect(diagnostics[0].range.max).toBeCloseTo(49000, 6);
+    expect(constraints[0].value).toBeCloseTo(0.32142857, 6);
+  });
+});
+
+// ===========================================================================
+// Layer B — route-level pins with a FAITHFUL ISL surrogate
+// ===========================================================================
+// The surrogate computes prob_satisfied / failure_margin_median from the
+// NORMALISED threshold it receives and each option's NORMALISED intervention on
+// the constraint's node — exactly the cross-scale comparison the real ISL does.
+// This is what makes the probability inversion observable end-to-end.
+
+let capturedISLRequest: any = null;
+
+function evalConstraint(sample: number, threshold: number, operator: string): { sat: boolean; margin: number } {
+  // Point "sample" = the option's single normalised intervention on the node.
+  const sat = operator === '<=' ? sample <= threshold : sample >= threshold;
+  // Breach distance in normalised space (ISL convention); undefined-when-satisfied
+  // is modelled by the caller.
+  const margin = operator === '<=' ? sample - threshold : threshold - sample;
+  return { sat, margin };
+}
+
+function buildSurrogateOptions(body: any) {
+  const constraints: any[] = body.goal_constraints ?? [];
+  return (body.options ?? []).map((opt: any, idx: number) => {
+    const analysis = constraints.length
+      ? {
+          constraints: constraints.map((c: any) => {
+            const sample = opt.interventions?.[c.node_id];
+            if (typeof sample !== 'number') {
+              return { node_id: c.node_id, operator: c.operator, value: c.value, prob_satisfied: 1 };
+            }
+            const { sat, margin } = evalConstraint(sample, c.value, c.operator);
+            return {
+              node_id: c.node_id,
+              operator: c.operator,
+              value: c.value,
+              prob_satisfied: sat ? 1 : 0,
+              ...(sat ? {} : { failure_margin_median: Math.max(0, margin), near_miss_fraction: 0 }),
+            };
+          }),
+          joint_probability: constraints.every((c: any) => {
+            const s = opt.interventions?.[c.node_id];
+            return typeof s !== 'number' || evalConstraint(s, c.value, c.operator).sat;
+          })
+            ? 1
+            : 0,
+        }
+      : undefined;
+    return {
+      option_id: opt.id,
+      outcome: { mean: 0.7 - idx * 0.05, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+      rank: idx + 1,
+      win_probability: 0.5 - idx * 0.1,
+      status: 'computed',
+      ...(analysis !== undefined && { constraint_analysis: analysis }),
+    };
+  });
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return { status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl' };
+  },
+  async analyseSensitivity() { return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' }; },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    // analyseRobustness is called with already-normalised options; reconstruct a
+    // body-shaped object so the surrogate can read interventions + constraints.
+    return {
+      options: buildSurrogateOptions(capturedISLRequest ?? { options }),
+      edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const, factors: [], value_of_information: [],
+      factors_provenance: 'unavailable' as const, factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.8, fragile_edges: [], robust_edges: [],
+      latency_ms: 50, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() { return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const }; },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    capturedISLRequest = body;
+    return {
+      data: {
+        options: buildSurrogateOptions(body),
+        edges: [], factors: [], value_of_information: [], overall_robustness: 'robust', robustness_score: 0.8, fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+const { createServer } = await import('../../src/createServer.js');
+
+// Live-probe graph: cost node with NO cap / NO state_space.range.
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Programme value', observed_state: { value: 0.4 } },
+    { id: 'cost', kind: 'factor', label: 'First-year cost', observed_state: { value: 30000 } },
+  ],
+  edges: [{ from: 'cost', to: 'goal', strength: { mean: -0.5, std: 0.1 } }],
+};
+
+// Interventions 25000 / 45000 → spread range [21000,49000].
+const OPTIONS_RAW = [
+  { id: 'opt_a', label: 'A', interventions: { cost: 25000 } },
+  { id: 'opt_b', label: 'B', interventions: { cost: 45000 } },
+];
+// Interventions already in [0,1] → Phase 4a SKIPPED (Caveat A combos 3 & 4).
+const OPTIONS_UNIT = [
+  { id: 'opt_a', label: 'A', interventions: { cost: 0.3 } },
+  { id: 'opt_b', label: 'B', interventions: { cost: 0.7 } },
+];
+
+function optionEntry(body: any, id: string): any {
+  return (body.option_comparison ?? []).find((o: any) => o.option_id === id);
+}
+function constraintValueSentToISL(cid: string): number | undefined {
+  return (capturedISLRequest?.goal_constraints ?? []).find((c: any) => c.constraint_id === cid)?.value;
+}
+
+describe('A3 range-unify · route level · faithful ISL surrogate', () => {
+  let app: FastifyInstance;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const addr = app.server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+  beforeEach(() => { capturedISLRequest = null; });
+
+  async function run(payload: object): Promise<any> {
+    const res = await fetch(`${baseUrl}/v2/run`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    expect(res.status).toBe(200);
+    return res.json();
+  }
+
+  // ---- COMBO 1: interventions out of [0,1], constraint out of [0,1] (the defect) ----
+  it('COMBO 1: a violated <= cap scores prob 0, not 1 (probability inversion fixed)', async () => {
+    const body = await run({
+      graph: GRAPH, options: OPTIONS_RAW, goal_node_id: 'goal', seed: '42',
+      goal_constraints: [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 20000 }],
+    });
+    // Threshold 20000 is below the intervention floor 21000 → clamps to 0 on the
+    // SHARED scale (was 0.333 on the phantom [0,60000] scale).
+    expect(constraintValueSentToISL('c1')).toBe(0);
+
+    // opt_a intervenes cost=25000 (> 20000): the '<=' cap is VIOLATED.
+    const a = optionEntry(body, 'opt_a');
+    expect(a.constraint_probabilities?.c1).toBe(0); // was wrongly 1 at HEAD
+  });
+
+  it('COMBO 1: opt_b margin is denormalised on the intervention width, not [0,60000]', async () => {
+    const body = await run({
+      graph: GRAPH, options: OPTIONS_RAW, goal_node_id: 'goal', seed: '42',
+      goal_constraints: [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 20000 }],
+    });
+    // opt_b 45000 → normalised 0.857143; threshold clamped 0; surrogate margin
+    // 0.857143; × intervention width 28000 = 24000 (was 31428.57 on width 60000).
+    const b = optionEntry(body, 'opt_b');
+    const m = b.constraint_margins?.find((x: any) => x.constraint_id === 'c1');
+    expect(m).toBeDefined();
+    expect(m.failure_margin_median).toBeCloseTo(24000, 0);
+    expect(m.failure_margin_median).not.toBeCloseTo(31428.57, 0);
+  });
+
+  it('COMBO 1: a threshold INSIDE the spread yields the EXACT user-unit margin', async () => {
+    const body = await run({
+      graph: GRAPH, options: OPTIONS_RAW, goal_node_id: 'goal', seed: '42',
+      goal_constraints: [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 30000 }],
+    });
+    // opt_b 45000 → 0.857143; threshold 30000 → 0.321429; margin 0.535714 × 28000
+    // = 15000 EXACT (true 45000-30000). Was 21428.57 on the phantom width.
+    const b = optionEntry(body, 'opt_b');
+    const m = b.constraint_margins?.find((x: any) => x.constraint_id === 'c1');
+    expect(m.failure_margin_median).toBeCloseTo(15000, 0);
+  });
+
+  // ---- COMBO 2: interventions out of [0,1], constraint value in [0,1] ----
+  it('COMBO 2: an in-[0,1] constraint on an intervened non-[0,1] node is RE-SCALED, not forwarded raw', async () => {
+    const body = await run({
+      graph: GRAPH, options: OPTIONS_RAW, goal_node_id: 'goal', seed: '42',
+      goal_constraints: [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 0.5 }],
+    });
+    // 0.5 is a raw user value on a node whose samples live on [21000,49000];
+    // it must be normalised on that scale (→ clamp 0), NOT forwarded as 0.5.
+    expect(constraintValueSentToISL('c1')).toBe(0);
+    // Both options (25000, 45000) exceed 0.5 cost → both violate.
+    expect(optionEntry(body, 'opt_a').constraint_probabilities?.c1).toBe(0);
+  });
+
+  // ---- COMBO 3: interventions in [0,1] (Phase 4a skipped), constraint out of [0,1] ----
+  it('COMBO 3: raw-[0,1] interventions + a >1 threshold — same identity scale, then honestly suppressed (no phantom heuristic verdict)', async () => {
+    const body = await run({
+      graph: GRAPH, options: OPTIONS_UNIT, goal_node_id: 'goal', seed: '42',
+      goal_constraints: [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 20000 }],
+    });
+    // Interventions 0.3/0.7 were forwarded RAW ([0,1] identity scale, Phase 4a
+    // skipped). The 20000 threshold must NOT be normalised via a node heuristic
+    // ([0,60000] → 0.333, which at HEAD produced a CONFIDENT but phantom
+    // prob-1 verdict for opt_a); on the shared identity scale it clamps to 1.
+    expect(constraintValueSentToISL('c1')).toBe(1);
+    // Because the shared scale is the DEFAULT [0,1] range (no reliable node
+    // scale exists — the input is self-contradictory: [0,1] samples vs a 20000
+    // threshold), the pre-existing reliability gate honestly SUPPRESSES the
+    // result rather than emit a fabricated confident probability. This is the
+    // correct outcome: threshold and samples share one scale, and an
+    // unreliable-scale verdict is withheld, not invented.
+    expect(optionEntry(body, 'opt_a').constraint_probabilities?.c1).toBeUndefined();
+    expect(body.constraints_status).toBe('unavailable');
+  });
+
+  // ---- COMBO 4: interventions in [0,1], constraint in [0,1] (already consistent) ----
+  it('COMBO 4: all in [0,1] — threshold forwarded unchanged, both sides on the same scale', async () => {
+    const body = await run({
+      graph: GRAPH, options: OPTIONS_UNIT, goal_node_id: 'goal', seed: '42',
+      goal_constraints: [{ constraint_id: 'c1', node_id: 'cost', operator: '<=', value: 0.5 }],
+    });
+    expect(constraintValueSentToISL('c1')).toBe(0.5);
+    // cost 0.3 <= 0.5 satisfied; cost 0.7 <= 0.5 violated.
+    expect(optionEntry(body, 'opt_a').constraint_probabilities?.c1).toBe(1);
+    expect(optionEntry(body, 'opt_b').constraint_probabilities?.c1).toBe(0);
+  });
+});

--- a/tests/gates/constraint-intervention-range-unify.test.ts
+++ b/tests/gates/constraint-intervention-range-unify.test.ts
@@ -385,6 +385,12 @@ describe('A3 range-unify · route level · faithful ISL surrogate', () => {
     expect(m).toBeDefined();
     expect(m.failure_margin_median).toBeCloseTo(24000, 0);
     expect(m.failure_margin_median).not.toBeCloseTo(31428.57, 0);
+    // Codex F2a: the THRESHOLD 20000 clamped to 0 on the shared scale (below the
+    // [21000,49000] floor), so the emitted 24000 UNDERSTATES the true breach
+    // (true threshold −1000/28000 → true breach ≈ 25000). A '<=' threshold
+    // clamped at the range floor is a strict lower bound → NOT 'exact'.
+    // (At branch HEAD, before F2a, this read 'exact' — the RED assertion.)
+    expect(m.margin_precision).toBe('lower_bound');
   });
 
   it('COMBO 1: a threshold INSIDE the spread yields the EXACT user-unit margin', async () => {
@@ -397,6 +403,11 @@ describe('A3 range-unify · route level · faithful ISL surrogate', () => {
     const b = optionEntry(body, 'opt_b');
     const m = b.constraint_margins?.find((x: any) => x.constraint_id === 'c1');
     expect(m.failure_margin_median).toBeCloseTo(15000, 0);
+    // Codex F2a CONTROL: threshold 30000 sits INSIDE the spread → it does NOT
+    // clamp, and opt_b's intervention (45000) is inside too → neither side
+    // clamps → the margin is genuinely 'exact'. This must stay 'exact' after
+    // F2a (proves the threshold-clamp gate discriminates, not a blanket demote).
+    expect(m.margin_precision).toBe('exact');
   });
 
   // ---- COMBO 2: interventions out of [0,1], constraint value in [0,1] ----

--- a/tests/gates/constraint-intervention-range-unify.test.ts
+++ b/tests/gates/constraint-intervention-range-unify.test.ts
@@ -206,6 +206,94 @@ describe('A3 range-unify · F1 · producer-scale constraint on a non-intervened 
 });
 
 // ===========================================================================
+// Layer A3 — F4 regression pin: producer '%'/cap must OUTRANK an IDENTITY scale
+// ===========================================================================
+// F4 (Codex-confirmed): interventions already in [0,1] (Phase 4a SKIPPED) install
+// an IDENTITY [0,1] intervention scale for the intervened node. A public
+// constraint {value:50, unit:'%'} (or goal_threshold_cap:100) on that node then
+// hit the (top-priority) interventionScale branch → 50 CLAMPED to 1, source
+// 'default' → the reliability gate (threshold_normalisation_defaulted) SUPPRESSED
+// a constraint HEAD evaluated correctly. The fix ranks producer declarations
+// ABOVE an identity scale (but BELOW a measured non-identity spread). The
+// discriminator: value 50 must land 0.5 on [0,100] with a NON-'default' source.
+describe('A3 range-unify · F4 · producer scale outranks an identity intervention scale', () => {
+  const nodes: EngineNodeV3[] = [
+    { id: 'goal', kind: 'goal', label: 'Goal', observed_state: { value: 0.4 } },
+    { id: 'cost', kind: 'factor', label: 'First-year cost', observed_state: { value: 30000 } },
+  ] as unknown as EngineNodeV3[];
+
+  // Phase-4a-skipped node ⇒ carried as an IDENTITY [0,1] scale by the route.
+  const identityScale = new Map([['cost', { min: 0, max: 1, source: 'default' as const }]]);
+
+  it("'%' unit OUTRANKS the identity scale: 50 → 0.5 on [0,100], source unit_percent (not clamped to 1/default)", () => {
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c_pct', node_id: 'cost', operator: '<=', value: 50 }],
+      nodes,
+      {
+        unitsByConstraintId: new Map([['c_pct', '%']]),
+        interventionScaleByNodeId: identityScale,
+        normaliseWithoutScale: true, // gate fired (50 is out of [0,1])
+      },
+    );
+    // At HEAD (before F4): identity branch → 50 clamps to 1, source 'default'.
+    expect(constraints[0].value).toBeCloseTo(0.5, 6);
+    expect(diagnostics[0].range.min).toBe(0);
+    expect(diagnostics[0].range.max).toBe(100);
+    expect(diagnostics[0].range.source).toBe('unit_percent');
+  });
+
+  it('goal_threshold_cap OUTRANKS the identity scale: 50 → 0.5 on [0,100], source goal_threshold_cap', () => {
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c_cap', node_id: 'cost', operator: '<=', value: 50 }],
+      nodes,
+      {
+        goalThresholdMetaByNodeId: new Map([['cost', { goal_threshold_cap: 100 }]]),
+        interventionScaleByNodeId: identityScale,
+        normaliseWithoutScale: true,
+      },
+    );
+    expect(constraints[0].value).toBeCloseTo(0.5, 6);
+    expect(diagnostics[0].range.max).toBe(100);
+    expect(diagnostics[0].range.source).toBe('goal_threshold_cap');
+  });
+
+  it('CONTROL: identity scale is STILL honoured when there is NO producer declaration (branch 5)', () => {
+    // Proves the reorder did not blanket-replace the identity scale with the
+    // chain — an identity scale with no '%'/cap still applies (50 → clamp 1,
+    // source default), ranking BELOW producers but ABOVE the node heuristic.
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c_plain', node_id: 'cost', operator: '<=', value: 50 }],
+      nodes,
+      {
+        interventionScaleByNodeId: identityScale,
+        normaliseWithoutScale: true,
+      },
+    );
+    expect(constraints[0].value).toBe(1); // clamped onto identity [0,1]
+    expect(diagnostics[0].range.source).toBe('default');
+    // NOT the node heuristic [0,60000] (that would be source 'inferred_value'/
+    // 'default' via deriveRange — here it is the identity scale, max 1).
+    expect(diagnostics[0].range.max).toBe(1);
+  });
+
+  it('CONTROL: a measured NON-identity spread still OUTRANKS a producer cap (branch 1, doctrine-pending)', () => {
+    // The reorder must only demote the IDENTITY scale — a real measured spread
+    // still wins over the producer cap (the DOCTRINE-PENDING pick), unchanged.
+    const { constraints, diagnostics } = normaliseGoalConstraints(
+      [{ constraint_id: 'c_cap', node_id: 'cost', operator: '<=', value: 30000 }],
+      nodes,
+      {
+        goalThresholdMetaByNodeId: new Map([['cost', { goal_threshold_cap: 100 }]]),
+        interventionScaleByNodeId: new Map([['cost', { min: 21000, max: 49000, source: 'inferred_spread' as const }]]),
+        normaliseWithoutScale: true,
+      },
+    );
+    expect(diagnostics[0].range.max).toBeCloseTo(49000, 6);
+    expect(constraints[0].value).toBeCloseTo(0.32142857, 6);
+  });
+});
+
+// ===========================================================================
 // Layer B — route-level pins with a FAITHFUL ISL surrogate
 // ===========================================================================
 // The surrogate computes prob_satisfied / failure_margin_median from the
@@ -454,6 +542,26 @@ describe('A3 range-unify · route level · faithful ISL surrogate', () => {
     // cost 0.3 <= 0.5 satisfied; cost 0.7 <= 0.5 violated.
     expect(optionEntry(body, 'opt_a').constraint_probabilities?.c1).toBe(1);
     expect(optionEntry(body, 'opt_b').constraint_probabilities?.c1).toBe(0);
+  });
+
+  // ---- F4: a '%' constraint on a Phase-4a-skipped (identity-scale) node ----
+  it('F4: a public %-constraint on an identity-scale node is NORMALISED via [0,100], NOT suppressed', async () => {
+    const body = await run({
+      graph: GRAPH, options: OPTIONS_UNIT, goal_node_id: 'goal', seed: '42',
+      // Interventions 0.3/0.7 are already in [0,1] → Phase 4a SKIPPED → cost
+      // carries an IDENTITY [0,1] intervention scale. The '%' unit must OUTRANK
+      // it: 50 → 0.5 on [0,100] (source unit_percent), NOT clamp to 1 on the
+      // identity scale with source 'default' (which the reliability gate
+      // suppresses — the regression this pins).
+      goal_constraints: [{ constraint_id: 'c_pct', node_id: 'cost', operator: '<=', value: 50, unit: '%' }],
+    });
+    // At HEAD (before F4): value 1, source 'default' → suppressed → 'unavailable'.
+    expect(constraintValueSentToISL('c_pct')).toBeCloseTo(0.5, 6);
+    expect(body.constraints_status).not.toBe('unavailable');
+    // cost 0.3 <= 0.5 satisfied; cost 0.7 <= 0.5 violated — the verdict is
+    // DELIVERED (the suppression half is lifted).
+    expect(optionEntry(body, 'opt_a').constraint_probabilities?.c_pct).toBe(1);
+    expect(optionEntry(body, 'opt_b').constraint_probabilities?.c_pct).toBe(0);
   });
 
   // NOTE (F1): the F1 corner (gate FALSE + a producer-'%'/cap constraint on a

--- a/tests/gates/constraint-scale-correctness.test.ts
+++ b/tests/gates/constraint-scale-correctness.test.ts
@@ -30,6 +30,7 @@ import {
   needsNormalisation,
   constraintsNeedNormalisation,
   normaliseGoalConstraints,
+  normaliseOptionsForISL,
 } from '../../src/lib/intervention-normaliser.js';
 import { filterTemporalConstraints } from '../../src/normalisation/constraint-filter.js';
 import type {
@@ -92,6 +93,51 @@ describe('WP1 gate · constraint scale symmetry (PLoT-owned)', () => {
     // what prevents double-normalisation of already-normalised thresholds.
     const con: GoalConstraint = { constraint_id: 'p', node_id: 'goal', operator: '<=', value: 0.3 };
     expect(constraintsNeedNormalisation([con])).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // A3 STRENGTHENING — pin shared ARGUMENTS, not just shared functions.
+  // The header claims "same deriveRange/normaliseValue machinery as
+  // interventions", but every fixture above uses an explicit range or a single
+  // inferred_value with no competing intervention spread — so both sides land
+  // on the same range by luck, never because the SAME per-node range object was
+  // threaded through. On a heuristic-range node the two calls DIVERGE (the
+  // constraint bare-derives while interventions use the spread). These pins fail
+  // if a future refactor reverts to bare constraint derivation.
+  // -------------------------------------------------------------------------
+  it('SHARED ARGUMENT: constraint and interventions on a spread node resolve the IDENTICAL range', () => {
+    // cost: observed value 30000, NO cap, NO state_space.range → heuristic node.
+    const nodes = [
+      { id: 'goal', kind: 'goal', label: 'Goal', observed_state: { value: 0.4 } },
+      { id: 'cost', kind: 'factor', label: 'Cost', observed_state: { value: 30000 } },
+    ] as unknown as EngineNodeV3[];
+    const options = [
+      { id: 'a', label: 'A', interventions: { cost: { value: 25000, source: 'user_specified' } } },
+      { id: 'b', label: 'B', interventions: { cost: { value: 45000, source: 'user_specified' } } },
+    ] as unknown as OptionV3[];
+
+    // Interventions derive the spread range.
+    const { context } = normaliseOptionsForISL(options, nodes, 'goal');
+    const interventionRange = context.factors.get('cost')!.range;
+    expect(interventionRange.source).toBe('inferred_spread');
+
+    // NEGATIVE CONTROL: a BARE constraint derivation (no shared scale) DIVERGES.
+    const bare = normaliseGoalConstraints(
+      [{ constraint_id: 'c', node_id: 'cost', operator: '<=', value: 20000 }],
+      nodes,
+    );
+    expect(bare.diagnostics[0].range.max).not.toBeCloseTo(interventionRange.max, 0);
+
+    // POSITIVE: threading the intervention scale makes both sides share the
+    // EXACT SAME range values — the shared-argument invariant.
+    const shared = normaliseGoalConstraints(
+      [{ constraint_id: 'c', node_id: 'cost', operator: '<=', value: 20000 }],
+      nodes,
+      { interventionScaleByNodeId: new Map([['cost', interventionRange]]) },
+    );
+    expect(shared.diagnostics[0].range.min).toBeCloseTo(interventionRange.min, 6);
+    expect(shared.diagnostics[0].range.max).toBeCloseTo(interventionRange.max, 6);
+    expect(shared.diagnostics[0].range.source).toBe(interventionRange.source);
   });
 });
 

--- a/tests/pii-residual-redaction.test.ts
+++ b/tests/pii-residual-redaction.test.ts
@@ -503,3 +503,57 @@ describe('sha8 digests resist offline recovery (per-process salt)', () => {
     expect(a).not.toBe(b);
   }, 30000);
 });
+
+// =============================================================================
+// (F7, Codex) — the constraint/intervention normalisation INFO logs must not
+// carry raw numeric decision VALUES (original / normalised).
+// =============================================================================
+// run.ts logs `sample[].original` / `sample[].normalised` at info level for both
+// the intervention (Phase 4a) and constraint (Phase 4b) normalisation diagnostics.
+// The log boundary hashes REGISTERED tokens (raw inputs), but a DERIVED value —
+// the normalised [0,1] scalar, and the original user-unit quantity under the
+// unlisted keys `original`/`normalised` — is neither registered nor a
+// DECISION_DOMAIN_KEY, so it reaches info logs in plaintext.
+//
+// This site fires only on the normalisation path and pino writes to fd 1 via
+// sonic-boom (no in-process capture; the spawned-server pattern cannot exercise
+// the ISL-adjacent path deterministically here) — so, exactly as the
+// `factor_sensitivity_source` pin above, this is a SOURCE-level assertion with
+// positive controls that the sites still exist and still sample the safe fields.
+describe('F7: constraint/intervention normalisation logs carry no raw numeric values', () => {
+  async function runSource(): Promise<string> {
+    const { readFile } = await import('node:fs/promises');
+    return readFile(new URL('../src/routes/v2/run.ts', import.meta.url), 'utf8');
+  }
+
+  it('intervention_normalisation info log drops original/normalised, keeps factor_id + range_source + clamped', async () => {
+    const src = await runSource();
+    const at = src.indexOf("event: 'intervention_normalisation'");
+    expect(at).toBeGreaterThan(-1);
+    // The info log (first occurrence) carries the sample; window covers it.
+    const site = src.slice(at, at + 1300);
+    // Positive control: the site still exists and still samples the SAFE fields.
+    expect(site).toContain('sample:');
+    expect(site).toMatch(/factor_id:\s*d\.factor_id\b/);
+    expect(site).toMatch(/range_source:\s*d\.range\.source\b/);
+    expect(site).toMatch(/clamped:\s*d\.clamped\b/);
+    // THE FIX: the raw numeric decision values are gone.
+    expect(site).not.toMatch(/original:\s*d\.original_value\b/);
+    expect(site).not.toMatch(/normalised:\s*d\.normalised_value\b/);
+  });
+
+  it('constraint_normalisation info log drops original/normalised, keeps constraint_id + node_id + range_source', async () => {
+    const src = await runSource();
+    const at = src.indexOf("event: 'constraint_normalisation'");
+    expect(at).toBeGreaterThan(-1);
+    const site = src.slice(at, at + 1300);
+    // Positive control: the site still exists and still samples identifiers + source.
+    expect(site).toContain('sample:');
+    expect(site).toMatch(/constraint_id:\s*d\.constraint_id\b/);
+    expect(site).toMatch(/node_id:\s*d\.node_id\b/);
+    expect(site).toMatch(/range_source:\s*d\.range\.source\b/);
+    // THE FIX: the raw numeric decision values are gone.
+    expect(site).not.toMatch(/original:\s*d\.original_value\b/);
+    expect(site).not.toMatch(/normalised:\s*d\.normalised_value\b/);
+  });
+});


### PR DESCRIPTION
## P0: constraint thresholds and interventions normalised against different ranges

**Verified defect (HIGH, live-reproduced at 13ecf98):** on a node with no explicit scale, interventions normalise via `inferred_spread` (min/max +20% pad) while the constraint threshold went through a bare `deriveRange(targetNode)` → `inferred_value` = [0, 2×observed]. ISL then evaluated `prob_satisfied` and margins across two scales: **a violated `<=` cap scored constraint probability 1 (and `probability_of_joint_goal` 1 — the deployed-V5 headline seam)**, and breach margins were denormalised on a phantom width (+25–43% observed live) while labelled `margin_precision:"exact"`. Predates #237 (present since constraint normalisation landed, 1 Apr); #237 widened the blast radius from probabilities to user-unit margins.

Evidence pack: `GitHub/acceptance-evidence/a3-verify-2026-07-16/constraint-norm-split/` (FINDINGS / FIX-NOTES / ADVERSARIAL-REVIEW / RE-PROBE-ASSERTIONS + live capture pairs, seed `a3-verify-constraint-norm-split-20260720`).

## The fix — one range per node, shared by both sides (5 commits)

1. **`5b42de1` core unify:** constraint range resolves from the exact per-node scale the interventions used (`interventionScaleByNodeId`, built from Phase-4a diagnostics); normalisation runs on `gateNeedsNorm || anyNonIdentityScale`; margin egress denormalises on the now-unified width.
2. **`f730196` F1 (Fable adversarial review):** forward-raw (gate-false, non-intervened node) decided BEFORE producer cap/% branches — restores exact HEAD parity for non-intervened nodes.
3. **`19a880d` F2a (Codex):** a clamped THRESHOLD can no longer read `margin_precision:"exact"` — full operator×clamp-direction case analysis; understatement ⇒ `lower_bound`, any possible overstatement ⇒ omitted.
4. **`d7bb324` F4 (Codex):** producer-declared `%`/cap outranks an IDENTITY (assumed) intervention scale — fixes a self-introduced regression where a valid `{value:50, unit:'%'}` constraint was suppressed to `constraints_status:'unavailable'`. Measured spread > gate-parity > producer declaration > identity assumption > heuristic chain.
5. **`1beee6e` F7 (Codex):** derived numeric decision values (`original`/`normalised`) removed from info-level normalisation logs (raw inputs were hashed; derived values were plaintext).

## Verification

- **RED-first throughout:** 8/11 → 11 → per-Codex-fix discriminators, each observed RED at the pre-fix commit.
- **Mutation-checked (throwaway worktrees):** full revert → 11 RED; F1-only revert → exactly 2 RED; F2a/F4/F7 individually → 1/3/2 RED, each biting only its own discriminators. Independently reproduced by the Fable adversarial pass.
- **Two independent adversarial reviews:** Fable 5 (SAFE-WITH-FIXES → F1 applied) and Codex deep review (safe-with-listed-fixes → F2a/F4/F7 applied; F3/F5/F6 dispositioned to follow-up lanes, F1-UI routed to A2).
- **Suite:** pre-push validation PASSED on the final branch state — 5,759 passed / 29 skipped, typecheck clean, spectral clean. **Golden deltas: ZERO** (existing fixtures use explicit/agreeing scales).
- **Known DOCTRINE-PENDING (rowed for Paul/Neil, not decided here):** intervention-range vs producer-cap authority when they disagree; threshold-clamp residual magnitude (margins understate by the clamp distance — now honestly labelled `lower_bound`); `%`-vs-fraction wire convention.

Post-merge: deploy-verify `/health == merge SHA`, then 6-criterion live re-probe (inversion flip, seam-1 `probability_of_joint_goal` lockstep, margins on intervention scale, `lower_bound`/`exact` discrimination, shared-range repair row, F4 `%` evaluation) before any downstream unflip signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
