### PR TITLE
fix(robustness): omit fragile-edge sp/severity/visible when ISL omits switch_probability (absent≠0)

### DIFF
--- a/src/integrations/isl/adapters/robustness-analysis.ts
+++ b/src/integrations/isl/adapters/robustness-analysis.ts
@@ -62,7 +62,12 @@ function normalizeFragileEdge(edge: ISLFragileEdgeInfo): NormalizedEdgeInfo {
     edge_id: edge.edge_id,
     from_id: edge.from_id ?? parsed.from,
     to_id: edge.to_id ?? parsed.to,
-    switch_probability: edge.switch_probability ?? 0,
+    // switch_probability: emit ONLY when ISL provides a finite value. Absent ≠ 0
+    // — a fabricated 0 fabricates BOTH severity ('warning') and the doctrine-013
+    // `visible` flag (false) downstream. Omit honestly when ISL omits it.
+    ...(typeof edge.switch_probability === 'number' && Number.isFinite(edge.switch_probability)
+      ? { switch_probability: edge.switch_probability }
+      : {}),
     // Passthrough marginal_switch_probability from ISL (optional field)
     ...(edge.marginal_switch_probability !== undefined
       ? { marginal_switch_probability: edge.marginal_switch_probability }
@@ -110,11 +115,13 @@ export function normalizeFragileEdges(
       // String format (legacy fallback)
       if (typeof edge === 'string') {
         const parsed = parseEdgeId(edge);
+        // Legacy STRING fragile edges carry NO switch_probability data — omit it
+        // (honest) rather than fabricate 0, which would fabricate severity
+        // ('warning') and the doctrine-013 `visible` flag (false) downstream.
         result.edges.push({
           edge_id: edge,
           from_id: parsed.from,
           to_id: parsed.to,
-          switch_probability: 0,
         });
         continue;
       }

--- a/src/integrations/isl/types/plot-types.ts
+++ b/src/integrations/isl/types/plot-types.ts
@@ -159,8 +159,13 @@ export interface NormalizedEdgeInfo {
   from_id: string;
   /** Target node ID */
   to_id: string;
-  /** Probability this edge causes recommendation to switch (0=fragile, 1=robust) */
-  switch_probability: number;
+  /**
+   * Probability this edge causes recommendation to switch (0=fragile, 1=robust).
+   * OPTIONAL: omitted when the source (ISL fragile edge, or a legacy string edge)
+   * carries no switch_probability — absent ≠ 0 (a fabricated 0 fabricates both
+   * severity and the doctrine-013 `visible` flag downstream).
+   */
+  switch_probability?: number;
   /** Marginal probability of recommendation switch for this edge */
   marginal_switch_probability?: number;
   /** Option that would win if this edge changes (from ISL) */

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -2677,8 +2677,12 @@ function buildResponse(
       // from_label and to_label from graph lookup, fall back to node ID if not found
       from_label: nodeLabelMap.get(edge.from_id) ?? edge.from_id,
       to_label: nodeLabelMap.get(edge.to_id) ?? edge.to_id,
-      // Severity classification from switch_probability (B1)
-      severity: classifyEdgeSeverity(edge.switch_probability),
+      // Severity classification from switch_probability (B1). Emitted ONLY when
+      // switch_probability is finite — omitted (spread-out) when absent/non-finite,
+      // exactly like the `visible` gate below (honesty: absent ≠ 'warning').
+      ...(classifyEdgeSeverity(edge.switch_probability) !== undefined && {
+        severity: classifyEdgeSeverity(edge.switch_probability),
+      }),
       // Doctrine 013 — producer-DISCLOSED visibility gate over switch_probability
       // (> 0.15). PLoT emits the flag but does NOT filter the array (the UI
       // decides render). Omitted when switch_probability is non-finite (honesty).

--- a/src/trust/edge-severity.ts
+++ b/src/trust/edge-severity.ts
@@ -9,9 +9,19 @@ export type EdgeSeverity = 'critical' | 'error' | 'warning';
  * Classify fragile edge severity from switch_probability.
  * - switch_probability > 0.7 → 'critical'
  * - switch_probability > 0.5 → 'error'
- * - switch_probability ≤ 0.5 → 'warning'
+ * - 0 ≤ switch_probability ≤ 0.5 → 'warning'
+ *
+ * Returns `undefined` (field omitted by the caller) when switch_probability is
+ * absent or non-finite — distinct from 'warning', which is a real low-but-present
+ * measurement. Mirrors `deriveFragileEdgeVisible`'s absent-handling so an sp-less
+ * fragile edge emits NEITHER severity NOR visible (honesty: absent ≠ 'warning').
  */
-export function classifyEdgeSeverity(switchProbability: number): EdgeSeverity {
+export function classifyEdgeSeverity(
+  switchProbability: number | null | undefined,
+): EdgeSeverity | undefined {
+  if (typeof switchProbability !== 'number' || !Number.isFinite(switchProbability)) {
+    return undefined;
+  }
   if (switchProbability > 0.7) return 'critical';
   if (switchProbability > 0.5) return 'error';
   return 'warning';
@@ -35,16 +45,14 @@ export const FRAGILE_EDGE_VISIBLE_MIN = 0.15;
  * switch_probability is absent or non-finite — distinct from `false`, which is
  * a real below-threshold measurement.
  *
- * KNOWN SEAM (rowed) — do NOT describe this field as absent-omitting
- * end-to-end. The upstream adapter (robustness-analysis.ts:65,
- * `normalizeFragileEdge`) currently defaults `switch_probability ?? 0` when ISL
- * omits it, so on the live /v2/run wire an sp-less fragile edge reaches this
- * helper as `0` and emits `visible:false` (consistent with its likewise-
- * defaulted `severity` on the same seam) — the helper's absent-omitting branch
- * is UNREACHABLE on the current wire. This is unreachable on current ISL output
- * (fragile edges always carry sp); the source `?? 0` kill is tracked
- * separately. See tests/doctrine-013-fragile-edge-visible.test.ts (the KNOWN
- * SEAM describe) for the disclosed pin.
+ * Absent-omitting is now end-to-end. The upstream adapter
+ * (robustness-analysis.ts, `normalizeFragileEdge` + the legacy-string branch)
+ * no longer defaults `switch_probability ?? 0` when ISL omits it, so an sp-less
+ * fragile edge reaches this helper as `undefined` and emits NO `visible` (and,
+ * via `classifyEdgeSeverity`, no `severity`) on the /v2/run wire. Unreachable on
+ * current ISL output (fragile edges always carry sp) ⇒ zero golden delta. See
+ * tests/doctrine-013-fragile-edge-visible.test.ts (the "SOURCE FIX (closed
+ * seam)" describe) for the end-to-end pin.
  */
 export function deriveFragileEdgeVisible(
   switchProbability: number | null | undefined,

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2351,11 +2351,17 @@ export interface NormalizedEdgeInfoV3 {
   from_label: string;
   /** Human-readable target node label (falls back to to_id if node not found) */
   to_label: string;
-  switch_probability: number;
+  /**
+   * OPTIONAL: omitted when the source edge carries no switch_probability
+   * (absent ≠ 0). When omitted, `severity` and `visible` are omitted too.
+   */
+  switch_probability?: number;
   /**
    * Severity classification derived from switch_probability.
-   * Thresholds: >0.7 → 'critical', >0.5 → 'error', ≤0.5 → 'warning'.
-   * Present on fragile_edges (switch_probability < 1); omitted on robust_edges.
+   * Thresholds: >0.7 → 'critical', >0.5 → 'error', 0–0.5 → 'warning'.
+   * Present on fragile_edges with a finite switch_probability; ABSENT when
+   * switch_probability is absent/non-finite (never fabricated 'warning') and on
+   * robust_edges.
    */
   severity?: 'critical' | 'error' | 'warning';
   /**

--- a/tests/b1-edge-severity.test.ts
+++ b/tests/b1-edge-severity.test.ts
@@ -43,4 +43,15 @@ describe('classifyEdgeSeverity', () => {
   it('boundary: 0.5 → warning (> 0.5, not ≥)', () => {
     expect(classifyEdgeSeverity(0.5)).toBe('warning');
   });
+
+  // Absent / non-finite → undefined (field omitted, not fabricated 'warning').
+  // Mirrors deriveFragileEdgeVisible: absent ≠ a real low measurement.
+  it('absent / non-finite switch_probability → undefined (severity omitted)', () => {
+    expect(classifyEdgeSeverity(undefined)).toBeUndefined();
+    expect(classifyEdgeSeverity(null)).toBeUndefined();
+    expect(classifyEdgeSeverity(NaN)).toBeUndefined();
+    expect(classifyEdgeSeverity(Infinity)).toBeUndefined();
+    expect(classifyEdgeSeverity(-Infinity)).toBeUndefined();
+  });
 });
+

--- a/tests/cil-phase0-fragile-edges.test.ts
+++ b/tests/cil-phase0-fragile-edges.test.ts
@@ -30,7 +30,6 @@ const FRAGILE_EDGE_V2_REQUIRED_KEYS = [
   'edge_id',
   'from_id',
   'to_id',
-  'switch_probability',
 ] as const;
 
 const FRAGILE_EDGE_V2_OPTIONAL_KEYS = [
@@ -38,6 +37,8 @@ const FRAGILE_EDGE_V2_OPTIONAL_KEYS = [
   'to_label',
   'alternative_winner_id',
   'alternative_winner_label',
+  // OPTIONAL: omitted for sp-less ISL edges and legacy string edges (absent ≠ 0).
+  'switch_probability',
   'marginal_switch_probability',
   'severity',
 ] as const;
@@ -52,7 +53,11 @@ function assertFragileEdgeV2Shape(edge: Record<string, unknown>, label: string):
   expect(typeof edge.edge_id, `${label}.edge_id`).toBe('string');
   expect(typeof edge.from_id, `${label}.from_id`).toBe('string');
   expect(typeof edge.to_id, `${label}.to_id`).toBe('string');
-  expect(typeof edge.switch_probability, `${label}.switch_probability`).toBe('number');
+  // switch_probability is OPTIONAL (omitted for sp-less/legacy-string edges);
+  // when present it must be a number.
+  if (edge.switch_probability !== undefined) {
+    expect(typeof edge.switch_probability, `${label}.switch_probability`).toBe('number');
+  }
 
   // edge_id must use "::" or "->" convention
   const edgeId = edge.edge_id as string;
@@ -109,17 +114,17 @@ describe('CIL Phase 0 — Task 1: fragile_edges shape consistency', () => {
       expect(result.edges).toHaveLength(2);
       expect(result.errors).toHaveLength(0);
 
-      // "::" separator
+      // "::" separator — legacy string edges carry no sp data: omitted, not 0.
       expect(result.edges[0].edge_id).toBe('price::revenue');
       expect(result.edges[0].from_id).toBe('price');
       expect(result.edges[0].to_id).toBe('revenue');
-      expect(result.edges[0].switch_probability).toBe(0);
+      expect(result.edges[0].switch_probability).toBeUndefined();
 
       // "->" separator
       expect(result.edges[1].edge_id).toBe('demand->supply');
       expect(result.edges[1].from_id).toBe('demand');
       expect(result.edges[1].to_id).toBe('supply');
-      expect(result.edges[1].switch_probability).toBe(0);
+      expect(result.edges[1].switch_probability).toBeUndefined();
     });
 
     it('returns empty array (not undefined/null) when no fragile edges', () => {
@@ -318,12 +323,12 @@ describe('CIL Phase 0 — Task 1: fragile_edges shape consistency', () => {
       const result = normalizeFragileEdges(edges, 'test-req');
       const edge = result.edges[0] as Record<string, unknown>;
 
-      // Snapshot: minimal keys
+      // Snapshot: minimal keys. String-parsed edges carry NO switch_probability
+      // (omitted — absent ≠ 0), so it is absent from the canonical minimal shape.
       expect(Object.keys(edge).sort()).toMatchInlineSnapshot(`
         [
           "edge_id",
           "from_id",
-          "switch_probability",
           "to_id",
         ]
       `);

--- a/tests/doctrine-013-fragile-edge-visible.test.ts
+++ b/tests/doctrine-013-fragile-edge-visible.test.ts
@@ -8,13 +8,13 @@
  * helper `deriveFragileEdgeVisible` OMITS the field on absent/non-finite input
  * (unit tests below). Threshold is DOCTRINE-PENDING (Neil), one const.
  *
- * KNOWN SEAM (rowed) — the absent-omitting behaviour is NOT end-to-end. The
- * upstream adapter (robustness-analysis.ts:65) defaults `switch_probability
- * ?? 0`, so on the live /v2/run wire an sp-less fragile edge emits
- * `visible:false` (its likewise-defaulted `severity` shares the seam), NOT an
- * omitted field. Pinned honestly by the "KNOWN SEAM" route describe below;
- * unreachable on current ISL output (fragile edges always carry sp); the source
- * `?? 0` kill is tracked separately.
+ * CLOSED SEAM — the absent-omitting behaviour is now end-to-end. The upstream
+ * adapter (robustness-analysis.ts, `normalizeFragileEdge` + the legacy-string
+ * branch) no longer defaults `switch_probability ?? 0`, so on the /v2/run wire
+ * an sp-less fragile edge emits NEITHER `switch_probability`, NOR `visible`, NOR
+ * `severity` — honest omission, not a fabricated 0/false/'warning'. Pinned by
+ * the "SOURCE FIX (closed seam)" route describe below; unreachable on current
+ * ISL output (fragile edges always carry sp) ⇒ zero golden delta.
  */
 
 import { describe, it, expect, beforeAll, vi } from 'vitest';
@@ -199,22 +199,18 @@ describe('013 route: visible gate lands on /v2/run robustness.fragile_edges', ()
   });
 });
 
-describe('013 KNOWN SEAM (rowed): an sp-less fragile edge fabricates visible:false via the upstream `?? 0`', () => {
-  // KNOWN SEAM (rowed): the upstream normalizer defaults switch_probability
-  // `?? 0` (robustness-analysis.ts:65), so an sp-less edge fabricates
-  // visible:false, consistent with its likewise-defaulted severity.
-  // deriveFragileEdgeVisible itself omits on absent (unit test above); the fix
-  // is the source `?? 0` kill, tracked separately. Unreachable on current ISL
-  // output (fragile edges always carry sp).
+describe('013 SOURCE FIX (closed seam): an sp-less fragile edge OMITS switch_probability, visible AND severity', () => {
+  // CLOSED SEAM: the upstream normalizer no longer defaults switch_probability
+  // `?? 0` (robustness-analysis.ts, `normalizeFragileEdge` + the legacy-string
+  // branch). An ISL fragile edge that OMITS switch_probability now reaches the
+  // /v2/run wire with switch_probability, `visible` AND `severity` ALL omitted —
+  // honest absence, not a fabricated 0 / false / 'warning'. This end-to-end pin
+  // was previously the "KNOWN SEAM (rowed)" describe that asserted the
+  // fabrication (visible:false, sp:0); the source `?? 0` kill closes it.
   //
-  // This converts the previously-circular route assertion (which read the
-  // already-defaulted wire sp and so could never SEE the fabrication) into a
-  // disclosed pin: it feeds the route an ISL fragile edge with NO
-  // switch_probability and asserts what the CURRENT wire honestly does. It
-  // PASSES today (visible:false) and would FAIL if the upstream `?? 0` were
-  // removed (visible would then be omitted) — i.e. this pin will alarm when the
-  // rowed source fix lands, at which point it must be updated to the honest
-  // absent⇒omitted expectation.
+  // Unreachable on current ISL output (fragile edges always carry sp) ⇒ ZERO
+  // golden delta; this feeds the route an sp-less ISL edge to prove the honest
+  // absent⇒omitted contract holds end-to-end.
   const SP_LESS_EDGE_ID = 'fac_dev_headcount->goal_productivity';
   let edges: any[];
   let spLess: any;
@@ -239,15 +235,15 @@ describe('013 KNOWN SEAM (rowed): an sp-less fragile edge fabricates visible:fal
     expect(spLess).toBeDefined();
   });
 
-  it('the pure helper WOULD omit visible on the absent input (the honest contract)', () => {
-    // For contrast: what an absent-omitting end-to-end path would produce.
-    expect(deriveFragileEdgeVisible(undefined)).toBeUndefined();
+  it('switch_probability is OMITTED (no `?? 0` fabrication)', () => {
+    expect(spLess.switch_probability).toBeUndefined();
   });
 
-  it('but the CURRENT wire emits visible:false (upstream `?? 0` fabrication)', () => {
-    // switch_probability was defaulted to 0 upstream, so deriveFragileEdgeVisible(0)
-    // → false and the field is EMITTED, not omitted. This is the rowed seam.
-    expect(spLess.switch_probability).toBe(0);
-    expect(spLess.visible).toBe(false);
+  it('visible is OMITTED (honest absence, not a fabricated false)', () => {
+    expect(spLess.visible).toBeUndefined();
+  });
+
+  it('severity is OMITTED (honest absence, not a fabricated warning)', () => {
+    expect(spLess.severity).toBeUndefined();
   });
 });

--- a/tests/isl-adapters.test.ts
+++ b/tests/isl-adapters.test.ts
@@ -288,7 +288,8 @@ describe('Robustness Analysis Adapter', () => {
       expect(result.edges[0].edge_id).toBe('a->b');
       expect(result.edges[0].from_id).toBe('a');
       expect(result.edges[0].to_id).toBe('b');
-      expect(result.edges[0].switch_probability).toBe(0);
+      // Legacy string edges carry no sp data — omitted, not fabricated 0.
+      expect(result.edges[0].switch_probability).toBeUndefined();
     });
 
     it('parses from_id and to_id from edge_id when missing', () => {
@@ -325,12 +326,12 @@ describe('Robustness Analysis Adapter', () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it('defaults switch_probability to 0 when missing', () => {
+    it('omits switch_probability when missing (absent ≠ 0)', () => {
       const edges = [{ edge_id: 'a->b' }];
 
       const result = normalizeFragileEdges(edges);
 
-      expect(result.edges[0].switch_probability).toBe(0);
+      expect(result.edges[0].switch_probability).toBeUndefined();
     });
   });
 

--- a/tests/robustness-analysis.test.ts
+++ b/tests/robustness-analysis.test.ts
@@ -129,7 +129,9 @@ describe('Edge Normalization in adaptRobustnessAnalysisResponse', () => {
     expect(result.fragile_edges).toHaveLength(1);
     expect(result.fragile_edges[0].from_id).toBe('nodeA');
     expect(result.fragile_edges[0].to_id).toBe('nodeB');
-    expect(result.fragile_edges[0].switch_probability).toBe(0); // Default for fragile
+    // sp-less ISL fragile edge: switch_probability is OMITTED, not fabricated 0
+    // (absent ≠ 0 — a fabricated 0 fabricates severity + doctrine-013 visible).
+    expect(result.fragile_edges[0].switch_probability).toBeUndefined();
   });
 
   it('tracks normalization errors for malformed edges', () => {


### PR DESCRIPTION
## Kill the fragile-edge `switch_probability ?? 0` fabrication at source (absent ≠ 0)

Follow-up from the doctrine-emits adversarial review. `normalizeFragileEdge` defaulted `switch_probability ?? 0` (`robustness-analysis.ts:65`) and hardcoded `0` for legacy string edges (`:117`). That fabricated `0` then drove **both** `severity` (`classifyEdgeSeverity(0)='warning'`) **and** the doctrine-013 `visible` flag (`deriveFragileEdgeVisible(0)=false`) to fabricated values on the /v2/run wire — same class as the `?? 0` margin kill in #237.

### Fix
An sp-less ISL fragile edge now emits **neither** `switch_probability`, `severity`, **nor** `visible` — honest omission.
- `classifyEdgeSeverity` → `EdgeSeverity | undefined` (`Number.isFinite` guard), mirroring `deriveFragileEdgeVisible`.
- `run.ts` spread-omits `severity` exactly like the existing `visible` gate.
- `switch_probability` optionalised on `NormalizedEdgeInfo`/`V3`.
- **Closes the #241 KNOWN-SEAM pin** — flipped from asserting the fabricated `visible:false` to asserting omission.

### Verification
- RED-first: the sp-less edge test is RED at `13847d7` (emitted sp=0 / severity='warning' / visible=false), GREEN after.
- Mutation (throwaway worktree): **9 RED across 5 files**, including 4 pre-existing tests that were *pinning the fabricated `0` as intended* (e.g. `robustness-analysis.test.ts:132` `toBe(0) // Default for fragile`) — flipped to honest omission, not weakened.
- **ZERO golden delta** (all current captures carry finite sp → no live behaviour change). `typecheck` clean.
- Trace-verified: only consumer of `fragile_edge.severity` is UI edge-styling; the "069 severity taxonomy" is a *different* field (`critique.severity`), not affected.

### A2 flag
`fragile_edge.severity` is now **optional** on the wire — the UI must treat an absent `severity` as unstyled/unknown, not assume present. Unreachable on current ISL data (ISL always emits sp), so no live change today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
