### PR TITLE
fix: adjacent-hunt bugs — direction-suspect honesty leak (3 surfaces), bad-index crash, false no-path-to-goal

### DIFF
--- a/src/coaching/m1-coaching.ts
+++ b/src/coaching/m1-coaching.ts
@@ -79,7 +79,18 @@ export function generateM1Coaching(
   }>,
   goalConstraints?: GoalConstraint[],
   factorSensitivityEnriched?: FactorSensitivityResultV3[],
-  constraintTargetsUnreliable?: boolean
+  constraintTargetsUnreliable?: boolean,
+  // A3 adjacent-hunt FIX #1 (coaching companion): TRUE when the auto-synthesised
+  // '>=' constraint's guessed direction is structurally unsatisfiable for at
+  // least one option (positive threshold + strictly-negative modelled outcome —
+  // isAutoConstraintDirectionSuspect). Distinct from constraintTargetsUnreliable
+  // (the suppressed-target partition), which is EMPTY on a decision-grade
+  // direction-suspect run. The joint-probability gate must ALSO abstain here:
+  // the near-0 joint_probability it would read is a mechanical sign-mismatch
+  // artefact, and FIX #1 already withholds the SAME number from the top-level
+  // wire block — emitting GOAL_FEASIBILITY_LOW from it would contradict that
+  // 'unavailable' verdict. Mirrors the wire gate's decision exactly.
+  constraintTargetDirectionSuspect?: boolean
 ): M1Coaching | null {
   const startTime = performance.now();
 
@@ -105,7 +116,16 @@ export function generateM1Coaching(
     // Producer honesty (item A): skipped when constraint targets are
     // unreliable — the joint probabilities are placeholder-derived and the
     // gate would fabricate a GOAL_FEASIBILITY_LOW claim from them.
-    if (goalConstraints && goalConstraints.length > 0 && !constraintTargetsUnreliable) {
+    // A3 adjacent-hunt FIX #1 (coaching companion): ALSO skipped when the
+    // target is direction-suspect — the near-0 joint_probability is a
+    // sign-mismatch artefact FIX #1 already withholds from the wire; emitting
+    // a feasibility verdict from it would contradict that 'unavailable'.
+    if (
+      goalConstraints &&
+      goalConstraints.length > 0 &&
+      !constraintTargetsUnreliable &&
+      !constraintTargetDirectionSuspect
+    ) {
       const jointProbGate = applyJointProbabilityGate(
         readiness, islResult, thresholds, modelCritiques
       );

--- a/src/lib/factor-influence.ts
+++ b/src/lib/factor-influence.ts
@@ -745,8 +745,13 @@ export function computeFactorSensitivityFromGraph(
   goalNodeId: string,
   fragileEdges?: FragileEdgeForVoi[]
 ): FactorSensitivityResultV3[] | null {
-  // Compute using the core algorithm
-  const influences = computeFactorInfluence(graph, goalNodeId);
+  // Compute using the core algorithm. A3 adjacent-hunt FIX #4: use the
+  // path-carrying variant (byte-identical influence/confidence/order — it wraps
+  // the SAME computeInfluenceFromPaths) so the zero_reason stamp below can tell
+  // a truly disconnected factor (paths.length === 0) apart from a CONNECTED
+  // factor whose only path carries zero net effect. `paths` is read locally for
+  // the stamp only and never egresses on the response object.
+  const influences = computeFactorInfluenceWithPaths(graph, goalNodeId);
 
   // Return null if no factors found (triggers ISL fallback)
   if (influences.length === 0) {
@@ -826,10 +831,16 @@ export function computeFactorSensitivityFromGraph(
         sampling_stability: null, // No ISL data at graph stage
       },
 
-      // Zero reason for factors with no path to goal
-      // Use original path-based confidence (f.confidence) to detect truly disconnected factors
+      // Zero reason for factors whose path-based influence AND confidence are 0.
+      // A3 adjacent-hunt FIX #4: {influence:0, confidence:0} collapses two
+      // distinct cases — a disconnected factor (paths.length === 0, early return
+      // in computeInfluenceFromPaths) and a CONNECTED factor whose only path has
+      // zero net effect (totalWeight === 0 discard). The former is genuinely
+      // "no path to goal"; the latter is connected and must NOT claim that.
+      // Distinguish by path count; 'zero_net_influence' is an additive
+      // open-vocabulary reason (consumers key only on 'intervention_override').
       zero_reason: f.influence === 0 && f.confidence === 0
-        ? 'no_path_to_goal'
+        ? (f.paths.length === 0 ? 'no_path_to_goal' : 'zero_net_influence')
         : undefined,
 
       // Mark source as graph-based

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -2063,7 +2063,19 @@ function buildConstraintFields(
   if (Array.isArray(analysis.conditional_probabilities) && analysis.conditional_probabilities.length > 0) {
     conditionalProbabilities = analysis.conditional_probabilities
       .filter((cp: any) =>
+        // A3 adjacent-hunt FIX #3 (crash hardening): an ISL index must be a
+        // valid array position for BOTH legs. The prior `< length` check alone
+        // let a negative or fractional index through — `islConstraints[idx]`
+        // was then `undefined` and `resolveConstraintId(undefined, idx)` threw,
+        // 500-ing (degrading to analysis_status:'failed') the whole /v2/run
+        // instead of dropping the one bad row. Require a non-negative integer
+        // in [0, length) — a bad row is DROPPED (honest omission), consistent
+        // with this file's untrusted-ISL numeric-egress posture.
+        Number.isInteger(cp.given_constraint_index) &&
+        cp.given_constraint_index >= 0 &&
         cp.given_constraint_index < islConstraints.length &&
+        Number.isInteger(cp.target_constraint_index) &&
+        cp.target_constraint_index >= 0 &&
         cp.target_constraint_index < islConstraints.length
       )
       .map((cp: any) => {

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -6535,6 +6535,30 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             processedIslResult,
           ).length > 0;
 
+          // A3 adjacent-hunt FIX #1 (coaching companion): mirror buildResponse's
+          // per-option direction-suspect detection so the coaching joint-prob
+          // gate abstains on the SAME suspicion FIX #1 uses to withhold the
+          // top-level wire block. Same inputs (processedIslResult +
+          // activeGoalConstraints) → same verdict as the wire gate: the single
+          // synthesised auto-constraint's guessed '>=' is structurally
+          // unsatisfiable for at least one option (positive threshold, p90 < 0,
+          // finite-guarded exactly as the option map is). Without this the gate
+          // reads the near-0 joint_probability directly and emits
+          // GOAL_FEASIBILITY_LOW — contradicting the 'unavailable' wire block.
+          const coachingConstraintTargetDirectionSuspect = (() => {
+            const autoConstraint = activeGoalConstraints?.find(
+              (c) => (c as { _internal?: { source?: string } })._internal?.source === 'auto_from_goal_threshold',
+            );
+            if (!autoConstraint) return false;
+            const islOptionData: any[] =
+              processedIslResult?.options ?? processedIslResult?.results ?? [];
+            return islOptionData.some(
+              (r) =>
+                hasAllRequiredOutcomeStats(r?.outcome) &&
+                isAutoConstraintDirectionSuspect(autoConstraint.value, r?.outcome?.p90),
+            );
+          })();
+
           m1Coaching = generateM1Coaching(
             filteredGraph,
             body.options,
@@ -6548,6 +6572,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                                  // confidence/influence match the public payload (audit
                                  // A1-PRIMARY: no raw-ISL signal under coaching field names).
             coachingConstraintTargetsUnreliable,  // Item A: skip joint-prob gate on unreliable targets
+            coachingConstraintTargetDirectionSuspect,  // FIX #1 companion: skip joint-prob gate on direction-suspect targets
           );
         } catch (err) {
           req.log.warn({

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -1866,7 +1866,16 @@ function buildConstraintFields(
   logger?: { warn: (obj: object, msg?: string) => void },
   // A3 trust marker: per-constraint scale provenance to attach to each
   // constraint_result. Additive; keyed by constraint_id.
-  scaleProvenanceByConstraintId?: Map<string, ConstraintScaleProvenance>
+  scaleProvenanceByConstraintId?: Map<string, ConstraintScaleProvenance>,
+  // A3 adjacent-hunt FIX #1: the node ids where the auto-constraint's guessed
+  // '>=' direction was found structurally unsatisfiable for at least one option
+  // (isAutoConstraintDirectionSuspect fired — see the per-option gate in
+  // buildResponse, which withholds probability_of_joint_goal /
+  // constraint_probabilities and populates this set). The top-level block below
+  // must withhold on the SAME suspicion; otherwise it re-emits the near-0
+  // prob_satisfied the per-option gate suppressed, under a fabricated
+  // 'computed'. Symmetric with suppressedConstraintTargets.
+  directionSuspectNodeIds?: ReadonlySet<string>
 ): {
   constraints_status?: ConstraintFeatureStatus;
   constraint_results?: ConstraintResult[];
@@ -2096,6 +2105,34 @@ function buildConstraintFields(
       raw_constraint_diagnostics: constraintDiagnostics,
       raw_conditional_probabilities: conditionalProbabilities,
       unreliable_targets: suppressedConstraintTargets,
+    });
+    return { constraints_status: 'unavailable' };
+  }
+
+  // A3 adjacent-hunt FIX #1 (honesty leak): mirror the suppressed-target gate
+  // above for the DIRECTION-SUSPECT partition. The per-option gate already
+  // withholds probability_of_joint_goal / constraint_probabilities when the
+  // auto-constraint's guessed '>=' is structurally unsatisfiable (positive
+  // threshold, strictly-negative modelled outcome) — but this top-level block
+  // otherwise re-emits the SAME near-0 prob_satisfied under 'computed', leaking
+  // the exact number the per-option path suppressed. A direction-suspect run can
+  // have an EMPTY suppressed partition (decision-grade target: real base +
+  // non-default range), so the earlier gate does not cover it. Withhold the
+  // whole block when any FORWARDED constraint targets a direction-suspect node —
+  // absence is honest; the WARNING-severity CONSTRAINT_DIRECTION_SUSPECT (emitted
+  // by the per-option path) explains why. Raw values stay in the diagnostics log.
+  if (
+    directionSuspectNodeIds &&
+    directionSuspectNodeIds.size > 0 &&
+    goalConstraints.some((gc) => directionSuspectNodeIds.has(gc.node_id))
+  ) {
+    logger?.warn({
+      event: 'constraint_results_suppressed',
+      reason: 'direction_suspect',
+      raw_constraint_results: constraintResults,
+      raw_constraint_diagnostics: constraintDiagnostics,
+      raw_conditional_probabilities: conditionalProbabilities,
+      direction_suspect_node_ids: [...directionSuspectNodeIds],
     });
     return { constraints_status: 'unavailable' };
   }
@@ -3179,6 +3216,9 @@ function buildResponse(
       constraintTargetPartition.suppressed,
       logger,
       constraintScaleProvenanceByConstraintId,
+      // A3 adjacent-hunt FIX #1: populated by the per-option direction-suspect
+      // gate above; withholds the top-level block on the SAME suspicion.
+      directionSuspectNodeIds,
     ),
 
     // Auto-noise disclosure (audit B3, P0). `auto_noise_applied` echoes

--- a/tests/conditional-probabilities-bad-index-hardening.fixture.test.ts
+++ b/tests/conditional-probabilities-bad-index-hardening.fixture.test.ts
@@ -1,0 +1,210 @@
+/**
+ * A3 adjacent-hunt FIX #3 — conditional_probabilities bad-index crash hardening.
+ *
+ * CONFIRMED PRE-EXISTING CRASH (RED before the fix):
+ *
+ * buildConstraintFields() filters ISL-supplied conditional_probabilities rows
+ * only on `given_constraint_index < islConstraints.length` (and target) — with
+ * NO `>= 0` / integer guard. A negative or fractional ISL index passes that
+ * check, then `islConstraints[idx]` is `undefined` and
+ * `resolveConstraintId(undefined, idx)` dereferences `undefined.node_id` and
+ * THROWS. The throw propagates out of buildResponse to the route's outermost
+ * catch, which degrades the ENTIRE /v2/run response to `analysis_status:
+ * 'failed'` + a PLOT_INTERNAL_ERROR critique — the whole analysis is lost
+ * because of one malformed row.
+ *
+ * Contract under test (consistent with the file's untrusted-ISL numeric-egress
+ * posture — a bad row is an honest omission, never a fabrication, and never a
+ * crash):
+ *   - a conditional_probabilities row with a negative index is DROPPED; the
+ *     response builds normally (analysis_status computed, valid rows survive).
+ *   - a row with a fractional index is DROPPED likewise.
+ *
+ * The ISL request/ISL service shape is not changed — the mock mirrors the live
+ * wire shapes used by tests/constraint-results-top-level-gating.fixture.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Mutable mock state — the conditional_probabilities array ISL returns.
+// ---------------------------------------------------------------------------
+
+let mockConditionalProbabilities: any[] = [];
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    const goalConstraints = body.goal_constraints || [];
+
+    const constraintAnalysis = goalConstraints.length > 0
+      ? {
+          constraint_analysis: {
+            joint_probability: 0.6,
+            constraints: goalConstraints.map((c: any) => ({
+              node_id: c.node_id,
+              operator: c.operator,
+              threshold: c.threshold ?? c.value,
+              prob_satisfied: 0.6,
+            })),
+            conditional_probabilities: mockConditionalProbabilities,
+          },
+        }
+      : {};
+
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+          win_probability: idx === 0 ? 0.6 : 0.4,
+          rank: idx + 1,
+          ...constraintAnalysis,
+        })),
+        factor_sensitivity: [],
+        robustness: { label: 'moderate', score: 0.6, fragile_edges: [], robust_edges: [] },
+        inference_warnings: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — two reliable (valued-target, declared '%' scale) constraints so
+// the top-level block is BUILT and reaches the conditional_probabilities map.
+// ---------------------------------------------------------------------------
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
+    { id: 'out_effectiveness', kind: 'outcome', label: 'Campaign effectiveness', observed_state: { value: 50 } },
+    { id: 'out_retention', kind: 'outcome', label: 'Customer retention', observed_state: { value: 50 } },
+    { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
+  ],
+  edges: [
+    { from: 'fac_budget', to: 'out_effectiveness', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'fac_budget', to: 'out_retention', strength: { mean: 0.4, std: 0.1 } },
+    { from: 'out_effectiveness', to: 'goal_growth', strength: { mean: 0.6, std: 0.1 } },
+    { from: 'out_retention', to: 'goal_growth', strength: { mean: 0.3, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt_a', label: 'Push campaign', interventions: { fac_budget: 0.8 } },
+  { id: 'opt_b', label: 'Hold steady', interventions: { fac_budget: 0.4 } },
+];
+
+const CONSTRAINTS = [
+  { constraint_id: 'effectiveness_floor', node_id: 'out_effectiveness', operator: '>=', value: 20, unit: '%', label: 'Effectiveness >= 20%' },
+  { constraint_id: 'retention_floor', node_id: 'out_retention', operator: '>=', value: 30, unit: '%', label: 'Retention >= 30%' },
+];
+
+/** A well-formed conditional row (index 0 given index 1) that must always survive. */
+const VALID_ROW = { given_constraint_index: 0, target_constraint_index: 1, probability: 0.5, effective_sample_size: 100 };
+
+async function run(app: FastifyInstance) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v2/run',
+    headers: { 'Content-Type': 'application/json' },
+    payload: JSON.stringify({
+      graph: GRAPH,
+      options: OPTIONS,
+      goal_node_id: 'goal_growth',
+      seed: 'conditional-bad-index-hardening',
+      goal_constraints: CONSTRAINTS,
+    }),
+  });
+  expect(res.statusCode).toBe(200);
+  return JSON.parse(res.body);
+}
+
+describe('conditional_probabilities bad-index hardening (A3 adjacent-hunt FIX #3)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    mockConditionalProbabilities = [];
+  });
+
+  it('CRASH: a NEGATIVE given_constraint_index drops the row, not the whole analysis', async () => {
+    // -1 passes the `< length` check (length 2) → islConstraints[-1] is
+    // undefined → resolveConstraintId(undefined, -1) throws on base.
+    mockConditionalProbabilities = [
+      VALID_ROW,
+      { given_constraint_index: -1, target_constraint_index: 0, probability: 0.4, effective_sample_size: 50 },
+    ];
+    try {
+      const body = await run(app);
+
+      // On base the throw degrades the ENTIRE response to failed +
+      // PLOT_INTERNAL_ERROR; the fix must build normally and drop only the row.
+      expect(body.analysis_status).not.toBe('failed');
+      const internalErr = (body.critiques ?? []).filter((c: any) => c.code === 'PLOT_INTERNAL_ERROR');
+      expect(internalErr).toHaveLength(0);
+
+      expect(body.constraints_status).toBe('computed');
+      // Only the well-formed row survives; the bad-index row is honestly dropped.
+      expect(body.conditional_probabilities).toEqual([
+        { given_constraint_id: 'effectiveness_floor', target_constraint_id: 'retention_floor', probability: 0.5, effective_sample_size: 100 },
+      ]);
+    } finally {
+      mockConditionalProbabilities = [];
+    }
+  });
+
+  it('CRASH: a FRACTIONAL given_constraint_index drops the row, not the whole analysis', async () => {
+    mockConditionalProbabilities = [
+      VALID_ROW,
+      { given_constraint_index: 1.5, target_constraint_index: 0, probability: 0.4, effective_sample_size: 50 },
+    ];
+    try {
+      const body = await run(app);
+
+      expect(body.analysis_status).not.toBe('failed');
+      const internalErr = (body.critiques ?? []).filter((c: any) => c.code === 'PLOT_INTERNAL_ERROR');
+      expect(internalErr).toHaveLength(0);
+
+      expect(body.constraints_status).toBe('computed');
+      expect(body.conditional_probabilities).toEqual([
+        { given_constraint_id: 'effectiveness_floor', target_constraint_id: 'retention_floor', probability: 0.5, effective_sample_size: 100 },
+      ]);
+    } finally {
+      mockConditionalProbabilities = [];
+    }
+  });
+});

--- a/tests/constraint-direction-suspect-top-level-gating.fixture.test.ts
+++ b/tests/constraint-direction-suspect-top-level-gating.fixture.test.ts
@@ -1,0 +1,228 @@
+/**
+ * A3 adjacent-hunt FIX #1 — direction-suspect top-level constraint_results leak.
+ *
+ * CONFIRMED PRE-EXISTING LEAK (RED before the fix):
+ *
+ * The per-option honesty gate withholds `probability_of_joint_goal` /
+ * `constraint_probabilities` when the auto-constraint's guessed '>=' direction
+ * is structurally unsatisfiable (isAutoConstraintDirectionSuspect fires:
+ * positive auto-threshold + strictly-negative modelled outcome). But the
+ * TOP-LEVEL constraint block built by buildConstraintFields() is gated ONLY on
+ * the suppressed-target partition — NOT on direction-suspicion. On a
+ * direction-suspect run whose targets are otherwise decision-grade (real base
+ * + non-default normalisation range ⇒ `suppressed` is empty), the top-level
+ * surface re-emits `constraint_results[].probability` = the first option's
+ * near-0 prob_satisfied under `constraints_status: 'computed'` — leaking the
+ * exact number the per-option gate just withheld.
+ *
+ * Contract under test (mirrors the suppressed-target top-level gate, for the
+ * direction-suspect partition):
+ *   - DIRECTION-SUSPECT run with `suppressed` empty: the top-level block is
+ *     withheld — `constraints_status: 'unavailable'` and NO constraint_results
+ *     / constraint_diagnostics / conditional_probabilities. Absence is honest;
+ *     the WARNING-severity CONSTRAINT_DIRECTION_SUSPECT explains WHY.
+ *   - CONTROL (positive/satisfiable outcome): the top-level block DELIVERS
+ *     unchanged — regression pin.
+ *
+ * The ISL request/ISL service shape is not changed — the mock mirrors
+ * tests/goal-fit-direction-defense.fixture.test.ts (live wire shapes).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Mutable mock state (per-request ISL behaviour)
+// ---------------------------------------------------------------------------
+
+/**
+ * 'negative': every option's modelled outcome stays negative even at p90
+ * (structurally can never satisfy '>= positive_threshold' → direction-suspect).
+ * 'positive': normal satisfiable-looking outcome (control / regression case).
+ */
+let outcomeMode: 'negative' | 'positive' = 'positive';
+
+/** The near-0 prob_satisfied the per-option gate withholds and the top-level block leaks. */
+const NEG_PROB = 0.02;
+const POS_PROB = 0.72;
+
+function buildOutcome(idx: number) {
+  if (outcomeMode === 'negative') {
+    // Whole modelled distribution below zero — '>= positive' unsatisfiable.
+    return { mean: -0.4, std: 0.1, p10: -0.6, p50: -0.4, p90: -0.1, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 };
+  }
+  return { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 };
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    const goalConstraints = body.goal_constraints || [];
+    const prob = outcomeMode === 'negative' ? NEG_PROB : POS_PROB;
+
+    const constraintAnalysis = goalConstraints.length > 0
+      ? {
+          constraint_analysis: {
+            joint_probability: prob,
+            constraints: goalConstraints.map((c: any) => ({
+              node_id: c.node_id,
+              operator: c.operator,
+              threshold: c.threshold ?? c.value,
+              prob_satisfied: prob,
+            })),
+          },
+        }
+      : {};
+
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: buildOutcome(idx),
+          win_probability: idx === 0 ? 0.6 : 0.4,
+          rank: idx + 1,
+          ...constraintAnalysis,
+        })),
+        factor_sensitivity: [],
+        robustness: { label: 'moderate', score: 0.6, fragile_edges: [], robust_edges: [] },
+        // NO CONSTRAINT_NODE_DEFAULT_BASE — the target has a real observed base,
+        // so `target_base_defaulted` never fires (suppressed partition empty).
+        inference_warnings: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — goal node carries a real observed base (value 50 ⇒ deriveRange
+// infers [0, 100], a NON-default normalisation range), so the auto-constraint's
+// target is decision-grade and `suppressed` stays empty. The auto-threshold is
+// a raw positive user quantity (20) that normalises against that [0,100] range.
+// ---------------------------------------------------------------------------
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal_growth', kind: 'goal', label: 'Net revenue change', observed_state: { value: 50 } },
+    { id: 'fac_spend', kind: 'factor', label: 'Marketing spend', observed_state: { value: 40 } },
+  ],
+  edges: [
+    { from: 'fac_spend', to: 'goal_growth', strength: { mean: 0.5, std: 0.1 } },
+  ],
+};
+
+// Interventions in RAW units (outside [0,1]) force the normalisation ladder to
+// run, so the constraint threshold is normalised against a recorded, non-default
+// range rather than forwarded raw.
+const OPTIONS = [
+  { id: 'opt_a', label: 'Increase spend', interventions: { fac_spend: 80 } },
+  { id: 'opt_b', label: 'Hold steady', interventions: { fac_spend: 30 } },
+];
+
+async function run(app: FastifyInstance, goalThreshold: number) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v2/run',
+    headers: { 'Content-Type': 'application/json' },
+    payload: JSON.stringify({
+      graph: GRAPH,
+      options: OPTIONS,
+      goal_node_id: 'goal_growth',
+      seed: 'direction-suspect-top-level-gating',
+      goal_threshold: goalThreshold,
+    }),
+  });
+  expect(res.statusCode).toBe(200);
+  return JSON.parse(res.body);
+}
+
+describe('top-level constraint_results gating by direction-suspicion (A3 adjacent-hunt FIX #1)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    outcomeMode = 'positive';
+  });
+
+  it('LEAK: direction-suspect run with empty suppressed partition must withhold the top-level block', async () => {
+    outcomeMode = 'negative';
+    try {
+      const body = await run(app, 20);
+
+      // Preconditions — the scenario is exactly the co-occurrence the leak needs.
+      // (a) direction-suspect fired:
+      const suspect = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_DIRECTION_SUSPECT',
+      );
+      expect(suspect).toHaveLength(1);
+      // (b) suppressed partition is EMPTY (real base + non-default range ⇒ target
+      //     is decision-grade → no CONSTRAINT_TARGET_UNRELIABLE):
+      const unreliable = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+      );
+      expect(unreliable).toHaveLength(0);
+      // (c) per-option honesty gate already holds:
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+      }
+
+      // THE LEAK (RED on base): the withheld ~0 prob re-surfaces at the top level
+      // as constraint_results[0].probability under a fabricated 'computed'.
+      expect(body.constraints_status).toBe('unavailable');
+      expect(body).not.toHaveProperty('constraint_results');
+      expect(body).not.toHaveProperty('constraint_diagnostics');
+      expect(body).not.toHaveProperty('conditional_probabilities');
+    } finally {
+      outcomeMode = 'positive';
+    }
+  });
+
+  it('CONTROL: satisfiable outcome — top-level constraint block DELIVERS unchanged', async () => {
+    outcomeMode = 'positive';
+    const body = await run(app, 20);
+
+    // No direction-suspicion, no suppression → the block delivers.
+    const suspect = (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'CONSTRAINT_DIRECTION_SUSPECT',
+    );
+    expect(suspect).toHaveLength(0);
+
+    expect(body.constraints_status).toBe('computed');
+    expect(Array.isArray(body.constraint_results)).toBe(true);
+    expect(body.constraint_results.length).toBe(1);
+    expect(body.constraint_results[0].probability).toBe(POS_PROB);
+  });
+});

