### PR TITLE
fix(optimise): honesty fixes — kill synthetic bands, 400 on invalid graph, method disclosure (A1 locus, R-9)

### DIFF
--- a/src/routes/v1/optimise.ts
+++ b/src/routes/v1/optimise.ts
@@ -295,7 +295,11 @@ export async function registerOptimiseRoute(app: FastifyInstance) {
     return reply.code(200).send({
       schema: 'optimise.v1',
       selected,
-      utility: { expected: finalUtility, p10: finalUtility * 0.9, p50: finalUtility, p90: finalUtility * 1.1 },
+      // R2 honesty: `expected` is a greedy-additive sum of per-action median deltas drawn
+      // from distinct kernel runs over different graphs — no single MC distribution backs it,
+      // so we do NOT fabricate p10/p50/p90 bands around it. Report only the computed point
+      // estimate; absent beats synthetic (previously p10=expected*0.9, p50=expected, p90=expected*1.1).
+      utility: { expected: finalUtility },
       explanations,
       meta: { 
         seed, 

--- a/src/routes/v1/optimise.ts
+++ b/src/routes/v1/optimise.ts
@@ -80,7 +80,24 @@ export async function registerOptimiseRoute(app: FastifyInstance) {
         fields: { field: 'body' }
       });
     }
-    
+
+    // R3: reject missing/invalid graph with a clean 400 (previously an unguarded
+    // `body.graph.nodes.length` at the completion log threw an uncaught 500). Guard
+    // here, before any downstream access to body.graph (priors/evidence/kernel).
+    if (
+      !body.graph ||
+      typeof body.graph !== 'object' ||
+      !Array.isArray(body.graph.nodes) ||
+      !Array.isArray(body.graph.edges)
+    ) {
+      return replyWithAppError(reply, {
+        type: 'BAD_INPUT',
+        statusCode: 400,
+        message: 'graph is required and must have nodes[] and edges[] arrays',
+        fields: { field: 'graph' }
+      });
+    }
+
     const seed = body.seed || 4242;
     const actionIds = new Set<string>();
     for (const action of body.actions) {

--- a/src/routes/v1/optimise.ts
+++ b/src/routes/v1/optimise.ts
@@ -53,6 +53,19 @@ async function evaluateUtility(graph: any, objective: any, seed: number): Promis
   return total;
 }
 
+// Honest method-disclosure markers (#240 scale_provenance tradition): the wire must
+// not imply capabilities this route does not have.
+// - greedy_independent_v1: a greedy-independent marginal-gain knapsack. Each action's
+//   gain is measured independently vs the baseline, then actions are added greedily by
+//   efficiency. It assumes ADDITIVE / INDEPENDENT action effects — it is NOT a joint
+//   combinatorial optimiser, so synergies / diminishing-returns are ignored and the
+//   greedy knapsack is not guaranteed optimal.
+// - edge_weight_scaling: an action's do:[{node_id,set_to}] MULTIPLIES the weight of every
+//   outgoing edge of node_id by set_to. It does NOT set the node's value (no Pearl
+//   do-operator); a leaf/no-outgoing node is a silent no-op. Flagged for Neil doctrine.
+const OPTIMISE_METHOD = 'greedy_independent_v1' as const;
+const OPTIMISE_ACTION_SEMANTICS = 'edge_weight_scaling' as const;
+
 export async function registerOptimiseRoute(app: FastifyInstance) {
   app.post(
     '/v1/optimise',
@@ -311,6 +324,9 @@ export async function registerOptimiseRoute(app: FastifyInstance) {
     
     return reply.code(200).send({
       schema: 'optimise.v1',
+      // Honest method disclosure (additive) — see const definitions above.
+      method: OPTIMISE_METHOD,
+      action_semantics: OPTIMISE_ACTION_SEMANTICS,
       selected,
       // R2 honesty: `expected` is a greedy-additive sum of per-action median deltas drawn
       // from distinct kernel runs over different graphs — no single MC distribution backs it,

--- a/tests/optimise.graph-validation.test.ts
+++ b/tests/optimise.graph-validation.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnServer, type ServerHandle } from './utils.js';
+
+/**
+ * R3: a request missing/invalid `graph` currently reaches the unguarded completion
+ * log (`body.graph.nodes.length` / `body.graph.edges.length`) and throws -> HTTP 500,
+ * or (graph.nodes as a string) silently 200s. The route must reject with a clean 400
+ * using the repo's standard BAD_INPUT error.v1 envelope (same shape as missing-budget).
+ *
+ * Each case fails at HEAD (500 or a wrong 200) and passes after the graph-presence guard.
+ */
+const validBudgetActionsObjective = {
+  budget: 10,
+  actions: [{ id: 'a1', cost: 2, do: [{ node_id: 'R', set_to: 3 }] }],
+  objective: { type: 'utility_linear', weights: { T: 1.0 } },
+  seed: 4242,
+};
+
+describe('POST /v1/optimise - R3 graph validation (clean 400, not 500)', () => {
+  let server: ServerHandle;
+
+  beforeAll(async () => { server = await spawnServer(); });
+  afterAll(async () => { await server.kill(); });
+
+  it('returns 400 with the error.v1 BAD_INPUT envelope when graph is missing', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBudgetActionsObjective }), // no graph
+    });
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    // Match the repo's standard envelope (top-level error.v1 + legacy error object).
+    expect(data.schema).toBe('error.v1');
+    expect(data.code).toBe('BAD_INPUT');
+    expect(data.error).toBeDefined();
+    expect(typeof data.error.message).toBe('string');
+    expect(data.error.message.toLowerCase()).toContain('graph');
+  });
+
+  it('returns 400 when graph is null', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ graph: null, ...validBudgetActionsObjective }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when graph.nodes is not an array', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ graph: { nodes: 'oops', edges: [] }, ...validBudgetActionsObjective }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when graph.edges is missing', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ graph: { nodes: [] }, ...validBudgetActionsObjective }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('still accepts a well-formed empty graph (no false-positive rejection)', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ graph: { nodes: [], edges: [] }, ...validBudgetActionsObjective }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/optimise.honesty-bands.test.ts
+++ b/tests/optimise.honesty-bands.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnServer, type ServerHandle } from './utils.js';
+
+/**
+ * R2: utility.p10/p50/p90 were SYNTHETIC (expected*0.9 / ==expected / expected*1.1),
+ * fabricated bands presented as computed uncertainty. The reported `expected` is a
+ * greedy-additive composition of per-action median deltas, so no single MC distribution
+ * backs it and no honest band exists. Fix = OMIT the bands; keep only `expected`.
+ *
+ * These tests fail at HEAD (4 keys incl. fabricated bands) and pass after the omit.
+ */
+describe('POST /v1/optimise - R2 no fabricated uncertainty bands', () => {
+  let server: ServerHandle;
+
+  beforeAll(async () => { server = await spawnServer(); });
+  afterAll(async () => { await server.kill(); });
+
+  it('reports only the computed expected, with no fabricated p10/p50/p90', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        graph: {
+          nodes: [{ id: 'R', label: 'R' }, { id: 'T', label: 'T' }],
+          edges: [{ from: 'R', to: 'T', weight: 1, belief_exists: 1 }],
+        },
+        budget: 10,
+        actions: [{ id: 'a1', cost: 2, do: [{ node_id: 'R', set_to: 3 }] }],
+        objective: { type: 'utility_linear', weights: { T: 1.0 } },
+        seed: 4242,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    // Positive control: the response DOES carry a computed point estimate...
+    expect(data.utility).toBeDefined();
+    expect(typeof data.utility.expected).toBe('number');
+    expect(data.utility.expected).not.toBe(0);
+
+    // ...and carries NOTHING ELSE. At HEAD utility has 4 keys incl. the synthetic
+    // bands, so this equality FAILS at HEAD (proves the test can see the presence).
+    expect(Object.keys(data.utility).sort()).toEqual(['expected']);
+    expect(data.utility.p10).toBeUndefined();
+    expect(data.utility.p50).toBeUndefined();
+    expect(data.utility.p90).toBeUndefined();
+  });
+
+  it('does not emit the synthetic +/-10% spread relationship around expected', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        graph: {
+          nodes: [{ id: 'R', label: 'R' }, { id: 'T', label: 'T' }],
+          edges: [{ from: 'R', to: 'T', weight: 1, belief_exists: 1 }],
+        },
+        budget: 10,
+        actions: [{ id: 'a1', cost: 2, do: [{ node_id: 'R', set_to: 5 }] }],
+        objective: { type: 'utility_linear', weights: { T: 1.0 } },
+        seed: 4242,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    // The tell-tale fabrication was p10 === expected*0.9 && p90 === expected*1.1.
+    // Absent bands cannot exhibit that relationship.
+    expect('p10' in data.utility).toBe(false);
+    expect('p90' in data.utility).toBe(false);
+  });
+});

