### PR TITLE
chore(optimise): /simplify cleanup — guard simplification, label co-location, test fold (zero-wire)

### DIFF
--- a/src/routes/v1/optimise.ts
+++ b/src/routes/v1/optimise.ts
@@ -63,8 +63,13 @@ async function evaluateUtility(graph: any, objective: any, seed: number): Promis
 // - edge_weight_scaling: an action's do:[{node_id,set_to}] MULTIPLIES the weight of every
 //   outgoing edge of node_id by set_to. It does NOT set the node's value (no Pearl
 //   do-operator); a leaf/no-outgoing node is a silent no-op. Flagged for Neil doctrine.
-const OPTIMISE_METHOD = 'greedy_independent_v1' as const;
-const OPTIMISE_ACTION_SEMANTICS = 'edge_weight_scaling' as const;
+const OPTIMISE_METHOD = 'greedy_independent_v1';
+const OPTIMISE_ACTION_SEMANTICS = 'edge_weight_scaling';
+// meta.solver names the SAME greedy-independent algorithm as OPTIMISE_METHOD above —
+// two hand-maintained labels, separately test-pinned, that can drift. Any change to the
+// optimiser algorithm MUST update BOTH this const and OPTIMISE_METHOD. (Unifying the two
+// wire values is a separate rowed item; do NOT change either string here.)
+const OPTIMISE_META_SOLVER = 'greedy_kernel_v1';
 
 export async function registerOptimiseRoute(app: FastifyInstance) {
   app.post(
@@ -97,12 +102,7 @@ export async function registerOptimiseRoute(app: FastifyInstance) {
     // R3: reject missing/invalid graph with a clean 400 (previously an unguarded
     // `body.graph.nodes.length` at the completion log threw an uncaught 500). Guard
     // here, before any downstream access to body.graph (priors/evidence/kernel).
-    if (
-      !body.graph ||
-      typeof body.graph !== 'object' ||
-      !Array.isArray(body.graph.nodes) ||
-      !Array.isArray(body.graph.edges)
-    ) {
+    if (!body.graph || !Array.isArray(body.graph.nodes) || !Array.isArray(body.graph.edges)) {
       return replyWithAppError(reply, {
         type: 'BAD_INPUT',
         statusCode: 400,
@@ -334,9 +334,9 @@ export async function registerOptimiseRoute(app: FastifyInstance) {
       // estimate; absent beats synthetic (previously p10=expected*0.9, p50=expected, p90=expected*1.1).
       utility: { expected: finalUtility },
       explanations,
-      meta: { 
-        seed, 
-        solver: 'greedy_kernel_v1', 
+      meta: {
+        seed,
+        solver: OPTIMISE_META_SOLVER,
         constraints_applied: appliedKeys,
         constraints_resolved: constraintsResolved
       }

--- a/tests/optimise.honesty-bands.test.ts
+++ b/tests/optimise.honesty-bands.test.ts
@@ -41,33 +41,9 @@ describe('POST /v1/optimise - R2 no fabricated uncertainty bands', () => {
 
     // ...and carries NOTHING ELSE. At HEAD utility has 4 keys incl. the synthetic
     // bands, so this equality FAILS at HEAD (proves the test can see the presence).
+    // The tell-tale fabrication was p10 === expected*0.9 && p90 === expected*1.1; a
+    // utility with only the `expected` key cannot exhibit that ±10% spread relationship,
+    // so this single keys-equality subsumes any per-band absence assertion.
     expect(Object.keys(data.utility).sort()).toEqual(['expected']);
-    expect(data.utility.p10).toBeUndefined();
-    expect(data.utility.p50).toBeUndefined();
-    expect(data.utility.p90).toBeUndefined();
-  });
-
-  it('does not emit the synthetic +/-10% spread relationship around expected', async () => {
-    const res = await fetch(`${server.baseUrl}/v1/optimise`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        graph: {
-          nodes: [{ id: 'R', label: 'R' }, { id: 'T', label: 'T' }],
-          edges: [{ from: 'R', to: 'T', weight: 1, belief_exists: 1 }],
-        },
-        budget: 10,
-        actions: [{ id: 'a1', cost: 2, do: [{ node_id: 'R', set_to: 5 }] }],
-        objective: { type: 'utility_linear', weights: { T: 1.0 } },
-        seed: 4242,
-      }),
-    });
-
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    // The tell-tale fabrication was p10 === expected*0.9 && p90 === expected*1.1.
-    // Absent bands cannot exhibit that relationship.
-    expect('p10' in data.utility).toBe(false);
-    expect('p90' in data.utility).toBe(false);
   });
 });


### PR DESCRIPTION
## What (1 commit, behavior-preserving — /simplify apply set, 22 Jul)
- Drop the redundant `typeof body.graph !== 'object'` guard clause (no value class it uniquely catches — falsy fails `!body.graph`, truthy primitives fail the `Array.isArray` checks with the same 400). All 5 validation tests pass unchanged.
- Drop two no-op `as const` on the disclosure consts (literal types already inferred).
- Lift the inline `meta.solver` string `'greedy_kernel_v1'` into `OPTIMISE_META_SOLVER`, co-located with `OPTIMISE_METHOD` + a cross-reference comment: both label the SAME greedy algorithm and must move together (mirror-drift made visible; **both wire values unchanged** — actual unification is a rowed item).
- Fold the wholly-subsumed second honesty-bands test into the first (keys-equality already proves band absence; single payload-independent return site). Net −1 test.

## Gate
Suite 5890→5889 (delta = exactly the fold), 0 failed · typecheck exit 0 · **ZERO golden deltas** (fixtures replay "All fixtures match") · full adjudication record: `acceptance-evidence/science-step1-2026-07-22/SIMPLIFY-FINDINGS-2026-07-22.md` (4-angle Fable review, apply/row/skip sets).

Expected pre-existing CI reds (verified NOT-this-diff): gates(windows-latest) colon-path · `audit` fast-uri advisory GHSA-v2hh-gcrm-f6hx (reproduced on clean base; dedicated fix outstanding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)