### PR TITLE
fix(auth): P0 — gate on matched route pattern, not raw req.url (percent-encoding bypass)

### DIFF
--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -27,16 +27,26 @@ import { authGuard } from '../../middleware/auth-guard.js';
 export async function registerV1Routes(app: FastifyInstance) {
   // Add consolidated auth guard hook for all /v1/* routes
   app.addHook('preHandler', async (req, reply) => {
-    // Only apply to /v1/* routes
-    if (req.url?.startsWith('/v1/')) {
+    // Only apply to /v1/* routes. Gate on the MATCHED ROUTE PATTERN
+    // (req.routeOptions.url), not the raw req.url: Fastify routes on the DECODED
+    // path, so a percent-encoded prefix (e.g. `/%761/optimise`, raw does not
+    // start with `/v1/`) would slip past a raw `req.url.startsWith('/v1/')`
+    // guard yet still dispatch to `/v1/optimise` → unauthenticated compute.
+    // routeOptions.url is the registered pattern (`/v1/optimise`, and
+    // `/v1/templates/:id/graph` for param routes) and `undefined` for a
+    // genuine 404 (nothing to protect).
+    if (req.routeOptions?.url?.startsWith('/v1/')) {
       // Skip auth for OPTIONS preflight requests - CORS plugin handles these
       // Browsers don't send Authorization headers on preflight
       if (req.method === 'OPTIONS') {
         return;
       }
-      // Allow demo bypass for GET /v1/stream, skip auth entirely for /v1/templates (read-only public)
-      const isStreamRoute = req.method === 'GET' && req.url.startsWith('/v1/stream');
-      const isTemplatesRoute = req.url.startsWith('/v1/templates');
+      // Allow demo bypass for GET /v1/stream, skip auth entirely for /v1/templates (read-only public).
+      // Read the matched route pattern here too, so an encoded path cannot forge
+      // a demo-bypass / templates-skip: the pattern is `/v1/stream` and
+      // `/v1/templates`(`/:id/graph`) only when that route actually matched.
+      const isStreamRoute = req.method === 'GET' && req.routeOptions?.url?.startsWith('/v1/stream') === true;
+      const isTemplatesRoute = req.routeOptions?.url?.startsWith('/v1/templates') === true;
       const authorized = await authGuard(req, reply, {
         allowDemoBypass: isStreamRoute,
         skipAuth: isTemplatesRoute,

--- a/src/routes/v2/index.ts
+++ b/src/routes/v2/index.ts
@@ -19,7 +19,13 @@ export async function registerV2Routes(app: FastifyInstance): Promise<void> {
   // unauthenticated callers cannot probe schema-validation behaviour.
   // authGuard reads only headers, which are available at onRequest.
   app.addHook('onRequest', async (req, reply) => {
-    if (!req.url?.startsWith('/v2/')) return;
+    // Gate on the MATCHED ROUTE PATTERN (req.routeOptions.url), not the raw
+    // req.url. Fastify routes on the DECODED path, so a percent-encoded prefix
+    // (e.g. `/%762/run`, raw does not start with `/v2/`) would slip past a raw
+    // `req.url.startsWith('/v2/')` guard yet still dispatch to `/v2/run` →
+    // unauthenticated compute. routeOptions.url is `/v2/run` for both `/v2/run`
+    // and `/%762/run`, and `undefined` for a genuine 404 (nothing to protect).
+    if (!req.routeOptions?.url?.startsWith('/v2/')) return;
     // CORS preflight carries no Authorization header by design.
     if (req.method === 'OPTIONS') return;
     if (!isV2AuthEnabled()) return;

--- a/tests/auth.encoding-bypass.test.ts
+++ b/tests/auth.encoding-bypass.test.ts
@@ -1,0 +1,178 @@
+/**
+ * P0 regression: auth bypass via percent-encoded route prefix.
+ *
+ * Both auth guards historically self-filtered on the RAW `req.url`
+ * (`req.url.startsWith('/vN/')`). Fastify routes on the DECODED path, so a
+ * percent-encoded prefix such as `/%762/run` (raw does NOT match `/v2/`) made
+ * the guard early-return (skip auth) while the router still dispatched to
+ * `/v2/run` → full UNAUTHENTICATED compute. Verified live on staging.
+ *
+ * Fix: gate on `req.routeOptions?.url` (the MATCHED ROUTE PATTERN), which is
+ * `/v2/run` for both `/v2/run` and `/%762/run`, and `undefined` for a genuine
+ * 404. These tests FAIL on the raw-url guard and PASS after the fix.
+ *
+ * Uses a REAL listening socket + raw TCP writes (curl --path-as-is equivalent)
+ * so the percent-encoding reaches the server unchanged — no client-side URL
+ * normalization can mask the bypass.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import net from 'node:net';
+import { createServer } from '../src/createServer.js';
+import type { FastifyInstance } from 'fastify';
+
+const validToken = 'test-token-encoding-guard-12345';
+
+let app: FastifyInstance;
+let port: number;
+
+// Send an EXACT request line over a raw socket (no client URL normalization).
+function rawRequest(
+  requestLine: string,
+  opts: { body?: string; headers?: Record<string, string> } = {}
+): Promise<{ status: number; body: string }> {
+  const body = opts.body ?? '';
+  const headers: Record<string, string> = {
+    Host: '127.0.0.1',
+    Connection: 'close',
+    ...(opts.headers ?? {}),
+  };
+  if (body) {
+    headers['Content-Type'] = headers['Content-Type'] ?? 'application/json';
+    headers['Content-Length'] = String(Buffer.byteLength(body));
+  }
+  const headerLines = Object.entries(headers)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\r\n');
+
+  return new Promise((resolve, reject) => {
+    const sock = net.connect(port, '127.0.0.1', () => {
+      sock.write(`${requestLine} HTTP/1.1\r\n${headerLines}\r\n\r\n${body}`);
+    });
+    let data = '';
+    sock.setTimeout(10000, () => {
+      sock.destroy();
+      reject(new Error(`raw request timed out: ${requestLine}`));
+    });
+    sock.on('data', (c) => {
+      data += c.toString();
+    });
+    sock.on('end', () => {
+      const m = data.match(/^HTTP\/1\.1 (\d+)/);
+      const idx = data.indexOf('\r\n\r\n');
+      resolve({
+        status: m ? Number(m[1]) : -1,
+        body: idx >= 0 ? data.slice(idx + 4) : '',
+      });
+    });
+    sock.on('error', reject);
+  });
+}
+
+const validGraphV1 = {
+  nodes: [
+    { id: 'a', label: 'A', type: 'decision' },
+    { id: 'b', label: 'B', type: 'outcome' },
+  ],
+  edges: [{ from: 'a', to: 'b' }],
+};
+
+beforeAll(async () => {
+  process.env.AUTH_ENABLED = '1';
+  process.env.AUTH_V2_ENABLED = '1'; // widen the Bearer gate to /v2/*
+  process.env.AUTH_TOKEN = validToken;
+  process.env.RATE_LIMIT_ENABLED = '0'; // avoid 429 flakiness under rapid raw requests
+
+  app = await createServer({ enableTestRoutes: false });
+  await app.listen({ port: 0, host: '127.0.0.1' });
+  const addr = app.server.address();
+  port = typeof addr === 'object' && addr ? addr.port : 0;
+});
+
+afterAll(async () => {
+  await app.close();
+  delete process.env.AUTH_ENABLED;
+  delete process.env.AUTH_V2_ENABLED;
+  delete process.env.AUTH_TOKEN;
+  delete process.env.RATE_LIMIT_ENABLED;
+});
+
+describe('P0: percent-encoded route-prefix auth bypass is closed', () => {
+  // --- Encoded-bypass vectors: MUST be rejected at the guard (401), not reach the handler ---
+  describe('encoded prefixes are auth-gated (RED before fix)', () => {
+    it('POST /%762/run (decodes to /v2/run) no-token → 401', async () => {
+      const r = await rawRequest('POST /%762/run', { body: '{}' });
+      expect(r.status).toBe(401);
+    });
+
+    it('POST /v%32/run (decodes to /v2/run) no-token → 401', async () => {
+      const r = await rawRequest('POST /v%32/run', { body: '{}' });
+      expect(r.status).toBe(401);
+    });
+
+    it('POST /%761/optimise (decodes to /v1/optimise) no-token → 401 (was FULL UNAUTH COMPUTE)', async () => {
+      const r = await rawRequest('POST /%761/optimise', {
+        body: JSON.stringify({ graph: validGraphV1, seed: 42 }),
+      });
+      expect(r.status).toBe(401);
+    });
+
+    it('POST /%761/validate (decodes to /v1/validate) no-token → 401', async () => {
+      const r = await rawRequest('POST /%761/validate', {
+        body: JSON.stringify({ graph: validGraphV1 }),
+      });
+      expect(r.status).toBe(401);
+    });
+  });
+
+  // --- Positive controls: literal-path behavior must be preserved ---
+  describe('literal paths still behave correctly (guard preserved)', () => {
+    it('POST /v2/run no-token → 401', async () => {
+      const r = await rawRequest('POST /v2/run', { body: '{}' });
+      expect(r.status).toBe(401);
+    });
+
+    it('POST /v2/run correct-token → NOT 401/403 (reaches handler)', async () => {
+      const r = await rawRequest('POST /v2/run', {
+        body: '{}',
+        headers: { Authorization: `Bearer ${validToken}` },
+      });
+      expect([401, 403]).not.toContain(r.status);
+    });
+
+    it('POST /v1/optimise correct-token → NOT 401/403 (reaches handler)', async () => {
+      const r = await rawRequest('POST /v1/optimise', {
+        body: JSON.stringify({ graph: validGraphV1, seed: 42 }),
+        headers: { Authorization: `Bearer ${validToken}` },
+      });
+      expect([401, 403]).not.toContain(r.status);
+    });
+
+    it('POST /v1/optimise no-token → 401', async () => {
+      const r = await rawRequest('POST /v1/optimise', {
+        body: JSON.stringify({ graph: validGraphV1, seed: 42 }),
+      });
+      expect(r.status).toBe(401);
+    });
+
+    it('GET /v1/templates (public read-only) still skips auth → NOT 401/403', async () => {
+      const r = await rawRequest('GET /v1/templates');
+      expect([401, 403]).not.toContain(r.status);
+    });
+
+    it('OPTIONS /v2/run preflight still skips auth → NOT 401/403', async () => {
+      const r = await rawRequest('OPTIONS /v2/run', {
+        headers: {
+          Origin: 'http://localhost:5173',
+          'Access-Control-Request-Method': 'POST',
+        },
+      });
+      expect([401, 403]).not.toContain(r.status);
+    });
+
+    it('POST /nope (genuine 404) is NOT auth-gated into a 401 → 404', async () => {
+      const r = await rawRequest('POST /nope', { body: '{}' });
+      expect(r.status).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
## P0 auth bypass — LIVE, verified, fixed

Both auth guards self-filtered on the RAW `req.url.startsWith('/vN/')`, but Fastify routes on the DECODED path. A percent-encoded prefix (`/%762/run`, raw does not start with `/v2/`) skipped the guard yet dispatched to `/v2/run` → **unauthenticated compute**. Verified LIVE on staging (auth ON): `/%761/optimise` no-token + valid body → **HTTP 200 with a real optimise result**. Activated by the R-8 flip (which closed literal paths but missed the encoded vector); NOT a regression (pre-flip everything was public) — fixed forward.

## Fix
Gate on the **matched route pattern** `req.routeOptions?.url` (what the router actually matched) instead of the attacker-controlled raw `req.url`, at both guard sites + the two v1 sub-path skips (stream/templates). `routeOptions.url` is `/v2/run` for both `/v2/run` and `/%762/run`, and `undefined` for a genuine 404 (nothing to protect). 3 files (v1/index.ts, v2/index.ts, +new test).

## Gates
- **RED-first** (real listening socket, raw TCP): pre-fix the 4 encoded discriminators reach the handler unauth (`/%761/validate` → **200 full compute**); post-fix **11/11** green (4 encoded → 401 + 7 positive controls: literal 401, correct-token reaches handler, templates-skip, OPTIONS preflight, genuine 404).
- **Mutation** (throwaway worktree): revert src → same 4 discriminators RED.
- **Full suite** (`npm test`, the pre-push gate): base 5894 → head 5905 (**+11 mine, 0 regressions**); typecheck clean; zero golden churn.
- **Security grep**: the two auth gates are the ONLY raw-url sites that drop a protection (both fixed); all other raw-url-prefix sites fail closed.
- **Fable security adversarial: SAFE** (`P0-FIX-ADVERSARIAL.md`) — ~45 bypass vectors executed on a real socket, ALL closed (double-encoding, `%2F`, case, `//`, traversal, null-byte, matrix-param → 404; fixed vectors → 401). Bonus: also closes an absolute-form-target bypass the old guard missed. Full guarded-route manifest verified — every compute route covered; skip-path forge impossible.

## Non-blocking notes (rowed, not in this fix's scope)
- **N1 (pre-existing, separate):** root `POST /critique` + `/improve` do unauthenticated compute (outside both old AND new /vN guard — never introduced here). Deterministic flow-critique/echo, no ISL/LLM, no secret egress. Needs its own decision (gate vs document as intentionally-public legacy). Flagged separately.
- **N2 (introduced, acceptable):** unmatched `/vN/*` now → 404 (was 401). Route set is already public via the unauthenticated `/v1/openapi.json`, so no new disclosure; 404-on-unknown is more correct.

Evidence: `acceptance-evidence/science-step1-2026-07-22/simplify2/{P0-P1-VERIFIED,P0-FIX-NOTES,P0-FIX-ADVERSARIAL}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)