### PR TITLE
test(contract): close F3 guard indirection bypass (Codex round-3 P2)

### DIFF
--- a/tests/contract/isl-factor-evpi-removed.guard.test.ts
+++ b/tests/contract/isl-factor-evpi-removed.guard.test.ts
@@ -52,6 +52,36 @@
  * separate lint lane. Rowed as an option if PLoT ever grows a family of these
  * cross-repo pins; not worth the scaffolding for one.)
  *
+ * ---------------------------------------------------------------------------
+ * ⚠⚠ ROUND-3 P2: THE AST REWRITE ABOVE WAS ITSELF BYPASSABLE. Read this before
+ * "simplifying" the broad net away.
+ * ---------------------------------------------------------------------------
+ * The first AST version matched SYNTACTIC SHAPES (property access, element
+ * access with a literal key, binding elements, …). Codex defeated all of them
+ * with one move — put the name in a variable:
+ *
+ *     const OLD = 'factor_evpi' as const; islResult[OLD];
+ *     const OLD = 'factor_evpi' as const; const { [OLD]: x } = islResult;
+ *     Reflect.get(islResult, 'factor_evpi');
+ *
+ * Reproduced at the bytes before this fix: all three returned ZERO findings —
+ * the vector [0,0,0] Codex reported. The guard read as protection and did not
+ * discriminate, which is worse than no guard because it buys false confidence.
+ * That is the estate's dominant defect class, and this file had been carrying a
+ * long comment about that class while being an instance of it.
+ *
+ * THE FIX, and why it is shaped this way: shape-matching is a losing game —
+ * every new indirection is a new shape, and enumerating shapes is the
+ * hand-maintained mirror again, one level up. So the NAME ITSELF is now
+ * contraband in any runtime value position. That cannot be defeated by
+ * indirection, because every indirection must still spell the name once
+ * somewhere. The precise shape detectors are kept ONLY because they produce a
+ * better failure message; the broad net is what actually holds the line.
+ *
+ * Consequence, accepted deliberately: a bare value-position string
+ * `'factor_evpi'` is now a FINDING (it used to be a negative control here).
+ * Every bypass begins as exactly that token.
+ *
  * THE ONE FAILURE MODE AN AST WALK HAS THAT A TEXT SCAN DOES NOT, and why it is
  * already closed: `createSourceFile` is error-tolerant and never throws, so a
  * file the parser could not make sense of would yield no nodes and contribute
