### PR TITLE
fix(analysis): stop 500 on malformed sequential_metadata.stages + log unhandled errors

### DIFF
--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -1490,7 +1490,32 @@ export async function createServer(opts: ServerOpts = {}) {
       req.log.warn({ evt: 'oversize', id: req.id, route: sanitizedRoute, bytes, reason: 'body_too_large' });
       return replyWithAppError(reply, { type: 'BAD_INPUT', statusCode: 413, message: 'Request entity too large' });
     }
-    // Fallback INTERNAL
+    // Fallback INTERNAL.
+    //
+    // This branch used to reply "Something went wrong" while logging NOTHING.
+    // Fastify does not auto-log once a custom error handler is installed, so an
+    // unhandled throw left no trace anywhere: a lane debugging live 500s on
+    // /v1/analysis/sequential and /v1/analysis/policy-tree had no log line to
+    // find and could not identify the failing line. An unexplainable 5xx is a
+    // defect in its own right, independent of whatever caused it.
+    //
+    // What is logged: the error's identity and stack only — never the request
+    // body, headers or query. Every field still passes through THE logger
+    // boundary (src/logging/log-boundary.ts), which digests the decision tokens
+    // registered from this request's body at preValidation, so user content
+    // interpolated into an error message is scrubbed there rather than here.
+    // `id` matches the `request_id` returned to the caller in the 500 body.
+    req.log.error({
+      evt: 'unhandled_error',
+      id: req.id,
+      route,
+      err_name: (err as any)?.name,
+      err_code: code || undefined,
+      err_message: emsgRaw,
+      status_code: (err as any)?.statusCode,
+      stack: (err as any)?.stack,
+    });
+
     const { msg } = await import('./lib/error-messages.js');
     return replyWithAppError(reply, { type: 'INTERNAL', statusCode: 500, message: msg('INTERNAL_UNEXPECTED') });
   });

--- a/src/routes/v1/analysis-policy-tree.ts
+++ b/src/routes/v1/analysis-policy-tree.ts
@@ -252,6 +252,26 @@ export async function registerPolicyTreeRoute(app: FastifyInstance) {
         });
       }
 
+      // Return early with validation errors if severe.
+      //
+      // `validation` was previously computed and then discarded here, so a
+      // structurally invalid graph produced a silently degraded tree with no
+      // signal to the caller — while sequential-validation.ts's own contract
+      // table documented this route as "Full validation, blocks on error →
+      // 400 BAD_INPUT". This makes the code match its documented contract.
+      // Warning-severity issues remain non-blocking.
+      if (!validation.valid) {
+        const errors = validation.issues.filter((i) => i.severity === 'error');
+        if (errors.length > 0) {
+          return replyWithAppError(reply, {
+            type: 'BAD_INPUT',
+            statusCode: 400,
+            message: `Sequential validation failed: ${errors[0].message}`,
+            fields: { code: errors[0].code },
+          });
+        }
+      }
+
       // Detect outcome node
       const seed = body.seed ?? 4242;
       let outcomeNode = body.outcome_node ?? '';

--- a/src/util/sequential-validation.ts
+++ b/src/util/sequential-validation.ts
@@ -28,6 +28,24 @@
  * - `MISSING_SEQUENTIAL_METADATA` (warning): Nodes have stages but no metadata
  * - `INVALID_DECISION_KIND` (warning): Decision node has wrong kind
  * - `FORWARD_REFERENCE` (warning): Edge from later stage to earlier stage
+ * - `INVALID_SEQUENTIAL_METADATA` (error): `stages` is not an array
+ * - `INVALID_STAGE_DEFINITION` (error): A `stages[]` entry is not a stage object
+ * - `MISSING_STAGE_ID_LIST` (warning): Stage omits `decisions`/`resolved_uncertainties`
+ * - `INVALID_STAGE_ID_LIST` (warning): Stage id list present but not an array
+ *
+ * ## This function must be TOTAL
+ *
+ * The analysis routes cast the request body (`req.body as ...`) with no runtime
+ * schema validation of `sequential_metadata`, so everything below is UNTRUSTED
+ * JSON whatever the TypeScript types promise. This function previously iterated
+ * `stage.decisions` directly; a caller that omitted the field (sending, say,
+ * `decision_node_id` instead) hit `for...of undefined`, and the resulting
+ * TypeError surfaced to users as an opaque 500 "Something went wrong" on both
+ * POST /v1/analysis/sequential and POST /v1/analysis/policy-tree.
+ *
+ * Rule for anyone editing this file: never index into a field of `graph`,
+ * `sequential_metadata` or a stage without first proving its shape. Malformed
+ * input must produce a typed issue, never a throw.
  */
 
 import type { Graph, StageDefinition, GraphNode, GraphEdge } from '../trust/types.js';
@@ -48,19 +66,106 @@ export interface SequentialValidationResult {
   nodes_by_stage: Map<number, string[]>;
 }
 