--- a/tests/constraint-direction-suspect-top-level-gating.fixture.test.ts
+++ b/tests/constraint-direction-suspect-top-level-gating.fixture.test.ts
@@ -38,19 +38,30 @@ import type { FastifyInstance } from 'fastify';
 /**
  * 'negative': every option's modelled outcome stays negative even at p90
  * (structurally can never satisfy '>= positive_threshold' → direction-suspect).
- * 'positive': normal satisfiable-looking outcome (control / regression case).
+ * 'positive': normal satisfiable-looking outcome + high joint prob (control /
+ * regression case — no critique because it's feasible).
+ * 'infeasible_positive': satisfiable-DIRECTION outcome (p90 > 0, so NOT
+ * direction-suspect) but a genuinely-low joint probability — a real
+ * "this may not reach the target" signal that MUST survive the coaching gate.
+ * This is the positive control that proves the direction-suspect skip does not
+ * over-suppress honest GOAL_FEASIBILITY_LOW warnings.
  */
-let outcomeMode: 'negative' | 'positive' = 'positive';
+let outcomeMode: 'negative' | 'positive' | 'infeasible_positive' = 'positive';
 
 /** The near-0 prob_satisfied the per-option gate withholds and the top-level block leaks. */
 const NEG_PROB = 0.02;
 const POS_PROB = 0.72;