@@ -128,18 +158,63 @@ interface Read {
  */
 function findReads(fileName: string, source: string, name: string): Read[] {
   const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, /* setParentNodes */ true, ts.ScriptKind.TS);
-  const found: Read[] = [];
+  // Keyed by source position so the broad net and the shape detectors cannot
+  // double-report the same token. A specific form (property-access,
+  // destructuring-bind, …) overwrites the generic `value-position-name`,
+  // because the specific label is the more useful failure message.
+  const found = new Map<number, Read>();
 
   const record = (node: ts.Node, form: string): void => {
-    const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
-    found.push({ line: line + 1, form, text: (sf.text.split('\n')[line] ?? '').trim() });
+    const pos = node.getStart(sf);
+    const existing = found.get(pos);
+    if (existing && existing.form !== 'value-position-name') return;
+    const { line } = sf.getLineAndCharacterOfPosition(pos);
+    found.set(pos, { line: line + 1, form, text: (sf.text.split('\n')[line] ?? '').trim() });
   };
 
   /** True for an identifier or string-literal key whose text is the hunted name. */
   const isHuntedKey = (node: ts.Node | undefined): boolean =>
     node !== undefined && (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) && node.text === name;
 
+  /**
+   * TYPE-ONLY position — the removed name is allowed to appear here, because
+   * re-DECLARATION is the compile-time pin's job (see header). Derived from node
+   * kinds, NOT from a filename allowlist: the type pin's
+   * `Extract<keyof R, 'factor_evpi'>` sits inside a TypeNode and is excluded
+   * structurally, so no file is ever exempted by name.
+   */
+  const isTypeOnlyPosition = (node: ts.Node): boolean => {
+    for (let a: ts.Node | undefined = node.parent; a; a = a.parent) {
+      if (ts.isTypeNode(a) || ts.isInterfaceDeclaration(a) || ts.isPropertySignature(a)) return true;
+    }
+    return false;
+  };
+
   const visit = (node: ts.Node): void => {
+    // ── BROAD NET (Codex round-3 P2) ────────────────────────────────────────
+    // Any occurrence of the removed name as a value-position string literal or
+    // identifier. The precise detectors below match SYNTACTIC SHAPES, so they
+    // are defeated by any indirection that moves the name out of the shape:
+    //
+    //   const OLD = 'factor_evpi' as const; islResult[OLD]           // const key
+    //   const OLD = 'factor_evpi' as const; const { [OLD]: x } = isl // computed key
+    //   Reflect.get(islResult, 'factor_evpi')                        // reflective
+    //
+    // All three returned ZERO findings from the shape-matchers — reproduced at
+    // the bytes as [0,0,0], exactly as Codex reported. A guard you can step
+    // around by renaming a variable is not a guard.
+    //
+    // So the name itself is now contraband in any runtime value position. This
+    // is deliberately BROADER than "a read": it cannot be defeated by
+    // indirection, because every indirection must still spell the name once.
+    if (
+      (ts.isStringLiteralLike(node) || ts.isIdentifier(node)) &&
+      node.text === name &&
+      !isTypeOnlyPosition(node)
+    ) {
+      record(node, 'value-position-name');
+    }
+
     if (ts.isPropertyAccessExpression(node) && node.name.text === name) {
       record(node.name, 'property-access');
     } else if (ts.isElementAccessExpression(node) && isHuntedKey(node.argumentExpression)) {
@@ -161,48 +236,59 @@ function findReads(fileName: string, source: string, name: string): Read[] {
   };
 
   visit(sf);
-  return found;
+  return [...found.values()].sort((a, b) => a.line - b.line);
 }
 
 /** Convenience: scan a synthetic snippet for the removed name. */
 const reads = (source: string): Read[] => findReads('snippet.ts', source, REMOVED_NAME);
+/** Positive-control helper: the snippet MUST produce at least one finding. */
+const caught = (source: string): boolean => reads(source).length > 0;
 
 describe('F3 fail-loud guard — PLoT must not consume the removed ISL `factor_evpi` wire field', () => {
   const files = collectTsFiles(SRC_DIR);
 
-  it('positive control: the walker fires on EVERY read form, including the multiline destructure the regex missed', () => {
+  it('⭐ positive control: THE INDIRECTION BYPASSES (Codex round-3 P2) — the shape-matchers alone returned [0,0,0]', () => {
+    // These three are the reason the broad value-position net exists. Each
+    // moves the name OUT of every syntactic shape the precise detectors match,
+    // and each was reproduced at the bytes against the shipped shape-only
+    // walker as ZERO findings — the vector Codex reported, [0,0,0].
+    // A guard you can step around by renaming a variable is not a guard.
+    expect(caught("const OLD_FIELD = 'factor_evpi' as const; const x = islResult[OLD_FIELD];")).toBe(true);
+    expect(caught("const OLD_FIELD = 'factor_evpi' as const; const { [OLD_FIELD]: x } = islResult;")).toBe(true);
+    expect(caught("const x = Reflect.get(islResult, 'factor_evpi');")).toBe(true);
+    // Same class, not in Codex's list — indirection via a lookup table, a
+    // template literal, and an aliased reflective read.
+    expect(caught("const KEYS = { old: 'factor_evpi' }; const x = islResult[KEYS.old];")).toBe(true);
+    expect(caught("const x = islResult[`factor_evpi`];")).toBe(true);
+    expect(caught("const get = Reflect.get; const x = get(islResult, 'factor_evpi');")).toBe(true);
+  });
+
+  it('positive control: every direct read form, including the multiline destructure', () => {
     // Round-1 forms.
-    expect(reads('const x = isl.factor_evpi;')).toHaveLength(1);
-    expect(reads('const x = isl?.factor_evpi;')).toHaveLength(1);
-    expect(reads("const w = islResult['factor_evpi'];")).toHaveLength(1);
-    expect(reads('const w = islResult["factor_evpi"];')).toHaveLength(1);
-    expect(reads('return { factor_evpi: src.other };')).toHaveLength(1);
+    expect(caught('const x = isl.factor_evpi;')).toBe(true);
+    expect(caught('const x = isl?.factor_evpi;')).toBe(true);
+    expect(caught("const w = islResult['factor_evpi'];")).toBe(true);
+    expect(caught('const w = islResult["factor_evpi"];')).toBe(true);
+    expect(caught('return { factor_evpi: src.other };')).toBe(true);
 
     // Round-2 form (shorthand destructuring, same line).
-    expect(reads('const { factor_evpi } = isl;')).toHaveLength(1);
-    expect(reads('const { factor_evpi, other } = isl;')).toHaveLength(1);
-    expect(reads('const { a, factor_evpi } = isl;')).toHaveLength(1);
-    expect(reads('const { factor_evpi = [] } = isl;')).toHaveLength(1);
-    expect(reads('const { factor_evpi: alias } = isl;')).toHaveLength(1);
+    expect(caught('const { factor_evpi } = isl;')).toBe(true);
+    expect(caught('const { factor_evpi, other } = isl;')).toBe(true);
+    expect(caught('const { a, factor_evpi } = isl;')).toBe(true);
+    expect(caught('const { factor_evpi = [] } = isl;')).toBe(true);
+    expect(caught('const { factor_evpi: alias } = isl;')).toBe(true);
 
-    // ⭐⭐ Round-3 forms — THE TWO THIS REWRITE EXISTS FOR. The bare name sits
-    // alone on its own line with no trailing `,`/`}`/`=`, so no same-line
-    // lookahead can see it. MEASURED: these are the ONLY two of the 17 forms in
-    // this test that the old regex missed — they are what makes the rewrite
-    // non-theatre. (Verified by running the old matcher over all 17; see the
-    // discrimination map in the PR body.)
-    expect(reads('const {\n  factor_evpi\n} = islResult;')).toHaveLength(1);
-    expect(reads('const {\n  factor_evpi\n    : alias\n} = islResult;')).toHaveLength(1);
+    // Round-3 multiline forms — the two the previous REGEX missed (measured:
+    // the only 2 of these direct forms it missed; the rest it also caught, so
+    // they are regression coverage, not evidence for that rewrite).
+    expect(caught('const {\n  factor_evpi\n} = islResult;')).toBe(true);
+    expect(caught('const {\n  factor_evpi\n    : alias\n} = islResult;')).toBe(true);
 
-    // Everything below here the OLD regex also caught — kept as regression
-    // coverage, NOT claimed as evidence for the rewrite. Being explicit about
-    // which assertions discriminate and which do not is the point: a control
-    // that passes both before and after proves nothing about the fix.
-    expect(reads('const {\n  factor_evpi,\n  other,\n} = islResult;')).toHaveLength(1); // trailing comma
-    expect(reads('const { robustness: { factor_evpi } } = isl;')).toHaveLength(1); // nested
-    expect(reads('function f({ factor_evpi }) { return factor_evpi; }')).toHaveLength(1); // param destructure
-    expect(reads('({ factor_evpi } = isl);')).toHaveLength(1); // destructuring assignment
-    expect(reads('const x = isl\n  .factor_evpi;')).toHaveLength(1); // access split across lines
+    expect(caught('const {\n  factor_evpi,\n  other,\n} = islResult;')).toBe(true);
+    expect(caught('const { robustness: { factor_evpi } } = isl;')).toBe(true);
+    expect(caught('function f({ factor_evpi }) { return factor_evpi; }')).toBe(true);
+    expect(caught('({ factor_evpi } = isl);')).toBe(true);
+    expect(caught('const x = isl\n  .factor_evpi;')).toBe(true);
   });
 
   it('negative control: the walker does NOT fire on the successors, on comments, or on the type pin', () => {
@@ -216,7 +302,13 @@ describe('F3 fail-loud guard — PLoT must not consume the removed ISL `factor_e
     // sees comment text at all, so this holds for any comment shape.
     expect(reads('// honestly-named successor to factor_evpi')).toEqual([]);
     expect(reads('/** reads factor_evpi and isl.factor_evpi */')).toEqual([]);
-    expect(reads('const s = "factor_evpi";')).toEqual([]); // bare string, not an access
+    // ⚠ DELIBERATE WIDENING (Codex round-3 P2) — a bare value-position string
+    // used to be a negative control here ("not an access, so harmless"). It is
+    // now a POSITIVE one, and that reclassification is the whole fix: every
+    // indirection bypass BEGINS as exactly this token. Treating it as harmless
+    // is what made the guard steppable. Asserted in the bypass block above; the
+    // line is kept here so the change of verdict is visible, not silent.
+    expect(caught('const s = "factor_evpi";')).toBe(true);
 
     // Re-DECLARATION is the compile-time pin's job, not this guard's; flagging
     // it here would fail on the file whose whole purpose is forbidding the field.


### PR DESCRIPTION
Closes Codex round-3 P2. **Test-only: zero `src/` diff, zero runtime or wire change.**

## The finding — the AST guard from #262 was itself bypassable

#262 replaced a regex with an AST walk that matched **syntactic shapes**. Codex defeated every one of them with a single move — put the name in a variable:

```ts
const OLD_FIELD = 'factor_evpi' as const; const x = islResult[OLD_FIELD];
const OLD_FIELD = 'factor_evpi' as const; const { [OLD_FIELD]: x } = islResult;
const x = Reflect.get(islResult, 'factor_evpi');
```

**Reproduced at the bytes before fixing**, against a replica of the shipped walker: result vector **`[0,0,0]`** — exactly what Codex reported.

A guard that reads as protection and does not discriminate is worse than no guard, because it buys false confidence. That is this estate's dominant defect class — and this file was carrying a long comment about that class while being an instance of it.

## Why the fix is shaped this way

Shape-matching is a losing game. Every new indirection is a new shape, and enumerating shapes is the hand-maintained mirror one level up — the same defect the AST rewrite was supposed to end.

So **the name itself is now contraband in any runtime value position.** That cannot be defeated by indirection, because every indirection must still spell the name once, somewhere. The precise shape detectors are retained *only* because they produce a better failure message; the broad net is what holds the line.

**Type positions are excluded structurally, not by filename** — an ancestor walk for `TypeNode` / `InterfaceDeclaration` / `PropertySignature`. The type pin's `Extract<keyof R, 'factor_evpi'>` is excluded because it *is* a type position, so **no file is exempted by name** and there is no allowlist to drift.

**Deliberate widening, stated rather than slipped in:** a bare value-position string `'factor_evpi'` was a *negative* control here ("not an access, so harmless"). It is now a **positive** one. That reclassification IS the fix — every bypass begins as exactly that token. The old assertion is kept in place, inverted, so the change of verdict is visible rather than silent.

Findings are deduped by source position so the broad net and the shape detectors cannot double-report one token; the specific label wins over the generic one.

## Verification

**Positive controls — 6/6 caught.** Codex's three, plus three of the same class I added: lookup-table indirection, template-literal key, aliased `Reflect.get`.

**Mutation check — each bypass planted in a REAL src file** (`src/integrations/isl/v2-envelope.ts`):

| Planted bypass | Shape-only walker | With broad net |
|---|---|---|
| const-key element access | GREEN (blind) | **RED** |
| const-key computed destructure | GREEN (blind) | **RED** |
| `Reflect.get` | GREEN (blind) | **RED** |
| *(clean src control)* | GREEN | **GREEN** |

**Negative controls hold:** `factor_evppi` / `p_win_sensitivity` untouched; comments invisible (AST never sees them); `interface R { factor_evpi?: never }` and `Extract<keyof R, 'factor_evpi'>` both excluded structurally. Real `src` is clean under the widened rule, with no exemptions needed.

## Gates

| Gate | Result |
|---|---|
| `scripts/pre-push-validate.sh` (authoritative) | **6/6 PASS, 0 failures** |
| `npm test` | **5924 passed / 29 skipped / 0 failed** |
| `npm run typecheck` | clean |
| Spectral OpenAPI lint | PASS |

Expect only the standing `gates (windows-latest)` red (fails at *Checkout* on `invalid path 'tools/sdk-smoke:python.mjs'`, before any code runs).

## Standing lesson

Enumerating the shapes an attacker can use is the same mistake as enumerating the strings — just at a higher altitude. **Where a guard can be expressed as "this token must not appear in this position", prefer that to "these N syntactic forms must not appear".** The first cannot be stepped around; the second always can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)