### PR TITLE
fix(importance): lever-aware importance_rank + basis disclosure + fragility-ordered fragile_edges

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -6501,11 +6501,51 @@ components:
                 type: string
               sensitivity_score:
                 type: number
+                description: >-
+                  ⚠ NOT ISL's sensitivity_score on the primary path. When
+                  `importance_basis` is `graph_structural` (every live response
+                  today) this is PLoT's own graph raw total causal effect, and
+                  is forced to 0 for option-controlled levers. ISL's value is
+                  not published. See the `substitutions` block in
+                  src/contracts/isl-to-ui.contract.ts.
+              importance_rank:
+                type: integer
+                minimum: 1
+                description: >-
+                  Rank 1 = most important. ⚠ NOT ISL's importance_rank on the
+                  primary path — read `importance_basis` first. Option-
+                  controlled levers (ISL zero_reason `intervention_override` or
+                  D-U structural union members) are ordered LAST: a lever is a
+                  decision lever, not a background uncertainty, so it never
+                  consumes a top importance slot. The emitted array order
+                  follows this rank, so `factor_sensitivity[0]` and
+                  `importance_rank == 1` agree.
+              importance_basis:
+                type: string
+                enum: [graph_structural, isl_uncertainty]
+                description: >-
+                  Producer disclosure of WHICH authority produced
+                  `importance_rank` (and the quantity behind
+                  `sensitivity_score` / `elasticity` / `direction` /
+                  `influence_score`). `graph_structural` = PLoT's graph path
+                  analysis, the live primary path. `isl_uncertainty` = the graph
+                  path returned nothing and ISL's own Monte-Carlo importance
+                  ordering is published. Emitted on every entry; exists because
+                  the two quantities share ISL's field NAMES and are otherwise
+                  indistinguishable to a consumer.
               importance_score:
                 type: number
                 minimum: 0
                 maximum: 1
-                description: Normalized importance score bounded to [0,1] for UI display
+                description: >-
+                  ⚠ NOT EMITTED by any build. `FactorSensitivityResultV3` has no
+                  `importance_score` member and no transform maps ISL's, so this
+                  field has never reached the wire on either the graph-primary or
+                  the ISL-fallback path (verified in the checked-in golden and
+                  against plot-lite-service-staging build 1dd45b6). Declared here
+                  historically; retained as a documented ABSENCE rather than
+                  deleted, because consumers were written against it. Declared as
+                  a drop in src/contracts/isl-to-ui.contract.ts. Do not read it.
               value_of_information:
                 type: number
               evpi_percentage_points:

--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -26,6 +26,33 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
   drops: [
     'metadata.n_samples',            // Superseded by outcome.n_samples per-option
     'recommendation_confidence',     // Removed in V3 schema migration
+    // ── Lane PLoT importance-authority (25 Jul 2026) — PREVIOUSLY UNDECLARED ──
+    // These six were dropped by the transforms but appeared nowhere in this
+    // list, which read as complete. A contract that lists 3 of 9 drops is worse
+    // than none. Declared here as a statement of FACT about today's wire; see
+    // ROADMAP row "PLoT: restore or rename the dropped ISL factor/edge
+    // measurements" for the decision on whether to stop dropping them.
+    //
+    // `FactorSensitivityResultV3` has no `importance_score` member at all, so
+    // this is dropped on BOTH paths — graph-primary AND the ISL-only fallback.
+    // It has never been on the wire. (`src/facts/mapper.ts` SYNTHESISES one from
+    // the already-substituted PLoT row; that is not a passthrough.)
+    'factor_sensitivity[].importance_score',
+    // ISL's own MC uncertainty-importance ordering. On the graph-primary path
+    // the published `factor_sensitivity[].importance_rank` is PLoT's own
+    // lever-aware ordering over graph influence, NOT this value — see the
+    // `substitutions` block below and the per-row `importance_basis` disclosure.
+    'factor_sensitivity[].importance_rank (ISL value, on the graph-primary path)',
+    // Same: ISL's MC-derived values are replaced by graph-derived quantities
+    // under the identical field names on the graph-primary path.
+    'factor_sensitivity[].sensitivity_score (ISL value, on the graph-primary path)',
+    'factor_sensitivity[].elasticity (ISL value, on the graph-primary path)',
+    'factor_sensitivity[].direction (ISL value, on the graph-primary path)',
+    // `EdgeSensitivityResultV3` has no `sensitivity_score` or `direction`
+    // member. transformEdgeSensitivity keeps elasticity/importance_rank/
+    // sensitivity_type/interpretation and drops these two on every path.
+    'edge_sensitivity[].sensitivity_score',
+    'edge_sensitivity[].direction',
     // Producer honesty (lane PLoT-H item B, 2026-07-07): ISL derives this as
     // option_wins[winner]/n_samples — the leader's win_probability relabelled,
     // zero independent information (verified byte-identical live: 0.59025 /
@@ -81,6 +108,13 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     { from: 'factor_sensitivity[].node_id', to: 'factor_sensitivity[].factor_id' },
     /** Factor label: ISL uses label, UI uses factor_label. */
     { from: 'factor_sensitivity[].label', to: 'factor_sensitivity[].factor_label' },
+    /**
+     * Edge endpoints (lane PLoT importance-authority, 25 Jul 2026 — previously
+     * UNDECLARED). Live V2 ISL entries carry from_id/to_id; the UI shape uses
+     * bare from/to. Only the composite `edge_id` derive was declared before.
+     */
+    { from: 'robustness.edge_sensitivity[].from_id', to: 'edge_sensitivity[].from' },
+    { from: 'robustness.edge_sensitivity[].to_id', to: 'edge_sensitivity[].to' },
     /** Per-option constraint probability: ISL nests as joint_probability. */
     { from: 'constraint_analysis.joint_probability', to: 'probability_of_joint_goal' },
     /** Top-level constraint value: ISL returns both threshold (primary) and value (computed); UI uses value. */
@@ -89,12 +123,75 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     { from: 'constraint_results[].prob_satisfied', to: 'constraint_results[].probability' },
   ],
 