+/** Genuinely-low feasibility (< readiness_joint_prob_floor 0.05) on a NON-suspect run. */
+const LOW_FEASIBLE_PROB = 0.03;
 
 function buildOutcome(idx: number) {
   if (outcomeMode === 'negative') {
     // Whole modelled distribution below zero — '>= positive' unsatisfiable.
     return { mean: -0.4, std: 0.1, p10: -0.6, p50: -0.4, p90: -0.1, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 };
   }
+  // 'positive' AND 'infeasible_positive' share a satisfiable-DIRECTION outcome
+  // (p90 > 0 ⇒ isAutoConstraintDirectionSuspect returns false). They differ
+  // only in the joint probability the mock reports below.
   return { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 };
 }
 
@@ -74,7 +85,11 @@ const mockISLService = {
   async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
     const options = body.options || [];
     const goalConstraints = body.goal_constraints || [];
-    const prob = outcomeMode === 'negative' ? NEG_PROB : POS_PROB;
+    const prob = outcomeMode === 'negative'
+      ? NEG_PROB
+      : outcomeMode === 'infeasible_positive'
+        ? LOW_FEASIBLE_PROB
+        : POS_PROB;
 
     const constraintAnalysis = goalConstraints.length > 0
       ? {
@@ -224,5 +239,94 @@ describe('top-level constraint_results gating by direction-suspicion (A3 adjacen
     expect(Array.isArray(body.constraint_results)).toBe(true);
     expect(body.constraint_results.length).toBe(1);
     expect(body.constraint_results[0].probability).toBe(POS_PROB);
+  });
+
+  // ---------------------------------------------------------------------------
+  // FIX #1 coaching companion (adversarial-pass finding #1): the leak also
+  // escapes via the M1 joint-probability gate. applyJointProbabilityGate reads
+  // the RAW ISL joint_probability directly, so on a direction-suspect run it
+  // emits GOAL_FEASIBILITY_LOW ("may not achieve the target") into
+  // m1_coaching.model_critiques — AND assembleBrief folds that into
+  // decision_brief.warnings[] — from the SAME near-0 the wire block now
+  // withholds. Post-FIX-#1 the response is internally INCOHERENT
+  // (constraints_status 'unavailable' vs a definite feasibility verdict). The
+  // coaching gate is guarded on the SUPPRESSED-target partition, which is EMPTY
+  // on this decision-grade direction-suspect run, so the guard never fires.
+  // The companion fix ORs the direction-suspect condition into that guard.
+  // ---------------------------------------------------------------------------
+
+  it('COACHING LEAK: direction-suspect run must NOT emit GOAL_FEASIBILITY_LOW in coaching or brief', async () => {
+    outcomeMode = 'negative';
+    try {
+      const body = await run(app, 20);
+
+      // Same co-occurrence preconditions as the wire-block LEAK test.
+      const suspect = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_DIRECTION_SUSPECT',
+      );
+      expect(suspect).toHaveLength(1);
+      const unreliable = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+      );
+      expect(unreliable).toHaveLength(0);
+      // Wire block already withheld (FIX #1) — the incoherence this test closes
+      // is coaching CONTRADICTING that 'unavailable'.
+      expect(body.constraints_status).toBe('unavailable');
+
+      // Positive control INSIDE the assertion: the coaching machinery IS present
+      // and DID run (so the absence below is a real skip, not a missing block).
+      expect(body.m1_coaching, 'm1_coaching must be generated').toBeTruthy();
+      expect(Array.isArray(body.m1_coaching.model_critiques)).toBe(true);
+
+      // THE COACHING LEAK (RED at 94b46e7): the withheld ~0 re-surfaces as a
+      // definite GOAL_FEASIBILITY_LOW feasibility verdict.
+      const coachingTypes = body.m1_coaching.model_critiques.map((c: any) => c.type);
+      expect(coachingTypes).not.toContain('GOAL_FEASIBILITY_LOW');
+
+      // Second wire surface (same root): decision_brief folds coaching critiques
+      // into warnings[]. It must not carry the direction-suspect feasibility claim.
+      // Hard presence assertion (not a vacuous guard): a 'computed' 2-option run
+      // always assembles a brief.
+      expect(body.decision_brief, 'decision_brief must be assembled').toBeTruthy();
+      const briefCodes = (body.decision_brief.warnings ?? []).map((w: any) => w.code);
+      expect(briefCodes).not.toContain('GOAL_FEASIBILITY_LOW');
+    } finally {
+      outcomeMode = 'positive';
+    }
+  });
+
+  it('POSITIVE CONTROL: genuinely-infeasible NON-suspect run STILL emits GOAL_FEASIBILITY_LOW', async () => {
+    // p90 > 0 ⇒ NOT direction-suspect; joint prob 0.03 < floor 0.05 ⇒ a real
+    // low-feasibility signal. The direction-suspect skip must NOT touch it.
+    outcomeMode = 'infeasible_positive';
+    try {
+      const body = await run(app, 20);
+
+      // NOT direction-suspect, and suppressed partition empty → the gate runs.
+      const suspect = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_DIRECTION_SUSPECT',
+      );
+      expect(suspect).toHaveLength(0);
+      const unreliable = (body.inference_warnings ?? []).filter(
+        (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+      );
+      expect(unreliable).toHaveLength(0);
+
+      // Honest low feasibility is DELIVERED on the wire block (not withheld)...
+      expect(body.constraints_status).toBe('computed');
+      expect(body.constraint_results[0].probability).toBe(LOW_FEASIBLE_PROB);
+
+      // ...and the honest GOAL_FEASIBILITY_LOW coaching critique SURVIVES
+      // (green both with and without the fix — the fix must not over-suppress).
+      expect(body.m1_coaching, 'm1_coaching must be generated').toBeTruthy();
+      const coachingTypes = body.m1_coaching.model_critiques.map((c: any) => c.type);
+      expect(coachingTypes).toContain('GOAL_FEASIBILITY_LOW');
+
+      expect(body.decision_brief, 'decision_brief must be assembled').toBeTruthy();
+      const briefCodes = (body.decision_brief.warnings ?? []).map((w: any) => w.code);
+      expect(briefCodes).toContain('GOAL_FEASIBILITY_LOW');
+    } finally {
+      outcomeMode = 'positive';
+    }
   });
 });

