### PR TITLE
feat(v2/run): extend driver_label to 4-valued 'biggest' (rank-1 by influence) — doctrine-039 D-7

### DIFF
--- a/src/lib/driver-label.ts
+++ b/src/lib/driver-label.ts
@@ -1,22 +1,30 @@
 /**
- * Doctrine 039 — producer-owned `driver_label`.
+ * Doctrine 039 — producer-owned `driver_label` (D-7: 4-valued).
  *
- * `driver_label` is a producer-owned 3-band label (strong/moderate/minor) over
- * the normalised influence scalar (`influence_score`). The band boundaries are
- * ratified FROM the UI's existing cut-points (useResultsSectionData.ts):
- * >=0.50 strong, >=0.20 moderate, else minor.
+ * `driver_label` is a producer-owned categorical driver-strength label over the
+ * normalised influence scalar (`influence_score`). It is now **4-valued** —
+ * `'biggest' | 'strong' | 'moderate' | 'minor'` — to MATCH the shape of the UI's
+ * `getSemanticLabel`, which adds a rank-1 'biggest'/'strongest' band on top of the
+ * three magnitude bands. The three magnitude cut-points are ratified FROM the UI's
+ * existing cut-points (useResultsSectionData.ts): >=0.50 strong, >=0.20 moderate,
+ * else minor. The rank-1 'biggest' band is SET-AWARE (needs every factor's
+ * influence), so it is applied by the caller's derive-pass — see
+ * `indexOfBiggestDriver` — NOT by the pure per-factor `deriveDriverLabel` helper.
  *
- * NOTE — this field is NOT yet a drop-in replacement for the UI's copy. The
- * UI's `getSemanticLabel` is 4-VALUED (it adds a rank-1 'biggest'/'strongest'
- * band) and keys off normalised |elasticity| / max, NOT the wire
- * `influence_score` — so the UI cannot fully drop its copy on this field alone.
- * Reconciling the rank-1 band and the elasticity-vs-influence basis is a
- * doctrine row (Neil/UI), tracked separately. This field is valid and honest as
- * a producer influence-band; it is not yet claimed to supersede getSemanticLabel.
+ * NOTE — this now matches getSemanticLabel's 4-valued SHAPE, but two things remain
+ * gated on UI confirmation (D-7 KEY UNCERTAINTY: the UI facts are unconfirmed):
+ *   1. BASIS FLIP — getSemanticLabel keys off normalised |elasticity| / max, while
+ *      this field keys off the wire `influence_score`. Reconciling the basis is a
+ *      doctrine row (Neil/UI), tracked separately.
+ *   2. UI ADOPTION — the UI dropping its own copy on this field is gated on the UI
+ *      team confirming both the 4th band and the basis. This field is valid and
+ *      honest as a producer influence-band today; it is not yet CLAIMED to
+ *      supersede getSemanticLabel until that confirmation lands.
  *
- * The label is a pure function of `influence_score`; a factor whose influence
- * is absent/non-finite gets NO label (the missing-vs-value honesty contract:
- * never fabricate 'minor' from a missing measurement).
+ * The magnitude label is a pure function of `influence_score`; a factor whose
+ * influence is absent/non-finite gets NO label (the missing-vs-value honesty
+ * contract: never fabricate 'minor' from a missing measurement) and is likewise
+ * NOT eligible to be 'biggest'.
  */
 
 /**
@@ -33,22 +41,73 @@ export const DRIVER_LABEL_STRONG_MIN = 0.5;
  */
 export const DRIVER_LABEL_MODERATE_MIN = 0.2;
 