+/** Total array read — untrusted input may put anything here. */
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+/** Human-readable stage reference for issue messages, safe on a missing label. */
+function stageRef(stage: StageDefinition): string {
+  const label = typeof stage.label === 'string' ? stage.label : '';
+  return label ? `${stage.index} ("${label}")` : `${stage.index}`;
+}
+
+/**
+ * Read a stage's list of node IDs without trusting the declared type.
+ *
+ * `StageDefinition` declares `decisions` and `resolved_uncertainties` as
+ * required `string[]`, but nothing validates the wire payload against that, so
+ * both may be absent or the wrong type. Neither case can be fatal: both routes
+ * derive their stages from `node.stage`, not from these lists, so the analysis
+ * is still computable — the omission is reported as a warning and the list is
+ * treated as empty rather than silently ignored.
+ *
+ * Pass `issues` only where the report should be recorded; internal re-reads
+ * omit it so the same omission is not reported twice.
+ */
+function readStageIdList(
+  stage: StageDefinition,
+  field: 'decisions' | 'resolved_uncertainties',
+  issues?: SequentialValidationIssue[]
+): string[] {
+  const raw = (stage as unknown as Record<string, unknown>)[field];
+
+  if (Array.isArray(raw)) {
+    return raw.filter((id): id is string => typeof id === 'string');
+  }
+
+  if (raw === undefined || raw === null) {
+    issues?.push({
+      code: 'MISSING_STAGE_ID_LIST',
+      message: `Stage ${stageRef(stage)} is missing "${field}". Treating it as empty — supply "${field}" as an array of node IDs for complete sequential validation.`,
+      severity: 'warning',
+    });
+  } else {
+    issues?.push({
+      code: 'INVALID_STAGE_ID_LIST',
+      message: `Stage ${stageRef(stage)} has "${field}" of type ${typeof raw}, expected an array of node IDs. Treating it as empty.`,
+      severity: 'warning',
+    });
+  }
+
+  return [];
+}
+
+/**
+ * Filter `stages` down to entries that are actually stage objects, reporting
+ * each reject as a typed error issue.
+ */
+function readStageDefinitions(
+  rawStages: unknown[],
+  issues: SequentialValidationIssue[]
+): StageDefinition[] {
+  const stages: StageDefinition[] = [];
+
+  rawStages.forEach((entry, i) => {
+    const isStageObject =
+      entry !== null &&
+      typeof entry === 'object' &&
+      !Array.isArray(entry) &&
+      typeof (entry as { index?: unknown }).index === 'number' &&
+      Number.isFinite((entry as { index: number }).index);
+
+    if (!isStageObject) {
+      issues.push({
+        code: 'INVALID_STAGE_DEFINITION',
+        message: `sequential_metadata.stages[${i}] is not a valid stage definition — expected an object with a numeric "index", received ${entry === null ? 'null' : Array.isArray(entry) ? 'array' : typeof entry}.`,
+        severity: 'error',
+      });
+      return;
+    }
+
+    stages.push(entry as StageDefinition);
+  });
+
+  return stages;
+}
+
 /**
  * Validate sequential graph metadata and node assignments
  */
 export function validateSequentialGraph(graph: Graph): SequentialValidationResult {
   const issues: SequentialValidationIssue[] = [];
-  const nodeMap = new Map<string, GraphNode>(graph.nodes.map((n) => [n.id, n]));
-  const edgeMap = buildEdgeMap(graph.edges);
+  const graphNodes = asArray<GraphNode>(graph?.nodes);
+  const graphEdges = asArray<GraphEdge>(graph?.edges);
+  const nodeMap = new Map<string, GraphNode>(graphNodes.map((n) => [n.id, n]));
+  const edgeMap = buildEdgeMap(graphEdges);
   const nodesByStage = new Map<number, string[]>();
 
   // If no sequential_metadata, check for node-level stage assignments
-  if (!graph.sequential_metadata) {
+  if (!graph?.sequential_metadata) {
     // Collect nodes with stage assignments
-    for (const node of graph.nodes) {
+    for (const node of graphNodes) {
       if (node.stage !== undefined) {
         const stageNodes = nodesByStage.get(node.stage) ?? [];
         stageNodes.push(node.id);
@@ -86,7 +191,7 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
     };
   }
 
-  const { stages, is_sequential } = graph.sequential_metadata;
+  const { stages: rawStages, is_sequential } = graph.sequential_metadata;
 
   if (!is_sequential) {
     return {
@@ -96,6 +201,23 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
       nodes_by_stage: new Map(),
     };
   }
+
+  // `stages` is untrusted: a non-array here used to reach `stages.map` and throw.
+  if (!Array.isArray(rawStages)) {
+    issues.push({
+      code: 'INVALID_SEQUENTIAL_METADATA',
+      message: `sequential_metadata.stages must be an array of stage definitions, received ${rawStages === null ? 'null' : typeof rawStages}.`,
+      severity: 'error',
+    });
+    return {
+      valid: false,
+      issues,
+      stage_count: 0,
+      nodes_by_stage: nodesByStage,
+    };
+  }
+
+  const stages = readStageDefinitions(rawStages, issues);
 
   // Validate stage indices are contiguous starting from 0
   const stageIndices = stages.map((s) => s.index).sort((a, b) => a - b);
@@ -112,13 +234,16 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
 
   // Validate each stage definition
   for (const stage of stages) {
+    const decisions = readStageIdList(stage, 'decisions', issues);
+    const resolvedUncertainties = readStageIdList(stage, 'resolved_uncertainties', issues);
+
     // Check decisions exist in graph
-    for (const decisionId of stage.decisions) {
+    for (const decisionId of decisions) {
       const node = nodeMap.get(decisionId);
       if (!node) {
         issues.push({
           code: 'MISSING_DECISION_NODE',
-          message: `Stage ${stage.index} ("${stage.label}") references decision node "${decisionId}" which does not exist in graph.`,
+          message: `Stage ${stageRef(stage)} references decision node "${decisionId}" which does not exist in graph.`,
           severity: 'error',
           affected_ids: [decisionId],
         });
@@ -133,12 +258,12 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
     }
 
     // Check resolved uncertainties exist in graph
-    for (const uncId of stage.resolved_uncertainties) {
+    for (const uncId of resolvedUncertainties) {
       const node = nodeMap.get(uncId);
       if (!node) {
         issues.push({
           code: 'MISSING_UNCERTAINTY_NODE',
-          message: `Stage ${stage.index} ("${stage.label}") references uncertainty node "${uncId}" which does not exist in graph.`,
+          message: `Stage ${stageRef(stage)} references uncertainty node "${uncId}" which does not exist in graph.`,
           severity: 'error',
           affected_ids: [uncId],
         });
@@ -146,12 +271,12 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
     }
 
     // Track nodes by stage
-    const stageNodeIds = [...stage.decisions, ...stage.resolved_uncertainties];
+    const stageNodeIds = [...decisions, ...resolvedUncertainties];
     nodesByStage.set(stage.index, stageNodeIds);
   }
 
   // Validate node stage assignments match stage definitions
-  for (const node of graph.nodes) {
+  for (const node of graphNodes) {
     if (node.stage !== undefined) {
       const stageDef = stages.find((s) => s.index === node.stage);
       if (!stageDef) {
@@ -167,7 +292,7 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
 
   // Validate no forward references (edges from later stages to earlier stages)
   const nodeStages = buildNodeStageMap(graph);
-  for (const edge of graph.edges) {
+  for (const edge of graphEdges) {
     const fromStage = nodeStages.get(edge.from);
     const toStage = nodeStages.get(edge.to);
 
@@ -183,8 +308,14 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
 
   // Validate discount factor if present
   const discountFactor = graph.sequential_metadata.default_discount_factor;
-  if (discountFactor !== undefined) {
-    if (discountFactor < 0 || discountFactor > 1) {
+  if (discountFactor !== undefined && discountFactor !== null) {
+    if (typeof discountFactor !== 'number' || !Number.isFinite(discountFactor)) {
+      issues.push({
+        code: 'INVALID_DISCOUNT_FACTOR',
+        message: `Discount factor must be a number between 0 and 1, received ${typeof discountFactor}.`,
+        severity: 'error',
+      });
+    } else if (discountFactor < 0 || discountFactor > 1) {
       issues.push({
         code: 'INVALID_DISCOUNT_FACTOR',
         message: `Discount factor must be between 0 and 1, got ${discountFactor}.`,
@@ -209,19 +340,23 @@ function buildNodeStageMap(graph: Graph): Map<string, number> {
   const nodeStages = new Map<string, number>();
 
   // First, use explicit node.stage assignments
-  for (const node of graph.nodes) {
-    if (node.stage !== undefined) {
+  for (const node of asArray<GraphNode>(graph?.nodes)) {
+    if (node?.stage !== undefined) {
       nodeStages.set(node.id, node.stage);
     }
   }
 
-  // Then, fill in from stage definitions
-  if (graph.sequential_metadata?.stages) {
-    for (const stage of graph.sequential_metadata.stages) {
-      for (const id of [...stage.decisions, ...stage.resolved_uncertainties]) {
-        if (!nodeStages.has(id)) {
-          nodeStages.set(id, stage.index);
-        }
+  // Then, fill in from stage definitions. Re-reads the id lists without an
+  // `issues` sink: any malformation here was already reported by the caller.
+  for (const stage of asArray<StageDefinition>(graph?.sequential_metadata?.stages)) {
+    if (!stage || typeof stage !== 'object' || typeof stage.index !== 'number') continue;
+    const ids = [
+      ...readStageIdList(stage, 'decisions'),
+      ...readStageIdList(stage, 'resolved_uncertainties'),
+    ];
+    for (const id of ids) {
+      if (!nodeStages.has(id)) {
+        nodeStages.set(id, stage.index);
       }
     }
   }
@@ -234,7 +369,8 @@ function buildNodeStageMap(graph: Graph): Map<string, number> {
  */
 function buildEdgeMap(edges: GraphEdge[]): Map<string, string[]> {
   const edgeMap = new Map<string, string[]>();
-  for (const edge of edges) {
+  for (const edge of asArray<GraphEdge>(edges)) {
+    if (!edge || typeof edge !== 'object') continue;
     const targets = edgeMap.get(edge.from) ?? [];
     targets.push(edge.to);
     edgeMap.set(edge.from, targets);
@@ -246,12 +382,12 @@ function buildEdgeMap(edges: GraphEdge[]): Map<string, string[]> {
  * Check if a graph is sequential (has multi-stage structure)
  */
 export function isSequentialGraph(graph: Graph): boolean {
-  if (graph.sequential_metadata?.is_sequential) {
+  if (graph?.sequential_metadata?.is_sequential) {
     return true;
   }
 
   // Check for node-level stage assignments
-  return graph.nodes.some((n) => n.stage !== undefined);
+  return asArray<GraphNode>(graph?.nodes).some((n) => n?.stage !== undefined);
 }
 
 /**
@@ -260,14 +396,14 @@ export function isSequentialGraph(graph: Graph): boolean {
 export function getMaxStage(graph: Graph): number {
   let maxStage = 0;
 
-  if (graph.sequential_metadata?.stages) {
-    for (const stage of graph.sequential_metadata.stages) {
+  for (const stage of asArray<StageDefinition>(graph?.sequential_metadata?.stages)) {
+    if (typeof stage?.index === 'number' && Number.isFinite(stage.index)) {
       maxStage = Math.max(maxStage, stage.index);
     }
   }
 
-  for (const node of graph.nodes) {
-    if (node.stage !== undefined) {
+  for (const node of asArray<GraphNode>(graph?.nodes)) {
+    if (typeof node?.stage === 'number' && Number.isFinite(node.stage)) {
       maxStage = Math.max(maxStage, node.stage);
     }
   }

--- a/tests/sequential-malformed-stages.regression.test.ts
+++ b/tests/sequential-malformed-stages.regression.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Regression pin: malformed `sequential_metadata.stages[]` must not 500.
+ *
+ * DEFECT (reproduced against staging build 04f6dbac, and offline here):
+ * `validateSequentialGraph` iterated `stage.decisions` and
+ * `stage.resolved_uncertainties` with no undefined guard. `StageDefinition`
+ * types both as required `string[]`, but the routes cast the request body
+ * (`req.body as SequentialAnalysisRequest`) with NO runtime validation of
+ * `sequential_metadata`, so any client omitting those arrays reached
+ * `for...of undefined` and crashed the handler:
+ *
+ *   POST /v1/analysis/sequential  -> 500 INTERNAL "Something went wrong"
+ *   POST /v1/analysis/policy-tree -> 500 INTERNAL "Something went wrong"
+ *
+ * The analysis itself never needed those arrays — both routes derive stages
+ * from `node.stage`. So the correct behaviour is a successful 200 carrying a
+ * typed, actionable validation issue naming the field that was ignored, not a
+ * rejection and certainly not a crash.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { registerSequentialAnalysisRoute } from '../src/routes/v1/analysis-sequential.js';
+import { registerPolicyTreeRoute } from '../src/routes/v1/analysis-policy-tree.js';
+import { validateSequentialGraph, getMaxStage } from '../src/util/sequential-validation.js';
+
+/**
+ * The prior lane's exact staging probe payload. Its stages carry
+ * `decision_node_id`/`timing` and NEITHER `decisions` NOR
+ * `resolved_uncertainties`.
+ */
+function malformedStagePayload() {
+  return {
+    graph: {
+      nodes: [
+        { id: 'd1', label: 'Launch pilot', kind: 'decision', stage: 0 },
+        { id: 'o1a', label: 'Pilot one region', kind: 'option', stage: 0, value: 60 },
+        { id: 'o1b', label: 'Pilot nationwide', kind: 'option', stage: 0, value: 40 },
+        { id: 'f1', label: 'Market response', kind: 'factor', stage: 0, value: 50 },
+        { id: 'd2', label: 'Scale or hold', kind: 'decision', stage: 1 },
+        { id: 'o2a', label: 'Scale up', kind: 'option', stage: 1, value: 70 },
+        { id: 'o2b', label: 'Hold', kind: 'option', stage: 1, value: 30 },
+        { id: 'out', label: '12-month profit', kind: 'outcome', stage: 1, value: 100 },
+      ],
+      edges: [
+        { from: 'o1a', to: 'f1', weight: 0.6 },
+        { from: 'o1b', to: 'f1', weight: 0.4 },
+        { from: 'f1', to: 'out', weight: 0.5 },
+        { from: 'o2a', to: 'out', weight: 0.7 },
+        { from: 'o2b', to: 'out', weight: 0.3 },
+      ],
+      sequential_metadata: {
+        is_sequential: true,
+        stages: [
+          { index: 0, label: 'Launch pilot', decision_node_id: 'd1', timing: 'now' },
+          { index: 1, label: 'Scale or hold', decision_node_id: 'd2', timing: 'next' },
+        ],
+      },
+    },
+    discount_factor: 0.95,
+    outcome_node: 'out',
+  };
+}
+
+/** Same graph, with the contract-declared stage fields present. */
+function wellFormedStagePayload() {
+  const p = malformedStagePayload();
+  p.graph.sequential_metadata.stages = [
+    { index: 0, label: 'Launch pilot', decisions: ['d1'], resolved_uncertainties: ['f1'] },
+    { index: 1, label: 'Scale or hold', decisions: ['d2'], resolved_uncertainties: [] },
+  ] as any;
+  return p;
+}
+
+describe('validateSequentialGraph — malformed stage definitions must not throw', () => {
+  it('does not throw when a stage omits decisions / resolved_uncertainties', () => {
+    const graph = malformedStagePayload().graph as any;
+
+    // RED before the fix: throws TypeError "stage.decisions is not iterable".
+    expect(() => validateSequentialGraph(graph)).not.toThrow();
+
+    const result = validateSequentialGraph(graph);
+
+    // The omission is surfaced, not silently swallowed.
+    const codes = result.issues.map((i) => i.code);
+    expect(codes).toContain('MISSING_STAGE_ID_LIST');
+
+    // Actionable: the issue names the stage and the exact field that was ignored.
+    const issue = result.issues.find((i) => i.code === 'MISSING_STAGE_ID_LIST')!;
+    expect(issue.severity).toBe('warning');
+    expect(issue.message).toContain('decisions');
+
+    // A missing optional-in-practice list is not fatal — analysis uses node.stage.
+    expect(result.valid).toBe(true);
+    expect(result.stage_count).toBe(2);
+  });
+
+  it('does not throw when stages is not an array', () => {
+    const graph = malformedStagePayload().graph as any;
+    graph.sequential_metadata.stages = 'not-an-array';
+
+    expect(() => validateSequentialGraph(graph)).not.toThrow();
+    const result = validateSequentialGraph(graph);
+    expect(result.issues.map((i) => i.code)).toContain('INVALID_SEQUENTIAL_METADATA');
+    expect(result.valid).toBe(false); // genuinely malformed -> route returns typed 400
+  });
+
+  it('does not throw when a stage entry is null or not an object', () => {
+    const graph = malformedStagePayload().graph as any;
+    graph.sequential_metadata.stages = [null, 42, { index: 0, label: 'ok', decisions: [], resolved_uncertainties: [] }];
+
+    expect(() => validateSequentialGraph(graph)).not.toThrow();
+    const result = validateSequentialGraph(graph);
+    expect(result.issues.map((i) => i.code)).toContain('INVALID_STAGE_DEFINITION');
+  });
+
+  it('does not throw when a stage id list is present but the wrong type', () => {
+    const graph = malformedStagePayload().graph as any;
+    graph.sequential_metadata.stages = [
+      { index: 0, label: 'Launch', decisions: 'd1', resolved_uncertainties: { a: 1 } },
+    ];
+
+    expect(() => validateSequentialGraph(graph)).not.toThrow();
+    const result = validateSequentialGraph(graph);
+    expect(result.issues.map((i) => i.code)).toContain('INVALID_STAGE_ID_LIST');
+  });
+
+  it('getMaxStage does not throw on malformed stages', () => {
+    const graph = malformedStagePayload().graph as any;
+    graph.sequential_metadata.stages = [null, { index: 3 }, 'x'];
+    expect(() => getMaxStage(graph)).not.toThrow();
+    expect(getMaxStage(graph)).toBe(3);
+  });
+
+  it('still validates a well-formed sequential graph with no issues', () => {
+    // Guards must not swallow the real validation behaviour.
+    const result = validateSequentialGraph(wellFormedStagePayload().graph as any);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.stage_count).toBe(2);
+  });
+});
+
+describe('POST /v1/analysis/sequential — malformed stages return 200, not 500', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await registerSequentialAnalysisRoute(app);
+    await registerPolicyTreeRoute(app);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  beforeEach(() => {
+    process.env.ENABLE_SEQUENTIAL_ANALYSIS = '1';
+    delete process.env.ISL_SEQUENTIAL_ENABLE;
+    delete process.env.ISL_POLICY_TREE_ENABLE;
+    delete process.env.ISL_ENABLE;
+  });
+
+  it('sequential: returns 200 for stages missing decisions[] (was 500 INTERNAL)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/analysis/sequential',
+      payload: malformedStagePayload(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.schema).toBe('sequential_analysis.v1');
+
+    // The ignored field is reported back to the caller, typed and actionable.
+    const codes = body.validation.issues.map((i: any) => i.code);
+    expect(codes).toContain('MISSING_STAGE_ID_LIST');
+  });
+
+  it('policy-tree: returns 200 for stages missing decisions[] (was 500 INTERNAL)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/analysis/policy-tree',
+      payload: malformedStagePayload(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.schema).toBe('policy_tree.v1');
+    expect(body.tree.nodes.length).toBeGreaterThan(1);
+  });
+
+  it('sequential: genuinely malformed stages get a typed 400, never a 500', async () => {
+    const payload = malformedStagePayload() as any;
+    payload.graph.sequential_metadata.stages = 'not-an-array';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/analysis/sequential',
+      payload,
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.payload);
+    // Typed and actionable, not "Something went wrong".
+    expect(body.code).toBe('INVALID_SEQUENTIAL_METADATA');
+    expect(body.error.type).toBe('BAD_INPUT');
+    expect(body.message).toContain('stages must be an array');
+    expect(body.message).not.toContain('Something went wrong');
+  });
+
+  it('policy-tree: genuinely malformed stages get a typed 400, never a 500', async () => {
+    // sequential-validation.ts documents this route as "Full validation, blocks
+    // on error -> 400 BAD_INPUT"; the route previously discarded `validation`.
+    const payload = malformedStagePayload() as any;
+    payload.graph.sequential_metadata.stages = 'not-an-array';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/analysis/policy-tree',
+      payload,
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.payload);
+    expect(body.code).toBe('INVALID_SEQUENTIAL_METADATA');
+    expect(body.error.type).toBe('BAD_INPUT');
+  });
+
+  /**
+   * POSITIVE CONTROL for the local fallback at analysis-sequential.ts:356.
+   *
+   * A fallback that never executes is guarantee theatre. This proves it runs
+   * AND that what it produces is non-empty — an assertion that it merely
+   * "returned an object" would pass even if the fallback computed nothing.
+   */
+  it('local fallback executes and produces non-vacuous content when ISL is off', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/analysis/sequential',
+      payload: wellFormedStagePayload(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+
+    expect(body.provenance).toBe('plot_fallback');
+    expect(body.analysis.stage_decisions.length).toBeGreaterThan(0);
+    expect(body.analysis.strategy_summary).toContain('Optimal strategy');
+    expect(body.analysis.strategy_summary).not.toBe('No sequential decisions found');
+    for (const d of body.analysis.stage_decisions) {
+      expect(typeof d.expected_value).toBe('number');
+      expect(Number.isFinite(d.expected_value)).toBe(true);
+      expect(d.optimal_option_id).toBeTruthy();
+    }
+  });
+});

--- a/tests/unhandled-error-logging.test.ts
+++ b/tests/unhandled-error-logging.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression pin: an unhandled route throw must be LOGGED, not silently
+ * converted into an opaque 500.
+ *
+ * DEFECT: `createServer.ts` installs a custom `setErrorHandler`. Fastify does
+ * not auto-log once a custom handler is installed, and the handler's fallback
+ * branch replied `INTERNAL / "Something went wrong"` while logging NOTHING.
+ * Measured on staging build 04f6dbac: zero level-50 records, and the error
+ * message present nowhere in the log stream. A lane debugging a live 500 had
+ * no log line to find — the failure was unexplainable by construction.
+ *
+ * The fix logs one error-level record correlated by request id. It carries the
+ * error identity and stack only. It never carries the request body, headers or
+ * query — and every field still passes through THE logger boundary
+ * (`src/logging/log-boundary.ts`), which digests registered decision tokens, so
+ * user content interpolated into an error message is scrubbed there.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { createServer } from '../src/createServer.js';
+
+const THROW_ROUTE = '/__lane_p_unhandled_throw';
+const THROW_MARKER = 'lane_p_unhandled_marker';
+const CONTROL_MARKER = 'lane_p_log_capture_control';
+const SECRET_ISH_BODY_VALUE = 'lane_p_body_value_must_not_be_logged';
+
+let app: FastifyInstance;
+let captured = '';
+let controlSeen = false;
+
+const prevAuth = process.env.AUTH_ENABLED;
+const prevSecret = process.env.TOKEN_HMAC_SECRET;
+
+beforeAll(async () => {
+  process.env.AUTH_ENABLED = '0';
+  process.env.TOKEN_HMAC_SECRET =
+    process.env.TOKEN_HMAC_SECRET ||
+    'abc123456789012345678901234567890123456789012345678901234567890123';
+
+  // The stdout hook MUST be installed before createServer(): pino binds its
+  // destination when the logger is constructed, so patching afterwards captures
+  // nothing. That mistake makes every assertion below vacuous, which is exactly
+  // what the positive control exists to catch — it did catch it.
+  const realWrite = process.stdout.write.bind(process.stdout);
+  (process.stdout as any).write = (chunk: any, ...rest: any[]) => {
+    try {
+      captured += String(chunk);
+    } catch {
+      /* ignore */
+    }
+    return (realWrite as any)(chunk, ...rest);
+  };
+
+  try {
+    app = await createServer({});
+    app.post(THROW_ROUTE, async () => {
+      throw new TypeError(THROW_MARKER);
+    });
+    await app.ready();
+
+    // POSITIVE CONTROL: a record we know is emitted. If this is not captured,
+    // the probe is blind and every assertion below would pass or fail
+    // vacuously — so the control is asserted first, as its own test.
+    app.log.error({ evt: CONTROL_MARKER });
+
+    await app.inject({
+      method: 'POST',
+      url: THROW_ROUTE,
+      payload: { note: SECRET_ISH_BODY_VALUE },
+    });
+  } finally {
+    (process.stdout as any).write = realWrite;
+  }
+
+  controlSeen = captured.includes(CONTROL_MARKER);
+});
+
+afterAll(async () => {
+  if (app) await app.close();
+  if (prevAuth === undefined) delete process.env.AUTH_ENABLED;
+  else process.env.AUTH_ENABLED = prevAuth;
+  if (prevSecret === undefined) delete process.env.TOKEN_HMAC_SECRET;
+  else process.env.TOKEN_HMAC_SECRET = prevSecret;
+});
+
+describe('unhandled route errors are diagnosable', () => {
+  it('POSITIVE CONTROL: the log probe can see log records at all', () => {
+    expect(captured.length).toBeGreaterThan(0);
+    expect(controlSeen).toBe(true);
+  });
+
+  it('emits an error-level log record for an unhandled throw', () => {
+    expect(controlSeen).toBe(true); // guard: never assert on a blind probe
+    const records = captured
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter((r): r is any => r !== null)
+      .filter((r) => r.evt === 'unhandled_error');
+
+    expect(records.length).toBeGreaterThan(0);
+    const rec = records[0];
+
+    expect(rec.level).toBe(50);
+    expect(rec.route).toBe(THROW_ROUTE);
+    expect(rec.err_name).toBe('TypeError');
+    expect(String(rec.err_message)).toContain(THROW_MARKER);
+    expect(String(rec.stack || '')).toContain('TypeError');
+    // Correlates with the request_id the client is handed in the 500 body.
+    expect(rec.id || rec.reqId).toBeTruthy();
+  });
+
+  /**
+   * Two distinct claims, because the plaintext check alone cannot pin the
+   * second one.
+   *
+   * Mutation-checked: injecting `body: req.body` into the log call did NOT
+   * fail the plaintext assertion — THE logger boundary digested the value to
+   * `{"sha8:...":"sha8:..."}` before it reached stdout. That is the boundary
+   * doing its job, but it means "no plaintext" is a property of the boundary,
+   * not of this log site. So the structural assertion below is what actually
+   * pins this call site's payload; it is the one that goes red on that mutant.
+   */
+  it('does not leak the request body in plaintext', () => {
+    expect(controlSeen).toBe(true); // guard: never assert absence on a blind probe
+    expect(captured).not.toContain(SECRET_ISH_BODY_VALUE);
+  });
+
+  it('the unhandled_error record carries no body, headers or query field', () => {
+    expect(controlSeen).toBe(true); // guard: never assert absence on a blind probe
+    const rec = captured
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter((r): r is any => r !== null)
+      .find((r) => r.evt === 'unhandled_error');
+
+    expect(rec).toBeTruthy(); // positive control: the record must exist to assert about it
+    expect(rec).not.toHaveProperty('body');
+    expect(rec).not.toHaveProperty('headers');
+    expect(rec).not.toHaveProperty('query');
+    expect(rec).not.toHaveProperty('payload');
+  });
+});


### PR DESCRIPTION
## Summary

`POST /v1/analysis/sequential` and `POST /v1/analysis/policy-tree` returned
`500 INTERNAL "Something went wrong"` on deployed staging (build `04f6dba`) for an
authed payload. Root cause, reproduced offline against the real modules:

```
TypeError: stage.decisions is not iterable
```

`validateSequentialGraph()` iterated `stage.decisions` and `stage.resolved_uncertainties`
directly. `StageDefinition` (`src/trust/types.ts:663`) types both as required `string[]`,
but the routes cast the request body (`req.body as SequentialAnalysisRequest`) with **no
runtime validation of `sequential_metadata`** — so a client omitting those arrays hit
`for...of undefined` and crashed the handler.

The throw is at `analysis-sequential.ts:165` / `analysis-policy-tree.ts:243` — roughly
190 lines **before** the local ISL fallback at `analysis-sequential.ts:356`, which is why
that fallback never ran for this input.

## ⚠️ Scope correction — this is narrower than it looked

Measured on deployed staging, same graph, only the `stages[]` shape differs:

| `stages[]` shape | `/v1/analysis/sequential` | `/v1/analysis/policy-tree` |
|---|---|---|
| `decision_node_id` + `timing` | **500 INTERNAL** | **500 INTERNAL** |
| `decisions[]` + `resolved_uncertainties[]` | **200** | **200** |

**Both routes already work on deployed staging for a contract-conformant payload.**
They are not broken server-side in general. What is broken is that a wrong-but-plausible
stage shape produces an opaque 5xx instead of a typed error — still worth fixing, but it
does not block surfacing these routes.

## Changes

**1. `src/util/sequential-validation.ts` — make the validator total**

`validateSequentialGraph`, `getMaxStage` and `isSequentialGraph` no longer index into any
field of `graph`, `sequential_metadata` or a stage without first proving its shape.
Guards cover non-array `stages`/`nodes`/`edges`, non-object stage entries, and
wrong-typed id lists. New typed issue codes, with the file's own contract table updated
in the same commit (it is a hand-maintained mirror):

| Code | Severity | Meaning |
|---|---|---|
| `INVALID_SEQUENTIAL_METADATA` | error | `stages` is not an array |
| `INVALID_STAGE_DEFINITION` | error | a `stages[]` entry is not a stage object |
| `MISSING_STAGE_ID_LIST` | warning | stage omits `decisions`/`resolved_uncertainties` |
| `INVALID_STAGE_ID_LIST` | warning | id list present but not an array |

A **missing** list is a warning, not an error: neither route needs those lists (both derive
stages from `node.stage`), so the analysis is still computable. The request now succeeds
and the ignored field is reported back in `validation.issues[]` rather than silently
dropped or fatal.

**2. `src/routes/v1/analysis-policy-tree.ts` — honour the documented contract**

The route computed `validation` and then **discarded it**, while
`sequential-validation.ts`'s own contract table documents this route as
*"Full validation, blocks on error → 400 BAD_INPUT"*. Code now matches its documentation.
Warning-severity issues remain non-blocking.

**3. `src/createServer.ts` — an unexplainable 5xx is a defect in its own right**

The custom `setErrorHandler`'s fallback branch replied `"Something went wrong"` while
logging **nothing**. Fastify does not auto-log once a custom error handler is installed.
Measured on this build: **zero level-50 records**, and the error message present nowhere
in the log stream — which is why this defect could not be diagnosed from server logs at
all. Now emits one error-level record (`evt: 'unhandled_error'`) correlated by the same
`request_id` the caller receives.

Logged: error identity + stack only — never body, headers or query. Every field still
passes through THE logger boundary (`src/logging/log-boundary.ts`), which digests the
decision tokens registered from this request at `preValidation`.

## Tests — RED-first and mutation-checked

New: `tests/sequential-malformed-stages.regression.test.ts`,
`tests/unhandled-error-logging.test.ts`.

All new assertions were confirmed RED before the fix. Mutation-check ran in a throwaway
worktree, each with its anchor asserted:

| Mutation | Result |
|---|---|
| revert `sequential-validation.ts` | **9 RED** |
| revert `analysis-policy-tree.ts` | **1 RED** (exactly the policy-tree 400 test) |
| revert `createServer.ts` | **1 RED**, positive control still green |
| inject `body: req.body` into the log call | **1 RED** (see below) |

**The last mutation caught a weak test of mine.** It initially did *not* bite: the body
*was* logged, but the logger boundary digested it to `{"sha8:…":"sha8:…"}` before stdout.
So "no plaintext body in logs" is a property of the **boundary**, not of this log site.
The test was strengthened to assert the record carries no `body`/`headers`/`query`/`payload`
key — that is the assertion that actually pins this call site, and it goes red on the mutant.
Incidentally this is direct evidence the logger boundary works as designed.

`tests/unhandled-error-logging.test.ts` carries its own **positive control**: the stdout
probe must prove it can see a known record before any assertion about log contents is
trusted. That control caught a real mistake during development — pino binds its
destination at logger construction, so patching stdout after `createServer()` captured
nothing and every assertion would have been vacuous.

Also pinned: a **positive control that the local ISL fallback at
`analysis-sequential.ts:356` actually executes** and produces non-vacuous content
(`provenance='plot_fallback'`, non-empty `stage_decisions`, finite expected values) —
not merely that it returned an object.

## Verification

- `npm run typecheck` — clean
- Pre-existing related suites unchanged: `sequential-validation` (18), `analysis-sequential` (19), `phase4-proxy` (16) — 53 passed
- Live-wire probe against deployed staging documented above

Live-wire confirmation *of the fix* is not possible until this lands on `staging`, since
staging deploys from that branch. Requesting review; **not merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