--- a/tests/factor-influence-zero-net-influence.unit.test.ts
+++ b/tests/factor-influence-zero-net-influence.unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * A3 adjacent-hunt FIX #4 — false 'no_path_to_goal' on a connected zero-strength factor.
+ *
+ * CONFIRMED PRE-EXISTING MISLABEL (RED before the fix):
+ *
+ * computeFactorSensitivityFromGraph stamps `zero_reason: 'no_path_to_goal'`
+ * whenever `f.influence === 0 && f.confidence === 0`. But those two path-based
+ * values collapse to {0, 0} for TWO structurally-distinct cases:
+ *   (a) a TRULY disconnected factor — findAllPathsToGoal returns [] (early
+ *       return in computeInfluenceFromPaths); and
+ *   (b) a CONNECTED factor whose only path carries zero net effect — e.g. a
+ *       single edge with strength.mean = 0 (exists_probability high enough to
+ *       survive buildEdgeLookup). The path IS found, but every path effect is 0,
+ *       so totalWeight = 0 and the weighted-confidence branch yields 0.
+ *
+ * Case (b) is CONNECTED, yet it lands on the same {0,0} and is falsely labelled
+ * "no path to goal". The correct label distinguishes the two: 'no_path_to_goal'
+ * only when paths.length === 0; a connected-but-zero factor gets a distinct
+ * reason ('zero_net_influence'). `zero_reason` is an open-vocabulary string
+ * (src/types/engine-v3.ts, contracts/schemas/plot-response.schema.json — plain
+ * `string`, no enum), and every consumer keys only on 'intervention_override',
+ * so the new value is additive.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeFactorSensitivityFromGraph } from '../src/lib/factor-influence.js';
+import type { EngineGraphV3 } from '../src/types/engine-v3.js';
+
+/**
+ * fac_a → goal via a SINGLE edge whose strength.mean is 0 but whose
+ * exists_probability (0.8) clears MIN_EXISTS_PROBABILITY — so the edge is in the
+ * lookup and a path IS found (paths.length === 1), but the path effect is 0.
+ */
+const CONNECTED_ZERO_STRENGTH_GRAPH: EngineGraphV3 = {
+  nodes: [
+    { id: 'fac_a', kind: 'factor', label: 'Factor A' },
+    { id: 'goal', kind: 'goal', label: 'Goal' },
+  ],
+  edges: [
+    {
+      from: 'fac_a',
+      to: 'goal',
+      exists_probability: 0.8, // edge EXISTS (survives buildEdgeLookup)
+      strength: { mean: 0, std: 0.1 }, // ...but carries zero net effect
+    },
+  ],
+};
+
+/** fac_a exists but has NO edge to the goal at all → paths.length === 0. */
+const DISCONNECTED_GRAPH: EngineGraphV3 = {
+  nodes: [
+    { id: 'fac_a', kind: 'factor', label: 'Factor A' },
+    { id: 'goal', kind: 'goal', label: 'Goal' },
+  ],
+  edges: [],
+};
+
+describe('factor zero_reason taxonomy (A3 adjacent-hunt FIX #4)', () => {
+  it('BUG: a CONNECTED zero-strength factor must NOT be labelled no_path_to_goal', () => {
+    const result = computeFactorSensitivityFromGraph(CONNECTED_ZERO_STRENGTH_GRAPH, 'goal');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+
+    const factor = result![0];
+    // It has zero net influence (single zero-strength path)...
+    expect(factor.sensitivity_score).toBe(0);
+    // ...but it IS connected — the label must reflect connected-zero, not disconnection.
+    expect(factor.zero_reason).not.toBe('no_path_to_goal');
+    expect(factor.zero_reason).toBe('zero_net_influence');
+  });
+
+  it('REGRESSION: a truly disconnected factor (no path) stays no_path_to_goal', () => {
+    const result = computeFactorSensitivityFromGraph(DISCONNECTED_GRAPH, 'goal');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+
+    const factor = result![0];
+    expect(factor.sensitivity_score).toBe(0);
+    expect(factor.zero_reason).toBe('no_path_to_goal');
+  });
+});