-/** Categorical driver-strength label over normalised influence. */
-export type DriverLabel = 'strong' | 'moderate' | 'minor';
+/**
+ * Categorical driver-strength label. 4-valued (D-7) to match the UI's
+ * `getSemanticLabel`: the set-aware rank-1 `'biggest'` band plus the three
+ * per-factor magnitude bands.
+ */
+export type DriverLabel = 'biggest' | 'strong' | 'moderate' | 'minor';
 
 /**
- * Derive the categorical driver label from a factor's normalised influence.
+ * The three magnitude bands `deriveDriverLabel` can return. `'biggest'` is a
+ * set-aware rank-1 override applied by the caller's derive-pass, never by the
+ * pure per-factor helper — so it is excluded here.
+ */
+export type MagnitudeDriverLabel = Exclude<DriverLabel, 'biggest'>;
+
+/**
+ * Derive the per-factor magnitude driver label from a factor's normalised
+ * influence. This is the pure 3-band helper; it NEVER returns `'biggest'`
+ * (that band is set-aware — see `indexOfBiggestDriver`).
  *
  * Returns `undefined` (field omitted by the caller) when influence is absent or
  * non-finite — distinct from 'minor', which is a real low-influence measurement.
  */
 export function deriveDriverLabel(
   influenceScore: number | null | undefined,
-): DriverLabel | undefined {
+): MagnitudeDriverLabel | undefined {
   if (typeof influenceScore !== 'number' || !Number.isFinite(influenceScore)) {
     return undefined;
   }
   if (influenceScore >= DRIVER_LABEL_STRONG_MIN) return 'strong';
   if (influenceScore >= DRIVER_LABEL_MODERATE_MIN) return 'moderate';
   return 'minor';
+}
+
+/** Minimal shape read by the set-aware rank-1 selector. */
+interface InfluenceCarrier {
+  influence_score?: number | null;
+}
+
+/**
+ * Set-aware rank-1 selector for the `'biggest'` driver band (D-7). Returns the
+ * index of the SINGLE factor with the greatest finite `influence_score`, or `-1`
+ * when no factor has a finite influence.
+ *
+ * The selection is magnitude-BLIND — it ranks by raw `influence_score`, never by
+ * the magnitude band — so the rank-1 factor is `'biggest'` UNCONDITIONAL of
+ * magnitude (it is 'biggest' even if its band would be 'minor'). This matches the
+ * UI `getSemanticLabel` rank-1 'biggest'/'strongest' band.
+ *   // DOCTRINE-PENDING (Neil/UX): 'biggest' is rank-1 unconditional; add a
+ *   // magnitude floor here if UX wants one.
+ *
+ * Ties on the max resolve to the FIRST such factor in the given (stable, emitted)
+ * order — deterministic — via the strict-`>` update (a later equal score never
+ * displaces the earlier one). A factor with absent/non-finite influence is NOT
+ * eligible (it carries no driver_label at all), so it can never be 'biggest'.
+ */
+export function indexOfBiggestDriver(
+  factors: ReadonlyArray<InfluenceCarrier>,
+): number {
+  let biggestIdx = -1;
+  let biggestScore = -Infinity;
+  for (let i = 0; i < factors.length; i++) {
+    const s = factors[i].influence_score;
+    if (typeof s !== 'number' || !Number.isFinite(s)) continue; // ineligible
+    if (s > biggestScore) {
+      biggestScore = s;
+      biggestIdx = i;
+    }
+  }
+  return biggestIdx;
 }

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -146,7 +146,7 @@ import { computeFactorSensitivityFromGraph, buildFactorStability, mergeIslConfid
 import { interventionTargetIdsFromOptions, isOptionControlledLever, factorIdOf, hasFactorIdConflict } from '../../lib/intervention-override.js';
 import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagMissingFromIsl } from '../../lib/auto-noise.js';
 import { sanitiseIslVoi, computeEvpiPercentagePoints, deriveEvidenceHint } from '../../lib/evpi-emission.js';
