### PR TITLE
fix(normaliser): preserve sign in negative-domain deriveRange (D-9 / adjacent-hunt #2)

### DIFF
--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -193,10 +193,11 @@ function isValidExtractedRange(range: [number, number] | undefined): range is [n
  * |          |                    | padding. Requires ≥2 values with variation.               |
  * |          |                    | Outlier guard: skipped if maxVal > minVal × 100.          |
  * |          |                    | Lower bound clamped to 0 when all values non-negative.    |
- * | 2        | `inferred_baseline`| `[min(0,2r), max(0,2r)]`, r = signed baseline/value of    |
- * |          |                    | larger magnitude. Sign-preserving (D-9): v≥0 → `[0,2r]`   |
- * |          |                    | (unchanged), v<0 → `[2r,0]` so a negative value maps to   |
- * |          |                    | ~0.5, not clamp-to-0.                                     |
+ * | 2        | `inferred_baseline`| `[min(0,2b,2v), max(0,2b,2v)]` over baseline b and (when   |
+ * |          |                    | finite) current value v. Sign-preserving AND CONTAINS     |
+ * |          |                    | BOTH (D-9): opposite-sign b/v both round-trip (e.g.       |
+ * |          |                    | b=-500,v=+600 → `[-1000,1200]`). Same-sign/single reduces |
+ * |          |                    | to `[0,2r]` (r≥0) / `[2r,0]` (r<0), unchanged.            |
  * | 3        | `inferred_value`   | `[min(0,2v), max(0,2v)]`, sign-preserving (D-9). Falls    |
  * |          |                    | through if value is 0.                                    |
  * | 4        | `default`          | `[0, 1]`. Used when value is 0, missing, or unavailable.  |
@@ -275,28 +276,29 @@ export function deriveRange(
 
   // Priority 2: Inferred from baseline and current value
   if (baseline !== undefined && typeof baseline === 'number') {
-    // Reference = the larger-magnitude of baseline/currentValue, SIGN PRESERVED.
-    // D-9 (PRESERVE SIGN): the derived range must CONTAIN the value's sign, so
-    // a negative-domain factor round-trips instead of clamping to 0. For a
-    // reference r: range = [min(0,2r), max(0,2r)] → [0,2r] for r≥0 (identical to
-    // the previous {0, 2×max(|baseline|,|value|)}, zero delta for positive
-    // factors) and [2r,0] for r<0 (e.g. r=-500 → {-1000,0}, so -500 → ~0.5).
-    let ref = baseline;
-    if (
-      currentValue !== undefined &&
-      typeof currentValue === 'number' &&
-      Math.abs(currentValue) > Math.abs(ref)
-    ) {
-      ref = currentValue;
+    // D-9 (CONTAIN BOTH, sign-preserving): the derived range must CONTAIN 0 AND
+    // both the (doubled) baseline and the (doubled) current value, so a
+    // negative-domain factor round-trips instead of clamping to 0 — AND an
+    // OPPOSITE-SIGN baseline/currentValue pair (e.g. baseline=-500,
+    // currentValue=+600) yields a range containing BOTH (-1000..1200), not just
+    // the larger-magnitude one ({0,1200}, which erased -500). The earlier
+    // larger-magnitude single-`ref` logic was incomplete for mixed signs.
+    //   candidates = [0, 2·baseline] (+ 2·currentValue when finite)
+    //   range = [min(candidates), max(candidates)]
+    // Reduces to the prior behaviour for the same-sign / single-value cases:
+    //   both ≥ 0 → [0, 2·max] · both < 0 → [2·min, 0] · single r → [min(0,2r), max(0,2r)]
+    // (zero delta for positive-domain factors; unchanged for both-negative and
+    // single-value). A baseline=0 with no currentValue collapses to {0,0} and
+    // falls through to Priority 3/4 exactly as before (isFiniteRange width guard).
+    const candidates = [0, 2 * baseline];
+    if (currentValue !== undefined && Number.isFinite(currentValue)) {
+      candidates.push(2 * currentValue);
     }
-
-    if (Math.abs(ref) > 0) {
-      const doubled = 2 * ref;
-      const min = Math.min(0, doubled);
-      const max = Math.max(0, doubled);
-      // F14: skip an overflow-width inferred range; fall through to value / default.
-      if (isFiniteRange(min, max)) return { min, max, source: 'inferred_baseline' };
-    }
+    const min = Math.min(...candidates);
+    const max = Math.max(...candidates);
+    // F14: only a finite POSITIVE-width range is usable (also rejects the {0,0}
+    // baseline=0 no-currentValue collapse); fall through to value / default.
+    if (isFiniteRange(min, max)) return { min, max, source: 'inferred_baseline' };
   }
 
   // Priority 3: Inferred from current value only

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -193,8 +193,12 @@ function isValidExtractedRange(range: [number, number] | undefined): range is [n
  * |          |                    | padding. Requires ≥2 values with variation.               |
  * |          |                    | Outlier guard: skipped if maxVal > minVal × 100.          |
  * |          |                    | Lower bound clamped to 0 when all values non-negative.    |
- * | 2        | `inferred_baseline`| `[0, 2 × max(|baseline|, |value|)]`.                     |
- * | 3        | `inferred_value`   | `[0, 2 × |value|]`. Falls through if value is 0.          |
+ * | 2        | `inferred_baseline`| `[min(0,2r), max(0,2r)]`, r = signed baseline/value of    |
+ * |          |                    | larger magnitude. Sign-preserving (D-9): v≥0 → `[0,2r]`   |
+ * |          |                    | (unchanged), v<0 → `[2r,0]` so a negative value maps to   |
+ * |          |                    | ~0.5, not clamp-to-0.                                     |
+ * | 3        | `inferred_value`   | `[min(0,2v), max(0,2v)]`, sign-preserving (D-9). Falls    |
+ * |          |                    | through if value is 0.                                    |
  * | 4        | `default`          | `[0, 1]`. Used when value is 0, missing, or unavailable.  |
  *
  * @param node Factor node
@@ -271,26 +275,40 @@ export function deriveRange(
 
   // Priority 2: Inferred from baseline and current value
   if (baseline !== undefined && typeof baseline === 'number') {
-    // Use baseline as reference point
-    // Range: [0, 2 × max(|baseline|, |currentValue|)]
-    const maxAbsValue = Math.max(
-      Math.abs(baseline),
-      currentValue !== undefined ? Math.abs(currentValue) : 0
-    );
+    // Reference = the larger-magnitude of baseline/currentValue, SIGN PRESERVED.
+    // D-9 (PRESERVE SIGN): the derived range must CONTAIN the value's sign, so
+    // a negative-domain factor round-trips instead of clamping to 0. For a
+    // reference r: range = [min(0,2r), max(0,2r)] → [0,2r] for r≥0 (identical to
+    // the previous {0, 2×max(|baseline|,|value|)}, zero delta for positive
+    // factors) and [2r,0] for r<0 (e.g. r=-500 → {-1000,0}, so -500 → ~0.5).
+    let ref = baseline;
+    if (
+      currentValue !== undefined &&
+      typeof currentValue === 'number' &&
+      Math.abs(currentValue) > Math.abs(ref)
+    ) {
+      ref = currentValue;
+    }
 
-    if (maxAbsValue > 0) {
-      const max = 2 * maxAbsValue;
+    if (Math.abs(ref) > 0) {
+      const doubled = 2 * ref;
+      const min = Math.min(0, doubled);
+      const max = Math.max(0, doubled);
       // F14: skip an overflow-width inferred range; fall through to value / default.
-      if (isFiniteRange(0, max)) return { min: 0, max, source: 'inferred_baseline' };
+      if (isFiniteRange(min, max)) return { min, max, source: 'inferred_baseline' };
     }
   }
 
   // Priority 3: Inferred from current value only
   if (currentValue !== undefined && typeof currentValue === 'number' && currentValue !== 0) {
-    // Range: [0, 2 × |currentValue|]
-    const max = 2 * Math.abs(currentValue);
+    // D-9 (PRESERVE SIGN): range = [min(0,2v), max(0,2v)] — [0,2v] for v>0
+    // (identical to the previous {0, 2×|v|}, zero delta for positive factors)
+    // and [2v,0] for v<0 (e.g. v=-500 → {-1000,0}, so -500 → ~0.5 not clamp-to-0).
+    const doubled = 2 * currentValue;
+    const min = Math.min(0, doubled);
+    const max = Math.max(0, doubled);
     // F14: skip an overflow-width inferred range; fall through to the default.
-    if (isFiniteRange(0, max)) return { min: 0, max, source: 'inferred_value' };
+    if (isFiniteRange(min, max)) return { min, max, source: 'inferred_value' };
   }
 
   // Priority 4: Default [0, 1]

--- a/tests/intervention-normaliser.test.ts
+++ b/tests/intervention-normaliser.test.ts
@@ -166,6 +166,39 @@ describe('deriveRange', () => {
       expect(range.source).toBe('inferred_baseline');
       expect(range.max).toBe(400000); // 2 × 200000
     });
+
+    it('positive baseline range is UNCHANGED (zero positive-case delta) [D-9]', () => {
+      // POSITIVE CONTROL: for v ≥ 0 the sign-preserving formula {min(0,2v),max(0,2v)}
+      // is byte-identical to the pre-D-9 {0, 2v}. This must stay GREEN both before
+      // and after the fix (proves zero change for positive-domain factors).
+      const node = createFactorNode('salary', 180000, 100000);
+      const range = deriveRange(node);
+
+      expect(range.source).toBe('inferred_baseline');
+      expect(range.min).toBe(0);
+      expect(range.max).toBe(360000); // 2 × max(|baseline|, |value|)
+      expect(normaliseValue(180000, range).normalised).toBeCloseTo(0.5);
+    });
+
+    it('preserves sign for negative baseline — round-trips, not clamped to 0 [D-9]', () => {
+      // RED at 733af0c: the branch returned {0, 2×|baseline|} = {0, 1000}, and
+      // normaliseValue(-500, {0,1000}) clamps to 0 — the sign/value is ERASED
+      // before ISL. D-9 (PRESERVE SIGN): the range must CONTAIN the value.
+      const node = createFactorNode('net_cash_position', -500, -500);
+      const range = deriveRange(node);
+
+      expect(range.source).toBe('inferred_baseline');
+      // Range contains the value's sign: {2v, 0} for v < 0.
+      expect(range.min).toBeLessThanOrEqual(-500);
+      expect(range.max).toBeGreaterThanOrEqual(-500);
+      expect(range.min).toBe(-1000);
+      expect(range.max).toBe(0);
+      // Round-trips to the symmetric midpoint instead of clamping to 0.
+      const { normalised, clamped } = normaliseValue(-500, range);
+      expect(normalised).not.toBe(0);
+      expect(normalised).toBeCloseTo(0.5);
+      expect(clamped).toBe(false);
+    });
   });
 
   describe('Priority 3: Inferred from current value only', () => {
@@ -178,12 +211,33 @@ describe('deriveRange', () => {
       expect(range.max).toBe(360000); // 2 × 180000
     });
 
-    it('handles negative current values', () => {
+    it('positive current value range is UNCHANGED (zero positive-case delta) [D-9]', () => {
+      // POSITIVE CONTROL: {min(0,2v),max(0,2v)} == {0,2v} for v ≥ 0. GREEN both ways.
+      const node = createFactorNode('temperature', 500);
+      const range = deriveRange(node);
+
+      expect(range.source).toBe('inferred_value');
+      expect(range.min).toBe(0);
+      expect(range.max).toBe(1000); // 2 × 500, identical to pre-D-9
+      expect(normaliseValue(500, range).normalised).toBeCloseTo(0.5);
+    });
+
+    it('handles negative current values — preserves sign so it round-trips [D-9]', () => {
+      // ⚠ This test PREVIOUSLY PINNED THE BUG: it asserted max=100 for value=-50,
+      // i.e. range {0,100}, under which normaliseValue(-50) clamps to 0 — the sign
+      // is erased before ISL. That assertion pinned the defect. Per D-9 (PRESERVE
+      // SIGN) the range now CONTAINS the value: {2v, 0} for v < 0.
       const node = createFactorNode('temperature', -50);
       const range = deriveRange(node);
 
       expect(range.source).toBe('inferred_value');
-      expect(range.max).toBe(100); // 2 × |-50|
+      expect(range.min).toBe(-100); // 2 × (-50)
+      expect(range.max).toBe(0);
+      // Round-trips to 0.5 instead of clamping to 0.
+      const { normalised, clamped } = normaliseValue(-50, range);
+      expect(normalised).not.toBe(0);
+      expect(normalised).toBeCloseTo(0.5);
+      expect(clamped).toBe(false);
     });
   });
 

--- a/tests/intervention-normaliser.test.ts
+++ b/tests/intervention-normaliser.test.ts
@@ -199,6 +199,31 @@ describe('deriveRange', () => {
       expect(normalised).toBeCloseTo(0.5);
       expect(clamped).toBe(false);
     });
+
+    it('OPPOSITE-SIGN baseline/currentValue — range CONTAINS BOTH, neither clamps [D-9 gap]', () => {
+      // RED at baa0a2b: the larger-magnitude single-`ref` logic picked
+      // ref = +600 (|600| > |-500|) → {0, 1200}, which does NOT contain -500,
+      // so normaliseValue(-500, {0,1200}) still clamps to 0 — the negative
+      // baseline is ERASED. D-9 requires the range to CONTAIN BOTH values, so
+      // both endpoints round-trip. baseline=-500, currentValue=+600 →
+      // candidates {0, 2·-500, 2·600} = {-1000, 1200}.
+      const node = createFactorNode('net_cash_position', 600, -500);
+      const range = deriveRange(node);
+
+      expect(range.source).toBe('inferred_baseline');
+      // Range CONTAINS both the baseline and the current value.
+      expect(range.min).toBeLessThanOrEqual(-500);
+      expect(range.max).toBeGreaterThanOrEqual(600);
+      expect(range.min).toBe(-1000); // 2 × -500
+      expect(range.max).toBe(1200); // 2 × 600
+      // The negative baseline round-trips instead of clamping to 0.
+      const neg = normaliseValue(-500, range);
+      expect(neg.normalised).not.toBe(0);
+      expect(neg.clamped).toBe(false);
+      // The positive current value also stays inside the range (no clamp).
+      const pos = normaliseValue(600, range);
+      expect(pos.clamped).toBe(false);
+    });
   });
 
   describe('Priority 3: Inferred from current value only', () => {


### PR DESCRIPTION
## Preserve sign in negative-domain intervention normalisation (adjacent-hunt #2 / D-9)

`deriveRange`'s `inferred_baseline` / `inferred_value` branches hardcoded `min=0` (via `Math.abs`), so a factor with a negative domain and no declared range (no `state_space.range`/`observed_state.cap`, single option → `inferred_spread` skipped) had a negative intervention **clamped to normalised 0** — the sign/value erased before ISL, corrupting the compute input (not just display). The sibling `inferred_spread` branch already preserves negatives; these didn't.

Ruling **D-9: preserve sign** — the option-count (1 vs ≥2) is a request accident, not a factor property; clamp-to-0 corrupts the ISL input; the pinned test was pinning the defect.

### The fix (two commits)
- **`baa0a2b`** — `inferred_value` → `{min(0,2v), max(0,2v)}`; `inferred_baseline` → sign-preserving. Positive/same-sign cases identical to today.
- **`eb71cdd`** — completion (caught in the lane owner's review): `inferred_baseline` now uses a candidate set `[0, 2·baseline, (2·currentValue if finite)]` and takes min/max, so it **contains BOTH** values — closing an opposite-sign gap (`baseline=-500, currentValue=+600` → `{-1000, 1200}`, was `{0, 1200}` which still erased `-500`).

Case table (all verified): both-negative `{-1000,0}`, both-positive `{0,1000}` (unchanged), single `{-1000,0}`, mixed `{-1000,1200}`; `baseline=0` collapses to `{0,0}` → falls through via the finite-width guard.

### Verification
- RED-first per case (negative round-trip, `inferred_value`, opposite-sign); the **pinned test that asserted the buggy `{0, 2|value|}` was corrected** (strengthened, not weakened). Per-commit mutation-checked.
- **Zero golden delta** (no fixture has a negative/mixed-sign factor without a declared range); `typecheck` clean; full suite **5882 passed / 0 failed**.
- **No marker interaction**: `inferred_baseline`/`inferred_value`/`default` are not in `DECISION_GRADE_SOURCES` (fail-closed non-members), so `decision_grade` is unaffected — marker/provenance suites green.
- **Neil-check (flagged):** whether a sign-aware *guess* for a single value with no declared range is right vs requiring negative-domain factors to declare `state_space.range`. Lean guess-and-preserve (strictly improves fidelity); one-line reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
