### PR TITLE
fix(auth): gate root /critique + /improve behind authGuard (N1 — close last public compute)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -15,7 +15,7 @@ info:
     - AUTH_ENABLED=1 requires Authorization: Bearer <token> on certain routes
     - ISL_ENABLE=1 enables ISL (Inference Service Layer) integration for enhanced causal validation and sensitivity analysis
     
-    **Legacy Routes**: /draft-flows, /critique, /improve (v0) remain for backwards compatibility.
+    **Legacy Routes**: /draft-flows, /critique, /improve (v0) remain for backwards compatibility. All three require Authorization: Bearer <token> when AUTH_ENABLED=1.
   contact:
     name: PLoT Engine
     url: https://github.com/Talchain/plot-lite-service

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -54,6 +54,6 @@ This page documents the frozen engine contracts, gating flags, determinism & cac
 - `GET /version` → `{ api, build, model }`
 - `GET /draft-flows?template=<T>&seed=<N>&budget=<N?>` → deterministic body + strong ETag, 304 if matched
 - `POST /draft-flows` → deterministic legacy; supports `Idempotency-Key`
-- `POST /critique` → deterministic rules; Ajv validated
-- `POST /improve` → echoes `parse_json`
+- `POST /critique` → deterministic rules; Ajv validated (requires `Authorization: Bearer <token>` when `AUTH_ENABLED=1`)
+- `POST /improve` → echoes `parse_json` (requires `Authorization: Bearer <token>` when `AUTH_ENABLED=1`)
 - (test-only) `GET /stream`, `POST /stream/cancel`, `/internal/replay-*`

--- a/docs/plot-lite-contract.md
+++ b/docs/plot-lite-contract.md
@@ -7,7 +7,7 @@ _Last updated: 2025-09-20 22:08 BST_
 
 Deterministic draft flow generation and critique for the Scenario Sandbox PoC.
 
-- Endpoints: `/draft-flows`, `/critique`, optional `/improve`, plus `/health` and `/version`.
+- Endpoints: `/draft-flows`, `/critique`, optional `/improve`, plus `/health` and `/version`. (`/draft-flows`, `/critique`, and `/improve` require `Authorization: Bearer <token>` when `AUTH_ENABLED=1`.)
 - Determinism: Same `parse_text` + `context` + `seed` => byte-identical `parse_json_hash` and list ordering.
 - Privacy: Service must not log `parse_text`. Callers should redact or hash on their side; provenance storage is org‑configurable.
 

--- a/openapi/openapi-plot-lite-v1.yaml
+++ b/openapi/openapi-plot-lite-v1.yaml
@@ -61,6 +61,7 @@ paths:
   /critique:
     post:
       summary: Critique an edited flow deterministically
+      description: 'Requires Authorization: Bearer <token> when AUTH_ENABLED=1.'
       operationId: critique
       requestBody:
         required: true
@@ -84,6 +85,7 @@ paths:
   /improve:
     post:
       summary: Apply deterministic micro-fixes (optional endpoint; feature-flagged)