-import { deriveDriverLabel } from '../../lib/driver-label.js';
+import { deriveDriverLabel, indexOfBiggestDriver } from '../../lib/driver-label.js';
 import {
   detectUnreliableConstraintTargets,
   partitionConstraintTargets,
@@ -6137,16 +6137,28 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // `evpi_percentage_points.minimum: 0`). The golden pricing-canary
         // fixture has no factor_evpi → always takes this path (byte-identical).
         if (factorSensitivity) {
-          // Doctrine 039 — producer-owned driver_label. Derive the categorical
-          // strong/moderate/minor band from each factor's FINAL emitted
-          // influence_score (single derive-pass over the merged array; the label
-          // can never disagree with the number it is emitted alongside). A
-          // suppressed lever keeps its structural influence_score, so its label
-          // stays consistent. Absent influence_score ⇒ field omitted (honesty).
+          // Doctrine 039 (D-7) — producer-owned driver_label, 4-valued. Single
+          // derive-pass over the FINAL merged array (the label can never disagree
+          // with the number it is emitted alongside); a suppressed lever keeps its
+          // structural influence_score, so its label stays consistent.
+          //
+          // (1) Per-factor magnitude band (strong/moderate/minor) from each
+          //     factor's FINAL emitted influence_score. Absent influence_score ⇒
+          //     field omitted (honesty; not eligible to be 'biggest' either).
           for (const f of factorSensitivity) {
             const label = deriveDriverLabel(f.influence_score);
             if (label !== undefined) f.driver_label = label;
           }
+          // (2) Set-aware rank-1 override: the SINGLE factor with the greatest
+          //     influence_score is 'biggest', UNCONDITIONAL of magnitude (matches
+          //     the UI getSemanticLabel rank-1 'biggest'/'strongest' band). Rank-1
+          //     is computed here — not in the pure per-factor helper — because it
+          //     needs every factor's influence (like dominant_factor). Ties on the
+          //     max resolve to the FIRST factor in the emitted order (deterministic);
+          //     an absent-influence factor is skipped. Not lever-skipped: a lever
+          //     legitimately has a driver_label (categorical over influence magnitude).
+          const biggestIdx = indexOfBiggestDriver(factorSensitivity);
+          if (biggestIdx >= 0) factorSensitivity[biggestIdx].driver_label = 'biggest';
 
           const factorEvpiMapping = FLAGS.ISL_FACTOR_EVPI_INTERNAL
             ? mapIslFactorEvpi(islResult)

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1887,14 +1887,18 @@ export interface FactorSensitivityResultV3 {
   /** Human-readable interpretation from ISL */
   interpretation?: string;
   /**
-   * Doctrine 039 — producer-owned categorical driver-strength label over
-   * `influence_score` (normalised influence). Emitted so the UI drops its
-   * `getSemanticLabel` cut-point. Bands (DOCTRINE-PENDING, Neil): >=0.50
-   * 'strong', >=0.20 'moderate', else 'minor'. ABSENT when `influence_score`
-   * is absent/non-finite (never fabricated from a missing value). See
+   * Doctrine 039 (D-7) — producer-owned categorical driver-strength label over
+   * `influence_score` (normalised influence). 4-valued, to match the shape of
+   * the UI's `getSemanticLabel`: the set-aware rank-1 'biggest' band plus three
+   * magnitude bands (DOCTRINE-PENDING, Neil): >=0.50 'strong', >=0.20
+   * 'moderate', else 'minor'. Exactly one factor per response is 'biggest' (the
+   * single greatest `influence_score`, unconditional of magnitude; ties → first
+   * in emitted order). ABSENT when `influence_score` is absent/non-finite (never
+   * fabricated from a missing value; not eligible to be 'biggest'). Basis flip
+   * (elasticity vs influence) + UI adoption remain UI-confirmation-gated. See
    * `src/lib/driver-label.ts`.
    */
-  driver_label?: 'strong' | 'moderate' | 'minor';
+  driver_label?: 'biggest' | 'strong' | 'moderate' | 'minor';
   /**
    * Value of information for this factor on the public response surface.
    *

--- a/tests/doctrine-039-driver-label.test.ts
+++ b/tests/doctrine-039-driver-label.test.ts
@@ -1,23 +1,31 @@
 /**
- * Doctrine 039 — producer-owned `driver_label`.
+ * Doctrine 039 (D-7) — producer-owned `driver_label`, 4-valued.
  *
- * PLoT emits a producer-owned categorical strong/moderate/minor label over the
- * normalised-influence scalar (`influence_score`). Cut-points ratified from the
- * UI's useResultsSectionData.ts:
- *   influence_score >= 0.50 → 'strong'
- *   influence_score >= 0.20 → 'moderate'
- *   otherwise              → 'minor'
- * NOTE: this does NOT supersede the UI's `getSemanticLabel`, which is 4-valued
- * (adds a rank-1 'biggest' band) and keys off normalised |elasticity|, not
- * influence_score — reconciling the two is a doctrine row (Neil/UI), tracked
- * separately (see src/lib/driver-label.ts header).
- * Absent/non-finite influence ⇒ NO label (honesty: never fabricate 'minor'
- * from a missing value). Thresholds are DOCTRINE-PENDING (Neil), one const each.
+ * PLoT emits a producer-owned categorical driver-strength label over the
+ * normalised-influence scalar (`influence_score`). It is now 4-valued to match
+ * the SHAPE of the UI's `getSemanticLabel`:
+ *   - three magnitude bands (cut-points ratified from useResultsSectionData.ts):
+ *       influence_score >= 0.50 → 'strong'
+ *       influence_score >= 0.20 → 'moderate'
+ *       otherwise              → 'minor'
+ *   - a set-aware rank-1 'biggest' band: the SINGLE factor with the greatest
+ *     `influence_score` is 'biggest', UNCONDITIONAL of magnitude. Ties on the max
+ *     resolve to the FIRST factor in the stable emitted order. A factor with
+ *     absent/non-finite influence gets NO label and is NOT eligible to be
+ *     'biggest'.
+ * NOTE: matching the SHAPE does not yet let the UI drop `getSemanticLabel` — the
+ * basis flip (elasticity vs influence) + UI adoption remain UI-confirmation-gated
+ * (D-7). Absent/non-finite influence ⇒ NO label (honesty). Magnitude thresholds
+ * are DOCTRINE-PENDING (Neil), one const each; 'biggest' is rank-1 unconditional
+ * (DOCTRINE-PENDING Neil/UX — a magnitude floor can be added later).
  *
- * Two describes:
- *  - unit: the pure helper `deriveDriverLabel` (the ratified cut-points).
- *  - route: the emit actually lands on the /v2/run wire, keyed off the
- *    factor's emitted influence_score (driven with the live 07-07 capture).
+ * Describes:
+ *  - unit: `deriveDriverLabel` — the pure 3-band magnitude helper (never 'biggest').
+ *  - unit: `indexOfBiggestDriver` — the set-aware rank-1 selector (argmax / ties /
+ *    single-factor / absent-not-eligible).
+ *  - route: the 4-valued emit lands on the /v2/run wire, keyed off each factor's
+ *    emitted influence_score, with exactly one 'biggest' on the rank-1 factor
+ *    (driven with the live 07-07 capture).
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
@@ -27,12 +35,13 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   deriveDriverLabel,
+  indexOfBiggestDriver,
   DRIVER_LABEL_STRONG_MIN,
   DRIVER_LABEL_MODERATE_MIN,
 } from '../src/lib/driver-label.js';
 
 // ---------------------------------------------------------------------------
-// Unit — pure helper
+// Unit — pure per-factor magnitude helper
 // ---------------------------------------------------------------------------
 
 describe('deriveDriverLabel — ratified normalised-influence cut-points', () => {
@@ -73,10 +82,88 @@ describe('deriveDriverLabel — ratified normalised-influence cut-points', () =>
     expect(DRIVER_LABEL_STRONG_MIN).toBe(0.5);
     expect(DRIVER_LABEL_MODERATE_MIN).toBe(0.2);
   });
+
+  // The magnitude helper is pure/per-factor and can NEVER return 'biggest';
+  // 'biggest' is a set-aware rank-1 override (indexOfBiggestDriver).
+  it("never returns 'biggest' (rank-1 is set-aware, not a magnitude band)", () => {
+    for (const s of [1, 0.99, 0.5, 0.2, 0.1, 0, 1e6]) {
+      expect(deriveDriverLabel(s)).not.toBe('biggest');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
-// Route — the emit lands on the /v2/run wire (live 07-07 capture, mocked ISL)
+// Unit — set-aware rank-1 selector (the 'biggest' band)
+// ---------------------------------------------------------------------------
+
+describe('indexOfBiggestDriver — set-aware rank-1 by influence_score', () => {
+  it('picks the index of the single greatest influence_score', () => {
+    const factors = [
+      { influence_score: 0.2 },
+      { influence_score: 0.9 }, // rank-1
+      { influence_score: 0.5 },
+    ];
+    expect(indexOfBiggestDriver(factors)).toBe(1);
+  });
+
+  it('argmax is magnitude-blind: a low-influence max is still rank-1 (biggest unconditional)', () => {
+    // Greatest influence here is 0.1 → magnitude band would be 'minor', yet it
+    // is still the rank-1 factor. The derive-pass stamps it 'biggest'
+    // unconditionally of magnitude.
+    const factors = [
+      { influence_score: 0.05 },
+      { influence_score: 0.1 }, // rank-1, but deriveDriverLabel(0.1) === 'minor'
+      { influence_score: 0.03 },
+    ];
+    const idx = indexOfBiggestDriver(factors);
+    expect(idx).toBe(1);
+    expect(deriveDriverLabel(factors[idx].influence_score)).toBe('minor');
+  });
+
+  it('ties on the max → the FIRST factor in emitted order (deterministic)', () => {
+    const factors = [
+      { influence_score: 0.4 },
+      { influence_score: 0.8 }, // first occurrence of the max
+      { influence_score: 0.8 }, // tie — must NOT win
+      { influence_score: 0.1 },
+    ];
+    expect(indexOfBiggestDriver(factors)).toBe(1);
+  });
+
+  it('single-factor → that factor (index 0) is rank-1', () => {
+    expect(indexOfBiggestDriver([{ influence_score: 0.42 }])).toBe(0);
+  });
+
+  it('empty array → -1 (no eligible factor)', () => {
+    expect(indexOfBiggestDriver([])).toBe(-1);
+  });
+
+  it('all influence absent/non-finite → -1 (none eligible to be biggest)', () => {
+    expect(
+      indexOfBiggestDriver([
+        { influence_score: undefined },
+        { influence_score: null },
+        { influence_score: NaN },
+        { influence_score: Infinity },
+        {},
+      ]),
+    ).toBe(-1);
+  });
+
+  it('a factor with absent influence is skipped even when it appears first', () => {
+    // The absent-influence factor at index 0 is NOT eligible; the real max is
+    // the finite 0.3 at index 2.
+    const factors = [
+      { influence_score: undefined }, // ineligible
+      { influence_score: 0.1 },
+      { influence_score: 0.3 }, // rank-1 among the eligible
+    ];
+    expect(indexOfBiggestDriver(factors)).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route — the 4-valued emit lands on the /v2/run wire (live 07-07 capture)
 // ---------------------------------------------------------------------------
 
 const FIXTURE_DIR = join(
@@ -153,7 +240,7 @@ function buildPlotBody() {
   };
 }
 
-describe('039 route: driver_label lands on /v2/run factor_sensitivity', () => {
+describe('039 route: 4-valued driver_label lands on /v2/run factor_sensitivity', () => {
   let app: FastifyInstance;
   let factors: any[];
 
@@ -180,8 +267,37 @@ describe('039 route: driver_label lands on /v2/run factor_sensitivity', () => {
     expect(factors.some((f) => f.driver_label !== undefined)).toBe(true);
   });
 
-  it('every emitted driver_label matches deriveDriverLabel(influence_score)', () => {
+  it("exactly ONE factor is 'biggest'", () => {
+    const biggest = factors.filter((f) => f.driver_label === 'biggest');
+    expect(biggest.length).toBe(1);
+  });
+
+  it("the 'biggest' factor is the single greatest influence_score (rank-1)", () => {
+    // Argmax over the EMITTED influence_score, computed independently of the field.
+    const eligible = factors.filter(
+      (f) => typeof f.influence_score === 'number' && Number.isFinite(f.influence_score),
+    );
+    expect(eligible.length).toBeGreaterThan(0);
+    const maxScore = Math.max(...eligible.map((f) => f.influence_score));
+    const argmax = factors.find((f) => f.influence_score === maxScore);
+    expect(argmax.driver_label).toBe('biggest');
+    // and no OTHER factor carries 'biggest'
     for (const f of factors) {
+      if (f !== argmax) expect(f.driver_label).not.toBe('biggest');
+    }
+  });
+
+  it('every NON-biggest driver_label matches the magnitude helper; the biggest is the argmax', () => {
+    const eligible = factors.filter(
+      (f) => typeof f.influence_score === 'number' && Number.isFinite(f.influence_score),
+    );
+    const maxScore = Math.max(...eligible.map((f) => f.influence_score));
+    const argmax = factors.find((f) => f.influence_score === maxScore);
+    for (const f of factors) {
+      if (f === argmax) {
+        expect(f.driver_label).toBe('biggest');
+        continue;
+      }
       const expected = deriveDriverLabel(f.influence_score);
       if (expected === undefined) {
         expect(f.driver_label).toBeUndefined();
@@ -191,10 +307,27 @@ describe('039 route: driver_label lands on /v2/run factor_sensitivity', () => {
     }
   });
 
-  it("driver_label is one of the ratified categories", () => {
+  it('a mid-rank factor keeps its magnitude band (strong/moderate), not biggest', () => {
+    // In the 07-07 capture the mid factors are dev_headcount (~0.72 → strong)
+    // and hiring_cost (~0.50 → moderate). Whichever mid factors exist, none is
+    // 'biggest' and each equals its magnitude band.
+    const eligible = factors.filter(
+      (f) => typeof f.influence_score === 'number' && Number.isFinite(f.influence_score),
+    );
+    const maxScore = Math.max(...eligible.map((f) => f.influence_score));
+    const mids = eligible.filter((f) => f.influence_score !== maxScore);
+    expect(mids.length).toBeGreaterThan(0);
+    for (const f of mids) {
+      expect(f.driver_label).not.toBe('biggest');
+      expect(f.driver_label).toBe(deriveDriverLabel(f.influence_score));
+      expect(['strong', 'moderate', 'minor']).toContain(f.driver_label);
+    }
+  });
+
+  it('driver_label is one of the 4 ratified categories', () => {
     for (const f of factors) {
       if (f.driver_label !== undefined) {
-        expect(['strong', 'moderate', 'minor']).toContain(f.driver_label);
+        expect(['biggest', 'strong', 'moderate', 'minor']).toContain(f.driver_label);
       }
     }
   });

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -517,7 +517,7 @@
       "elasticity_std": 0,
       "rank_flip_rate": 0,
       "stability_method": "bootstrap_20",
-      "driver_label": "strong",
+      "driver_label": "biggest",
       "range_derivation_source": "default"
     },
     {
@@ -1618,7 +1618,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:f92b82a0565a21f5"
+    "response_content_hash": "rch_v2:36d21c5efb11cff9"
   },
   "meta": {
     "seed_used": "2034401427",


### PR DESCRIPTION
## Extend `driver_label` to 4-valued (`biggest`) — doctrine-039 reconciliation (D-7)

Follow-up to the doctrine-emits adversarial finding F4: the 3-valued `driver_label` was not a drop-in for the UI's `getSemanticLabel`, which is 4-valued (rank-1 `biggest`/`strongest`). Per ruling **D-7**, `driver_label` now emits `biggest` for the single rank-1 factor by `influence_score`, then strong (≥0.50) / moderate (≥0.20) / minor by magnitude — a true drop-in for the UI's 4-valued shape.

- `biggest` = rank-1 by influence, **unconditional** of magnitude (matches the reported UI semantics; `DOCTRINE-PENDING (Neil/UX)` if a floor is later wanted).
- Set-aware: computed in the derive-pass (`indexOfBiggestDriver`), not the pure per-factor helper — argmax by influence, absent-influence ineligible, first-on-ties (deterministic), guarded `if (biggestIdx >= 0)` so an all-absent graph produces no `biggest`.
- `deriveDriverLabel(influence)` stays the pure 3-band magnitude helper; `DriverLabel` type widened.

### Verification
- RED-first: 8 `biggest`-mechanism tests RED at `13847d7`, 24/24 GREEN after; edges covered — ties (first-order), unconditional-over-`minor`, single-factor (index 0), absent-influence (skipped, ineligible).
- Mutation (throwaway worktree): 2 load-bearing — neutralise the override → 3 route tests RED; break the helper → 8 RED.
- **Golden delta — exactly the rank-1 factor:** one `driver_label` change, `fac_tech_lead` `strong`→`biggest` (influence_score **1.0**, max of {1.0, 0.724, 0.497, 0.390} → proven rank-1). No other value changed.
- **Freshness `response_hash` UNCHANGED** (`60e3ac21…` before/after) — only the content digest moved, so no UI dedupe impact. `typecheck` clean; 235/235 adjacent suites.

### ⚠ UI-gated remainder (NOT resolved by this PR)
This matches `getSemanticLabel`'s 4-valued **shape**, but two things stay gated on UI confirmation (A3 is DGAI-git-forbidden — the UI facts are self-report):
1. **Basis flip** — `getSemanticLabel` keys off normalised `|elasticity|`, this keys off wire `influence_score` (D-7 rules influence canonical on the science; needs Neil/UI ratification).
2. **UI adoption** — the UI dropping its own copy is gated on UI-team confirmation + the A2 lane (currently deferred). This field is valid/honest as a producer influence-band today; it is **not** claimed to supersede `getSemanticLabel` until that confirmation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