--- a/tests/optimise.method-disclosure.test.ts
+++ b/tests/optimise.method-disclosure.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnServer, type ServerHandle } from './utils.js';
+
+/**
+ * Honest method disclosure (additive, #240 scale_provenance tradition): the wire must
+ * not imply capabilities the route lacks. The optimiser is a greedy-independent
+ * marginal-gain knapsack (assumes additive/independent action effects; NOT a joint
+ * combinatorial optimiser) and actions SCALE outgoing edge weights (NOT a do-operator
+ * that sets node values). Disclose both on the response.
+ *
+ * Fails at HEAD (fields absent) and passes once the markers are emitted.
+ */
+describe('POST /v1/optimise - honest method disclosure', () => {
+  let server: ServerHandle;
+
+  beforeAll(async () => { server = await spawnServer(); });
+  afterAll(async () => { await server.kill(); });
+
+  it('discloses method and action_semantics on the response', async () => {
+    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        graph: {
+          nodes: [{ id: 'R', label: 'R' }, { id: 'T', label: 'T' }],
+          edges: [{ from: 'R', to: 'T', weight: 1, belief_exists: 1 }],
+        },
+        budget: 10,
+        actions: [{ id: 'a1', cost: 2, do: [{ node_id: 'R', set_to: 3 }] }],
+        objective: { type: 'utility_linear', weights: { T: 1.0 } },
+        seed: 4242,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.method).toBe('greedy_independent_v1');
+    expect(data.action_semantics).toBe('edge_weight_scaling');
+  });
+});