+      description: 'Requires Authorization: Bearer <token> when AUTH_ENABLED=1.'
       operationId: improve
       requestBody:
         required: true

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -1195,6 +1195,7 @@ export async function createServer(opts: ServerOpts = {}) {
   });
 
   app.post('/critique', async (req: any, reply) => {
+    if (!(await authGuard(req, reply))) return;
     const body = req.body || {};
     // Sensitive scan (fast path then deep)
     {
@@ -1266,6 +1267,7 @@ export async function createServer(opts: ServerOpts = {}) {
   });
 
   app.post('/improve', async (req: any, reply) => {
+    if (!(await authGuard(req, reply))) return;
     const { parse_json } = req.body || {};
     if (typeof parse_json === 'undefined') { const { errorResponse } = await import('./errors.js'); return reply.code(400).send(errorResponse('BAD_INPUT', 'Field parse_json is required', 'Provide a parse_json object to be echoed back')); }
     return { parse_json, fix_applied: [] };

--- a/tests/auth.root-critique-improve.routes.test.ts
+++ b/tests/auth.root-critique-improve.routes.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Auth Guard on root POST /critique and POST /improve
+ *
+ * These two root-mounted compute routes previously ran UNAUTHENTICATED. After
+ * the R-8 auth flip they were the only compute routes still publicly reachable.
+ * This suite pins that they are now front-gated by the same conditional authGuard
+ * that protects /draft-flows and /v1/*:
+ *   - AUTH_ENABLED unset  → guard allows (auth-off callers unchanged)
+ *   - AUTH_ENABLED=1, no token    → 401 (WWW-Authenticate: Bearer, code UNAUTHORIZED)
+ *   - AUTH_ENABLED=1, wrong token → 403 (code FORBIDDEN)
+ *   - AUTH_ENABLED=1, correct token → reaches the handler (behaviour byte-preserved)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer } from '../src/createServer.js';
+import type { FastifyInstance } from 'fastify';
+
+const validFlow = {
+  nodes: [
+    { id: 'n1', type: 'decision', label: 'Adjust price', baseline: 99 },
+    { id: 'n2', type: 'outcome', label: 'Revenue', baseline: 100000 },
+  ],
+  edges: [{ id: 'e1', from: 'n1', to: 'n2', weight: 0.4, belief: 0.7 }],
+  comments: [],
+  metadata: { thresholds: [99] },
+};
+
+describe('Auth Guard on root /critique + /improve (AUTH_ENABLED=1)', () => {
+  let app: FastifyInstance;
+  let port: number;
+  const validToken = 'root-compute-token-12345';
+
+  beforeAll(async () => {
+    process.env.AUTH_ENABLED = '1';
+    process.env.PLOT_AUTH_TOKEN = validToken;
+    // 64-hex secret so secret-validation / token rate-limiting stay satisfied.
+    process.env.TOKEN_HMAC_SECRET = 'a'.repeat(64);
+
+    app = await createServer({ enableTestRoutes: false });
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const addr = app.server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    delete process.env.AUTH_ENABLED;
+    delete process.env.PLOT_AUTH_TOKEN;
+    delete process.env.TOKEN_HMAC_SECRET;
+  });
+
+  const routes = ['/critique', '/improve'] as const;
+
+  describe('Missing auth token → 401', () => {
+    for (const path of routes) {
+      it(`POST ${path} returns 401 without token`, async () => {
+        const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ parse_json: validFlow }),
+        });
+        expect(res.status).toBe(401);
+        expect(res.headers.get('www-authenticate')).toBe('Bearer');
+        const data = await res.json();
+        expect(data.schema).toBe('error.v1');
+        expect(data.code).toBe('UNAUTHORIZED');
+        expect(data.message).toContain('Missing bearer token');
+      });
+    }
+  });
+
+  describe('Invalid auth token → 403', () => {
+    for (const path of routes) {
+      it(`POST ${path} returns 403 with wrong token`, async () => {
+        const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer wrong-token',
+          },
+          body: JSON.stringify({ parse_json: validFlow }),
+        });
+        expect(res.status).toBe(403);
+        const data = await res.json();
+        expect(data.schema).toBe('error.v1');
+        expect(data.code).toBe('FORBIDDEN');
+        expect(data.message).toContain('Invalid token');
+      });
+    }
+  });
+
+  describe('Valid auth token → reaches handler (behaviour preserved)', () => {
+    it('POST /critique accepts valid token and runs the critique', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/critique`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${validToken}`,
+        },
+        body: JSON.stringify({ parse_json: validFlow }),
+      });
+      expect(res.status).toBe(200);
+      const arr = await res.json();
+      expect(Array.isArray(arr)).toBe(true);
+      expect(arr.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('POST /critique with valid token but no parse_json reaches handler (400 BAD_INPUT, not 401/403)', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/critique`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${validToken}`,
+        },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error?.type).toBe('BAD_INPUT');
+    });
+
+    it('POST /improve accepts valid token and echoes parse_json', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/improve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${validToken}`,
+        },
+        body: JSON.stringify({ parse_json: { nodes: [], edges: [] } }),
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({ parse_json: { nodes: [], edges: [] }, fix_applied: [] });
+    });
+  });
+});
+
+describe('Auth Guard disabled (AUTH_ENABLED unset) — root /critique + /improve unchanged', () => {
+  let app: FastifyInstance;
+  let port: number;
+
+  beforeAll(async () => {
+    delete process.env.AUTH_ENABLED;
+    delete process.env.PLOT_AUTH_TOKEN;
+
+    app = await createServer({ enableTestRoutes: false });
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const addr = app.server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /critique works without any token when auth disabled', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/critique`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parse_json: validFlow }),
+    });
+    expect(res.status).toBe(200);
+    const arr = await res.json();
+    expect(Array.isArray(arr)).toBe(true);
+  });
+
+  it('POST /improve works without any token when auth disabled', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/improve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parse_json: { nodes: [], edges: [] } }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ parse_json: { nodes: [], edges: [] }, fix_applied: [] });
+  });
+});


### PR DESCRIPTION
## N1 — the last public compute routes, now gated

After the R-8 auth flip + the #255 encoding-bypass fix, the root-mounted legacy routes `POST /critique` and `POST /improve` were the ONLY compute routes still reachable unauthenticated (they don't start with /vN, so neither the /v1 nor /v2 guard covered them). `/improve` no-token returned a real 200 result on live staging.

## Safe to gate — zero-breaking caller manifest (both halves)
- **A3 (PLoT-internal):** the only root-`/critique` callers are tests that run auth-OFF (no AUTH_ENABLED, no bearer) → transparent to an auth-conditional gate; root `/improve` is docs-only.
- **A1 (CEE + UI):** ZERO callers, manifest-grade (seam-first: CEE's only PLoT paths are /v2/run + /v1/validate-patch; UI's netlify splat composes only /v1/*, /v2/run, /version), plus a UI plot-fetch-all-seams CI guard.

## Fix (2 lines, mirrors /draft-flows exactly)
`if (!(await authGuard(req, reply))) return;` as the FIRST line of each handler. `authGuard` is auth-conditional: early-returns `true` when `AUTH_ENABLED!='1'` (so the auth-off tests stay green); when `='1'`, no-token→401, wrong-token→403, correct→handler. Inline handler-level guard ⇒ **bypass-proof by construction** (fires whenever the handler fires — the #255 prefix-encoding class does not apply).

## Gates
- **RED-first** (real socket, auth on): pre-fix 4 fail (both routes no-token→200, wrong→200); post-fix 9 pass (no-token→401, wrong→403, correct→200/echo, empty→400 handler, auth-off→200 unchanged). Mutation-checked (remove both guard lines → exactly the 4 gating tests RED).
- **A3 local live-verify** (my Fable-grade gate): auth-on /critique+/improve no-token→401, wrong→403, valid-token→200; **encoded `/%63ritique` no-token→401** (bypass-proof confirmed); auth-off both→200 (transparent).
- Full suite base 5905 → head 5914 (+9 mine, 0 regressions); typecheck 0; build 0; openapi lint 0 errors; zero golden churn. Docs updated (engine.md, plot-lite-contract.md, both openapi specs) — one line each noting auth-when-enabled.

On deploy: R-8 upgrades from "known-public exception" to **fully closed** — every PLoT compute route authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)