### PR TITLE
fix(auth): resolve expected bearer from single PLOT_AUTH_TOKEN source (flip-readiness, INERT)

### DIFF
--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -1,5 +1,6 @@
 import pino from 'pino';
 import { ISL_TIMEOUT_MS, CEE_TIMEOUT_MS, worstCaseMs, resolveIslMaxRetries } from './config/timeouts.js';
+import { getExpectedAuthToken } from './config/auth-token.js';
 
 const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
@@ -8,9 +9,14 @@ const logger = pino({
 export function validateEnv(): void {
   const errors: string[] = [];
 
-  // AUTH validation
-  if (process.env.AUTH_ENABLED === '1' && !process.env.AUTH_TOKEN) {
-    errors.push('AUTH_ENABLED=1 requires AUTH_TOKEN to be set');
+  // AUTH validation — a flip to AUTH_ENABLED=1 must have an expected token from
+  // the single resolved source (PLOT_AUTH_TOKEN, or the historical AUTH_TOKEN
+  // fallback). Without this reconciliation the boot would exit(1) on staging,
+  // where only PLOT_AUTH_TOKEN is provisioned — a boot crash strictly worse than
+  // the 403 this change exists to prevent. Fires only when AUTH_ENABLED=1 → inert
+  // until the flip.
+  if (process.env.AUTH_ENABLED === '1' && !getExpectedAuthToken()) {
+    errors.push('AUTH_ENABLED=1 requires AUTH_TOKEN or PLOT_AUTH_TOKEN to be set');
   }
 
   // PORT validation

--- a/src/config/auth-token.ts
+++ b/src/config/auth-token.ts
@@ -1,0 +1,26 @@
+/**
+ * Single source of truth for the server-side Bearer auth secret.
+ *
+ * Every live caller (CEE PLoTClient, the staging smoke + load-probe workflows)
+ * already sends the value provisioned as PLOT_AUTH_TOKEN — that is the
+ * caller-facing name, and on staging it is the ONLY auth var actually set
+ * (AUTH_TOKEN is unset there). The historical/documented server-side name is
+ * AUTH_TOKEN (env.example, render.yaml, docs/RENDER_SETUP.md, config-validator).
+ *
+ * We resolve PLOT_AUTH_TOKEN first, then fall back to AUTH_TOKEN, so a single
+ * reader satisfies BOTH the deployed staging reality AND any env
+ * (production / local dev / CI) that still provisions the historical name.
+ * One resolver, no hand-maintained two-var mirror: rotating the deployed
+ * secret can never silently strand the guard on an empty expected token
+ * (the silent-breakage-on-rotation class).
+ *
+ * `||` (not `??`) so an empty-string PLOT_AUTH_TOKEN also falls through to
+ * AUTH_TOKEN — matching the original guard's `AUTH_TOKEN || ''` idiom.
+ *
+ * Read fresh on every call (env may change between tests / at runtime); never
+ * cache. This function performs NO auth decision — callers gate it behind
+ * AUTH_ENABLED so it is inert while auth is off.
+ */
+export function getExpectedAuthToken(): string {
+  return String(process.env.PLOT_AUTH_TOKEN || process.env.AUTH_TOKEN || '').trim();
+}

--- a/src/middleware/auth-guard.ts
+++ b/src/middleware/auth-guard.ts
@@ -9,6 +9,7 @@ import type { FastifyRequest, FastifyReply } from 'fastify';
 import { timingSafeEqual } from 'crypto';
 import { replyWithAppError } from '../errors.js';
 import { isDemoMode } from './demo-mode.js';
+import { getExpectedAuthToken } from '../config/auth-token.js';
 
 export interface AuthGuardOptions {
   /** Allow demo mode bypass (for SSE streaming routes) */
@@ -78,7 +79,12 @@ export async function authGuard(
   // Get authorization header
   const headers = req.headers || {};
   const authHeader = String(headers.authorization || headers.Authorization || '');
-  const expectedToken = String(process.env.AUTH_TOKEN || '').trim();
+  // Single source of truth: PLOT_AUTH_TOKEN (the caller-facing name every live
+  // caller — CEE PLoTClient — already sends, and the only auth var provisioned
+  // on staging) with a fallback to the historical AUTH_TOKEN. No two-var mirror
+  // to keep in sync. This read is reached only after the AUTH_ENABLED early-return
+  // above, so it stays inert until the auth flip.
+  const expectedToken = getExpectedAuthToken();
 
   // Check for Bearer token
   if (!authHeader.startsWith('Bearer ')) {

--- a/src/routes/ops/snapshot.ts
+++ b/src/routes/ops/snapshot.ts
@@ -6,6 +6,7 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { timingSafeEqual } from 'crypto';
 import { replyWithAppError } from '../../errors.js';
+import { getExpectedAuthToken } from '../../config/auth-token.js';
 import {
   getEngineP95Ms,
   getEngineP95MsRolling,
@@ -29,7 +30,10 @@ async function opsAuthGuard(req: FastifyRequest, reply: FastifyReply): Promise<F
   // If AUTH_ENABLED='1', use standard bearer auth
   if (process.env.AUTH_ENABLED === '1') {
     const hdr = String((req.headers?.authorization || req.headers?.Authorization || '') || '');
-    const expected = String(process.env.AUTH_TOKEN || '').trim();
+    // Same single source of truth as the main auth guard: PLOT_AUTH_TOKEN
+    // (caller-facing / provisioned) with an AUTH_TOKEN fallback. Reached only
+    // inside the AUTH_ENABLED==='1' branch, so inert until the auth flip.
+    const expected = getExpectedAuthToken();
 
     if (!hdr.startsWith('Bearer ')) {
       try {

--- a/tests/auth.plot-token-reconcile.test.ts
+++ b/tests/auth.plot-token-reconcile.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Auth-token reconciliation — the guard's expected Bearer token now resolves from
+ * a single source (getExpectedAuthToken): PLOT_AUTH_TOKEN first (the caller-facing
+ * name every live caller — CEE PLoTClient — already sends, and the ONLY auth var
+ * provisioned on PLoT staging), falling back to the historical AUTH_TOKEN.
+ *
+ * Before this change the guard read process.env.AUTH_TOKEN directly, so a future
+ * AUTH_ENABLED flip on staging (where AUTH_TOKEN is unset) would 403 every Bearer
+ * caller. These tests pin the reconciled behaviour, using the same /v2 onRequest
+ * harness as v2-auth-guard.test.ts (enforcement needs AUTH_ENABLED=1 + AUTH_V2_ENABLED=1).
+ *
+ * RED-first: against the pre-change guard, "valid PLOT_AUTH_TOKEN → 400" gets a 403
+ * (expected token resolves empty from the unset AUTH_TOKEN), so the accept case fails.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { registerV2Routes } from '../src/routes/v2/index.js';
+
+const ENV_KEYS = ['AUTH_ENABLED', 'AUTH_V2_ENABLED', 'AUTH_TOKEN', 'PLOT_AUTH_TOKEN'] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  // Start from a clean slate so a leaked shell/CI value can't mask a RED.
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerV2Routes(app);
+  await app.ready();
+  return app;
+}
+
+async function postRun(app: FastifyInstance, headers: Record<string, string> = {}) {
+  return app.inject({
+    method: 'POST',
+    url: '/v2/run',
+    headers: { 'content-type': 'application/json', ...headers },
+    // Deliberately schema-INVALID: an authorized request reaches validation and
+    // gets a plain 400; an unauthorized one is rejected by auth first (401/403).
+    payload: {},
+  });
+}
+
+describe('auth-token reconcile — PLOT_AUTH_TOKEN is the resolved expected token', () => {
+  beforeEach(() => {
+    process.env.AUTH_ENABLED = '1';
+    process.env.AUTH_V2_ENABLED = '1';
+    process.env.PLOT_AUTH_TOKEN = 'plot-secret-token';
+    // AUTH_TOKEN deliberately UNSET — mirrors staging (only PLOT_AUTH_TOKEN provisioned).
+  });
+
+  it('valid PLOT_AUTH_TOKEN Bearer passes the auth layer (400 from validation, not 403)', async () => {
+    const app = await buildApp();
+    const res = await postRun(app, { authorization: 'Bearer plot-secret-token' });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('wrong Bearer token → 403', async () => {
+    const app = await buildApp();
+    const res = await postRun(app, { authorization: 'Bearer wrong-token' });
+    expect(res.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('missing Authorization → 401', async () => {
+    const app = await buildApp();
+    const res = await postRun(app);
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+});
+
+describe('auth-token reconcile — precedence and fallback', () => {
+  it('PLOT_AUTH_TOKEN takes precedence over AUTH_TOKEN when both are set', async () => {
+    process.env.AUTH_ENABLED = '1';
+    process.env.AUTH_V2_ENABLED = '1';
+    process.env.PLOT_AUTH_TOKEN = 'plot-wins';
+    process.env.AUTH_TOKEN = 'legacy-loses';
+
+    const app = await buildApp();
+    // The PLOT value authenticates...
+    const ok = await postRun(app, { authorization: 'Bearer plot-wins' });
+    expect(ok.statusCode).toBe(400);
+    // ...and the legacy value does NOT (it was not the resolved expected token).
+    const bad = await postRun(app, { authorization: 'Bearer legacy-loses' });
+    expect(bad.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('falls back to AUTH_TOKEN when PLOT_AUTH_TOKEN is unset (prod/dev/CI alias)', async () => {
+    process.env.AUTH_ENABLED = '1';
+    process.env.AUTH_V2_ENABLED = '1';
+    process.env.AUTH_TOKEN = 'legacy-only-token';
+    // PLOT_AUTH_TOKEN deliberately UNSET.
+
+    const app = await buildApp();
+    const res = await postRun(app, { authorization: 'Bearer legacy-only-token' });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+});


### PR DESCRIPTION
## What (1 commit — R-8 flip precondition, INERT while AUTH_ENABLED=0)
PLoT's auth guard validated the incoming Bearer against `process.env.AUTH_TOKEN`, which is **unset on PLoT staging** (only `PLOT_AUTH_TOKEN` is provisioned — the value CEE already sends). A flip to `AUTH_ENABLED=1` today would 403 every caller AND — the byte-manifest's key finding — **boot-crash** via `config-validator.ts` (`AUTH_ENABLED=1 && !AUTH_TOKEN → process.exit(1)`).

Reconciles all **three** token readers (guard, ops/snapshot, config-validator) through one resolver:
```ts
getExpectedAuthToken() = String(process.env.PLOT_AUTH_TOKEN || process.env.AUTH_TOKEN || '').trim()
```
Single source, fallback accepts both the deployed staging reality (PLOT_AUTH_TOKEN) and the historical/prod name (AUTH_TOKEN) — no hand-maintained two-var mirror (rotating the secret can't silently strand the guard). No CEE change: CEE already sends PLOT_AUTH_TOKEN's value (sha-matched).

## Why INERT / safe to land ahead of the flip
The guard early-returns at `if (!isAuthEnabled()) return true` (L64-66) **before** reading the token (L87); the other two readers are inside `AUTH_ENABLED==='1'` gates. With staging at AUTH_ENABLED=0, nothing changes live. Deploy-verify = build-confirm.

## Adversarial (Fable, fail-closed, SECURITY): SAFE (evidence: `acceptance-evidence/science-step1-2026-07-22/auth-token-reconcile/{NOTES,ADVERSARIAL}.md`)
37-row bypass truth-matrix → **0 authorized-when-shouldn't**; empty-expected never authorizes (`!expectedToken` short-circuits before timingSafeEqual); empty-token+AUTH_ENABLED=1 → boot exit(1) (verified in child processes); config-validator = strict improvement, not a weakening; timing-safe path + 401/403 envelopes byte-identical; flip-readiness proven (CEE-shaped Bearer→authorized, tokenless→401, wrong→403, boot exit 0 where OLD crashes).

## ⚠ Flip-runbook residuals (for whoever executes the flip — NOT blocking this inert merge)
1. Set `AUTH_ENABLED` to exactly `'1'` — `'true'` leaves auth silently OFF (pre-existing booleanString).
2. `/v2` additionally needs `AUTH_V2_ENABLED=1` (`/v1` gates on AUTH_ENABLED alone).
3. Confirm CEE-staging and PLoT-staging `PLOT_AUTH_TOKEN` **values** match at flip time (dashboard fact).

## Gates
RED-first +5 tests (env-key-delete positive-control hygiene) · mutation: guard reverted → the 2 PLOT-discriminating tests RED · typecheck exit 0 · full suite 5894/0 · ZERO golden deltas (no compute path). Expected CI: windows colon-path red only (audit now green post-fast-uri).

🤖 Generated with [Claude Code](https://claude.com/claude-code)