### PR TITLE
fix(contract): unknown-key semantic parity + shorthand-destructuring guard (Codex F9/F3 round-2)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -5825,6 +5825,11 @@ components:
     runRequestV3:
       type: object
       required: [graph, options, goal_node_id]
+      # Codex re-confirm F9 (D-23.19): the runtime rejects unknown top-level keys
+      # (run.ts strict allowlist + Ajv additionalProperties:false), so the public
+      # contract must SAY so — without this line a client generated from the spec
+      # accepts keys the live route 400s (semantic drift the name-only gate missed).
+      additionalProperties: false
       description: V2 run request with explicit intervention bundles
       properties:
         graph:

--- a/tests/contract/isl-factor-evpi-removed.guard.test.ts
+++ b/tests/contract/isl-factor-evpi-removed.guard.test.ts
@@ -68,8 +68,17 @@ function isCommentLine(line: string): boolean {
 // — it would false-positive on this guard's own compile-time sibling
 // (isl-no-factor-evpi.type-pin.ts references `'factor_evpi'` to FORBID it) and
 // on legitimate historical trailing-comment provenance.
+// D-23.19 (Codex re-confirm F3): two SHORTHAND-DESTRUCTURING branches added —
+// `const { factor_evpi } = isl` has no dot, no colon, no bracket, so the
+// original three branches missed it (Codex's positive-control attack).
+//   [{,]\s*factor_evpi\s*(?=[,}=])  — same-line shorthand ({ factor_evpi },
+//                                     { factor_evpi, x }, { factor_evpi = d })
+//   ^\s*factor_evpi\s*(?=[,}=])     — multiline destructure/object lines that
+//                                     START with the bare name
+// Both require [,}=] AFTER the name, so the type-pin's `factor_evpi?: never`
+// (the `?` intervenes) and `factor_evppi` (trailing guard) still never match.
 const OLD_NAME_CONSUMER =
-  /(?:\.\s*factor_evpi|\bfactor_evpi\s*:|\[\s*['"]factor_evpi['"]\s*\])(?![A-Za-z0-9_])/;
+  /(?:\.\s*factor_evpi|\bfactor_evpi\s*:|\[\s*['"]factor_evpi['"]\s*\]|[{,]\s*factor_evpi\s*(?=[,}=])|^\s*factor_evpi\s*(?=[,}=]))(?![A-Za-z0-9_])/;
 // The retained successor as a bare token — present in src as the field name
 // `factor_evppi` (engine-v3.ts) and the passthrough key (run-contract-keys.ts).
 const NEW_NAME_TOKEN = /\bfactor_evppi\b/;
@@ -82,10 +91,20 @@ describe('F3 fail-loud guard — PLoT must not consume the removed ISL `factor_e
     expect(OLD_NAME_CONSUMER.test('const x = isl.factor_evpi;')).toBe(true);
     expect(OLD_NAME_CONSUMER.test('return { factor_evpi: src.factor_evpi };')).toBe(true);
     expect(OLD_NAME_CONSUMER.test("const w = islResult['factor_evpi'];")).toBe(true);
-    // ...and MUST NOT fire on the retained new names (the p_win/EVPPI successors).
+    // D-23.19: shorthand destructuring — Codex's positive-control attack showed
+    // `const { factor_evpi } = isl` evaded all three original branches.
+    expect(OLD_NAME_CONSUMER.test('const { factor_evpi } = isl;')).toBe(true);
+    expect(OLD_NAME_CONSUMER.test('const { factor_evpi, other } = isl;')).toBe(true);
+    expect(OLD_NAME_CONSUMER.test('const { a, factor_evpi } = isl;')).toBe(true);
+    expect(OLD_NAME_CONSUMER.test('const { factor_evpi = [] } = isl;')).toBe(true);
+    expect(OLD_NAME_CONSUMER.test('  factor_evpi,')).toBe(true); // multiline destructure line
+    // ...and MUST NOT fire on the retained new names (the p_win/EVPPI successors)
+    // nor on the type-pin's forbidding declaration.
     expect(OLD_NAME_CONSUMER.test('const y = isl.factor_evppi;')).toBe(false);
     expect(OLD_NAME_CONSUMER.test("const y2 = isl['factor_evppi'];")).toBe(false);
     expect(OLD_NAME_CONSUMER.test('const z = isl.p_win_sensitivity;')).toBe(false);
+    expect(OLD_NAME_CONSUMER.test('const { factor_evppi } = isl;')).toBe(false);
+    expect(OLD_NAME_CONSUMER.test('  factor_evpi?: never;')).toBe(false); // type-pin form
   });
 
   it('positive control: the scan reaches real code (the retained successor `factor_evppi` IS present in src/)', () => {

--- a/tests/contract/openapi-runtime-drift.test.ts
+++ b/tests/contract/openapi-runtime-drift.test.ts
@@ -76,6 +76,40 @@ describe('OpenAPI ↔ runtime drift gate — /v2/run request/response wire contr
     ).toEqual([]);
   });
 
+  it('published runRequestV3 semantically REJECTS unknown top-level keys (D-23.19, Codex F9)', async () => {
+    // The name-only comparison above passed while the SEMANTICS drifted: the
+    // route 400s unknown top-level keys (strict allowlist + Ajv
+    // additionalProperties:false) but the published spec silently ACCEPTED
+    // them, so a spec-generated client could send keys the live route rejects.
+    const schema = spec?.components?.schemas?.runRequestV3;
+    expect(
+      schema.additionalProperties,
+      'runRequestV3 must declare additionalProperties:false to match the route',
+    ).toBe(false);
+
+    // EXECUTE the published top-level semantics (a faithful projection of the
+    // schema's own top-level keys + additionalProperties; $ref internals are
+    // irrelevant to the unknown-KEY semantic under test).
+    const AjvMod = await import('ajv');
+    const Ajv = (AjvMod as any).default ?? AjvMod;
+    const ajv = new Ajv({ strict: false });
+    const topLevelProjection = {
+      type: 'object',
+      properties: Object.fromEntries(Object.keys(schema.properties).map((k) => [k, {}])),
+      additionalProperties: schema.additionalProperties,
+    };
+    const validate = ajv.compile(topLevelProjection);
+    // positive control: a known-keys-only body passes the projection...
+    expect(validate({ goal_node_id: 'g' })).toBe(true);
+    // ...and the unknown key is REJECTED — matching the live route's 400
+    // (pinned by the runtime unknown-key tests), closing the semantic drift.
+    expect(validate({ goal_node_id: 'g', not_a_real_key: true })).toBe(false);
+    // counterfactual control: WITHOUT the declaration the same body passes —
+    // proving this test discriminates on exactly the fixed line.
+    const withoutDecl = ajv.compile({ ...topLevelProjection, additionalProperties: true });
+    expect(withoutDecl({ goal_node_id: 'g', not_a_real_key: true })).toBe(true);
+  });
+
   it('every ISL top-level enrichment passthrough key is documented as a runResponseV3 property', () => {
     const specKeys = new Set(propsOf('runResponseV3'));
     const undocumented = ISL_TOPLEVEL_ENRICHMENT_KEYS.filter((k) => !specKeys.has(k));


### PR DESCRIPTION
## What

The PLoT half of the Codex re-confirmation round-2 batch (D-23.19):

- **F9**: `runRequestV3` now declares `additionalProperties: false` (the route already rejects unknown top-level keys; the published spec silently accepted them — semantic drift the name-only gate missed). The drift gate now **executes** the published top-level semantics via Ajv with positive + counterfactual controls, so the next semantic drift fails CI rather than shipping.
- **F3**: the removed-`factor_evpi` guard missed shorthand destructuring (`const { factor_evpi } = isl`) — Codex's positive-control attack. Two regex branches added (same-line + multiline forms) with controls proving `factor_evppi` and the type-pin's `factor_evpi?: never` still never match.

Name-parity safety: the existing exact-equality gate (spec properties == runtime allowlist, both directions) already passes, so the new constraint cannot reject keys the runtime accepts.

## Gates
Full `npm test` exit 0 (incl. build/fixtures/OpenAPI/loadcheck); typecheck clean; `openapi:lint` 0 errors (1 pre-existing unused-component warning). Mutations: spec-line removal and a planted shorthand consumer each flip their gate RED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)