### PR TITLE
test(contract): AST-based F3 guard — closes Codex round-3 P2 (multiline destructure miss)

### DIFF
--- a/tests/contract/isl-factor-evpi-removed.guard.test.ts
+++ b/tests/contract/isl-factor-evpi-removed.guard.test.ts
@@ -19,6 +19,58 @@
  * run.ts types `islResult` as `any`, so the type pin alone cannot see an
  * untyped read.
  *
+ * ---------------------------------------------------------------------------
+ * ⚠ WHY THIS IS AN AST WALK AND NO LONGER A LINE REGEX (Codex round-3, P2).
+ * ---------------------------------------------------------------------------
+ * The previous matcher was a per-line regular expression. Round 2 had already
+ * patched it once for shorthand destructuring; round 3 found the next hole in
+ * the same class — a MULTILINE destructure:
+ *
+ *     const {
+ *       factor_evpi
+ *     } = islResult;
+ *
+ * The bare name sits alone on its line with no trailing `,`/`}`/`=`, so every
+ * same-line lookahead branch missed it. That miss was reproduced at the bytes
+ * before this rewrite: the read above, planted in `src/integrations/isl/
+ * v2-envelope.ts`, left the old guard passing 3/3 — a stranded consumer, live
+ * in src, invisible to its own guard. The AST walker fails on that same plant,
+ * naming `v2-envelope.ts:52 [destructuring-bind]`. That plant, not the synthetic
+ * snippets, is the load-bearing proof this rewrite bites.
+ *
+ * Patching a regex per reported hole is the hand-maintained-mirror defect
+ * (root CLAUDE.md trap #12) wearing a different hat: the list of syntactic
+ * forms a human remembered to encode WILL drift from the syntax TypeScript
+ * actually accepts, and the drift always reads as green. So the matcher is now
+ * DERIVED from the parse tree — line breaks, whitespace, comments, string
+ * literals, nesting and renaming all stop mattering, because we ask the
+ * compiler what the code MEANS instead of what it LOOKS LIKE.
+ *
+ * (An ESLint rule was the other option Codex named. Same AST, but it would
+ * need a custom-plugin package plus `eslint.config.js` wiring, and it would
+ * move the check out of `npm test` — where this gate already runs — into a
+ * separate lint lane. Rowed as an option if PLoT ever grows a family of these
+ * cross-repo pins; not worth the scaffolding for one.)
+ *
+ * THE ONE FAILURE MODE AN AST WALK HAS THAT A TEXT SCAN DOES NOT, and why it is
+ * already closed: `createSourceFile` is error-tolerant and never throws, so a
+ * file the parser could not make sense of would yield no nodes and contribute
+ * zero findings SILENTLY. It cannot happen here — `tsconfig.json` includes all
+ * .ts under src recursively and excludes only node_modules/dist, so the set tsc
+ * checks is the same set this walk collects (measured: 315 files each), and
+ * `npm run typecheck` runs in both CI and `scripts/pre-push-validate.sh`. An
+ * unparseable src file fails tsc long before it reaches this guard.
+ * Deliberately NOT re-asserted here: a "every file yields ≥1 statement" check
+ * would fire on a legitimate comment-only module (measured: comment-only source
+ * parses to zero statements), i.e. it would be a broken alarm guarding
+ * something an existing derived gate already guarantees.
+ *
+ * WHAT THIS GUARD DELIBERATELY DOES NOT FLAG: a `factor_evpi` PropertySignature
+ * in a type/interface declaration, and the bare string literal in the type
+ * pin's `Extract<..., 'factor_evpi'>`. Re-DECLARATION of the field is the
+ * compile-time pin's job; flagging it here would fail on the very file that
+ * forbids it. This guard owns READS.
+ *
  * The new outcome-unit `factor_evppi` is deliberately NOT wired into the
  * win-probability `evpi_percentage_points` ranking surface (unit mismatch;
  * withheld pending the S5 typed-surface reconciliation, D-23.8). It rides the
@@ -29,8 +81,12 @@ import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src');
+
+/** The removed ISL wire field this guard exists to keep out of PLoT src. */
+const REMOVED_NAME = 'factor_evpi';
 
 /** Recursively collect every .ts file under src/. */
 function collectTsFiles(dir: string): string[] {
@@ -44,88 +100,148 @@ function collectTsFiles(dir: string): string[] {
   return out;
 }
 
-/**
- * True for a PURE comment line (JSDoc/banner or full-line `//`). We skip these
- * so a historical reference to the old name inside a doc-comment (e.g.
- * "honestly-named successor to factor_evpi") counts as provenance, not a live
- * consumer. We deliberately DO NOT try to strip string literals — naive
- * string-stripping mangles a large real file (regex literals, apostrophes in
- * comments) and silently deletes the very tokens we scan for. The CONSUMER
- * regex below is precise enough (dot-access / object-key read) that ordinary
- * prose never matches it, so line-level comment skipping is sufficient.
- */
-function isCommentLine(line: string): boolean {
-  const t = line.trim();
-  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') || t.startsWith('*/');
+interface Read {
+  /** 1-indexed line of the offending read. */
+  line: number;
+  /** Which syntactic form matched — reported so a failure is actionable. */
+  form: string;
+  /** The source line, trimmed. */
+  text: string;
 }
 
-// A read/consume of the OLD name: `.factor_evpi` (dot access), `factor_evpi:`
-// (object-key read/bind), or `['factor_evpi']` / `["factor_evpi"]` (bracket /
-// dynamic access) — but NEVER `factor_evpi` immediately followed by another
-// letter/digit/underscore (so `factor_evppi` never matches). Bracket coverage
-// closes the dynamic-access gap (e.g. `islResult['factor_evpi']`) that a
-// dot-only matcher would miss. NOTE: a bare-token scan is deliberately NOT used
-// — it would false-positive on this guard's own compile-time sibling
-// (isl-no-factor-evpi.type-pin.ts references `'factor_evpi'` to FORBID it) and
-// on legitimate historical trailing-comment provenance.
-// D-23.19 (Codex re-confirm F3): two SHORTHAND-DESTRUCTURING branches added —
-// `const { factor_evpi } = isl` has no dot, no colon, no bracket, so the
-// original three branches missed it (Codex's positive-control attack).
-//   [{,]\s*factor_evpi\s*(?=[,}=])  — same-line shorthand ({ factor_evpi },
-//                                     { factor_evpi, x }, { factor_evpi = d })
-//   ^\s*factor_evpi\s*(?=[,}=])     — multiline destructure/object lines that
-//                                     START with the bare name
-// Both require [,}=] AFTER the name, so the type-pin's `factor_evpi?: never`
-// (the `?` intervenes) and `factor_evppi` (trailing guard) still never match.
-const OLD_NAME_CONSUMER =
-  /(?:\.\s*factor_evpi|\bfactor_evpi\s*:|\[\s*['"]factor_evpi['"]\s*\]|[{,]\s*factor_evpi\s*(?=[,}=])|^\s*factor_evpi\s*(?=[,}=]))(?![A-Za-z0-9_])/;
-// The retained successor as a bare token — present in src as the field name
-// `factor_evppi` (engine-v3.ts) and the passthrough key (run-contract-keys.ts).
-const NEW_NAME_TOKEN = /\bfactor_evppi\b/;
+/**
+ * Return every READ of `name` in `source`, derived from the TypeScript parse
+ * tree. Covers, by construction and regardless of formatting:
+ *
+ *   property access        isl.factor_evpi          isl?.factor_evpi
+ *   element access         isl['factor_evpi']       isl["factor_evpi"]
+ *   destructuring bind     const { factor_evpi } = isl          (any layout)
+ *                          const { factor_evpi: alias } = isl
+ *                          const { factor_evpi = fallback } = isl
+ *                          const { robustness: { factor_evpi } } = isl
+ *                          function f({ factor_evpi }) {}
+ *   object-literal key     { factor_evpi: value }   { factor_evpi }
+ *   destructuring assign   ({ factor_evpi } = isl)
+ *
+ * `createSourceFile` is error-tolerant, so a file that does not typecheck still
+ * parses far enough to be scanned — this never silently skips a file.
+ */
+function findReads(fileName: string, source: string, name: string): Read[] {
+  const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, /* setParentNodes */ true, ts.ScriptKind.TS);
+  const found: Read[] = [];
+
+  const record = (node: ts.Node, form: string): void => {
+    const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+    found.push({ line: line + 1, form, text: (sf.text.split('\n')[line] ?? '').trim() });
+  };
+
+  /** True for an identifier or string-literal key whose text is the hunted name. */
+  const isHuntedKey = (node: ts.Node | undefined): boolean =>
+    node !== undefined && (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) && node.text === name;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node) && node.name.text === name) {
+      record(node.name, 'property-access');
+    } else if (ts.isElementAccessExpression(node) && isHuntedKey(node.argumentExpression)) {
+      record(node.argumentExpression, 'element-access');
+    } else if (ts.isBindingElement(node)) {
+      // `propertyName` is set only when the binding renames (`{ factor_evpi: a }`);
+      // otherwise the bound `name` IS the property being read.
+      const key = node.propertyName ?? node.name;
+      if (isHuntedKey(key)) record(key, 'destructuring-bind');
+    } else if (ts.isPropertyAssignment(node) && isHuntedKey(node.name)) {
+      record(node.name, 'object-literal-key');
+    } else if (ts.isShorthandPropertyAssignment(node) && node.name.text === name) {
+      // Covers both `{ factor_evpi }` in an object literal and the
+      // destructuring-ASSIGNMENT form `({ factor_evpi } = isl)`, which the
+      // parser represents as a shorthand property, not a binding element.
+      record(node.name, 'shorthand-property');
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sf);
+  return found;
+}
+
+/** Convenience: scan a synthetic snippet for the removed name. */
+const reads = (source: string): Read[] => findReads('snippet.ts', source, REMOVED_NAME);
 
 describe('F3 fail-loud guard — PLoT must not consume the removed ISL `factor_evpi` wire field', () => {
   const files = collectTsFiles(SRC_DIR);
 
-  it('positive control: the matcher discriminates old-name reads (dot/key/bracket) from the new names (not vacuous)', () => {
-    // MUST see a genuine old-name read in every access form...
-    expect(OLD_NAME_CONSUMER.test('const x = isl.factor_evpi;')).toBe(true);
-    expect(OLD_NAME_CONSUMER.test('return { factor_evpi: src.factor_evpi };')).toBe(true);
-    expect(OLD_NAME_CONSUMER.test("const w = islResult['factor_evpi'];")).toBe(true);
-    // D-23.19: shorthand destructuring — Codex's positive-control attack showed
-    // `const { factor_evpi } = isl` evaded all three original branches.
-    expect(OLD_NAME_CONSUMER.test('const { factor_evpi } = isl;')).toBe(true);
-    expect(OLD_NAME_CONSUMER.test('const { factor_evpi, other } = isl;')).toBe(true);
-    expect(OLD_NAME_CONSUMER.test('const { a, factor_evpi } = isl;')).toBe(true);
-    expect(OLD_NAME_CONSUMER.test('const { factor_evpi = [] } = isl;')).toBe(true);
-    expect(OLD_NAME_CONSUMER.test('  factor_evpi,')).toBe(true); // multiline destructure line
-    // ...and MUST NOT fire on the retained new names (the p_win/EVPPI successors)
-    // nor on the type-pin's forbidding declaration.
-    expect(OLD_NAME_CONSUMER.test('const y = isl.factor_evppi;')).toBe(false);
-    expect(OLD_NAME_CONSUMER.test("const y2 = isl['factor_evppi'];")).toBe(false);
-    expect(OLD_NAME_CONSUMER.test('const z = isl.p_win_sensitivity;')).toBe(false);
-    expect(OLD_NAME_CONSUMER.test('const { factor_evppi } = isl;')).toBe(false);
-    expect(OLD_NAME_CONSUMER.test('  factor_evpi?: never;')).toBe(false); // type-pin form
+  it('positive control: the walker fires on EVERY read form, including the multiline destructure the regex missed', () => {
+    // Round-1 forms.
+    expect(reads('const x = isl.factor_evpi;')).toHaveLength(1);
+    expect(reads('const x = isl?.factor_evpi;')).toHaveLength(1);
+    expect(reads("const w = islResult['factor_evpi'];")).toHaveLength(1);
+    expect(reads('const w = islResult["factor_evpi"];')).toHaveLength(1);
+    expect(reads('return { factor_evpi: src.other };')).toHaveLength(1);
+
+    // Round-2 form (shorthand destructuring, same line).
+    expect(reads('const { factor_evpi } = isl;')).toHaveLength(1);
+    expect(reads('const { factor_evpi, other } = isl;')).toHaveLength(1);
+    expect(reads('const { a, factor_evpi } = isl;')).toHaveLength(1);
+    expect(reads('const { factor_evpi = [] } = isl;')).toHaveLength(1);
+    expect(reads('const { factor_evpi: alias } = isl;')).toHaveLength(1);
+
+    // ⭐⭐ Round-3 forms — THE TWO THIS REWRITE EXISTS FOR. The bare name sits
+    // alone on its own line with no trailing `,`/`}`/`=`, so no same-line
+    // lookahead can see it. MEASURED: these are the ONLY two of the 17 forms in
+    // this test that the old regex missed — they are what makes the rewrite
+    // non-theatre. (Verified by running the old matcher over all 17; see the
+    // discrimination map in the PR body.)
+    expect(reads('const {\n  factor_evpi\n} = islResult;')).toHaveLength(1);
+    expect(reads('const {\n  factor_evpi\n    : alias\n} = islResult;')).toHaveLength(1);
+
+    // Everything below here the OLD regex also caught — kept as regression
+    // coverage, NOT claimed as evidence for the rewrite. Being explicit about
+    // which assertions discriminate and which do not is the point: a control
+    // that passes both before and after proves nothing about the fix.
+    expect(reads('const {\n  factor_evpi,\n  other,\n} = islResult;')).toHaveLength(1); // trailing comma
+    expect(reads('const { robustness: { factor_evpi } } = isl;')).toHaveLength(1); // nested
+    expect(reads('function f({ factor_evpi }) { return factor_evpi; }')).toHaveLength(1); // param destructure
+    expect(reads('({ factor_evpi } = isl);')).toHaveLength(1); // destructuring assignment
+    expect(reads('const x = isl\n  .factor_evpi;')).toHaveLength(1); // access split across lines
   });
 
-  it('positive control: the scan reaches real code (the retained successor `factor_evppi` IS present in src/)', () => {
-    const anyNewName = files.some((f) =>
-      readFileSync(f, 'utf8')
-        .split('\n')
-        .some((line) => !isCommentLine(line) && NEW_NAME_TOKEN.test(line)),
-    );
-    expect(anyNewName).toBe(true);
+  it('negative control: the walker does NOT fire on the successors, on comments, or on the type pin', () => {
+    // The retained successors must never trip the guard.
+    expect(reads('const y = isl.factor_evppi;')).toEqual([]);
+    expect(reads("const y2 = isl['factor_evppi'];")).toEqual([]);
+    expect(reads('const { factor_evppi } = isl;')).toEqual([]);
+    expect(reads('const z = isl.p_win_sensitivity;')).toEqual([]);
+
+    // Provenance prose is not a consumer — and unlike the regex, the AST never
+    // sees comment text at all, so this holds for any comment shape.
+    expect(reads('// honestly-named successor to factor_evpi')).toEqual([]);
+    expect(reads('/** reads factor_evpi and isl.factor_evpi */')).toEqual([]);
+    expect(reads('const s = "factor_evpi";')).toEqual([]); // bare string, not an access
+
+    // Re-DECLARATION is the compile-time pin's job, not this guard's; flagging
+    // it here would fail on the file whose whole purpose is forbidding the field.
+    expect(reads('interface R { factor_evpi?: never }')).toEqual([]);
+    expect(reads("type T = Extract<keyof R, 'factor_evpi'>;")).toEqual([]);
+  });
+
+  it('positive control: the scan reaches real src code (a live ISL field read IS found there)', () => {
+    // Trap #13 — an absence assertion must first prove it can SEE a presence.
+    // This runs the SAME walker over the REAL tree, hunting a field PLoT genuinely
+    // reads (`islResult?.robustness?.edge_e_values` and friends). Non-zero here
+    // proves: collectTsFiles found real files, they parsed, and the detector fires
+    // on live source — not just on synthetic strings.
+    // If this ever drops to zero, RE-ANCHOR it to another live read; do not delete it.
+    expect(files.length).toBeGreaterThan(0);
+    const liveReads = files.flatMap((f) => findReads(f, readFileSync(f, 'utf8'), 'edge_e_values'));
+    expect(liveReads.length).toBeGreaterThan(0);
   });
 
   it('no src file reads the removed `factor_evpi` name as a wire field', () => {
     const offenders: string[] = [];
     for (const f of files) {
-      readFileSync(f, 'utf8')
-        .split('\n')
-        .forEach((line, i) => {
-          if (!isCommentLine(line) && OLD_NAME_CONSUMER.test(line)) {
-            offenders.push(`${f.replace(SRC_DIR, 'src')}:${i + 1}: ${line.trim()}`);
-          }
-        });
+      for (const r of findReads(f, readFileSync(f, 'utf8'), REMOVED_NAME)) {
+        offenders.push(`${f.replace(SRC_DIR, 'src')}:${r.line} [${r.form}]: ${r.text}`);
+      }
     }
     expect(offenders, `stranded consumer(s) of removed ISL field factor_evpi:\n${offenders.join('\n')}`).toEqual([]);
   });


### PR DESCRIPTION
Closes the only open finding from Codex round 3 (P2). **Test-only: zero `src/` diff, zero runtime or wire change.**

## The defect

The F3 fail-loud guard matched the removed ISL wire field `factor_evpi` with a **per-line regex**. A multiline destructure evades it:

```ts
const {
  factor_evpi
} = islResult;
```

The bare name sits alone on its line with no trailing `,` / `}` / `=`, so both destructuring branches fail their same-line lookahead.

Round 2 had **already patched this same regex once** (same-line shorthand). Patching per reported hole is the hand-maintained-mirror defect: the list of syntactic forms a human remembered to encode drifts from the syntax TypeScript actually accepts, and the drift always reads green. So this fixes the mechanism, not the hole.

**Not a runtime block** — no such consumer exists in PLoT today. The guard was blind, not breached.

## RED-first, at the bytes

Planted a realistic stranded consumer in a **real** src file (`src/integrations/isl/v2-envelope.ts`, inside `getIslEdgeEValues`):

| | old regex | AST walker |
|---|---|---|
| clean `src/` | 3/3 pass | 4/4 pass |
| `src/` + planted multiline read | **3/3 pass — BLIND** | **RED**: `src/integrations/isl/v2-envelope.ts:52 [destructuring-bind]: factor_evpi` |

The compile-time sibling pin cannot see it either — the read is untyped, which is exactly the case the runtime guard exists to cover. Plant reverted before commit.

## The fix

Matcher derived from the TypeScript parse tree (`ts.createSourceFile` + `forEachChild`) instead of the text. Detected forms: property access (incl. optional chaining) · element access with a string-literal key · `BindingElement` using `propertyName ?? name` (so renamed / defaulted / nested / parameter destructures are covered **at any layout**) · `PropertyAssignment` key · `ShorthandPropertyAssignment` (also how the parser models destructuring *assignment* `({ factor_evpi } = isl)`).

Deliberately **not** flagged: `PropertySignature` declarations and the type pin's `Extract<..., 'factor_evpi'>` string literal. Re-declaration is the compile-time pin's job, and flagging it would fail the very file that forbids the field. This guard owns READS — and that separation now falls out of the node kinds rather than needing an allowlist.

Comments and string literals stop mattering entirely (the AST never sees them), so the old `isCommentLine` heuristic is gone.

**AST over an ESLint rule** — the other option named in review. A custom rule needs a plugin package plus `eslint.config.js` wiring, and would move the check out of `npm test` where this gate already runs (verified: `vitest.config.ts` includes `tests/**/*.test.ts`, no exclusion for this path). Rowed as an option if PLoT grows a family of these cross-repo pins.

## Mutation check — measured, not assumed

Ran the **verbatim old matcher** (with its original line-splitting caller) over all 17 forms this test asserts:

| Form | Old regex |
|---|---|
| **multiline destructure, bare name alone on line** | **MISSED** |
| **multiline destructure, colon split to next line** | **MISSED** |
| prop access · optional chain · element access `'`/`"` · object-literal key | caught |
| shorthand same-line (+other, other+, default, renamed) | caught |
| multiline destructure **with trailing comma** | caught |
| nested · param destructure · destructuring assignment · access split across lines | caught |

**Exactly 2 of 17 discriminate.** The test says so in-line and labels the other 15 as regression coverage rather than evidence — a control that passes both before and after proves nothing about the fix. An earlier draft of that comment claimed the nested/param/split forms were uncatchable by a line matcher; that was false and is corrected.

## Positive control that would have gone vacuous

The old "scan reaches real code" control asserted the *new* name `factor_evppi` appears in `src/`. Under an AST walker that control is **vacuous**: `factor_evppi` occurs in src only as a `PropertySignature` (`engine-v3.ts:1092`) and as bare string-literal array elements (`run-contract-keys.ts:37`, `structural-keys.generated.ts:167`) — none of which are read forms the walker inspects.

Re-anchored to `edge_e_values`, which PLoT genuinely **reads** via property access in 4+ src files. The control now runs the *same walker* over the *real tree* and requires a non-zero hit, so it proves file collection + parse + detection all fire on live source. It carries an instruction to re-anchor, not delete, if it ever drops to zero.

## Gates

| Gate | Result |
|---|---|
| `scripts/pre-push-validate.sh` (authoritative) | **6/6 PASS, 0 failures** |
| `npm test` | **559 files / 5923 passed, 29 skipped, 0 failed** (exit 0) |
| `npm run typecheck` | clean |
| `npm run lint` | 97 warnings / 0 errors — **identical to the untouched `8cf8bb29` baseline** (stash-compared); this file contributes **0** lint output. Pre-existing `--max-warnings 0` red, not introduced here. |
| Spectral OpenAPI lint | PASS |

Base `8cf8bb29` (== live staging). Evidence: `acceptance-evidence/a3-2026-07-24/f3-guard-ast/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)