### PR DESCRIPTION
## Adjacent-code bug-hunt fixes — 3 confirmed pre-existing bugs (+ a 3rd-surface leak closure)

A recall-focused multi-agent hunt over the constraint/normalisation/robustness code **adjacent to but untouched by** the recent A3 session found 5 confirmed pre-existing bugs (5 more candidates refuted by adversarial verify). This PR fixes the 3 clear ones; #2 (a normalisation decision) and #5 (a rare edge) are rowed.

### FIX #1 (HIGH) — direction-suspect honesty leak, closed across all 3 surfaces
On a direction-suspect run (auto-synthesised `>=` threshold structurally unsatisfiable — positive threshold, every option's modelled p90 < 0), the near-0 joint probability is a sign-mismatch artefact, not a signal. The per-option loop already withheld it, but two other surfaces leaked it:
- **`57c957f`** — the top-level `constraint_results` block re-emitted it with `constraints_status:'computed'`. Now withheld (`'unavailable'`) when a forwarded constraint targets a direction-suspect node — symmetric with the suppressed-target gate.
- **`4f32e43`** — `m1-coaching.applyJointProbabilityGate` read the *raw* ISL joint probability and emitted a `GOAL_FEASIBILITY_LOW` critique (and into `decision_brief.warnings[]`). Found by the adversarial pass: the wire-only fix left the response *internally incoherent* (wire withholds, coaching asserts). The coaching gate abstains too now, via the same `isAutoConstraintDirectionSuspect` verdict. Positive control: a genuinely-infeasible non-suspect run STILL warns.

### FIX #3 (MED) — crash hardening
`conditional_probabilities` filtered ISL indices on the upper bound only; a negative/fractional index dereferenced `undefined` and 500'd the whole `/v2/run` response. Now requires `Number.isInteger && >= 0 && < length`; a bad row is dropped (honest omission), matching the file's untrusted-ISL posture. (`7cbe370`)

### FIX #4 (MED) — false "no path to goal"
A *connected* factor whose only edge has `strength.mean=0` was labelled `zero_reason:'no_path_to_goal'` (confidence zeroed by the totalWeight discard, not disconnection). Now stamps `'no_path_to_goal'` only when `paths.length===0`, else the new `'zero_net_influence'` (open-vocabulary field; consumers key only on `'intervention_override'`). Swapped to `computeFactorInfluenceWithPaths` — structurally identical influence/confidence (verified by body-diff + zero golden delta). (`94b46e7`)

### Verification
- Every fix RED-first reproduced (incl. the exact TypeError crash for #3 and the incoherent coaching critique for #1's companion); per-commit mutation-checked in throwaway worktrees.
- **Zero golden delta** (291/291); `typecheck` clean; full suite **5878 passed / 0 failed**. Freshness `response_hash` unchanged by construction (hashes the request).
- #1 got an adversarial pass (Opus — Fable out of credits) which found the coaching surface; ordering/over-withholding/status all refuted. Records: `acceptance-evidence/a3-verify-2026-07-16/{ADJACENT-HUNT-FIXES,FIX1-ADVERSARIAL}.md`.

### Rowed (not this PR)
#2 negative-domain sign loss (ruled D-9 preserve-sign — separate build) · #5 extreme-ratio outlier collapse (rare, intentional guard). See `ADJACENT-HUNT-ROWS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
