### PR TITLE
refactor(trust): extract deriveMarginPrecision into a tested pure helper (behavior-preserving)

### DIFF
--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -160,6 +160,7 @@ import {
 import { NEAR_TIE_THRESHOLD } from '../../trust/result-coherence.js';
 import { assessGraphIdentifiability, toIdentifiabilityResponse, detectUnmeasuredConfounding } from '../../trust/identifiability-v2.js';
 import { classifyEdgeSeverity, deriveFragileEdgeVisible } from '../../trust/edge-severity.js';
+import { deriveMarginPrecision } from '../../trust/margin-precision.js';
 import { deriveConfidenceTier, reconcileConfidenceTier } from '../../trust/confidence-tier.js';
 import { detectDominantFactor } from '../../trust/factor-dominance.js';
 import type { IdentifiabilityAssessment } from '../../types/engine-v3.js';
@@ -2430,29 +2431,10 @@ function buildResponse(
             // per-option INTERVENTION clamp (a clamped sample) and the
             // constraint THRESHOLD clamp (a threshold pushed outside the shared
             // range) — independently of constraintNormRanges, and only claim
-            // what the evidence supports.
-            //
-            // Case analysis (why each clamp/operator pairing is understatement
-            // vs overstatement of the emitted breach margin):
-            //   INTERVENTION clamp (the SAMPLE moves):
-            //     - high-clamp ('<='): true sample ≥ emitted ⇒ true breach ≥
-            //       emitted ⇒ understates → lower_bound.
-            //     - low-clamp  ('>='): true sample ≤ emitted ⇒ understates.
-            //     - the two opposite pairings could OVERSTATE ⇒ no claim.
-            //   THRESHOLD clamp (the THRESHOLD moves — the MIRROR direction):
-            //     - '<=' threshold clamped LOW (to the floor, normalised 0): the
-            //       true threshold is below 0, so the true breach (sample −
-            //       threshold) is LARGER ⇒ emitted understates → lower_bound.
-            //     - '>=' threshold clamped HIGH (to the ceiling, normalised 1):
-            //       true threshold above 1, true breach (threshold − sample)
-            //       LARGER ⇒ understates → lower_bound.
-            //     - '<=' clamped HIGH / '>=' clamped LOW: the emitted breach
-            //       could OVERSTATE the true breach ⇒ NEVER claim a bound.
-            // Precedence: ANY possible overstatement ⇒ OMIT (cannot prove a
-            // lower bound, and it is not exact). Otherwise ANY understatement ⇒
-            // 'lower_bound'. Otherwise (no clamp on either side) 'exact' — but
-            // ONLY when the target factor is diagnosed (else clamp state is
-            // unknown, e.g. a non-intervened target, and no claim is made).
+            // what the evidence supports. The truth table over
+            // {operator, interventionClamp, thresholdClamp, diagnosed} and its
+            // understatement/overstatement case analysis + precedence live in
+            // deriveMarginPrecision (src/trust/margin-precision.ts).
             const clampDir = optionClampDirectionByFactor?.get(optionId)?.get(c.node_id);
             const hasDiagnostic = optionDiagnosedFactors?.get(optionId)?.has(c.node_id) ?? false;
             // F2a threshold-clamp direction, derived from the scale-provenance map
@@ -2460,26 +2442,14 @@ function buildResponse(
             // this is byte-identical to the former dedicated param).
             const thresholdClamp = constraintScaleProvenanceByConstraintId?.get(cid)?.threshold_clamped;
 
-            const interventionUnderstates =
-              (clampDir === 'high' && c.operator === '<=') ||
-              (clampDir === 'low' && c.operator === '>=');
-            const interventionOverstates = clampDir !== undefined && !interventionUnderstates;
-
-            const thresholdUnderstates =
-              (thresholdClamp === 'low' && c.operator === '<=') ||
-              (thresholdClamp === 'high' && c.operator === '>=');
-            const thresholdOverstates = thresholdClamp !== undefined && !thresholdUnderstates;
-
-            if (interventionOverstates || thresholdOverstates) {
-              // At least one clamp may inflate the emitted margin above the true
-              // breach ⇒ we cannot honestly claim 'lower_bound', and it is not
-              // 'exact'. OMIT.
-            } else if (interventionUnderstates || thresholdUnderstates) {
-              entry.margin_precision = 'lower_bound';
-            } else if (hasDiagnostic) {
-              // Neither side clamped in any direction and the target factor is
-              // diagnosed (thresholdClamp is necessarily undefined here) ⇒ exact.
-              entry.margin_precision = 'exact';
+            const mp = deriveMarginPrecision({
+              operator: c.operator,
+              interventionClamp: clampDir,
+              thresholdClamp,
+              diagnosed: hasDiagnostic,
+            });
+            if (mp !== undefined) {
+              entry.margin_precision = mp;
             }
           }
           if (nmf !== undefined) {

--- a/src/trust/margin-precision.ts
+++ b/src/trust/margin-precision.ts
@@ -1,0 +1,98 @@
+/**
+ * margin_precision derivation (Codex F1 (b)+(c) + F2a).
+ *
+ * Extracted verbatim (R4) from the per-option constraint_margins builder in
+ * routes/v2/run.ts. Pure truth table over
+ * {operator, interventionClamp, thresholdClamp, diagnosed} with a 3-level
+ * precedence. Returns the `margin_precision` value the caller sets on a
+ * ConstraintMargin entry, or `undefined` when no honest claim can be made — in
+ * which case the caller OMITS the field (absent ≠ a value).
+ */
+
+export interface MarginPrecisionInputs {
+  /**
+   * The constraint operator. Types as `string` because the value flows in from
+   * `ISLConstraintResult.operator` (a raw `string`); only the recognized
+   * literals `'<='` and `'>='` drive a claim — any other value yields no
+   * understatement/overstatement, exactly as the original inline `=== '<='` /
+   * `=== '>='` comparisons did.
+   */
+  operator: string;
+  /**
+   * Per-option INTERVENTION clamp direction for the target factor, if the
+   * factor's sample was clamped ('low'/'high'); `undefined` when unclamped.
+   */
+  interventionClamp: 'low' | 'high' | undefined;
+  /**
+   * Constraint THRESHOLD clamp direction (the threshold pushed outside the
+   * shared normalisation range), if clamped; `undefined` when unclamped.
+   */
+  thresholdClamp: 'low' | 'high' | undefined;
+  /**
+   * Whether the target factor is diagnosed. When false the clamp state is
+   * unknown (e.g. a non-intervened target) and no `'exact'` claim is made.
+   */
+  diagnosed: boolean;
+}
+
+/**
+ * Consult BOTH recorded clamp states — the per-option INTERVENTION clamp (a
+ * clamped sample) and the constraint THRESHOLD clamp (a threshold pushed
+ * outside the shared range) — and only claim what the evidence supports.
+ *
+ * Case analysis (why each clamp/operator pairing is understatement
+ * vs overstatement of the emitted breach margin):
+ *   INTERVENTION clamp (the SAMPLE moves):
+ *     - high-clamp ('<='): true sample ≥ emitted ⇒ true breach ≥
+ *       emitted ⇒ understates → lower_bound.
+ *     - low-clamp  ('>='): true sample ≤ emitted ⇒ understates.
+ *     - the two opposite pairings could OVERSTATE ⇒ no claim.
+ *   THRESHOLD clamp (the THRESHOLD moves — the MIRROR direction):
+ *     - '<=' threshold clamped LOW (to the floor, normalised 0): the
+ *       true threshold is below 0, so the true breach (sample −
+ *       threshold) is LARGER ⇒ emitted understates → lower_bound.
+ *     - '>=' threshold clamped HIGH (to the ceiling, normalised 1):
+ *       true threshold above 1, true breach (threshold − sample)
+ *       LARGER ⇒ understates → lower_bound.
+ *     - '<=' clamped HIGH / '>=' clamped LOW: the emitted breach
+ *       could OVERSTATE the true breach ⇒ NEVER claim a bound.
+ * Precedence: ANY possible overstatement ⇒ OMIT (cannot prove a
+ * lower bound, and it is not exact). Otherwise ANY understatement ⇒
+ * 'lower_bound'. Otherwise (no clamp on either side) 'exact' — but
+ * ONLY when the target factor is diagnosed (else clamp state is
+ * unknown, e.g. a non-intervened target, and no claim is made).
+ */
+export function deriveMarginPrecision({
+  operator,
+  interventionClamp,
+  thresholdClamp,
+  diagnosed,
+}: MarginPrecisionInputs): 'exact' | 'lower_bound' | undefined {
+  const interventionUnderstates =
+    (interventionClamp === 'high' && operator === '<=') ||
+    (interventionClamp === 'low' && operator === '>=');
+  const interventionOverstates =
+    interventionClamp !== undefined && !interventionUnderstates;
+
+  const thresholdUnderstates =
+    (thresholdClamp === 'low' && operator === '<=') ||
+    (thresholdClamp === 'high' && operator === '>=');
+  const thresholdOverstates =
+    thresholdClamp !== undefined && !thresholdUnderstates;
+
+  if (interventionOverstates || thresholdOverstates) {
+    // At least one clamp may inflate the emitted margin above the true
+    // breach ⇒ we cannot honestly claim 'lower_bound', and it is not
+    // 'exact'. OMIT.
+    return undefined;
+  }
+  if (interventionUnderstates || thresholdUnderstates) {
+    return 'lower_bound';
+  }
+  if (diagnosed) {
+    // Neither side clamped in any direction and the target factor is
+    // diagnosed (thresholdClamp is necessarily undefined here) ⇒ exact.
+    return 'exact';
+  }
+  return undefined;
+}

--- a/tests/trust/margin-precision.test.ts
+++ b/tests/trust/margin-precision.test.ts
@@ -1,0 +1,206 @@
+/**
+ * R4 — deriveMarginPrecision truth-table unit tests.
+ *
+ * Behavior-preserving extraction of the inline margin_precision derivation from
+ * routes/v2/run.ts. This file is the direct seam the route logic never had:
+ * the full truth table over
+ *   operator            ∈ {'<=', '>='}
+ *   interventionClamp    ∈ {undefined, 'low', 'high'}
+ *   thresholdClamp       ∈ {undefined, 'low', 'high'}
+ *   diagnosed            ∈ {true, false}
+ * = 36 cases, with a hand-written expected column (an oracle independent of the
+ * implementation, so a mutated helper is caught).
+ *
+ * Precedence encoded by the oracle:
+ *   1. ANY possible OVERSTATE (interventionOverstates OR thresholdOverstates)
+ *      ⇒ undefined (caller OMITS — cannot claim a bound).
+ *   2. else ANY UNDERSTATE (interventionUnderstates OR thresholdUnderstates)
+ *      ⇒ 'lower_bound'.
+ *   3. else diagnosed ⇒ 'exact'; else undefined.
+ * Direction rules:
+ *   interventionUnderstates: (clamp 'high' && '<=') OR (clamp 'low' && '>=').
+ *   thresholdUnderstates:    (clamp 'low'  && '<=') OR (clamp 'high' && '>=').
+ *   overstates = clamp present AND not the understate direction.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveMarginPrecision } from '../../src/trust/margin-precision.js';
+
+type Operator = '<=' | '>=';
+type Clamp = 'low' | 'high' | undefined;
+type Expected = 'exact' | 'lower_bound' | undefined;
+
+interface Row {
+  operator: Operator;
+  interventionClamp: Clamp;
+  thresholdClamp: Clamp;
+  diagnosed: boolean;
+  expected: Expected;
+}
+
+// Hand-derived oracle — 36 rows. Expected values reasoned from the precedence
+// above, NOT re-computed from the helper's code (that would be tautological).
+const TRUTH_TABLE: Row[] = [
+  // ---- operator '<=' ----
+  { operator: '<=', interventionClamp: undefined, thresholdClamp: undefined, diagnosed: true,  expected: 'exact' },
+  { operator: '<=', interventionClamp: undefined, thresholdClamp: undefined, diagnosed: false, expected: undefined },
+  { operator: '<=', interventionClamp: undefined, thresholdClamp: 'low',     diagnosed: true,  expected: 'lower_bound' },
+  { operator: '<=', interventionClamp: undefined, thresholdClamp: 'low',     diagnosed: false, expected: 'lower_bound' },
+  { operator: '<=', interventionClamp: undefined, thresholdClamp: 'high',    diagnosed: true,  expected: undefined },
+  { operator: '<=', interventionClamp: undefined, thresholdClamp: 'high',    diagnosed: false, expected: undefined },
+  { operator: '<=', interventionClamp: 'low',     thresholdClamp: undefined, diagnosed: true,  expected: undefined },
+  { operator: '<=', interventionClamp: 'low',     thresholdClamp: undefined, diagnosed: false, expected: undefined },
+  { operator: '<=', interventionClamp: 'low',     thresholdClamp: 'low',     diagnosed: true,  expected: undefined },
+  { operator: '<=', interventionClamp: 'low',     thresholdClamp: 'low',     diagnosed: false, expected: undefined },
+  { operator: '<=', interventionClamp: 'low',     thresholdClamp: 'high',    diagnosed: true,  expected: undefined },
+  { operator: '<=', interventionClamp: 'low',     thresholdClamp: 'high',    diagnosed: false, expected: undefined },
+  { operator: '<=', interventionClamp: 'high',    thresholdClamp: undefined, diagnosed: true,  expected: 'lower_bound' },
+  { operator: '<=', interventionClamp: 'high',    thresholdClamp: undefined, diagnosed: false, expected: 'lower_bound' },
+  { operator: '<=', interventionClamp: 'high',    thresholdClamp: 'low',     diagnosed: true,  expected: 'lower_bound' },
+  { operator: '<=', interventionClamp: 'high',    thresholdClamp: 'low',     diagnosed: false, expected: 'lower_bound' },
+  { operator: '<=', interventionClamp: 'high',    thresholdClamp: 'high',    diagnosed: true,  expected: undefined },
+  { operator: '<=', interventionClamp: 'high',    thresholdClamp: 'high',    diagnosed: false, expected: undefined },
+  // ---- operator '>=' ----
+  { operator: '>=', interventionClamp: undefined, thresholdClamp: undefined, diagnosed: true,  expected: 'exact' },
+  { operator: '>=', interventionClamp: undefined, thresholdClamp: undefined, diagnosed: false, expected: undefined },
+  { operator: '>=', interventionClamp: undefined, thresholdClamp: 'low',     diagnosed: true,  expected: undefined },
+  { operator: '>=', interventionClamp: undefined, thresholdClamp: 'low',     diagnosed: false, expected: undefined },
+  { operator: '>=', interventionClamp: undefined, thresholdClamp: 'high',    diagnosed: true,  expected: 'lower_bound' },
+  { operator: '>=', interventionClamp: undefined, thresholdClamp: 'high',    diagnosed: false, expected: 'lower_bound' },
+  { operator: '>=', interventionClamp: 'low',     thresholdClamp: undefined, diagnosed: true,  expected: 'lower_bound' },
+  { operator: '>=', interventionClamp: 'low',     thresholdClamp: undefined, diagnosed: false, expected: 'lower_bound' },
+  { operator: '>=', interventionClamp: 'low',     thresholdClamp: 'low',     diagnosed: true,  expected: undefined },
+  { operator: '>=', interventionClamp: 'low',     thresholdClamp: 'low',     diagnosed: false, expected: undefined },
+  { operator: '>=', interventionClamp: 'low',     thresholdClamp: 'high',    diagnosed: true,  expected: 'lower_bound' },
+  { operator: '>=', interventionClamp: 'low',     thresholdClamp: 'high',    diagnosed: false, expected: 'lower_bound' },
+  { operator: '>=', interventionClamp: 'high',    thresholdClamp: undefined, diagnosed: true,  expected: undefined },
+  { operator: '>=', interventionClamp: 'high',    thresholdClamp: undefined, diagnosed: false, expected: undefined },
+  { operator: '>=', interventionClamp: 'high',    thresholdClamp: 'low',     diagnosed: true,  expected: undefined },
+  { operator: '>=', interventionClamp: 'high',    thresholdClamp: 'low',     diagnosed: false, expected: undefined },
+  { operator: '>=', interventionClamp: 'high',    thresholdClamp: 'high',    diagnosed: true,  expected: undefined },
+  { operator: '>=', interventionClamp: 'high',    thresholdClamp: 'high',    diagnosed: false, expected: undefined },
+];
+
+const label = (r: Row) =>
+  `${r.operator} · iClamp=${String(r.interventionClamp)} · tClamp=${String(r.thresholdClamp)} · diagnosed=${r.diagnosed} ⇒ ${String(r.expected)}`;
+
+describe('deriveMarginPrecision — 36-case truth table', () => {
+  it('covers exactly 36 cases (2 × 3 × 3 × 2)', () => {
+    expect(TRUTH_TABLE).toHaveLength(36);
+    // No duplicate input rows.
+    const keys = new Set(
+      TRUTH_TABLE.map(
+        r => `${r.operator}|${r.interventionClamp}|${r.thresholdClamp}|${r.diagnosed}`,
+      ),
+    );
+    expect(keys.size).toBe(36);
+  });
+
+  for (const row of TRUTH_TABLE) {
+    it(label(row), () => {
+      expect(
+        deriveMarginPrecision({
+          operator: row.operator,
+          interventionClamp: row.interventionClamp,
+          thresholdClamp: row.thresholdClamp,
+          diagnosed: row.diagnosed,
+        }),
+      ).toBe(row.expected);
+    });
+  }
+
+  it('output distribution matches the precedence: 2 exact, 12 lower_bound, 22 undefined', () => {
+    const counts = { exact: 0, lower_bound: 0, undefined: 0 };
+    for (const row of TRUTH_TABLE) {
+      const out = deriveMarginPrecision({
+        operator: row.operator,
+        interventionClamp: row.interventionClamp,
+        thresholdClamp: row.thresholdClamp,
+        diagnosed: row.diagnosed,
+      });
+      if (out === 'exact') counts.exact += 1;
+      else if (out === 'lower_bound') counts.lower_bound += 1;
+      else counts.undefined += 1;
+    }
+    expect(counts).toEqual({ exact: 2, lower_bound: 12, undefined: 22 });
+  });
+});
+
+describe('deriveMarginPrecision — named real cases', () => {
+  it("'<=' + thresholdClamp 'low' (response-1 scenario) ⇒ 'lower_bound'", () => {
+    expect(
+      deriveMarginPrecision({
+        operator: '<=',
+        interventionClamp: undefined,
+        thresholdClamp: 'low',
+        diagnosed: true,
+      }),
+    ).toBe('lower_bound');
+    // Also holds when the target is NOT diagnosed — the understatement claim
+    // does not depend on the diagnostic flag.
+    expect(
+      deriveMarginPrecision({
+        operator: '<=',
+        interventionClamp: undefined,
+        thresholdClamp: 'low',
+        diagnosed: false,
+      }),
+    ).toBe('lower_bound');
+  });
+
+  it("no clamp + diagnosed ⇒ 'exact'", () => {
+    expect(
+      deriveMarginPrecision({
+        operator: '<=',
+        interventionClamp: undefined,
+        thresholdClamp: undefined,
+        diagnosed: true,
+      }),
+    ).toBe('exact');
+    expect(
+      deriveMarginPrecision({
+        operator: '>=',
+        interventionClamp: undefined,
+        thresholdClamp: undefined,
+        diagnosed: true,
+      }),
+    ).toBe('exact');
+  });
+
+  it('no clamp + not diagnosed ⇒ undefined', () => {
+    expect(
+      deriveMarginPrecision({
+        operator: '<=',
+        interventionClamp: undefined,
+        thresholdClamp: undefined,
+        diagnosed: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("'<=' + interventionClamp 'low' (overstate) ⇒ undefined even when diagnosed", () => {
+    // Overstatement wins over the diagnostic — the emitted margin could exceed
+    // the true breach, so no bound can be claimed.
+    expect(
+      deriveMarginPrecision({
+        operator: '<=',
+        interventionClamp: 'low',
+        thresholdClamp: undefined,
+        diagnosed: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('overstatement takes precedence over a co-present understatement', () => {
+    // '<=' with interventionClamp 'high' (understates) BUT thresholdClamp 'high'
+    // (overstates) ⇒ OMIT: any possible overstatement wins.
+    expect(
+      deriveMarginPrecision({
+        operator: '<=',
+        interventionClamp: 'high',
+        thresholdClamp: 'high',
+        diagnosed: true,
+      }),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Extract `deriveMarginPrecision` into a tested pure helper (R4 — behavior-preserving)

Follow-up from the `/simplify` altitude review. `margin_precision` was a 25-line clamp/operator truth table inlined in the per-option loop of the 33-parameter `buildResponse` — the one intricate trust derivation that never got the pure-helper treatment its siblings did (`driver-label.ts`, `deriveEvidenceHint`, `deriveFragileEdgeVisible`), and testable only through the full route harness.

### Change
- New `src/trust/margin-precision.ts` — `deriveMarginPrecision({operator, interventionClamp, thresholdClamp, diagnosed}): 'exact' | 'lower_bound' | undefined`, with the case-analysis comment moved onto the helper. Logic is a verbatim lift: same direction rules, same 3-level precedence (any-possible-overstate ⇒ omit ≻ any-understate ⇒ lower_bound ≻ diagnosed ⇒ exact).
- Route site: resolve the clamp/diagnosed inputs as before, then one call; −20 lines from the mega-function.
- `operator` kept typed `string` (matching `ISLConstraintResult.operator`) — no `as`-cast, identical to the inline `===` comparison.

### Verification
- **New `tests/trust/margin-precision.test.ts`** — the truth table's first direct seam: 43 tests enumerating both operators × interventionClamp{none,low,high} × thresholdClamp{none,low,high} × diagnosed{y,n}. Distribution: 2 exact / 12 lower_bound / 22 undefined; all named cases hold.
- **Mutation:** flipping the precedence to understate-before-overstate → 10 RED (exactly the co-present understate+overstate rows + the distribution assertion) — the test discriminates the precedence.
- **Golden delta EMPTY** (hard gate — `margin_precision` byte-identical). `typecheck` clean. Route/gate tests (`constraint-margin-plumbing`, `v2-run.margin-sensitivity.contract`, range-unify, scale-correctness) 57 passed / 4 pre-existing skips. No existing assertion value changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
