### PR TITLE
fix(deps): clear find-my-way DDoS advisory GHSA-c96f-x56v-gq3h (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6222,9 +6222,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   },
   "overrides": {
     "fast-uri@3": "3.1.4",
-    "fast-uri@4": "4.1.1"
+    "fast-uri@4": "4.1.1",
+    "find-my-way@9": "9.7.0"
   }
 }


### PR DESCRIPTION
## What
Targeted `overrides` clearing the newly-published HIGH advisory **GHSA-c96f-x56v-gq3h** (find-my-way — *DDoS with HTTP2*, CWE-1321, CVSS 7.5) from the single installed line:
- `find-my-way@9` → **9.7.0** (was **9.6.0** via `fastify@5.10.0`)

## Why an override (not a Fastify bump)
`fastify@5.10.0` is **already the latest 5.x** and declares `find-my-way: ^9.6.0`, which still resolves to the vulnerable **9.6.0** — so a Fastify bump is neither available nor effective. The `overrides` pin is the only mechanism, and it is the minimal one: **9.7.0** is the advisory's patched version (range `<=9.6.0`), the **same major** (∈ Fastify's own `^9.6.0`), and its direct deps are **identical** to 9.6.0 → **zero new transitive deps**. Mirrors the fast-uri fix (#252). Lockfile regenerated via `npm install` (never hand-edited); diff scoped to `package.json` + `package-lock.json` (find-my-way version/resolved/integrity only). **No source changes.**

## Why now
Newly published; `audit` was green in an earlier arc. Unrelated to any feature diff — reproduced on a clean base (tip `5dae8df1`).

## Gates (base tip `5dae8df1`)
- `npm audit --omit=dev --audit-level=high` → **exit 1 (1 high) → exit 0 (0 vulnerabilities)** — the point of this PR; the `audit` check here is the proof.
- Full `npm test` → **5921 passed / 29 skipped — byte-identical to base (zero test delta)**; Test Files 559 passed / 4 skipped.
- `npm run typecheck` → exit 0. eslint → **97 warnings unchanged** (no headroom consumed).
- Goldens **"All fixtures match (4 cases)"**; `/draft-flows` loadcheck response-hashes **byte-identical to base** (router patch changes no wire behavior); OpenAPI lightweight check passed.
- Repo pre-push validation: **6 checks, 0 failures**.

Expected CI: `gates (windows-latest)` colon-path = the documented pre-existing red. `validate-structure` should NOT fire (no spec touched). **`audit` should be GREEN on this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)