### PR DESCRIPTION
## What (3 commits, one per fix — /v1/optimise, the ruled A1 "best combination" locus; ZERO callers exist)
- **e0cbb28 — R2: synthetic bands KILLED.** `utility.p10/p50/p90` were `expected*0.9 / ==expected / *1.1` — fabricated bands presented as computed. Deeper finding: `expected` is a greedy-additive sum of per-action median deltas from DISTINCT kernel runs over DIFFERENT graphs — no single MC distribution backs it, so NO honest band exists without changing the estimator (rowed: exact/joint upgrade). Response now `utility:{expected}` only. Complete reader manifest (adversarially verified, positive-controlled): zero readers of the killed bands anywhere (repo, both SDKs, fixtures, examples, cross-repo indicative sweep).
- **8bb236d — R3: missing/invalid `graph` → clean 400** (`BAD_INPUT` via the repo's `replyWithAppError` envelope), guarded before any graph access; positive control pins no over-rejection (well-formed empty graph still 200). Previously an unguarded deref → 500.
- **df058f5 — honest method disclosure (additive):** `method:"greedy_independent_v1"` + `action_semantics:"edge_weight_scaling"` — the wire must not imply joint/exact optimisation or Pearl do() semantics the route doesn't have. Both markers verified truthful at the bytes by the adversarial pass.

## Evidence (full gate)
RED-first 7 failed / 1 passed at base (digit-reproduced independently) · per-fix mutation isolation in throwaway worktrees (2/4+control/1 RED, cross-isolation clean, independently re-run) · suite 553 files / 5890 tests / 0 failed · typecheck exit 0 · ZERO golden deltas · openapi untouched and spec-legal (utility declared opaque; marker documentation = follow-up) · **Adversarial verdict: SAFE** (`acceptance-evidence/science-step1-2026-07-22/a1-optimise-fixes/ADVERSARIAL.md`).

## Rowed (pre-existing at base, surfaced by the adversarial — not in this diff)
Input-validation 500s beyond the graph corner (missing `objective` / non-array `actions` / numeric-id tie crash / null nodes) · `constraints.must` effects excluded from `utility.expected` (honesty-adjacent, doctrine) · greedy selects harmful affordable actions · `(e.weight||1)` weight-0 corner vs the marker wording (folds into the Neil do-semantics row) · stale SDK OptimiseResponse mirror · solver/method label doc.

Expected CI: pre-existing `gates (windows-latest)` colon-path red; macos+ubuntu = the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)