+  /**
+   * Producer-name / local-value collisions on `factor_sensitivity[]`.
+   *
+   * `/v2/run` makes GRAPH-derived factor sensitivity PRIMARY and ISL the
+   * FALLBACK (`src/routes/v2/run.ts`, commit `f6f7255`, 22 Jan 2026 — a
+   * deliberate, long-standing precedence, rationale: the graph path uses edge
+   * path analysis and has no dependency on `parameter_uncertainties`). The
+   * merge (`mergeIslConfidenceIntoGraphFactors`) carries over ISL's bootstrap
+   * STABILITY DIAGNOSTICS only (`attribution_stability`, `elasticity_std`,
+   * `rank_flip_rate`, `stability_method`, `value_*`).
+   *
+   * The collision: the graph values are published under ISL's field names, so
+   * on the live wire `sensitivity_score`/`elasticity`/`direction`/
+   * `importance_rank` all LOOK like ISL measurements and are not. Verified
+   * against the checked-in capture+golden pair
+   * (`tests/fixtures/isl-v2-live-20260707/`) and against a live
+   * plot-lite-service-staging call on build `1dd45b6`.
+   *
+   * `importance_rank` is additionally LEVER-AWARE (not a raw graph index):
+   * option-controlled levers are ordered last. See
+   * `src/lib/importance-authority.ts`.
+   */
+  substitutions: [
+    {
+      field: 'factor_sensitivity[].importance_rank',
+      producer_quantity: "ISL Monte-Carlo uncertainty importance (ordered by its own sensitivity_score/importance_score)",
+      published_quantity: "PLoT lever-aware ordering over graph path-analysis influence (option-controlled levers ordered last)",
+      when: "graph-primary path (importance_basis === 'graph_structural'), i.e. every live response where the graph path returns factors",
+      disclosed_by: 'factor_sensitivity[].importance_basis',
+      why: 'Graph-derived factor sensitivity is PRIMARY (f6f7255). ISL rank is not published; the graph ordering carries the ISL field name.',
+    },
+    {
+      field: 'factor_sensitivity[].sensitivity_score',
+      producer_quantity: 'ISL MC sensitivity score (0-1, normalised to max)',
+      published_quantity: 'graph raw total causal effect (FactorInfluence.influence) — 0 for option-controlled levers (LEVER_SUPPRESSION_FIELDS)',
+      when: "graph-primary path (importance_basis === 'graph_structural')",
+      disclosed_by: 'factor_sensitivity[].importance_basis',
+      why: 'Same precedence choice; different quantity, same name.',
+    },
+    {
+      field: 'factor_sensitivity[].elasticity',
+      producer_quantity: 'ISL MC elasticity (outcome units per factor unit, signed)',
+      published_quantity: 'graph normalised influence (equal to influence_score) — 0 for option-controlled levers',
+      when: "graph-primary path (importance_basis === 'graph_structural')",
+      disclosed_by: 'factor_sensitivity[].importance_basis',
+      why: 'Same precedence choice. NOTE the units differ from ISL elasticity — do not compare across the two bases.',
+    },
+    {
+      field: 'factor_sensitivity[].direction',
+      producer_quantity: 'sign of ISL MC elasticity',
+      published_quantity: 'sign of the graph path-product influence',
+      when: "graph-primary path (importance_basis === 'graph_structural')",
+      disclosed_by: 'factor_sensitivity[].importance_basis',
+      why: 'Same precedence choice. The two can disagree (live: fac_dev_headcount ISL negative, published positive).',
+    },
+  ],
+
   transforms: [
     {
       kind: 'derive',
       from: ['from_id', 'to_id'],
       to: 'edge_sensitivity[].edge_id',
       why: 'Composite key: "${from_id}::${to_id}" (double-colon canonical format; live V2 nested entries carry from_id/to_id — legacy fixture entries carry edge_from/edge_to and are accepted equivalently)',
+    },
+    {
+      kind: 'reshape',
+      from: 'robustness.fragile_edges[]',
+      to: 'robustness.fragile_edges[]',
+      why: 'REORDERED, most-fragile-first (switch_probability desc, missing sorts last, stable). ISL does not emit these in fragility order — live build 1dd45b6 returned [0.075, 0.281, 0.375, 0.487, 0.569, 0.61, 0.307], so [0] was the LEAST fragile. Multiple PLoT and CEE consumers read the head of this array without sorting it. See normalizeFragileEdges in src/integrations/isl/adapters/robustness-analysis.ts.',
     },
     {
       kind: 'reshape',
@@ -118,7 +215,15 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     'fragile_edges[].severity',          // B1: classified from switch_probability (>0.7→critical, >0.5→error, ≤0.5→warning)
     'robust_edges[].from_label',
     'robust_edges[].to_label',
-    'factor_sensitivity[].source',       // Constant: 'isl'
+    // ⚠ CORRECTED 25 Jul 2026 (lane PLoT importance-authority). This line used
+    // to read "Constant: 'isl'". That has been FALSE since f6f7255 (22 Jan
+    // 2026) made the graph path primary: every live row publishes
+    // `source: 'graph'` (verified in the checked-in golden AND against
+    // plot-lite-service-staging build 1dd45b6). A contract line that describes
+    // the pre-change world is the hand-maintained-mirror defect this file
+    // exists to prevent.
+    'factor_sensitivity[].source',       // 'graph' on the primary path | 'isl' on the ISL-only fallback. A legacy/object provenance label — for the RANKING basis read importance_basis, not this.
+    'factor_sensitivity[].importance_basis', // Lane PLoT importance-authority: 'graph_structural' | 'isl_uncertainty'. The runtime disclosure for every entry in `substitutions` below.
     'factor_sensitivity[].confidence_source', // B (tier-B): 'plot_unified_from_isl_bootstrap' | 'plot_unified_from_graph' — honest provenance tag (audit A1-PRIMARY)
     'factor_sensitivity[].confidence_provenance', // B (tier-B): typed disclosure object {computation_source, formula_version, is_provisional, calibration_status, input_quality} — audit A1-PRIMARY
     'auto_noise_applied',                // B (tier-B): boolean echo of ISL's auto-noise flag — present on analysis_status ∈ {computed, partial}, null when ISL omits — audit B3

--- a/src/contracts/plot-to-isl.contract.ts
+++ b/src/contracts/plot-to-isl.contract.ts
@@ -23,6 +23,34 @@ export interface BoundaryTransform {
   why: string;
 }
 
+/**
+ * A SUBSTITUTION: the boundary keeps the producer's field NAME but replaces its
+ * VALUE with a locally-computed quantity, and does not publish the producer's.
+ *
+ * Added by lane PLoT importance-authority (25 Jul 2026) because this category
+ * was not representable before, and so went undeclared for six months: a
+ * substitution is neither a `drop` (the key is still on the wire), nor a
+ * `rename` (the name is unchanged), nor an `enrichment` (the producer DID send
+ * a value — it was discarded). That is precisely the shape a consumer cannot
+ * detect, which is why it needs its own name in the contract.
+ *
+ * Every substitution MUST name a `disclosed_by` field on the wire, so a consumer
+ * can tell at runtime which quantity it is holding.
+ */
+export interface BoundarySubstitution {
+  /** The wire field whose name is the producer's and whose value is not. */
+  field: string;
+  /** What the producer sent under this name. */
+  producer_quantity: string;
+  /** What the boundary publishes under this name instead. */
+  published_quantity: string;
+  /** When the substitution applies (e.g. only on a given source path). */
+  when: string;
+  /** The wire field a consumer reads to know which quantity it holds. */
+  disclosed_by: string;
+  why: string;
+}
+
 export interface BoundaryContract {
   name: string;
   drops: string[];
@@ -30,6 +58,8 @@ export interface BoundaryContract {
   renames: BoundaryRename[];
   transforms: BoundaryTransform[];
   enriched: string[];
+  /** Producer-name / local-value collisions. See `BoundarySubstitution`. */
+  substitutions?: BoundarySubstitution[];
 }
 
 /**

--- a/src/integrations/isl/adapters/robustness-analysis.ts
+++ b/src/integrations/isl/adapters/robustness-analysis.ts
@@ -147,6 +147,36 @@ export function normalizeFragileEdges(
       result.errors.push({ edge_type: 'fragile', error: errorMsg, raw_value: edge });
     }
   }
+  // ── Fragility ORDER (lane PLoT importance-authority, 25 Jul 2026) ──
+  //
+  // ISL emits `fragile_edges` in an order that is NOT fragility order. Live on
+  // plot-lite-service-staging build 1dd45b6 the array came back with
+  // switch_probability [0.075, 0.281, 0.375, 0.487, 0.569, 0.61, 0.307] —
+  // `[0]` was the LEAST fragile of seven and the maximum sat at index 5. PLoT
+  // preserved that order verbatim, so every downstream `[0]` reader named the
+  // least fragile edge as the most fragile. Confirmed consumers of the head of
+  // this array, none of which sort it themselves:
+  //   - PLoT  `src/assembly/decision-brief.ts` buildWhatWouldChange (presentation order)
+  //   - PLoT  `src/routes/v2/run.ts` sensitive_parameters recommendations (.slice(0,3))
+  //   - CEE   `src/cee/decision-review/decompose.ts` `fragileEdges[0]` → `stabilityHint.top_fragile_edge`
+  //   - CEE   `src/orchestrator/context/analysis-compact.ts` deriveTopFragileEdges (.slice(0,3), no sort)
+  //   - CEE   several `renderableFragileEdges(analysis)[0]` advice-gate sites that inherit that order
+  // Consumers that already take a max/sort (PLoT `pickTopFragile`, CEE
+  // `deriveTopFragileEdgesFromTopLevel`, `resolveCautionCandidate`) are
+  // unaffected — sorting an already-max-first array is a no-op for them.
+  //
+  // Descending by switch_probability. Entries with NO switch_probability (the
+  // legacy STRING format deliberately omits it rather than fabricating 0) sort
+  // LAST, and never ahead of a measured edge. Ties and missing-vs-missing keep
+  // their arrival order (stable sort, Node ≥ 11 guarantees stability), so this
+  // is deterministic.
+  result.edges.sort((a, b) => {
+    const pa = typeof a.switch_probability === 'number' && Number.isFinite(a.switch_probability)
+      ? a.switch_probability : -Infinity;
+    const pb = typeof b.switch_probability === 'number' && Number.isFinite(b.switch_probability)
+      ? b.switch_probability : -Infinity;
+    return pb - pa;
+  });
   return result;
 }
 

--- a/src/lib/importance-authority.ts
+++ b/src/lib/importance-authority.ts
@@ -1,0 +1,140 @@
+/**
+ * Importance authority — which quantity `/v2/run` publishes as "what matters
+ * most", and who is allowed to hold rank 1.
+ *
+ * ## The problem this module fixes (lane PLoT importance-authority, 25 Jul 2026)
+ *
+ * `/v2/run` publishes several "what matters most" surfaces in ONE body, and
+ * before this module they disagreed with each other on the live wire
+ * (plot-lite-service-staging build `1dd45b6`, real request, ISL in the loop):
+ *
+ * | surface | named #1 | applies the lever doctrine? |
+ * |---|---|---|
+ * | `factor_sensitivity[].importance_rank` = 1 | `fac_tech_lead` (a lever) | NO |
+ * | `factor_sensitivity[].driver_label` = `'biggest'` | `fac_tech_lead` | NO |
+ * | `decision_brief.top_drivers[0]` | `fac_hiring_cost` | yes |
+ * | `m1_coaching.evidence_gaps[0]` | `fac_hiring_cost` | yes |
+ * | `decision_brief.warnings[DOMINANT_FACTOR]` | `fac_hiring_cost` | yes |
+ * | ISL's own `importance_rank` = 1 | `fac_hiring_cost` | n/a |
+ *
+ * `fac_tech_lead` is an option-pinned LEVER. The same response publishes it at
+ * `sensitivity_score: 0`, `elasticity: 0`, `value_of_information: 0`,
+ * `zero_reason: 'intervention_override'` — PLoT deliberately zeroes all of those
+ * (`LEVER_SUPPRESSION_FIELDS`) and deliberately withholds its EVPI, with the
+ * stated reason that emitting it would *"rank the lever as an investigation
+ * priority"*. Crowning that same factor `importance_rank: 1` and `'biggest'` is
+ * a direct contradiction of PLoT's own ratified doctrine, stated plainly at
+ * `src/coaching/evidence-gaps.ts`:
+ *
+ * > *"Intervention-target factors are decision levers (set directly by options),
+ * > not background uncertainties to validate, so they are excluded BEFORE the
+ * > rank/quartile gate. Applying eligibility first prevents levers from consuming
+ * > the top-k slots and hiding valid non-lever factors that ranked below them in
+ * > the enriched importance order."*
+ *
+ * ## What this module does NOT do
+ *
+ * **It is not a graph-vs-ISL precedence flip.** Graph-derived factor sensitivity
+ * stays PRIMARY (`src/routes/v2/run.ts`, commit `f6f7255`). `influence_score` and
+ * `influence_rank` keep their exact graph-derived values under their own,
+ * correct names — a lever still tops `influence_rank`, because it genuinely does
+ * top the structural influence order. Only the ORDERING published as
+ * `importance_rank`, and eligibility for the set-aware `'biggest'` crown, become
+ * lever-aware. Both are *importance* claims; `influence_*` is a *structure*
+ * measurement.
+ */
+
+import { isOptionControlledLever } from './intervention-override.js';
+
+/**
+ * Which authority produced the row's `importance_rank`, disclosed on every
+ * `factor_sensitivity` entry so a consumer can never again be unable to tell.
+ *
+ * - `'graph_structural'` — the rank orders PLoT's own graph path-analysis
+ *   influence (`computeFactorSensitivityFromGraph`). This is the live default:
+ *   graph-derived factor sensitivity is PRIMARY.
+ * - `'isl_uncertainty'` — the graph path returned nothing and the ISL fallback
+ *   fired, so the rank is ISL's own Monte-Carlo uncertainty-importance ordering,
+ *   passed through verbatim.
+ *
+ * In BOTH cases option-controlled levers are ordered last — see
+ * `applyLeverAwareImportanceOrder`.
+ */
+export type ImportanceBasis = 'graph_structural' | 'isl_uncertainty';
+
+export const IMPORTANCE_BASIS_GRAPH: ImportanceBasis = 'graph_structural';
+export const IMPORTANCE_BASIS_ISL: ImportanceBasis = 'isl_uncertainty';
+
+/** Minimal shape the ordering reads. Matches `FactorSensitivityResultV3`. */
+interface RankableFactor {
+  factor_id?: string;
+  node_id?: string;
+  zero_reason?: string | null;
+  importance_rank?: number;
+  influence_score?: number | null;
+}
+
+/**
+ * Re-derive `importance_rank` so that every non-lever outranks every lever,
+ * and emit the array in that order.
+ *
+ * Relative order WITHIN each partition is preserved exactly as it arrived (the
+ * graph influence order on the primary path, ISL's own importance order on the
+ * fallback path) — this function only moves levers to the back. The returned
+ * array is a new array; entries are mutated in place for `importance_rank` only.
+ *
+ * NO-OP (returns the input array untouched, byte-identically) when the partition
+ * is degenerate — zero levers, or zero non-levers — because there is then no
+ * lever displacing a genuine uncertainty driver and nothing to fix. That keeps
+ * the change surgically scoped to the exact case that produces the harm.
+ *
+ * The emitted ARRAY ORDER follows `importance_rank` after this pass, so a
+ * downstream `factor_sensitivity[0]` reader (a common "top driver" idiom) gets
+ * the same answer as an `importance_rank === 1` reader. `influence_rank` is a
+ * named field and is NOT re-derived, so it still carries the graph order.
+ */
+export function applyLeverAwareImportanceOrder<T extends RankableFactor>(
+  factors: T[],
+  structuralLeverIds: ReadonlySet<string>,
+): T[] {
+  const levers: T[] = [];
+  const nonLevers: T[] = [];
+  for (const f of factors) {
+    (isOptionControlledLever(f, structuralLeverIds) ? levers : nonLevers).push(f);
+  }
+  // Degenerate partition — nothing is being displaced. Return the SAME array
+  // reference so the no-op is provably byte-identical.
+  if (levers.length === 0 || nonLevers.length === 0) {
+    return factors;
+  }
+  const ordered = [...nonLevers, ...levers];
+  for (let i = 0; i < ordered.length; i++) {
+    ordered[i].importance_rank = i + 1;
+  }
+  return ordered;
+}
+
+/**
+ * ── NOT DONE HERE, ON PURPOSE: the `driver_label: 'biggest'` crown ──
+ *
+ * `driver_label`'s rank-1 `'biggest'` band (`src/lib/driver-label.ts`,
+ * Doctrine 039 / D-7) is argmax over `influence_score` and is NOT lever-aware,
+ * so on the live wire it lands on the option-pinned lever while
+ * `importance_rank: 1` (above) lands on the top genuine uncertainty driver.
+ * Those two disagree by design as of this lane. Reasons for leaving it:
+ *
+ *   1. `'biggest'` is DEFINED as the greatest `influence_score`. Gating it makes
+ *      the label contradict the number in its own row (a lever at
+ *      influence_score 1.0 labelled 'strong' beneath a 0.497 labelled
+ *      'biggest') — trading one incoherence for another.
+ *   2. The basis question ("should driver_label rank on influence or on
+ *      elasticity/importance?") is ALREADY an open doctrine row owned by
+ *      Neil/UI, recorded in driver-label.ts. A producer should not settle it
+ *      unilaterally inside an unrelated fix.
+ *   3. Blast radius today is zero: censused 25 Jul at the consumer tips
+ *      (UI `039f479a`, CEE `f00b8ef6`) — `factor_sensitivity[].driver_label`
+ *      has NO read site in either repo.
+ *
+ * The divergence is PINNED by tests/importance-rank-lever-doctrine.fixture.test.ts
+ * so it cannot drift silently while the ruling is pending.
+ */

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -149,6 +149,11 @@ import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagM
 import { sanitiseIslVoi, computeEvpiPercentagePoints, deriveEvidenceHint } from '../../lib/evpi-emission.js';
 import { deriveDriverLabel, indexOfBiggestDriver } from '../../lib/driver-label.js';
 import {
+  applyLeverAwareImportanceOrder,
+  IMPORTANCE_BASIS_GRAPH,
+  IMPORTANCE_BASIS_ISL,
+} from '../../lib/importance-authority.js';
+import {
   detectUnreliableConstraintTargets,
   partitionConstraintTargets,
   buildConstraintTargetUnreliableMessage,
@@ -6148,6 +6153,44 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           factorSensitivitySource = 'isl';
         }
 
+        // ── Importance authority (lane PLoT importance-authority, 25 Jul 2026) ──
+        //
+        // Up to here `importance_rank` is a bare positional index over the graph
+        // influence order (`computeFactorSensitivityFromGraph`: `importance_rank:
+        // index + 1`) — byte-identical to `influence_rank` on every row, so it
+        // carried ZERO additional information and, crucially, ranked
+        // option-pinned LEVERS at the top.
+        //
+        // That contradicted PLoT's own ratified lever doctrine, which the SAME
+        // response body already applies on three other surfaces
+        // (decision_brief.top_drivers, m1_coaching.evidence_gaps, the
+        // DOMINANT_FACTOR warning): an option-pinned lever is a decision lever,
+        // not a background uncertainty, so it must not consume the top
+        // importance slots. Live-verified on staging build 1dd45b6: the wire
+        // crowned `fac_tech_lead` (`sensitivity_score: 0`, `elasticity: 0`,
+        // `zero_reason: 'intervention_override'`) at `importance_rank: 1` while
+        // those three surfaces all named `fac_hiring_cost`, as did ISL.
+        //
+        // NOT a precedence flip: graph-derived sensitivity stays PRIMARY and
+        // `influence_score`/`influence_rank` keep their exact graph values under
+        // their own names (a lever still tops `influence_rank` — it genuinely
+        // does top the structural influence order). Only the *importance* claim
+        // becomes lever-aware. See src/lib/importance-authority.ts.
+        if (factorSensitivity) {
+          factorSensitivity = applyLeverAwareImportanceOrder(factorSensitivity, structuralLeverIds);
+          // Producer disclosure: which authority the rank came from. Constant
+          // per response, emitted per row so no consumer can hold the number
+          // without the basis. 'graph_structural' on the primary path;
+          // 'isl_uncertainty' when the graph path returned nothing and ISL's own
+          // Monte-Carlo importance order is what is published.
+          const importanceBasis = factorSensitivitySource === 'isl'
+            ? IMPORTANCE_BASIS_ISL
+            : IMPORTANCE_BASIS_GRAPH;
+          for (const f of factorSensitivity) {
+            f.importance_basis = importanceBasis;
+          }
+        }
+
         // Enrich factor sensitivity with heuristic EVPI percentage points.
         //
         // F3 (ISL #103 / D-23.15): the former ISL COUNTERFACTUAL path — which
@@ -6195,6 +6238,27 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           //     max resolve to the FIRST factor in the emitted order (deterministic);
           //     an absent-influence factor is skipped. Not lever-skipped: a lever
           //     legitimately has a driver_label (categorical over influence magnitude).
+          //
+          //     ⚠ KNOWN DIVERGENCE, DELIBERATELY LEFT (lane PLoT importance-authority,
+          //     25 Jul 2026 — ROADMAP row "Doctrine 039: what basis does
+          //     driver_label rank on?"). Because this crown is argmax over
+          //     `influence_score` and NOT lever-aware, it can — and on the live
+          //     wire does — land on an option-pinned lever the same response
+          //     publishes at `sensitivity_score: 0` / `elasticity: 0`, i.e. on a
+          //     DIFFERENT factor from `importance_rank: 1`, which IS lever-aware.
+          //     That divergence is NOT fixed here on purpose:
+          //       · 'biggest' is DEFINED by Doctrine 039 as the greatest
+          //         `influence_score`. Gating it would make the label contradict
+          //         the number published in the same row — trading one incoherence
+          //         for another — so it needs the doctrine's basis question
+          //         (already DOCTRINE-PENDING, Neil/UI, see src/lib/driver-label.ts)
+          //         answered first, not a unilateral producer change.
+          //       · Blast radius today is ZERO: censused 25 Jul at the tips
+          //         (UI 039f479a, CEE f00b8ef6) — `factor_sensitivity[].driver_label`
+          //         has NO read site in either consumer.
+          //     The divergence is PINNED (not merely commented) by
+          //     tests/importance-rank-lever-doctrine.fixture.test.ts so it cannot
+          //     drift silently while the ruling is pending.
           const biggestIdx = indexOfBiggestDriver(factorSensitivity);
           if (biggestIdx >= 0) factorSensitivity[biggestIdx].driver_label = 'biggest';
 

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1934,8 +1934,44 @@ export interface FactorSensitivityResultV3 {
   elasticity?: number;
   /** Direction of influence on goal */
   direction?: 'positive' | 'negative' | 'mixed' | 'unknown';
-  /** Importance ranking (1 = most important) - same as influence_rank for graph-based */
+  /**
+   * Importance ranking (1 = most important) — the producer's answer to "what
+   * matters most".
+   *
+   * ⚠ This is NOT ISL's `importance_rank` passed through. On the primary path it
+   * orders PLoT's graph path-analysis influence; ISL's own value is not
+   * published. The basis is disclosed per row on `importance_basis` — read that
+   * before interpreting this number.
+   *
+   * Option-controlled levers (ISL `zero_reason: 'intervention_override'` OR D-U
+   * structural union members) are ordered LAST on both paths: a lever is a
+   * decision lever, not a background uncertainty, so it never consumes a top
+   * importance slot (the same doctrine `evidence_gaps` and
+   * `decision_brief.top_drivers` apply). A lever still tops `influence_rank` —
+   * that field is the ungated structural measurement.
+   *
+   * The emitted array order follows this rank, so `factor_sensitivity[0]` and
+   * `importance_rank === 1` agree. See `src/lib/importance-authority.ts`.
+   */
   importance_rank?: number;
+  /**
+   * Producer disclosure: WHICH authority produced `importance_rank` (and the
+   * quantity `influence_score`/`sensitivity_score`/`elasticity` are computed
+   * from) on this response.
+   *
+   * - `'graph_structural'` — PLoT's own graph path analysis
+   *   (`computeFactorSensitivityFromGraph`), the live primary path. ISL's
+   *   `importance_score` / `importance_rank` / `sensitivity_score` /
+   *   `elasticity` / `direction` are NOT on the wire in this case; only its
+   *   bootstrap stability diagnostics are merged in.
+   * - `'isl_uncertainty'` — the graph path returned nothing, so ISL's own
+   *   Monte-Carlo uncertainty-importance ordering is what is published.
+   *
+   * Exists because the two quantities share ISL's field NAMES and are otherwise
+   * indistinguishable to a consumer. Declared in
+   * `src/contracts/isl-to-ui.contract.ts`.
+   */
+  importance_basis?: 'graph_structural' | 'isl_uncertainty';
   /** Human-readable interpretation from ISL */
   interpretation?: string;
   /**

--- a/src/util/structural-keys.generated.ts
+++ b/src/util/structural-keys.generated.ts
@@ -210,6 +210,7 @@ export const STRUCTURAL_KEYS: ReadonlySet<string> = new Set([
   "id_mismatch",
   "idempotency_key",
   "identifiability",
+  "importance_basis",
   "importance_rank",
   "improvement_guidance",
   "include_e_values",

--- a/tests/cil-phase0-fragile-edges.test.ts
+++ b/tests/cil-phase0-fragile-edges.test.ts
@@ -186,21 +186,25 @@ describe('CIL Phase 0 — Task 1: fragile_edges shape consistency', () => {
       expect(Array.isArray(result.fragile_edges)).toBe(true);
       expect(result.fragile_edges).toHaveLength(2);
 
-      // First fragile edge — full fields
-      const fe0 = result.fragile_edges[0];
-      expect(fe0.edge_id).toBe('fac_price::goal_revenue');
-      expect(fe0.from_id).toBe('fac_price');
-      expect(fe0.to_id).toBe('goal_revenue');
-      expect(fe0.switch_probability).toBe(0.25);
-      expect(fe0.alternative_winner_id).toBe('opt-b');
-      expect(fe0.marginal_switch_probability).toBe(0.12);
+      // Field mapping asserted by IDENTITY, not position: the adapter now
+      // publishes fragile_edges most-fragile-first, so the 0.45 edge leads.
+      const fePrice = result.fragile_edges.find((e: any) => e.edge_id === 'fac_price::goal_revenue')!;
+      expect(fePrice).toBeDefined();
+      expect(fePrice.from_id).toBe('fac_price');
+      expect(fePrice.to_id).toBe('goal_revenue');
+      expect(fePrice.switch_probability).toBe(0.25);
+      expect(fePrice.alternative_winner_id).toBe('opt-b');
+      expect(fePrice.marginal_switch_probability).toBe(0.12);
 
-      // Second fragile edge — no alternative_winner
-      const fe1 = result.fragile_edges[1];
-      expect(fe1.edge_id).toBe('fac_demand->goal_revenue');
-      expect(fe1.from_id).toBe('fac_demand');
-      expect(fe1.to_id).toBe('goal_revenue');
-      expect(fe1.switch_probability).toBe(0.45);
+      // The other fragile edge — no alternative_winner
+      const feDemand = result.fragile_edges.find((e: any) => e.edge_id === 'fac_demand->goal_revenue')!;
+      expect(feDemand).toBeDefined();
+      expect(feDemand.from_id).toBe('fac_demand');
+      expect(feDemand.to_id).toBe('goal_revenue');
+      expect(feDemand.switch_probability).toBe(0.45);
+
+      // …and the ORDER itself is the fragility order (the input was ascending).
+      expect(result.fragile_edges.map((e: any) => e.switch_probability)).toEqual([0.45, 0.25]);
     });
 
     it('graph with no fragile edges → fragile_edges: [] (empty array)', () => {

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -488,72 +488,6 @@
   "conditional_winners": [],
   "factor_sensitivity": [
     {
-      "factor_id": "fac_tech_lead",
-      "factor_label": "Tech Lead in Place",
-      "influence_score": 1,
-      "influence_rank": 1,
-      "sensitivity_score": 0,
-      "elasticity": 0,
-      "direction": "positive",
-      "importance_rank": 1,
-      "value_of_information": 0,
-      "confidence": 0.3,
-      "confidence_source": "plot_unified_from_isl_bootstrap",
-      "confidence_provenance": {
-        "computation_source": "plot_unified_from_isl_bootstrap",
-        "formula_version": "plot_unified_v3",
-        "is_provisional": true,
-        "calibration_status": "provisional_pending_pilot_calibration",
-        "input_quality": "standard"
-      },
-      "confidence_components": {
-        "structural_certainty": 0.5,
-        "sampling_stability": 0
-      },
-      "zero_reason": "intervention_override",
-      "source": "graph",
-      "flip_risk_category": "isolated",
-      "attribution_stability": "negligible",
-      "elasticity_std": 0,
-      "rank_flip_rate": 0,
-      "stability_method": "bootstrap_20",
-      "driver_label": "biggest",
-      "range_derivation_source": "default"
-    },
-    {
-      "factor_id": "fac_dev_headcount",
-      "factor_label": "Developer Headcount Added",
-      "influence_score": 0.7243656922228352,
-      "influence_rank": 2,
-      "sensitivity_score": 0,
-      "elasticity": 0,
-      "direction": "positive",
-      "importance_rank": 2,
-      "value_of_information": 0,
-      "confidence": 0.3,
-      "confidence_source": "plot_unified_from_isl_bootstrap",
-      "confidence_provenance": {
-        "computation_source": "plot_unified_from_isl_bootstrap",
-        "formula_version": "plot_unified_v3",
-        "is_provisional": true,
-        "calibration_status": "provisional_pending_pilot_calibration",
-        "input_quality": "standard"
-      },
-      "confidence_components": {
-        "structural_certainty": 0.5,
-        "sampling_stability": 0
-      },
-      "zero_reason": "intervention_override",
-      "source": "graph",
-      "flip_risk_category": "isolated",
-      "attribution_stability": "negligible",
-      "elasticity_std": 0,
-      "rank_flip_rate": 0,
-      "stability_method": "bootstrap_20",
-      "driver_label": "strong",
-      "range_derivation_source": "default"
-    },
-    {
       "factor_id": "fac_hiring_cost",
       "factor_label": "Hiring and Salary Cost",
       "influence_score": 0.4971042471042471,
@@ -561,7 +495,7 @@
       "sensitivity_score": -0.175,
       "elasticity": 0.4971042471042471,
       "direction": "negative",
-      "importance_rank": 3,
+      "importance_rank": 1,
       "value_of_information": 0,
       "confidence": 0.44075,
       "confidence_source": "plot_unified_from_isl_bootstrap",
@@ -582,6 +516,7 @@
       "elasticity_std": 0.01101973,
       "rank_flip_rate": 0.3,
       "stability_method": "bootstrap_20",
+      "importance_basis": "graph_structural",
       "driver_label": "moderate",
       "evpi_percentage_points": 0,
       "evpi_method": "heuristic",
@@ -595,7 +530,7 @@
       "sensitivity_score": 0.13745631067961164,
       "elasticity": 0.39045780474351904,
       "direction": "positive",
-      "importance_rank": 4,
+      "importance_rank": 2,
       "value_of_information": 0,
       "confidence": 0.44455,
       "confidence_source": "plot_unified_from_isl_bootstrap",
@@ -617,10 +552,79 @@
       "rank_flip_rate": 0.05,
       "stability_method": "bootstrap_20",
       "value_defaulted": true,
+      "importance_basis": "graph_structural",
       "driver_label": "moderate",
       "evpi_percentage_points": 0,
       "evpi_method": "heuristic",
       "evidence_hint": false
+    },
+    {
+      "factor_id": "fac_tech_lead",
+      "factor_label": "Tech Lead in Place",
+      "influence_score": 1,
+      "influence_rank": 1,
+      "sensitivity_score": 0,
+      "elasticity": 0,
+      "direction": "positive",
+      "importance_rank": 3,
+      "value_of_information": 0,
+      "confidence": 0.3,
+      "confidence_source": "plot_unified_from_isl_bootstrap",
+      "confidence_provenance": {
+        "computation_source": "plot_unified_from_isl_bootstrap",
+        "formula_version": "plot_unified_v3",
+        "is_provisional": true,
+        "calibration_status": "provisional_pending_pilot_calibration",
+        "input_quality": "standard"
+      },
+      "confidence_components": {
+        "structural_certainty": 0.5,
+        "sampling_stability": 0
+      },
+      "zero_reason": "intervention_override",
+      "source": "graph",
+      "flip_risk_category": "isolated",
+      "attribution_stability": "negligible",
+      "elasticity_std": 0,
+      "rank_flip_rate": 0,
+      "stability_method": "bootstrap_20",
+      "importance_basis": "graph_structural",
+      "driver_label": "biggest",
+      "range_derivation_source": "default"
+    },
+    {
+      "factor_id": "fac_dev_headcount",
+      "factor_label": "Developer Headcount Added",
+      "influence_score": 0.7243656922228352,
+      "influence_rank": 2,
+      "sensitivity_score": 0,
+      "elasticity": 0,
+      "direction": "positive",
+      "importance_rank": 4,
+      "value_of_information": 0,
+      "confidence": 0.3,
+      "confidence_source": "plot_unified_from_isl_bootstrap",
+      "confidence_provenance": {
+        "computation_source": "plot_unified_from_isl_bootstrap",
+        "formula_version": "plot_unified_v3",
+        "is_provisional": true,
+        "calibration_status": "provisional_pending_pilot_calibration",
+        "input_quality": "standard"
+      },
+      "confidence_components": {
+        "structural_certainty": 0.5,
+        "sampling_stability": 0
+      },
+      "zero_reason": "intervention_override",
+      "source": "graph",
+      "flip_risk_category": "isolated",
+      "attribution_stability": "negligible",
+      "elasticity_std": 0,
+      "rank_flip_rate": 0,
+      "stability_method": "bootstrap_20",
+      "importance_basis": "graph_structural",
+      "driver_label": "strong",
+      "range_derivation_source": "default"
     }
   ],
   "factor_stability": [
@@ -818,32 +822,6 @@
           "impact_reason_code": "FRAGILE_EDGE"
         },
         {
-          "dedup_key": "isl_engine:flagged:node:fac_tech_lead:confidence",
-          "source_service": "isl_engine",
-          "action": "flagged",
-          "entity_type": "node",
-          "entity_id": "fac_tech_lead",
-          "field": "confidence",
-          "from_value": null,
-          "to_value": 0.3,
-          "reason": "Factor Tech Lead in Place has low confidence (30%)",
-          "impact": "high",
-          "impact_reason_code": "HIGH_INFLUENCE_FACTOR"
-        },
-        {
-          "dedup_key": "isl_engine:flagged:node:fac_dev_headcount:confidence",
-          "source_service": "isl_engine",
-          "action": "flagged",
-          "entity_type": "node",
-          "entity_id": "fac_dev_headcount",
-          "field": "confidence",
-          "from_value": null,
-          "to_value": 0.3,
-          "reason": "Factor Developer Headcount Added has low confidence (30%)",
-          "impact": "high",
-          "impact_reason_code": "HIGH_INFLUENCE_FACTOR"
-        },
-        {
           "dedup_key": "isl_engine:flagged:node:fac_hiring_cost:confidence",
           "source_service": "isl_engine",
           "action": "flagged",
@@ -866,14 +844,40 @@
           "from_value": null,
           "to_value": 0.44455,
           "reason": "Factor Team Technical Maturity has low confidence (44%)",
-          "impact": "medium",
+          "impact": "high",
           "impact_reason_code": "HIGH_INFLUENCE_FACTOR"
+        },
+        {
+          "dedup_key": "isl_engine:flagged:node:fac_tech_lead:confidence",
+          "source_service": "isl_engine",
+          "action": "flagged",
+          "entity_type": "node",
+          "entity_id": "fac_tech_lead",
+          "field": "confidence",
+          "from_value": null,
+          "to_value": 0.3,
+          "reason": "Factor Tech Lead in Place has low confidence (30%)",
+          "impact": "high",
+          "impact_reason_code": "HIGH_INFLUENCE_FACTOR"
+        },
+        {
+          "dedup_key": "isl_engine:flagged:node:fac_dev_headcount:confidence",
+          "source_service": "isl_engine",
+          "action": "flagged",
+          "entity_type": "node",
+          "entity_id": "fac_dev_headcount",
+          "field": "confidence",
+          "from_value": null,
+          "to_value": 0.3,
+          "reason": "Factor Developer Headcount Added has low confidence (30%)",
+          "impact": "low",
+          "impact_reason_code": "STRUCTURAL_ONLY"
         }
       ],
       "total_count": 10,
       "high_impact_count": 9,
-      "medium_impact_count": 1,
-      "low_impact_count": 0
+      "medium_impact_count": 0,
+      "low_impact_count": 1
     },
     "thresholds_used": {
       "headline_clear_winner_delta": 0.2,
@@ -1045,27 +1049,40 @@
   "robustness": {
     "fragile_edges": [
       {
-        "edge_id": "fac_dev_headcount->out_throughput",
-        "from_id": "fac_dev_headcount",
-        "to_id": "out_throughput",
-        "switch_probability": 0.075,
-        "marginal_switch_probability": 0.42,
+        "edge_id": "fac_tech_lead->out_technical_quality",
+        "from_id": "fac_tech_lead",
+        "to_id": "out_technical_quality",
+        "switch_probability": 0.61,
+        "marginal_switch_probability": 0.23,
         "alternative_winner_id": "opt_two_devs",
-        "from_label": "Developer Headcount Added",
-        "to_label": "Development Throughput",
-        "severity": "warning",
-        "visible": false,
+        "from_label": "Tech Lead in Place",
+        "to_label": "Technical Quality and Architecture",
+        "severity": "error",
+        "visible": true,
         "alternative_winner_label": "Hire Two Developers"
       },
       {
-        "edge_id": "out_throughput->goal_productivity",
-        "from_id": "out_throughput",
+        "edge_id": "out_technical_quality->goal_productivity",
+        "from_id": "out_technical_quality",
         "to_id": "goal_productivity",
-        "switch_probability": 0.281,
-        "marginal_switch_probability": 0.03,
+        "switch_probability": 0.569,
+        "marginal_switch_probability": 0.21,
         "alternative_winner_id": "opt_two_devs",
-        "from_label": "Development Throughput",
+        "from_label": "Technical Quality and Architecture",
         "to_label": "Increase Team Productivity",
+        "severity": "error",
+        "visible": true,
+        "alternative_winner_label": "Hire Two Developers"
+      },
+      {
+        "edge_id": "fac_dev_headcount->risk_coordination",
+        "from_id": "fac_dev_headcount",
+        "to_id": "risk_coordination",
+        "switch_probability": 0.487,
+        "marginal_switch_probability": 0,
+        "alternative_winner_id": "opt_two_devs",
+        "from_label": "Developer Headcount Added",
+        "to_label": "Team Coordination Overhead",
         "severity": "warning",
         "visible": true,
         "alternative_winner_label": "Hire Two Developers"
@@ -1084,45 +1101,6 @@
         "alternative_winner_label": "Hire Two Developers"
       },
       {
-        "edge_id": "fac_dev_headcount->risk_coordination",
-        "from_id": "fac_dev_headcount",
-        "to_id": "risk_coordination",
-        "switch_probability": 0.487,
-        "marginal_switch_probability": 0,
-        "alternative_winner_id": "opt_two_devs",
-        "from_label": "Developer Headcount Added",
-        "to_label": "Team Coordination Overhead",
-        "severity": "warning",
-        "visible": true,
-        "alternative_winner_label": "Hire Two Developers"
-      },
-      {
-        "edge_id": "out_technical_quality->goal_productivity",
-        "from_id": "out_technical_quality",
-        "to_id": "goal_productivity",
-        "switch_probability": 0.569,
-        "marginal_switch_probability": 0.21,
-        "alternative_winner_id": "opt_two_devs",
-        "from_label": "Technical Quality and Architecture",
-        "to_label": "Increase Team Productivity",
-        "severity": "error",
-        "visible": true,
-        "alternative_winner_label": "Hire Two Developers"
-      },
-      {
-        "edge_id": "fac_tech_lead->out_technical_quality",
-        "from_id": "fac_tech_lead",
-        "to_id": "out_technical_quality",
-        "switch_probability": 0.61,
-        "marginal_switch_probability": 0.23,
-        "alternative_winner_id": "opt_two_devs",
-        "from_label": "Tech Lead in Place",
-        "to_label": "Technical Quality and Architecture",
-        "severity": "error",
-        "visible": true,
-        "alternative_winner_label": "Hire Two Developers"
-      },
-      {
         "edge_id": "risk_coordination->goal_productivity",
         "from_id": "risk_coordination",
         "to_id": "goal_productivity",
@@ -1133,6 +1111,32 @@
         "to_label": "Increase Team Productivity",
         "severity": "warning",
         "visible": true,
+        "alternative_winner_label": "Hire Two Developers"
+      },
+      {
+        "edge_id": "out_throughput->goal_productivity",
+        "from_id": "out_throughput",
+        "to_id": "goal_productivity",
+        "switch_probability": 0.281,
+        "marginal_switch_probability": 0.03,
+        "alternative_winner_id": "opt_two_devs",
+        "from_label": "Development Throughput",
+        "to_label": "Increase Team Productivity",
+        "severity": "warning",
+        "visible": true,
+        "alternative_winner_label": "Hire Two Developers"
+      },
+      {
+        "edge_id": "fac_dev_headcount->out_throughput",
+        "from_id": "fac_dev_headcount",
+        "to_id": "out_throughput",
+        "switch_probability": 0.075,
+        "marginal_switch_probability": 0.42,
+        "alternative_winner_id": "opt_two_devs",
+        "from_label": "Developer Headcount Added",
+        "to_label": "Development Throughput",
+        "severity": "warning",
+        "visible": false,
         "alternative_winner_label": "Hire Two Developers"
       }
     ],
@@ -1261,9 +1265,9 @@
       "Team Technical Maturity"
     ],
     "what_would_change": [
-      "Development Throughput → Increase Team Productivity",
       "Technical Quality and Architecture → Increase Team Productivity",
-      "Team Coordination Overhead → Increase Team Productivity"
+      "Team Coordination Overhead → Increase Team Productivity",
+      "Development Throughput → Increase Team Productivity"
     ],
     "robustness": "fragile",
     "warnings": [
@@ -1425,7 +1429,7 @@
         "label": "Developer Headcount Added",
         "sensitivity_score": 0,
         "importance_score": 0,
-        "importance_rank": 2,
+        "importance_rank": 4,
         "elasticity": 0,
         "direction": "positive",
         "confidence": 0.3,
@@ -1438,7 +1442,7 @@
         "isl_request_id": "__VOLATILE__",
         "n_samples": 10000
       },
-      "content_hash": "6328d59d1577f9e9"
+      "content_hash": "38fd5d2b2f426534"
     },
     {
       "fact_id": "__VOLATILE__",
@@ -1454,7 +1458,7 @@
         "label": "Hiring and Salary Cost",
         "sensitivity_score": 0.4971042471042471,
         "importance_score": 0.4971042471042471,
-        "importance_rank": 3,
+        "importance_rank": 1,
         "elasticity": 0.4971042471042471,
         "direction": "negative",
         "confidence": 0.44075,
@@ -1467,7 +1471,7 @@
         "isl_request_id": "__VOLATILE__",
         "n_samples": 10000
       },
-      "content_hash": "1b078eb246e060e2"
+      "content_hash": "bfe2baa993203588"
     },
     {
       "fact_id": "__VOLATILE__",
@@ -1483,7 +1487,7 @@
         "label": "Team Technical Maturity",
         "sensitivity_score": 0.39045780474351904,
         "importance_score": 0.39045780474351904,
-        "importance_rank": 4,
+        "importance_rank": 2,
         "elasticity": 0.39045780474351904,
         "direction": "positive",
         "confidence": 0.44455,
@@ -1496,7 +1500,7 @@
         "isl_request_id": "__VOLATILE__",
         "n_samples": 10000
       },
-      "content_hash": "29dd19919af45252"
+      "content_hash": "1c5920bad28446f5"
     },
     {
       "fact_id": "__VOLATILE__",
@@ -1512,7 +1516,7 @@
         "label": "Tech Lead in Place",
         "sensitivity_score": 0,
         "importance_score": 0,
-        "importance_rank": 1,
+        "importance_rank": 3,
         "elasticity": 0,
         "direction": "positive",
         "confidence": 0.3,
@@ -1525,7 +1529,7 @@
         "isl_request_id": "__VOLATILE__",
         "n_samples": 10000
       },
-      "content_hash": "43d316b1bc131bbd"
+      "content_hash": "d7e7a5dca2cbc1df"
     },
     {
       "fact_id": "__VOLATILE__",
@@ -1620,7 +1624,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:e9467483d37018f9"
+    "response_content_hash": "rch_v2:9ca33a38c081fa08"
   },
   "meta": {
     "seed_used": "2034401427",

--- a/tests/importance-rank-lever-doctrine.fixture.test.ts
+++ b/tests/importance-rank-lever-doctrine.fixture.test.ts
@@ -1,0 +1,315 @@
+/**
+ * `/v2/run` importance-authority coherence pin (lane PLoT importance-authority,
+ * 25 Jul 2026).
+ *
+ * ## What this pins, and why
+ *
+ * `/v2/run` publishes FOUR "what matters most" surfaces in one body. Three of
+ * them apply PLoT's ratified option-lever doctrine — an option-pinned lever is a
+ * DECISION LEVER, not a background uncertainty, so it is excluded from
+ * importance/investigation rankings (`src/coaching/evidence-gaps.ts`, the
+ * `LEVER_SUPPRESSION_FIELDS` zeroing in `src/lib/factor-influence.ts`, and the
+ * EVPI skip in `src/routes/v2/run.ts` whose stated reason is that emitting it
+ * would "rank the lever as an investigation priority").
+ *
+ * `factor_sensitivity[].importance_rank` and the set-aware
+ * `driver_label: 'biggest'` crown did NOT apply it. Live-verified on
+ * plot-lite-service-staging build 1dd45b6 (== staging tip) with this exact
+ * request: `fac_tech_lead` — an `intervention_override` lever published at
+ * `sensitivity_score: 0` and `elasticity: 0` — came back `importance_rank: 1`
+ * and `driver_label: 'biggest'`, while `decision_brief.top_drivers[0]`,
+ * `m1_coaching.evidence_gaps` and the DOMINANT_FACTOR warning in the SAME body
+ * all named `fac_hiring_cost`. ISL's own `importance_rank: 1` is also
+ * `fac_hiring_cost`.
+ *
+ * Every assertion below FAILS on the pre-fix build. Mutation-checked by
+ * reverting the fix hunks in a throwaway worktree.
+ *
+ * NOTE ON PRECEDENCE: this is NOT a graph-vs-ISL precedence flip. `influence_score`
+ * and `influence_rank` stay byte-identical graph-derived values under their own
+ * names; only the ordering of `importance_rank` (and eligibility for the
+ * 'biggest' crown) changes, and only for option-controlled levers.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'isl-v2-live-20260707',
+);
+
+const capturePlain = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-staging-capture.json'), 'utf8'),
+);
+const requestA = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-v2-request.json'), 'utf8'),
+);
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(): Promise<{ data: T | null; error: string | null }> {
+    return { data: JSON.parse(JSON.stringify(capturePlain)) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+function buildPlotBody() {
+  return {
+    graph: {
+      nodes: requestA.graph.nodes.map((n: any) => ({
+        id: n.id,
+        kind: n.kind,
+        label: n.label,
+        ...(n.observed_state?.value !== undefined && n.observed_state?.value !== null
+          ? { observed_state: { value: n.observed_state.value } }
+          : {}),
+      })),
+      edges: requestA.graph.edges.map((e: any) => ({
+        from: e.from,
+        to: e.to,
+        exists_probability: e.exists_probability,
+        strength: { mean: e.strength.mean, std: e.strength.std },
+      })),
+    },
+    options: requestA.options.map((o: any) => ({
+      id: o.id,
+      label: o.label,
+      interventions: Object.fromEntries(
+        Object.entries(o.interventions).map(([nodeId, value]) => [
+          nodeId,
+          { value, source: 'user_specified' },
+        ]),
+      ),
+    })),
+    goal_node_id: requestA.goal_node_id,
+    seed: String(requestA.seed),
+  };
+}
+
+/** The option-pinned levers in this fixture, derived from the REQUEST (the
+ *  canonical D-U source of lever identity), not from the response. */
+const LEVER_IDS: ReadonlySet<string> = new Set(
+  requestA.options.flatMap((o: any) => Object.keys(o.interventions ?? {})),
+);
+
+describe('/v2/run importance-authority coherence (fixture isl-v2-live-20260707)', () => {
+  let app: FastifyInstance;
+  let body: any;
+  let factors: any[];
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: buildPlotBody(),
+    });
+    expect(res.statusCode).toBe(200);
+    body = JSON.parse(res.body);
+    factors = body.factor_sensitivity as any[];
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ---------------------------------------------------------------------
+  // POSITIVE CONTROLS — prove the assertions below can SEE something.
+  // Without these, a shape change (empty array, renamed field, levers gone)
+  // would make every doctrine assertion vacuously true.
+  // ---------------------------------------------------------------------
+  it('positive control: the fixture really does carry levers AND non-levers, both with finite influence', () => {
+    expect(LEVER_IDS.size).toBeGreaterThan(0);
+    expect(factors.length).toBeGreaterThanOrEqual(2);
+    const levers = factors.filter((f) => LEVER_IDS.has(f.factor_id));
+    const nonLevers = factors.filter((f) => !LEVER_IDS.has(f.factor_id));
+    expect(levers.length, 'fixture must contain at least one lever').toBeGreaterThan(0);
+    expect(nonLevers.length, 'fixture must contain at least one non-lever').toBeGreaterThan(0);
+    // A lever must out-INFLUENCE every non-lever here, or the ranking defect
+    // cannot manifest and this whole spec would pass for the wrong reason.
+    const maxLeverInfluence = Math.max(...levers.map((f) => f.influence_score ?? -Infinity));
+    const maxNonLeverInfluence = Math.max(...nonLevers.map((f) => f.influence_score ?? -Infinity));
+    expect(Number.isFinite(maxLeverInfluence)).toBe(true);
+    expect(Number.isFinite(maxNonLeverInfluence)).toBe(true);
+    expect(
+      maxLeverInfluence,
+      'a lever must top the raw graph influence order, else the defect cannot fire',
+    ).toBeGreaterThan(maxNonLeverInfluence);
+    // And that lever must be a genuinely SUPPRESSED one (sensitivity zeroed).
+    const topLever = levers.find((f) => f.influence_score === maxLeverInfluence);
+    expect(topLever.sensitivity_score).toBe(0);
+    expect(topLever.elasticity).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------
+  // THE DEFECT — RED before the fix
+  // ---------------------------------------------------------------------
+  it('importance_rank 1 is never an option-controlled lever when a non-lever exists', () => {
+    const rank1 = factors.find((f) => f.importance_rank === 1);
+    expect(rank1, 'some factor must hold importance_rank 1').toBeDefined();
+    expect(
+      LEVER_IDS.has(rank1.factor_id),
+      `importance_rank 1 went to lever "${rank1.factor_id}" (sensitivity_score ${rank1.sensitivity_score})`,
+    ).toBe(false);
+  });
+
+  it('importance_rank orders every non-lever ahead of every lever (total order preserved, no gaps, no ties)', () => {
+    const ranks = factors.map((f) => f.importance_rank);
+    expect(new Set(ranks).size, 'importance_rank must be unique per factor').toBe(factors.length);
+    expect([...ranks].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: factors.length }, (_, i) => i + 1),
+    );
+    const worstNonLever = Math.max(
+      ...factors.filter((f) => !LEVER_IDS.has(f.factor_id)).map((f) => f.importance_rank),
+    );
+    const bestLever = Math.min(
+      ...factors.filter((f) => LEVER_IDS.has(f.factor_id)).map((f) => f.importance_rank),
+    );
+    expect(bestLever).toBeGreaterThan(worstNonLever);
+  });
+
+  it('NON-REGRESSION: influence_rank/influence_score are untouched graph values (this is not a precedence flip)', () => {
+    // The lever still TOPS influence_rank, because it genuinely does top the
+    // structural influence order. Only the *importance* claim moved.
+    const influenceRank1 = factors.find((f) => f.influence_rank === 1);
+    expect(LEVER_IDS.has(influenceRank1.factor_id)).toBe(true);
+    expect(influenceRank1.influence_score).toBe(1);
+    // And influence_rank is still a dense 1..n over the graph order.
+    const iRanks = factors.map((f) => f.influence_rank).sort((a, b) => a - b);
+    expect(iRanks).toEqual(Array.from({ length: factors.length }, (_, i) => i + 1));
+  });
+
+  // ---------------------------------------------------------------------
+  // PINNED DIVERGENCE — deliberately NOT fixed by this lane.
+  //
+  // `driver_label: 'biggest'` (Doctrine 039 / D-7) is argmax over
+  // `influence_score` and is NOT lever-aware, so it disagrees with
+  // `importance_rank: 1`. Left alone on purpose: gating it would make the label
+  // contradict the number in its own row, its BASIS is already an open doctrine
+  // row owned by Neil/UI (src/lib/driver-label.ts), and blast radius is zero —
+  // censused 25 Jul at UI 039f479a / CEE f00b8ef6, `driver_label` has NO read
+  // site in either consumer.
+  //
+  // This test exists so the divergence CANNOT drift silently while the ruling is
+  // pending: if someone changes either rule, this goes RED and forces a decision.
+  // ---------------------------------------------------------------------
+  it("PINNED DIVERGENCE: 'biggest' still follows argmax(influence_score) and therefore still lands on the lever", () => {
+    const biggest = factors.filter((f) => f.driver_label === 'biggest');
+    expect(biggest.length, "exactly one factor carries the 'biggest' crown").toBe(1);
+    const maxInfluence = Math.max(...factors.map((f) => f.influence_score));
+    expect(biggest[0].influence_score).toBe(maxInfluence);
+    // ⚠ The crown IS on a lever, and that lever publishes zero sensitivity.
+    expect(LEVER_IDS.has(biggest[0].factor_id)).toBe(true);
+    expect(biggest[0].sensitivity_score).toBe(0);
+    // ⚠ …and it is NOT the factor this same response ranks importance_rank 1.
+    const rank1 = factors.find((f) => f.importance_rank === 1);
+    expect(biggest[0].factor_id).not.toBe(rank1.factor_id);
+  });
+
+  it('every non-biggest driver_label is still the pure magnitude band over influence_score', () => {
+    const maxInfluence = Math.max(...factors.map((f) => f.influence_score));
+    for (const f of factors) {
+      if (f.influence_score === maxInfluence) continue;
+      expect(['strong', 'moderate', 'minor'], f.factor_id).toContain(f.driver_label);
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // INTERNAL COHERENCE — the same body must not contradict itself
+  // ---------------------------------------------------------------------
+  it('importance_rank 1 agrees with decision_brief.top_drivers[0] in the SAME response body', () => {
+    const rank1 = factors.find((f) => f.importance_rank === 1);
+    const topDriver = body.decision_brief?.top_drivers?.[0];
+    expect(topDriver, 'decision_brief.top_drivers must be populated for this fixture').toBeDefined();
+    expect(rank1.factor_label).toBe(topDriver.factor_label);
+  });
+
+  it('importance_rank 1 agrees with the top m1_coaching.evidence_gaps entry (the other lever-aware surface)', () => {
+    const rank1 = factors.find((f) => f.importance_rank === 1);
+    const gaps = body.m1_coaching?.evidence_gaps ?? [];
+    expect(gaps.length, 'evidence_gaps must be populated for this fixture').toBeGreaterThan(0);
+    expect(rank1.factor_id).toBe(gaps[0].factor_id);
+  });
+
+  // ---------------------------------------------------------------------
+  // CROSS-AUTHORITY — on THIS fixture the fix also reconciles PLoT with ISL.
+  // Fixture-specific by construction (documented, not a general guarantee).
+  // ---------------------------------------------------------------------
+  it("PLoT's importance_rank 1 is the same factor as ISL's importance_rank 1 on this capture", () => {
+    const islRank1 = (capturePlain.factor_sensitivity as any[]).find((f) => f.importance_rank === 1);
+    expect(islRank1?.node_id).toBe('fac_hiring_cost'); // pin the fixture's own premise
+    const rank1 = factors.find((f) => f.importance_rank === 1);
+    expect(rank1.factor_id).toBe(islRank1.node_id);
+  });
+
+  // ---------------------------------------------------------------------
+  // FRAGILE-EDGE ORDER — `[0]` must be the MOST fragile edge
+  // ---------------------------------------------------------------------
+  it('positive control: the raw ISL capture really is NOT fragility-ordered', () => {
+    const raw = (capturePlain.robustness?.fragile_edges ?? []) as any[];
+    expect(raw.length, 'fixture must carry several fragile edges').toBeGreaterThan(2);
+    const probs = raw.map((e) => e.switch_probability);
+    expect(probs.every((p) => typeof p === 'number')).toBe(true);
+    // If ISL ever starts emitting these sorted, this control fails LOUD and the
+    // ordering assertion below becomes vacuous — exactly what we want to be told.
+    const alreadySorted = probs.every((p, i) => i === 0 || probs[i - 1] >= p);
+    expect(alreadySorted, 'ISL capture is already sorted — the ordering pin is now vacuous').toBe(false);
+    expect(probs[0], 'in this capture [0] is NOT the max').toBeLessThan(Math.max(...probs));
+  });
+
+  it('robustness.fragile_edges is published most-fragile-first', () => {
+    const edges = (body.robustness?.fragile_edges ?? []) as any[];
+    expect(edges.length).toBeGreaterThan(2);
+    const probs = edges.map((e) => e.switch_probability);
+    expect(probs.every((p) => typeof p === 'number')).toBe(true);
+    for (let i = 1; i < probs.length; i++) {
+      expect(probs[i - 1], `fragile_edges[${i - 1}] must be >= [${i}]`).toBeGreaterThanOrEqual(probs[i]);
+    }
+    expect(probs[0]).toBe(Math.max(...probs));
+    // No edge lost or duplicated by the sort.
+    const raw = (capturePlain.robustness.fragile_edges as any[]).map((e) => e.switch_probability);
+    expect([...probs].sort()).toEqual([...raw].sort());
+  });
+
+  // ---------------------------------------------------------------------
+  // DISCLOSURE — a consumer must be able to tell WHICH quantity it holds
+  // ---------------------------------------------------------------------
+  it('every factor row discloses the basis behind its importance/influence numbers', () => {
+    expect(factors.length).toBeGreaterThan(0);
+    for (const f of factors) {
+      expect(f.importance_basis, f.factor_id).toBe('graph_structural');
+    }
+  });
+});

--- a/tests/isl-adapters.test.ts
+++ b/tests/isl-adapters.test.ts
@@ -272,11 +272,38 @@ describe('Robustness Analysis Adapter', () => {
       const result = normalizeFragileEdges(edges);
 
       expect(result.edges).toHaveLength(2);
-      expect(result.edges[0].edge_id).toBe('a->b');
-      expect(result.edges[0].from_id).toBe('a');
-      expect(result.edges[0].to_id).toBe('b');
-      expect(result.edges[0].switch_probability).toBe(0.3);
+      // Field mapping asserted by IDENTITY, not position — normalizeFragileEdges
+      // sorts most-fragile-first (see the ordering test below), so `a->b`
+      // (0.3) is no longer index 0.
+      const ab = result.edges.find((e) => e.edge_id === 'a->b')!;
+      expect(ab).toBeDefined();
+      expect(ab.from_id).toBe('a');
+      expect(ab.to_id).toBe('b');
+      expect(ab.switch_probability).toBe(0.3);
       expect(result.errors).toHaveLength(0);
+    });
+
+    it('sorts most-fragile-first (ISL does not emit fragility order)', () => {
+      // Deliberately supplied ascending, i.e. the SHAPE of the live ISL wire,
+      // where fragile_edges[0] was the LEAST fragile.
+      const edges = [
+        { edge_id: 'low', from_id: 'a', to_id: 'b', switch_probability: 0.075 },
+        { edge_id: 'mid', from_id: 'c', to_id: 'd', switch_probability: 0.4 },
+        { edge_id: 'high', from_id: 'e', to_id: 'f', switch_probability: 0.61 },
+      ];
+      const result = normalizeFragileEdges(edges);
+      expect(result.edges.map((e) => e.edge_id)).toEqual(['high', 'mid', 'low']);
+    });
+
+    it('sorts entries with NO switch_probability last, never ahead of a measured edge', () => {
+      // Legacy STRING entries deliberately carry no switch_probability (omitted
+      // rather than fabricated as 0) — they must not outrank a measured edge.
+      const result = normalizeFragileEdges([
+        'legacy_a->legacy_b',
+        { edge_id: 'measured', from_id: 'c', to_id: 'd', switch_probability: 0.02 },
+      ]);
+      expect(result.edges.map((e) => e.edge_id)).toEqual(['measured', 'legacy_a->legacy_b']);
+      expect(result.edges[1].switch_probability).toBeUndefined();
     });
 
     it('handles string format edges (legacy)', () => {


### PR DESCRIPTION
## The defect: `/v2/run` contradicted itself about what matters most

Live-verified on **plot-lite-service-staging build `1dd45b6`** (== staging tip, so the deployed build
is exactly this code), real `POST /v2/run` with live ISL in the loop — not repo defaults, not the
render yamls:

| surface (one response body) | names #1 | applies PLoT's lever doctrine? |
|---|---|---|
| `factor_sensitivity[].importance_rank` = 1 | **Tech Lead in Place** | **NO** |
| `factor_sensitivity[].driver_label` = `biggest` | **Tech Lead in Place** | **NO** |
| `m1_coaching.key_drivers[0]` | **Tech Lead in Place** | **NO** |
| `decision_brief.top_drivers[0]` | Hiring and Salary Cost | yes |
| `m1_coaching.evidence_gaps[0]` | Hiring and Salary Cost | yes |
| `decision_brief` `DOMINANT_FACTOR` warning | Hiring and Salary Cost | yes |
| ISL's own `importance_rank` = 1 | Hiring and Salary Cost | n/a |

`fac_tech_lead` is an **option-pinned lever**. The same response forcibly zeroes its
`sensitivity_score`, `elasticity`, `value_of_information` and `elasticity_std`
(`LEVER_SUPPRESSION_FIELDS`) and withholds its EVPI with the stated reason that emitting it would
*"rank the lever as an investigation priority"*. `src/coaching/evidence-gaps.ts` states the doctrine
outright: levers are *"not background uncertainties to validate, so they are excluded BEFORE the
rank/quartile gate… prevents levers from consuming the top-k slots"*.

**Every surface that applied that ratified doctrine agreed with ISL. Every surface that did not,
named the lever.** So this fix needs no new ruling — it applies PLoT's existing doctrine to the field
that was missed.

## This is NOT a graph-vs-ISL precedence flip

Graph-derived factor sensitivity stays **PRIMARY** (`f6f7255`, 22 Jan — a deliberate, long-standing
choice; its commit body carries the field-mapping table, so the collision was decided, just never
declared). `influence_score` and `influence_rank` keep their **exact** graph values under their own,
correct names — the lever still tops `influence_rank`, because it genuinely does top the structural
influence order. Only the *importance* claim moved. Pinned by a non-regression test.

Note `importance_rank` was byte-identical to `influence_rank` on every live row, so it carried **zero
additional information**. Nothing is lost.

## Changes

1. **`importance_rank`** re-derived so every non-lever outranks every lever; the emitted array order
   follows it, so `factor_sensitivity[0]` and `importance_rank === 1` agree. No-op on a degenerate
   partition (all levers, or no levers) — returns the same array reference. New module
   `src/lib/importance-authority.ts`.
2. **`importance_basis`** (`'graph_structural' | 'isl_uncertainty'`) on every row — the runtime
   disclosure of *which authority produced the rank*. Before this, the graph quantity rode ISL's field
   names with ISL's values discarded and **no way for any consumer to detect it**.
3. **`robustness.fragile_edges` sorted most-fragile-first.** ISL does not emit fragility order — live
   it came back `[0.075, 0.281, 0.375, 0.487, 0.569, 0.61, 0.307]`, so `[0]` was the **least** fragile
   of seven. Consumers that read the head without sorting: PLoT `decision-brief.buildWhatWouldChange`,
   PLoT `sensitive_parameters` recommendations, CEE `decompose.ts` `fragileEdges[0]` →
   `stabilityHint.top_fragile_edge`, CEE `deriveTopFragileEdges`, and several CEE advice-gate
   `renderableFragileEdges(analysis)[0]` sites. Consumers that already sort/max (PLoT `pickTopFragile`,
   CEE `deriveTopFragileEdgesFromTopLevel`, every live UI site) are unaffected — sorting an
   already-max-first array is a no-op for them.
4. **Contract honesty.** New `BoundarySubstitution` category (producer-name/local-value collisions were
   not *representable* before, which is why this went undeclared for six months); **6 previously
   undeclared drops** declared; **2 undeclared renames** (`from_id`→`from`, `to_id`→`to`) declared; the
   fragile-edge reorder declared; and the **false `factor_sensitivity[].source // Constant: 'isl'`
   line corrected** — every live row has published `'graph'` since `f6f7255`.
5. **OpenAPI.** `importance_basis` + `importance_rank` documented with the lever semantics;
   `sensitivity_score` annotated as a substitution; **`importance_score` marked NOT EMITTED** — the
   hand-authored spec was advertising a field that has never been on the wire (`FactorSensitivityResultV3`
   has no such member on either path).

## Deliberately NOT changed — rowed instead

- **`driver_label: 'biggest'` still lands on the lever.** I built the lever gate, then **reverted it**.
  `'biggest'` is *defined* by Doctrine 039 as argmax `influence_score`; gating it makes the label
  contradict the number in its own row (lever at 1.0 → `'strong'`, beneath a 0.497 → `'biggest'`) —
  trading one incoherence for another. Its **basis** is already an open doctrine row owned by Neil/UI
  (`src/lib/driver-label.ts`). Blast radius is **zero**: censused at the consumer tips (UI `039f479a`,
  CEE `f00b8ef6`) — `factor_sensitivity[].driver_label` has **no read site in either repo**.
  → **PINNED by a test** so it cannot drift silently while the ruling is pending.
- **`m1_coaching.key_drivers` still ranks the lever #1** — same class, CEE-facing, its sibling
  `evidence_gaps` already excludes levers.
- **`importance_score` / `edge_sensitivity.sensitivity_score` / `.direction`: declared, not un-dropped.**
  Un-dropping alone fixes nothing — the UI rebuilds `factor_sensitivity` rows from an explicit
  allowlist on 2 of 3 mapper branches and on all of V5, so a restored field reaches no consumer without
  a UI change.
- **No Fastify response schema for `/v2/run`** — genuinely too large for this lane, so rowed rather
  than half-done.

## Evidence

- **RED-first.** `tests/importance-rank-lever-doctrine.fixture.test.ts` fails **8 of 9** on the pre-fix
  build. It carries **positive controls** first, so no assertion can pass vacuously: it proves the
  fixture really contains levers *and* non-levers, that a lever really tops the raw influence order
  (else the defect cannot fire), and that the raw ISL capture really is *not* fragility-ordered.
- **Mutation-checked in a throwaway worktree**, runner sanity-checked GREEN (12 tests) before mutating.
  Three independent mutations, each biting on its own: neutralise the lever-aware ordering → **6 RED**;
  neutralise the fragile-edge sort → **4 RED** across 3 files; neutralise `importance_basis` → **1 RED**.
  Restored → 12 green.
- **Full authoritative gate green:** `npm test` **exit 0**, 560 files / 5938 tests passed, 0 failed.
  Pre-push validation passed, 6 checks, 0 failures.
- **Golden regenerated deliberately; every byte of the delta is accounted for** (identity-matched, not
  positional). One knock-on, and it is the same defect propagating: `m1_coaching.assumptions_ledger`
  moved `fac_dev_headcount` (a suppressed lever, elasticity 0) from `high`/`HIGH_INFLUENCE_FACTOR` →
  `low`/`STRUCTURAL_ONLY`, and `fac_team_maturity` (a genuine uncertainty driver) from `medium` →
  `high` — `classifyFactorImpact` gates on `importance_rank <= 3`, so the lever was earning a
  "high influence" assumption label purely from a rank it should never have held.

## Cross-repo blast radius (censused at the tips, 25 Jul)

Schema pins: UI `0.22.0` · CEE `0.23.0` · PLoT `0.22.0`.

- **`importance_rank`** — UI `responseMapper.sortFactorsByImportance` uses it as the **primary sort
  key**, and CEE `/v1/review` `robustnessSynthesis` sorts investigation suggestions on it. Both now
  order genuine uncertainty drivers ahead of levers. **This is the intended behaviour change.**
- **`importance_basis`** — additive. Verified it is neither rejected nor stripped on any live ingress
  seam in CEE (`.passthrough()` throughout; the `/v2/run` HTTP client discards the parse result and
  returns the raw body). In the UI it survives on the `top_level` mapper branch and is dropped on the
  other two and on V5 — i.e. **safe but currently inert there**; a UI-side change is needed for it to
  land. Rowed.
- **`fragile_edges` order** — no live UI site assumes wire order (every consumer sorts or max-scans);
  several CEE sites do, and are fixed by this.
- **`driver_label`** — zero read sites in either repo.