### PR TITLE
fix(deps): clear fast-uri GHSA-v2hh-gcrm-f6hx on BOTH major lines (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "yaml": "^2.8.1"
       },
       "engines": {
-        "node": ">=20 <21",
+        "node": ">=20.3.0 <21",
         "npm": ">=10 <11"
       }
     },
@@ -1106,6 +1106,22 @@
         "ajv-formats": "^3.0.1",
         "fast-uri": "^3.0.0"
       }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/@fastify/cors": {
       "version": "11.1.0",
@@ -3179,6 +3195,22 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -5930,6 +5962,22 @@
         "rfdc": "^1.2.0"
       }
     },
+    "node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -5954,9 +6002,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
       "funding": [
         {
           "type": "github",
@@ -6041,22 +6089,6 @@
         "json-schema-ref-resolver": "^3.0.0",
         "rfdc": "^1.2.0"
       }
-    },
-    "node_modules/fastify/node_modules/fast-uri": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.0.tgz",
-      "integrity": "sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastify/node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -109,5 +109,9 @@
     "typescript": "^5.9.2",
     "vitest": "^3.2.4",
     "yaml": "^2.8.1"
+  },
+  "overrides": {
+    "fast-uri@3": "3.1.4",
+    "fast-uri@4": "4.1.1"
   }
 }


### PR DESCRIPTION
## What
Targeted `overrides` clearing the HIGH advisory **GHSA-v2hh-gcrm-f6hx** (fast-uri host confusion) from **both** installed major lines (Codex cross-service review F9; verified at tip 6075c91):
- `fast-uri@3` → **3.1.4** (was 3.1.3 via ajv, @fastify/ajv-compiler, fast-json-stringify@6)
- `fast-uri@4` → **4.1.1** (was 4.1.0 via fast-json-stringify@7)

Patched versions verified against the advisory + npm registry. Lockfile regenerated via npm (never hand-edited); diff scope verified line-by-line — **zero unrelated package bumps** (the single engines-metadata line is pre-existing base drift, proven by a plain install on untouched base producing the identical line). `npm audit fix` deliberately NOT used (it would sweep the other 23 unrelated advisories into the diff).

## Why now
This advisory has been redding the `audit` CI job on **every PLoT PR** since ~22 Jul (reproduced on clean base). CEE cleared its own instance yesterday (#622). This PR restores audit to a meaningful green — the check on THIS PR is the proof.

## Gates
`npm audit --omit=dev --audit-level=high` → exit 0, 0 vulnerabilities (was exit 1 on base) · typecheck exit 0 · full suite **5889 passed / 29 skipped — byte-identical to base, zero test deltas** · golden fixtures "All fixtures match" + determinism payload stable ×10 · evidence: `acceptance-evidence/science-step1-2026-07-22/fastauri-fix/NOTES.md`.

Expected CI: `gates (windows-latest)` colon-path = the one remaining documented pre-existing red. **`audit` should be GREEN on this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)