### PR TITLE
fix(v2/run): scale_provenance false-divergence on equal ranges — record+project range_unified (behavior-changing)

### DIFF
--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -54,6 +54,17 @@ export function isIdentityRange(r: NormalisationRange): boolean {
 }
 
 /**
+ * True iff two ranges are the SAME scale — equal numeric bounds. Source-agnostic
+ * by design (A3 R1): "equal bounds = same scale" — a measured intervention spread
+ * `[0, cap]` and a producer `goal_threshold_cap` `[0, cap]` describe the identical
+ * scale even though their `source` strings differ, so the threshold IS on the
+ * samples' scale and did NOT diverge. Compares min AND max by value.
+ */
+export function rangesEqual(a: NormalisationRange, b: NormalisationRange): boolean {
+  return a.min === b.min && a.max === b.max;
+}
+
+/**
  * Intervention hints from CE (Context Engine).
  * Used to provide additional metadata for normalisation.
  */
@@ -1000,6 +1011,19 @@ export interface ConstraintNormalisationResult {
      * labels an understated margin 'exact'.
      */
     clamped: boolean;
+    /**
+     * A3 R1: recorded at ladder-decision time (here — where BOTH the resolved
+     * range and the node's intervention scale are in hand), so the trust marker
+     * can PROJECT it rather than re-derive it 700 lines away. TRUE when the
+     * threshold's scale did NOT diverge from the node's producer-declared scale:
+     * a measured (non-identity) intervention spread was adopted as the threshold
+     * scale (ladder branch 1) AND a producer declared a DIFFERENT scale
+     * (goal_threshold_cap / '%') for the same node. NUMERIC-equality test — equal
+     * bounds are the SAME scale (no divergence). No producer declaration, an
+     * identity (assumed) intervention scale, or no intervention scale ⇒ TRUE
+     * (nothing to diverge from).
+     */
+    range_unified: boolean;
     /** True when the node's CEE-stamped goal_threshold was preferred (P0-C1) */
     used_node_goal_threshold?: boolean;
   }>;
@@ -1145,6 +1169,28 @@ export function normaliseGoalConstraints(
         : { min: 0, max: 1, source: 'default' };
     }
 
+    // A3 R1 (false-divergence fix): decide range_unified HERE, at ladder-decision
+    // time, and record it in the diagnostic — the trust marker then PROJECTS it
+    // (no re-derivation from inputs 700 lines away). Divergence — range_unified
+    // FALSE — arises ONLY when a MEASURED (non-identity) intervention spread was
+    // adopted as the threshold scale (branch 1) while a producer declared a
+    // scale (goal_threshold_cap / '%') for the same node AND the two scales
+    // DIFFER NUMERICALLY. Equal bounds are the SAME scale ⇒ the threshold sits on
+    // the samples' scale ⇒ NO divergence (the bug this fixes assumed divergence on
+    // mere co-presence). No producer declaration, an identity (assumed) scale, or
+    // no intervention scale ⇒ nothing to diverge from ⇒ TRUE.
+    const producerDeclaredRange: NormalisationRange | undefined =
+      typeof nodeCap === 'number' && Number.isFinite(nodeCap) && nodeCap > 0
+        ? { min: 0, max: nodeCap, source: 'goal_threshold_cap' }
+        : isPercentUnit(unit)
+          ? { min: 0, max: 100, source: 'unit_percent' }
+          : undefined;
+    const rangeUnified =
+      interventionScale === undefined ||
+      interventionScaleIsIdentity ||
+      producerDeclaredRange === undefined ||
+      rangesEqual(interventionScale, producerDeclaredRange);
+
     // Normalise value
     let { normalised, clamped } = normaliseValue(value, range);
 
