### PR TITLE
refactor(v2/run): /simplify cleanup — dedup guards, fix decision_grade doc-drift, drop redundant param (behavior-preserving)

### DIFF
--- a/src/integrations/isl/adapters/robustness-analysis.ts
+++ b/src/integrations/isl/adapters/robustness-analysis.ts
@@ -17,6 +17,7 @@ import type {
   NormalizedEdgeInfo,
   EdgeNormalizationError,
 } from '../types/plot-types.js';
+import { isFiniteNumber } from '../../../util/numeric.js';
 
 // -----------------------------------------------------------------------------
 // Edge ID Parsing Helpers
@@ -65,7 +66,7 @@ function normalizeFragileEdge(edge: ISLFragileEdgeInfo): NormalizedEdgeInfo {
     // switch_probability: emit ONLY when ISL provides a finite value. Absent ≠ 0
     // — a fabricated 0 fabricates BOTH severity ('warning') and the doctrine-013
     // `visible` flag (false) downstream. Omit honestly when ISL omits it.
-    ...(typeof edge.switch_probability === 'number' && Number.isFinite(edge.switch_probability)
+    ...(isFiniteNumber(edge.switch_probability)
       ? { switch_probability: edge.switch_probability }
       : {}),
     // Passthrough marginal_switch_probability from ISL (optional field)

--- a/src/lib/driver-label.ts
+++ b/src/lib/driver-label.ts
@@ -27,6 +27,8 @@
  * NOT eligible to be 'biggest'.
  */
 
+import { isFiniteNumber } from '../util/numeric.js';
+
 /**
  * DOCTRINE-PENDING (Neil): the "strong" driver band floor over normalised
  * influence. Ratified from the UI's getSemanticLabel cut-point (0.50). A future
@@ -66,7 +68,7 @@ export type MagnitudeDriverLabel = Exclude<DriverLabel, 'biggest'>;
 export function deriveDriverLabel(
   influenceScore: number | null | undefined,
 ): MagnitudeDriverLabel | undefined {
-  if (typeof influenceScore !== 'number' || !Number.isFinite(influenceScore)) {
+  if (!isFiniteNumber(influenceScore)) {
     return undefined;
   }
   if (influenceScore >= DRIVER_LABEL_STRONG_MIN) return 'strong';
@@ -103,7 +105,7 @@ export function indexOfBiggestDriver(
   let biggestScore = -Infinity;
   for (let i = 0; i < factors.length; i++) {
     const s = factors[i].influence_score;
-    if (typeof s !== 'number' || !Number.isFinite(s)) continue; // ineligible
+    if (!isFiniteNumber(s)) continue; // ineligible
     if (s > biggestScore) {
       biggestScore = s;
       biggestIdx = i;

--- a/src/lib/evpi-emission.ts
+++ b/src/lib/evpi-emission.ts
@@ -18,6 +18,8 @@
  *   emits `m1_coaching.evidence_gaps[].evpi_percentage_points`.
  */
 
+import { isFiniteNumber } from '../util/numeric.js';
+
 /**
  * Sanitise an ISL-emitted `value_of_information` value to satisfy PLoT's
  * non-negative VOI contract. ISL emits VOI via a Monte Carlo estimator which
@@ -168,10 +170,10 @@ export function deriveEvidenceHint(args: {
   voi?: number | null;
 }): boolean | undefined {
   const { realEvpiPp, voi } = args;
-  if (typeof realEvpiPp === 'number' && Number.isFinite(realEvpiPp)) {
+  if (isFiniteNumber(realEvpiPp)) {
     return realEvpiPp >= EVPI_HINT_MIN_PP;
   }
-  if (typeof voi === 'number' && Number.isFinite(voi)) {
+  if (isFiniteNumber(voi)) {
     return voi > VOI_HINT_MIN;
   }
   return undefined;

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -41,6 +41,19 @@ export interface NormalisationRange {
 }
 
 /**
+ * True iff `r` is the IDENTITY range `[0,1]`. Doctrine-load-bearing: an identity
+ * intervention scale is the marker for "this scale is an ASSUMPTION, not a
+ * MEASURED spread" — the node was intervened while Phase 4a was SKIPPED (all
+ * interventions already in [0,1]). A NON-identity range is a measured
+ * ground-truth spread. The two rank very differently in the constraint priority
+ * ladder (identity is demoted below producer declarations). Ignores `source` —
+ * only the numeric bounds decide.
+ */
+export function isIdentityRange(r: NormalisationRange): boolean {
+  return r.min === 0 && r.max === 1;
+}
+
+/**
  * Intervention hints from CE (Context Engine).
  * Used to provide additional metadata for normalisation.
  */
@@ -995,16 +1008,27 @@ export interface ConstraintNormalisationResult {
 /**
  * Normalise goal constraint values to [0,1] space.
  *
- * Uses the same deriveRange() function as interventions, extended with two
- * producer-declared constraint scales (P0-C1) that outrank the node-derived
- * chain:
+ * Uses the same deriveRange() function as interventions, resolved through a
+ * measurement/producer priority ladder (F4, Codex-confirmed reorder). This
+ * header MIRRORS the authoritative inline `Derive range` comment in the loop
+ * body below — keep the two in sync:
  *
- * | Priority | Source               | Rule                                            |
- * |----------|----------------------|-------------------------------------------------|
- * | 0        | `goal_threshold_cap` | Node's CEE-stamped cap. Range [0, cap].         |
- * | 1        | `unit_percent`       | Constraint unit is '%'. Range [0, 100] (house   |
- * |          |                      | doctrine: '%' always normalises against 100).   |
- * | 2+       | deriveRange(node)    | Existing chain (explicit_cap → … → default).    |
+ * | Priority | Source                            | Rule                                             |
+ * |----------|-----------------------------------|--------------------------------------------------|
+ * | 1        | `interventionScale` (NON-identity)| A MEASURED sample spread is ground truth; the    |
+ * |          |                                   | threshold shares the exact scale its samples     |
+ * |          |                                   | occupy. Wins even over a producer cap (DOCTRINE- |
+ * |          |                                   | PENDING).                                        |
+ * | 2        | forward-raw                       | Gate FALSE + no intervention scale ⇒ value       |
+ * |          |                                   | already in [0,1]; forwarded verbatim (HEAD       |
+ * |          |                                   | parity, F1). Outranks producers.                 |
+ * | 3        | `goal_threshold_cap`              | Producer-declared. Node's CEE-stamped cap.       |
+ * |          |                                   | Range [0, cap].                                  |
+ * | 4        | `unit_percent`                    | Producer-declared. Constraint unit is '%'.       |
+ * |          |                                   | Range [0, 100] (house doctrine).                 |
+ * | 5        | `interventionScale` (IDENTITY)    | Phase-4a-skipped ASSUMED [0,1] scale; ranks      |
+ * |          |                                   | below producer declarations, above the heuristic.|
+ * | 6        | deriveRange(node)                 | Existing chain (explicit_cap → … → default).     |
  *
  * Additionally, when the node carries a CEE-stamped, already-normalised
  * finite `goal_threshold` in [0,1] that corresponds to the same target
@@ -1036,6 +1060,11 @@ export function normaliseGoalConstraints(
     nodeMap.set(node.id, node);
   }
 
+  // Loop-invariant (does not vary per constraint). Default TRUE so every existing
+  // caller (unit tests, code paths that omit the flag) keeps the pre-fix chain
+  // behaviour for scale-less constraints.
+  const applyChainWithoutScale = extras?.normaliseWithoutScale ?? true;
+
   for (const constraint of constraints) {
     const { constraint_id, node_id, operator, value, label, weight } = constraint;
 
@@ -1054,10 +1083,7 @@ export function normaliseGoalConstraints(
     // [0,1]) — it is an ASSUMPTION, not a measured spread. A NON-identity scale
     // is a measured ground-truth spread. The two rank very differently below.
     const interventionScaleIsIdentity =
-      interventionScale !== undefined && interventionScale.min === 0 && interventionScale.max === 1;
-    // Default TRUE so every existing caller (unit tests, code paths that omit
-    // the flag) keeps the pre-fix chain behaviour for scale-less constraints.
-    const applyChainWithoutScale = extras?.normaliseWithoutScale ?? true;
+      interventionScale !== undefined && isIdentityRange(interventionScale);
 
     // Derive range. Priority ladder (F4, Codex-confirmed reorder):
     //   1  interventionScale, NON-identity — a MEASURED spread is ground truth;
@@ -1156,11 +1182,16 @@ export function normaliseGoalConstraints(
     };
     normalisedConstraints.push(normalisedConstraint);
 
-    // Add repair record. A forwarded-raw constraint (gate FALSE, no intervention
-    // scale) is an identity no-op — emit no repair, so repairs_applied stays
-    // byte-identical to the pre-fix "gate false ⇒ no constraint normalisation"
-    // path.
+    // A forwarded-raw constraint (gate FALSE, no intervention scale) is an
+    // identity no-op — skip BOTH the repair record AND the diagnostic so the
+    // response stays byte-identical to the pre-fix "gate false ⇒ no constraint
+    // normalisation" path. (A synthetic 'default'-range diagnostic emitted here
+    // would trip constraint-reliability.ts's threshold_normalisation_defaulted
+    // and SUPPRESS a constraint that HEAD delivered; and no diagnostic ⇒ no
+    // constraintNormalisationRanges entry ⇒ the reliability gate and margin
+    // denorm behave exactly as before.)
     if (!forwardedRawUnchanged) {
+      // Add repair record.
       repairs.push({
         field: `constraint.value.${constraint_id}`,
         action: 'normalised',
@@ -1168,17 +1199,7 @@ export function normaliseGoalConstraints(
         to_value: normalised,
         reason: `normalised range=[${range.min},${range.max}] source=${range.source}${clamped ? ' (clamped)' : ''}${usedNodeGoalThreshold ? ' (node goal_threshold preferred)' : ''}`,
       });
-    }
-
-    // Add diagnostic. A forwarded-raw constraint underwent NO transform, so it
-    // contributes no normalisation range — emitting a synthetic 'default' range
-    // here would make the callers treat it as identical to the pre-fix
-    // "gate false ⇒ function not called" state. Crucially, that synthetic
-    // 'default' range would trip constraint-reliability.ts
-    // (threshold_normalisation_defaulted) and SUPPRESS a constraint that HEAD
-    // delivered. So skip it: no diagnostic ⇒ no constraintNormalisationRanges
-    // entry ⇒ the reliability gate and margin denorm behave exactly as before.
-    if (!forwardedRawUnchanged) {
+      // Add diagnostic.
       diagnostics.push({
         constraint_id,
         node_id,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -171,6 +171,7 @@ import {
   normaliseGoalConstraints,
   constraintsNeedNormalisation,
   isPercentUnit,
+  isIdentityRange,
   type NormalisationContext,
   type NormalisationDiagnostic,
   type NormalisationRange,
@@ -183,6 +184,7 @@ import type { ProposalCardV1 } from '../../review-pass/types.js';
 import { assembleFactObjects, type ISLResponseInput } from '../../facts/index.js';
 import type { FactObjectV1, FactLineage } from '../../facts/types.js';
 import { finiteNum, prob01, nonNeg, nonNegInt, hasAllRequiredOutcomeStats } from './numeric-egress-guards.js';
+import { isFiniteNumber } from '../../util/numeric.js';
 import {
   assessEnrichmentContract,
   shouldAssessEnrichmentContract,
@@ -1812,12 +1814,11 @@ function buildConstraintScaleProvenance(
 
     const interventionScale = interventionScaleByNodeId.get(c.node_id);
     const nonIdentitySpread =
-      interventionScale !== undefined &&
-      !(interventionScale.min === 0 && interventionScale.max === 1);
+      interventionScale !== undefined && !isIdentityRange(interventionScale);
 
     const nodeCap = goalThresholdMetaByNodeId.get(c.node_id)?.goal_threshold_cap;
     const producerDeclarationOnNode =
-      (typeof nodeCap === 'number' && Number.isFinite(nodeCap) && nodeCap > 0) ||
+      (isFiniteNumber(nodeCap) && nodeCap > 0) ||
       isPercentUnit(unitsByConstraintId.get(c.constraint_id));
 
     // Divergence (D-2 disclosing itself): a MEASURED intervention spread overrode
@@ -2208,16 +2209,15 @@ function buildResponse(
   // and not clamped" (margin is exact) from "never diagnosed" (clamp state
   // unknown → no precision claim may be made).
   optionDiagnosedFactors?: Map<string, Set<string>>,
-  // Codex F2a: per-constraint THRESHOLD clamp direction ('low' = clamped at the
-  // range floor, 'high' = at the ceiling). Present ONLY when the constraint
-  // threshold itself clamped during normalisation. Independent of the per-option
-  // intervention clamp above — a threshold can clamp while every intervention
-  // sits inside the range (the response-1 defect: cap below the intervention
-  // floor). Feeds constraint_margins margin_precision.
-  constraintThresholdClampByConstraintId?: Map<string, 'low' | 'high'>,
   // A3 trust marker: per-constraint scale provenance (keyed by constraint_id).
   // Feeds BOTH the top-level constraint_results[].scale_provenance and the
-  // per-option constraints_decision_grade aggregate below.
+  // per-option constraints_decision_grade aggregate below. Also the sole source
+  // of the Codex F2a per-constraint THRESHOLD clamp direction: each entry's
+  // `threshold_clamped` ('low' = clamped at the range floor, 'high' = at the
+  // ceiling; absent = threshold sat inside the range) is read at the
+  // constraint_margins margin_precision site below — independent of the
+  // per-option intervention clamp (a threshold can clamp while every
+  // intervention sits inside the range: the response-1 defect).
   constraintScaleProvenanceByConstraintId?: Map<string, ConstraintScaleProvenance>
 ): RunResponseV3 {
   // Producer honesty (lane PLoT-H item A): detect goal constraints whose
@@ -2272,6 +2272,11 @@ function buildResponse(
   // Map ISL results to response format
   // ISL V2 uses 'options' field; V1 uses 'results'. Check both for compatibility.
   const islOptionData = islResult?.options ?? islResult?.results;
+  // Loop-invariant: the active constraint ids (the scale-provenance map's keys)
+  // do NOT vary per option — materialise once rather than per .map iteration.
+  const activeConstraintIds = constraintScaleProvenanceByConstraintId
+    ? [...constraintScaleProvenanceByConstraintId.keys()]
+    : undefined;
   const optionComparison = islOptionData?.map((r: any) => {
     const optionId = r.option_id ?? r.id;
     const option = options?.find((o) => o.id === optionId);
@@ -2450,7 +2455,10 @@ function buildResponse(
             // unknown, e.g. a non-intervened target, and no claim is made).
             const clampDir = optionClampDirectionByFactor?.get(optionId)?.get(c.node_id);
             const hasDiagnostic = optionDiagnosedFactors?.get(optionId)?.has(c.node_id) ?? false;
-            const thresholdClamp = constraintThresholdClampByConstraintId?.get(cid);
+            // F2a threshold-clamp direction, derived from the scale-provenance map
+            // (its `threshold_clamped` is built from the SAME F2a clamp map, so
+            // this is byte-identical to the former dedicated param).
+            const thresholdClamp = constraintScaleProvenanceByConstraintId?.get(cid)?.threshold_clamped;
 
             const interventionUnderstates =
               (clampDir === 'high' && c.operator === '<=') ||
@@ -2545,9 +2553,7 @@ function buildResponse(
           const probs = result.constraint_probabilities;
           const participating = Object.keys(probs);
           if (participating.length > 0) {
-            const coversAllActiveConstraints = [
-              ...constraintScaleProvenanceByConstraintId.keys(),
-            ].every((cid) => cid in probs);
+            const coversAllActiveConstraints = (activeConstraintIds ?? []).every((cid) => cid in probs);
             result.constraints_decision_grade =
               coversAllActiveConstraints &&
               participating.every(
@@ -2672,29 +2678,29 @@ function buildResponse(
 
     // Enrich fragile edges with labels (Schema v2.6: from_label, to_label, alternative_winner_label)
     // and severity classification (B1: ported from UI thresholds unchanged)
-    const enrichedFragileEdges: NormalizedEdgeInfoV3[] = fragileResult.edges.map(edge => ({
-      ...edge,
-      // from_label and to_label from graph lookup, fall back to node ID if not found
-      from_label: nodeLabelMap.get(edge.from_id) ?? edge.from_id,
-      to_label: nodeLabelMap.get(edge.to_id) ?? edge.to_id,
-      // Severity classification from switch_probability (B1). Emitted ONLY when
-      // switch_probability is finite — omitted (spread-out) when absent/non-finite,
-      // exactly like the `visible` gate below (honesty: absent ≠ 'warning').
-      ...(classifyEdgeSeverity(edge.switch_probability) !== undefined && {
-        severity: classifyEdgeSeverity(edge.switch_probability),
-      }),
-      // Doctrine 013 — producer-DISCLOSED visibility gate over switch_probability
-      // (> 0.15). PLoT emits the flag but does NOT filter the array (the UI
-      // decides render). Omitted when switch_probability is non-finite (honesty).
-      ...(deriveFragileEdgeVisible(edge.switch_probability) !== undefined && {
-        visible: deriveFragileEdgeVisible(edge.switch_probability),
-      }),
-      // Resolve alternative_winner_label from option ID (null when no alternative winner)
-      alternative_winner_id: edge.alternative_winner_id ?? null,
-      alternative_winner_label: edge.alternative_winner_id
-        ? (optionLabelMap.get(edge.alternative_winner_id) ?? edge.alternative_winner_id)
-        : null,
-    }));
+    const enrichedFragileEdges: NormalizedEdgeInfoV3[] = fragileResult.edges.map(edge => {
+      // Severity classification (B1) and the doctrine-013 producer-DISCLOSED
+      // `visible` gate (> 0.15) are each a pure function of switch_probability —
+      // compute ONCE. Both are emitted ONLY when switch_probability is finite —
+      // omitted (spread-out) when absent/non-finite (honesty: absent ≠
+      // 'warning'/false). PLoT discloses `visible` but does NOT filter the array
+      // (the UI decides render).
+      const severity = classifyEdgeSeverity(edge.switch_probability);
+      const visible = deriveFragileEdgeVisible(edge.switch_probability);
+      return {
+        ...edge,
+        // from_label and to_label from graph lookup, fall back to node ID if not found
+        from_label: nodeLabelMap.get(edge.from_id) ?? edge.from_id,
+        to_label: nodeLabelMap.get(edge.to_id) ?? edge.to_id,
+        ...(severity !== undefined && { severity }),
+        ...(visible !== undefined && { visible }),
+        // Resolve alternative_winner_label from option ID (null when no alternative winner)
+        alternative_winner_id: edge.alternative_winner_id ?? null,
+        alternative_winner_label: edge.alternative_winner_id
+          ? (optionLabelMap.get(edge.alternative_winner_id) ?? edge.alternative_winner_id)
+          : null,
+      };
+    });
 
     // Enrich robust edges with labels (Schema v2.6)
     const enrichedRobustEdges: NormalizedEdgeInfoV3[] = robustResult.edges.map(edge => ({
@@ -5322,9 +5328,13 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           // raw constraint value already sits in [0,1] (Caveat A combo 2): that
           // value is a raw user quantity on the intervention scale and must be
           // re-scaled onto it, not forwarded as an already-normalised number.
-          const anyNonIdentityScale = [...interventionScaleByNodeId.values()].some(
-            r => !(r.min === 0 && r.max === 1),
-          );
+          let anyNonIdentityScale = false;
+          for (const r of interventionScaleByNodeId.values()) {
+            if (!isIdentityRange(r)) {
+              anyNonIdentityScale = true;
+              break;
+            }
+          }
 
           if (gateNeedsNorm || anyNonIdentityScale) {
             const constraintNormResult = normaliseGoalConstraints(
@@ -5345,24 +5355,23 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             );
             constraintsForISL = constraintNormResult.constraints;
 
-            // Store ranges for denormalisation of failure_margin_median in
-            // response. After A3 unify these are the SAME ranges the samples
-            // live on, so the two margin-egress paths (run.ts ~1885, ~2269)
-            // denormalise on the correct (intervention) width automatically.
-            constraintNormalisationRanges = new Map(
-              constraintNormResult.diagnostics.map(d => [d.constraint_id, d.range])
-            );
-
-            // Codex F2a: derive the per-constraint THRESHOLD clamp direction from
-            // the SAME diagnostics (single source of truth — not a parallel
-            // hand-maintained structure). Direction from the recorded post-clamp
-            // normalised_value: 0 ⇒ clamped at the range floor ('low'), 1 ⇒ at the
-            // ceiling ('high'). Only clamped thresholds get an entry; an interior
-            // normalised value under a degenerate (zero-width) range is
-            // indeterminate and recorded as neither (the margin egress then makes
-            // no precision claim).
+            // Single pass over the constraint diagnostics builds BOTH per-constraint
+            // maps from the SAME source of truth (derive-don't-mirror):
+            //  - constraintNormalisationRanges: the range each threshold normalised
+            //    against, for failure_margin_median denorm. After A3 unify these are
+            //    the SAME ranges the samples live on, so the two margin-egress paths
+            //    (run.ts ~1885, ~2269) denormalise on the correct (intervention)
+            //    width automatically.
+            //  - constraintThresholdClampByConstraintId (Codex F2a): the THRESHOLD
+            //    clamp direction, from the recorded post-clamp normalised_value
+            //    (0 ⇒ range floor 'low', 1 ⇒ ceiling 'high'). Only clamped
+            //    thresholds get an entry; an interior value under a degenerate
+            //    (zero-width) range is indeterminate and recorded as neither (the
+            //    margin egress then makes no precision claim).
+            constraintNormalisationRanges = new Map<string, NormalisationRange>();
             constraintThresholdClampByConstraintId = new Map<string, 'low' | 'high'>();
             for (const d of constraintNormResult.diagnostics) {
+              constraintNormalisationRanges.set(d.constraint_id, d.range);
               if (!d.clamped) continue;
               const direction = d.normalised_value <= 0 ? 'low' : d.normalised_value >= 1 ? 'high' : undefined;
               if (direction === undefined) continue;
@@ -7101,8 +7110,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           req.log,  // logger for fact_objects assembly logging
           optionClampDirectionByFactor,  // 1d + Codex F1: per-option clamp DIRECTION map for margin_precision
           optionDiagnosedFactors,  // Codex F1: factors with a recorded diagnostic (exact vs unknown)
-          constraintThresholdClampByConstraintId,  // Codex F2a: per-constraint threshold clamp direction for margin_precision
-          constraintScaleProvenanceByConstraintId  // A3 trust marker: scale_provenance + constraints_decision_grade
+          constraintScaleProvenanceByConstraintId  // A3 trust marker: scale_provenance + constraints_decision_grade (also carries F2a threshold_clamped)
         ));
       } catch (err) {
         req.log.error({

--- a/src/trust/edge-severity.ts
+++ b/src/trust/edge-severity.ts
@@ -3,6 +3,8 @@
  * Thresholds ported from UI useResultsSectionData.ts unchanged.
  */
 
+import { isFiniteNumber } from '../util/numeric.js';
+
 export type EdgeSeverity = 'critical' | 'error' | 'warning';
 
 /**
@@ -19,7 +21,7 @@ export type EdgeSeverity = 'critical' | 'error' | 'warning';
 export function classifyEdgeSeverity(
   switchProbability: number | null | undefined,
 ): EdgeSeverity | undefined {
-  if (typeof switchProbability !== 'number' || !Number.isFinite(switchProbability)) {
+  if (!isFiniteNumber(switchProbability)) {
     return undefined;
   }
   if (switchProbability > 0.7) return 'critical';
@@ -57,7 +59,7 @@ export const FRAGILE_EDGE_VISIBLE_MIN = 0.15;
 export function deriveFragileEdgeVisible(
   switchProbability: number | null | undefined,
 ): boolean | undefined {
-  if (typeof switchProbability !== 'number' || !Number.isFinite(switchProbability)) {
+  if (!isFiniteNumber(switchProbability)) {
     return undefined;
   }
   return switchProbability > FRAGILE_EDGE_VISIBLE_MIN;

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -388,13 +388,11 @@ export interface ConstraintScaleProvenance {
    */
   threshold_clamped?: 'low' | 'high';
   /**
-   * FROZEN derivation:
-   *   (range_unified OR producer-declared source
-   *      [goal_threshold_cap | unit_percent | explicit_cap | explicit(=state_space)])
-   *   AND NOT threshold_clamped
-   *   AND source ∉ { inferred_value, default }.
-   * Conservative: inferred_value/default ⇒ false even when internally consistent
-   * (ruling D-5). This is a marker only; no new suppression rides on it.
+   * Producer-owned trust marker. See `DECISION_GRADE_SOURCES` +
+   * `buildConstraintScaleProvenance` in `routes/v2/run.ts` for the authoritative
+   * derivation (whitelist form; the OR-disjunct was removed in the F-A1
+   * amendment). Conservative / fail-closed (ruling D-5). This is a marker only;
+   * no new suppression rides on it.
    */
   decision_grade: boolean;
 }
@@ -1890,8 +1888,9 @@ export interface FactorSensitivityResultV3 {
    * Doctrine 039 (D-7) — producer-owned categorical driver-strength label over
    * `influence_score` (normalised influence). 4-valued, to match the shape of
    * the UI's `getSemanticLabel`: the set-aware rank-1 'biggest' band plus three
-   * magnitude bands (DOCTRINE-PENDING, Neil): >=0.50 'strong', >=0.20
-   * 'moderate', else 'minor'. Exactly one factor per response is 'biggest' (the
+   * magnitude bands (DOCTRINE-PENDING, Neil): >= DRIVER_LABEL_STRONG_MIN
+   * 'strong', >= DRIVER_LABEL_MODERATE_MIN 'moderate', else 'minor'. Exactly one
+   * factor per response is 'biggest' (the
    * single greatest `influence_score`, unconditional of magnitude; ties → first
    * in emitted order). ABSENT when `influence_score` is absent/non-finite (never
    * fabricated from a missing value; not eligible to be 'biggest'). Basis flip
@@ -1965,8 +1964,8 @@ export interface FactorSensitivityResultV3 {
   /**
    * Doctrine 014 — producer-owned "gather evidence" gate. Gates on the REAL
    * per-factor counterfactual EVPI where present (evpi_percentage_points with
-   * evpi_method 'counterfactual', >= EVPI_HINT_MIN_PP = 0.5pp), else falls back
-   * to the heuristic VOI (value_of_information > VOI_HINT_MIN = 0.05). Both
+   * evpi_method 'counterfactual', >= EVPI_HINT_MIN_PP), else falls back
+   * to the heuristic VOI (value_of_information > VOI_HINT_MIN). Both
    * thresholds DOCTRINE-PENDING (Neil). ABSENT when there is no basis (no real
    * EVPI and no finite VOI) and on option-controlled levers (not evidence-gap
    * candidates). See `src/lib/evpi-emission.ts` (`deriveEvidenceHint`).
@@ -2370,7 +2369,7 @@ export interface NormalizedEdgeInfoV3 {
   severity?: 'critical' | 'error' | 'warning';
   /**
    * Doctrine 013 — producer-DISCLOSED visibility gate over `switch_probability`.
-   * `visible = switch_probability > FRAGILE_EDGE_VISIBLE_MIN` (0.15, ratified
+   * `visible = switch_probability > FRAGILE_EDGE_VISIBLE_MIN` (ratified
    * from the UI's THRESHOLDS.FRAGILE_EDGE_FILTER; DOCTRINE-PENDING, Neil). PLoT
    * DISCLOSES the gate but does NOT filter the array — the UI decides render.
    * ABSENT when switch_probability is absent/non-finite (never fabricated). See


### PR DESCRIPTION
## /simplify cleanup — session PLoT diff (marker + emits + fixes)

Behavior-preserving quality pass over the session's cumulative change, from a 4-angle review (reuse / simplification / efficiency / altitude). **No behavior change — the hard gate was zero golden delta + no test file modified.**

### The two that matter most — live doc-drift I'd introduced (mirror-drift class)
- **`engine-v3.ts` `decision_grade` doc** still restated the *old OR-disjunct formula* that the F-A1 whitelist fix dropped — a consumer reading the contract doc would have reproduced the killed wrong-TRUE cell. Now points at the authoritative `DECISION_GRADE_SOURCES` / `buildConstraintScaleProvenance` instead of restating.
- **`normaliseGoalConstraints` JSDoc** still showed the pre-fix 3-row ladder (goal_threshold_cap @ priority 0). Updated to the current 6-branch ladder.

### Dedup / reuse / efficiency
- 8 inline `typeof x === 'number' && Number.isFinite(x)` guards → the repo's SSoT `isFiniteNumber` (polarity + type-guard narrowing preserved).
- Identity-range predicate `min===0 && max===1` written 3× → one exported `isIdentityRange` with the assumption-vs-measured doc carried once.
- `classifyEdgeSeverity`/`deriveFragileEdgeVisible` each double-called per fragile edge → one const each.
- Dropped a redundant `buildResponse` param (`constraintThresholdClampByConstraintId`) — the clamp direction is already carried on each `scale_provenance` entry; byte-equivalence of the read verified.
- Remote docs cite threshold const *names* not values (so a future Neil re-ratification changes one const, not scattered prose); loop-invariant hoists; folded duplicate diagnostic passes.

### Verification
- **Golden/snapshot diff EMPTY**; **no test file modified** (`git diff tests/ fixtures/` empty) — nothing but references could have changed, and none did.
- `npm run typecheck` clean; affected suite 786 passed / 4 skipped / 0 failed (constraint/margin/reliability/drivers/robustness/severity/doctrine/evpi + full-route golden pin). `margin_precision` confirmed byte-identical via the golden pin.

### Deferred (rowed, behavior-adjacent — out of a quality-only pass)
R1 (scale_provenance false-divergence on equal ranges — a real conservative false-negative), R4 (extract `deriveMarginPrecision` into a tested helper), R2/R3/R5/R6 (RangeSource vocab, clamp-at-source, evidence context object, module-owned driver labels) — see `acceptance-evidence/a3-verify-2026-07-16/SIMPLIFY-FINDINGS-2026-07-21.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