@@ -1211,6 +1257,8 @@ export function normaliseGoalConstraints(
         // stamp was preferred, `clamped` was reset to false above (the stamp is
         // an exact in-[0,1] value, no clamp), so this is correct in that branch too.
         clamped,
+        // A3 R1: the scale-unity decision, recorded for the trust marker to project.
+        range_unified: rangeUnified,
         ...(usedNodeGoalThreshold && { used_node_goal_threshold: true }),
       });
     }

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -171,7 +171,6 @@ import {
   needsNormalisation,
   normaliseGoalConstraints,
   constraintsNeedNormalisation,
-  isPercentUnit,
   isIdentityRange,
   type NormalisationContext,
   type NormalisationDiagnostic,
@@ -185,7 +184,6 @@ import type { ProposalCardV1 } from '../../review-pass/types.js';
 import { assembleFactObjects, type ISLResponseInput } from '../../facts/index.js';
 import type { FactObjectV1, FactLineage } from '../../facts/types.js';
 import { finiteNum, prob01, nonNeg, nonNegInt, hasAllRequiredOutcomeStats } from './numeric-egress-guards.js';
-import { isFiniteNumber } from '../../util/numeric.js';
 import {
   assessEnrichmentContract,
   shouldAssessEnrichmentContract,
@@ -1760,8 +1758,10 @@ function collectGoalThresholdNodeMeta(
  * Member vocabulary:
  *   - inferred_spread  — a MEASURED intervention spread; the threshold shares the
  *                        samples' own scale (D-2 sameness). Grade-worthy only when
- *                        range_unified (a producer declaration it overrode makes
- *                        range_unified false ⇒ fails the AND, correctly).
+ *                        range_unified (a producer declaration it overrode with a
+ *                        NUMERICALLY DIFFERENT scale makes range_unified false ⇒
+ *                        fails the AND, correctly; an equal-bounds producer scale
+ *                        is the SAME scale ⇒ still unified, A3 R1).
  *   - explicit         — a node-level `state_space.range` declaration.
  *   - explicit_cap     — a node-level `observed_state.cap` declaration.
  *   - goal_threshold_cap / unit_percent — the constraint's own producer scale.
@@ -1784,6 +1784,18 @@ function collectGoalThresholdNodeMeta(
  * EXCLUDED pending Neil (MARKER-ADVERSARIAL.md O-2 — one-line promotions if
  * ratified). The frozen field shapes are unaffected; this is the internal
  * decision-grade source membership only.
+ *
+ * A3 R1 (range_unified is PROJECTED, not re-derived): the scale-unity decision is
+ * made once, at ladder-decision time in `normaliseGoalConstraints` (which holds
+ * BOTH the resolved range and the node's intervention scale), recorded on the
+ * per-constraint diagnostic, and threaded here as `rangeUnifiedByCid`. Divergence
+ * is a NUMERIC inequality (a measured spread adopted as the threshold scale while
+ * a producer declared a DIFFERENT scale) — equal bounds are the SAME scale, so an
+ * intervention spread `[0,cap]` matching a producer cap `[0,cap]` is unified, not
+ * diverged (the false-divergence fix). A never-normalised constraint (no
+ * diagnostic) has no intervention scale ⇒ nothing to diverge from ⇒ unified.
+ * `decision_grade`'s derivation (the whitelist AND) is unchanged — only its
+ * `range_unified` input is now correct + projected.
  */
 const DECISION_GRADE_SOURCES: ReadonlySet<RangeSource> = new Set<RangeSource>([
   'inferred_spread',
@@ -1800,9 +1812,13 @@ function buildConstraintScaleProvenance(
   // normalisation (forwarded-raw / already in [0,1], no diagnostic).
   constraintNormRanges: Map<string, NormalisationRange> | undefined,
   thresholdClampByCid: Map<string, 'low' | 'high'> | undefined,
-  interventionScaleByNodeId: Map<string, NormalisationRange>,
-  goalThresholdMetaByNodeId: Map<string, GoalThresholdNodeMeta>,
-  unitsByConstraintId: Map<string, string>,
+  // A3 R1: the range-unity decision RECORDED by normaliseGoalConstraints at
+  // ladder-decision time (from the SAME diagnostics as the maps above), keyed by
+  // constraint_id. Present iff the constraint was normalised. This marker PROJECTS
+  // it — no re-derivation of nonIdentitySpread/producerDeclaration from raw inputs
+  // 700 lines away (derive-don't-mirror). See the diagnostic's `range_unified`
+  // field for the numeric-equality divergence rule.
+  rangeUnifiedByCid: Map<string, boolean> | undefined,
 ): Map<string, ConstraintScaleProvenance> {
   const out = new Map<string, ConstraintScaleProvenance>();
   for (const c of activeConstraints) {
@@ -1813,21 +1829,11 @@ function buildConstraintScaleProvenance(
     const source: RangeSource = constraintNormRanges?.get(c.constraint_id)?.source ?? 'default';
     const thresholdClamp = thresholdClampByCid?.get(c.constraint_id);
 
-    const interventionScale = interventionScaleByNodeId.get(c.node_id);
-    const nonIdentitySpread =
-      interventionScale !== undefined && !isIdentityRange(interventionScale);
-
-    const nodeCap = goalThresholdMetaByNodeId.get(c.node_id)?.goal_threshold_cap;
-    const producerDeclarationOnNode =
-      (isFiniteNumber(nodeCap) && nodeCap > 0) ||
-      isPercentUnit(unitsByConstraintId.get(c.constraint_id));
-
-    // Divergence (D-2 disclosing itself): a MEASURED intervention spread overrode
-    // a producer declaration on the same node. Only THIS makes range_unified
-    // false — a shared scale, a never-intervened node, or a producer overriding
-    // an ASSUMED identity scale are all unified.
-    const diverged = nonIdentitySpread && producerDeclarationOnNode;
-    const rangeUnified = !diverged;
+    // range_unified is a PURE PROJECTION of the normalisation diagnostic (A3 R1).
+    // A normalised constraint carries its recorded decision; a NEVER-normalised
+    // constraint (no diagnostic ⇒ no intervention scale ⇒ nothing to diverge from)
+    // is unified by construction.
+    const rangeUnified = rangeUnifiedByCid?.get(c.constraint_id) ?? true;
 
     // F-A1 whitelist derivation: range must be unified, unclamped, AND its source
     // must be an explicitly-trusted member. A non-member (inferred_value, default,
@@ -5188,6 +5194,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // clamped). A clamped threshold makes the emitted breach margin a strict
         // bound — the margin egress uses this to avoid mislabelling it 'exact'.
         let constraintThresholdClampByConstraintId: Map<string, 'low' | 'high'> | undefined;
+        // A3 R1: per-constraint range-unity decision, recorded by
+        // normaliseGoalConstraints at ladder-decision time (entry present ONLY for
+        // a normalised constraint — a diagnostic exists). The trust marker PROJECTS
+        // this instead of re-deriving it; absence ⇒ never-normalised ⇒ unified.
+        let constraintRangeUnifiedByCid: Map<string, boolean> | undefined;
         // A3 trust marker: per-constraint scale provenance (built in Phase 4b
         // below once the constraint ranges + clamp map + intervention scales are
         // known). Feeds constraint_results[].scale_provenance and
@@ -5340,8 +5351,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             //    margin egress then makes no precision claim).
             constraintNormalisationRanges = new Map<string, NormalisationRange>();
             constraintThresholdClampByConstraintId = new Map<string, 'low' | 'high'>();
+            //  - constraintRangeUnifiedByCid (A3 R1): the range-unity decision the
+            //    normaliser recorded at ladder-decision time — projected verbatim
+            //    by the trust marker (derive-don't-mirror). Set BEFORE the clamp
+            //    `continue` so every diagnostic contributes it.
+            constraintRangeUnifiedByCid = new Map<string, boolean>();
             for (const d of constraintNormResult.diagnostics) {
               constraintNormalisationRanges.set(d.constraint_id, d.range);
+              constraintRangeUnifiedByCid.set(d.constraint_id, d.range_unified);
               if (!d.clamped) continue;
               const direction = d.normalised_value <= 0 ? 'low' : d.normalised_value >= 1 ? 'high' : undefined;
               if (direction === undefined) continue;
@@ -5379,19 +5396,18 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
 
           // A3 trust marker (additive; D-2/D-5): build the per-constraint scale
           // provenance from the SAME #239 machinery — the resolved constraint
-          // range source, the F2a threshold-clamp map, the per-node intervention
-          // scale, and the producer metadata. Covers EVERY active constraint
-          // (the else branch above leaves constraintNormalisationRanges /
-          // constraintThresholdClampByConstraintId undefined → those forwarded-raw
-          // constraints disclose as source 'default', decision_grade false —
-          // fail-closed). No new suppression: this only discloses.
+          // range source, the F2a threshold-clamp map, and the range-unity
+          // decision the normaliser already recorded (A3 R1 — projected, not
+          // re-derived). Covers EVERY active constraint (the else branch above
+          // leaves constraintNormalisationRanges / constraintThresholdClampByConstraintId
+          // / constraintRangeUnifiedByCid undefined → those forwarded-raw
+          // constraints disclose as source 'default', range_unified true,
+          // decision_grade false — fail-closed). No new suppression: only discloses.
           constraintScaleProvenanceByConstraintId = buildConstraintScaleProvenance(
             activeGoalConstraints,
             constraintNormalisationRanges,
             constraintThresholdClampByConstraintId,
-            interventionScaleByNodeId,
-            goalThresholdMetaByNodeId,
-            constraintUnitsByConstraintId,
+            constraintRangeUnifiedByCid,
           );
         }
 

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -372,12 +372,14 @@ export interface ConstraintScaleProvenance {
    */
   source: RangeSource;
   /**
-   * True when the threshold's range is identical by construction to the range
-   * this node's interventions used or would use — TRUE for a shared intervention
-   * scale AND for never-intervened nodes resolving through the same chain. FALSE
-   * precisely when the resolution DIVERGED: a producer-declared cap/'%' on the
-   * node was overridden by a MEASURED intervention spread (ruling D-2 disclosing
-   * itself).
+   * True when the threshold's range is the SAME scale as the range this node's
+   * interventions used or would use — TRUE for a shared intervention scale AND for
+   * never-intervened nodes resolving through the same chain. FALSE precisely when
+   * the resolution DIVERGED: a producer-declared cap/'%' on the node was overridden
+   * by a MEASURED intervention spread ON A NUMERICALLY DIFFERENT SCALE (ruling D-2
+   * disclosing itself). Equal bounds are the same scale — an intervention spread
+   * `[0,cap]` matching a producer cap `[0,cap]` is unified, not diverged (A3 R1
+   * false-divergence fix).
    */
   range_unified: boolean;
   /**

--- a/tests/gates/constraint-scale-provenance-marker.test.ts
+++ b/tests/gates/constraint-scale-provenance-marker.test.ts
@@ -254,4 +254,64 @@ describe('A3 constraint trust marker · scale_provenance + constraints_decision_
     expect('constraints_decision_grade' in a).toBe(false);
     expect(raw).not.toMatch(/"constraints_decision_grade"/);
   });
+
+  // (f) A3 R1 FALSE-DIVERGENCE FIX: a MEASURED intervention spread that is
+  //     NUMERICALLY EQUAL to the node's producer cap is NOT a divergence — the
+  //     threshold sits on the samples' own scale. Interventions 10000/70000 →
+  //     spread [0,82000] (source inferred_spread); node goal_threshold_cap 82000 →
+  //     producer scale [0,82000]. Equal bounds ⇒ range_unified TRUE ⇒
+  //     decision_grade TRUE. Threshold 40000 sits INSIDE [0,82000] (unclamped).
+  //     RED at HEAD (graded range_unified:false / decision_grade:false); GREEN after.
+  it('(f) equal-range: measured spread == producer cap ⇒ range_unified true, decision_grade true (R1 fix)', async () => {
+    const COST_CAP_82K = {
+      id: 'cost', kind: 'factor', label: 'First-year cost',
+      observed_state: { value: 30000 }, goal_threshold_cap: 82000,
+    };
+    const body = await run({
+      graph: { nodes: [NODES[0], COST_CAP_82K], edges: [EDGES[0]] },
+      options: [
+        { id: 'opt_a', label: 'A', interventions: { cost: 10000 } },
+        { id: 'opt_b', label: 'B', interventions: { cost: 70000 } },
+      ],
+      goal_node_id: 'goal', seed: '42',
+      goal_constraints: [{ constraint_id: 'c_eq', node_id: 'cost', operator: '<=', value: 40000 }],
+    });
+    const sp = topLevelConstraint(body, 'c_eq')?.scale_provenance;
+    expect(sp).toBeDefined();
+    expect(sp.source).toBe('inferred_spread');
+    expect(sp.range_unified).toBe(true);
+    expect('threshold_clamped' in sp).toBe(false); // 40000 ∈ [0,82000] ⇒ unclamped
+    expect(sp.decision_grade).toBe(true);
+    // Sole participating constraint is decision-grade ⇒ aggregate true on both.
+    expect(optionEntry(body, 'opt_a').constraints_decision_grade).toBe(true);
+    expect(optionEntry(body, 'opt_b').constraints_decision_grade).toBe(true);
+  });
+
+  // (g) POSITIVE CONTROL: a GENUINE divergence must STILL grade false — proves the
+  //     R1 fix narrows divergence to a NUMERIC inequality, it does NOT flip
+  //     everything true. Interventions 25000/45000 → spread [21000,49000]; node
+  //     goal_threshold_cap 40000 → producer scale [0,40000]. Unequal ⇒ diverged ⇒
+  //     range_unified FALSE ⇒ decision_grade FALSE. Threshold 30000 is INSIDE
+  //     [21000,49000] (unclamped), so range_unified is the SOLE cause (not a clamp).
+  //     GREEN before AND after the fix, and GREEN after a mutation-revert.
+  it('(g) POSITIVE CONTROL genuine divergence (spread != cap) ⇒ range_unified false, decision_grade false', async () => {
+    const COST_CAP_40K = {
+      id: 'cost', kind: 'factor', label: 'First-year cost',
+      observed_state: { value: 30000 }, goal_threshold_cap: 40000,
+    };
+    const body = await run({
+      graph: { nodes: [NODES[0], COST_CAP_40K], edges: [EDGES[0]] },
+      options: OPTIONS_SPREAD, // interventions 25000/45000 → spread [21000,49000]
+      goal_node_id: 'goal', seed: '42',
+      goal_constraints: [{ constraint_id: 'c_div', node_id: 'cost', operator: '<=', value: 30000 }],
+    });
+    const sp = topLevelConstraint(body, 'c_div')?.scale_provenance;
+    expect(sp).toBeDefined();
+    expect(sp.source).toBe('inferred_spread');
+    expect(sp.range_unified).toBe(false);
+    expect('threshold_clamped' in sp).toBe(false); // 30000 ∈ [21000,49000] ⇒ unclamped
+    expect(sp.decision_grade).toBe(false);
+    expect(optionEntry(body, 'opt_a').constraints_decision_grade).toBe(false);
+    expect(optionEntry(body, 'opt_b').constraints_decision_grade).toBe(false);
+  });
 });


### PR DESCRIPTION
## Fix scale_provenance false-divergence on equal ranges (R1 — behavior-changing)

Follow-up from the `/simplify` altitude review. The constraint trust marker's `range_unified` was re-derived in `buildConstraintScaleProvenance` as `nonIdentitySpread && producerDeclarationOnNode` — i.e. it flagged divergence whenever a measured spread and a producer declaration merely **co-existed**, even when the two ranges were **numerically equal**. So a constraint whose intervention scale happened to equal its producer cap (`[0,cap]` == `[0,cap]`) was wrongly graded `range_unified:false` / `decision_grade:false` — a conservative false-negative that withholds trust from a correctly-scaled constraint.

### Fix (deep form — record the decision, project it)
`range_unified` is now decided **once**, in `normaliseGoalConstraints` at ladder-decision time (where both the resolved range and the node's intervention scale are in hand), recorded on the per-constraint diagnostic beside `clamped`, and **projected** by `buildConstraintScaleProvenance` — no re-derivation of ladder predicates 700 lines away.
- New `rangesEqual` (source-agnostic min/max equality) beside `isIdentityRange`.
- Divergence = a non-identity **measured** spread was adopted (branch 1) AND a producer declared a scale for the node AND **the two differ numerically** (`!rangesEqual`). Equal bounds ⇒ same scale ⇒ no divergence.
- This is a strict AND-narrowing of the old predicate over the **same** declaration set (`{goal_threshold_cap, unit_percent}`), so `range_unified` — and hence `decision_grade` — can only flip **false→true**. `decision_grade`'s whitelist AND, `constraints_decision_grade` partial-participation, and absence-fail-closed are **byte-untouched**; only the `range_unified` input changed.

### Verification
- RED-first + **positive control**: equal-range (spread==cap) → `range_unified:true`/`decision_grade:true` (RED→GREEN); genuine divergence (`[21000,49000]` vs `[0,40000]`) → stays `false` both ways (proves the fix doesn't over-correct).
- Mutation-check (throwaway worktree); full PLoT suite **5867 passed / 0 fail**; `typecheck` clean.
- **Golden delta ZERO** (no fixture exercises the equal-range combo); freshness `graph_hash` (request-derived) untouched — only a genuine equal-range response's content digest would move.
- **Adversarial pass (Opus — Fable was out of credits):** no wrong-TRUE path — `rangesEqual` fails-closed on NaN; the `?? true` projection default is benign (only forwarded-raw constraints are map-missing, and their `source:'default'` fails the whitelist independently); marker invariant tests intact (+60 lines, 0 weakened). Verdict SAFE. Record: `acceptance-evidence/a3-verify-2026-07-16/R1-ADVERSARIAL.md`.

### Rowed (pre-existing, not this PR)
The divergence check considers only `{goal_threshold_cap, unit_percent}`; a node whose `explicit_cap`/`state_space` range is overridden by a different spread isn't flagged (both old and new code miss it identically). Doctrine+build follow-up filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
