### PR TITLE
refactor(sequential-validation): one stage-definition predicate, normalised once [P1]

### DIFF
--- a/src/util/sequential-validation.ts
+++ b/src/util/sequential-validation.ts
@@ -46,6 +46,11 @@
  * Rule for anyone editing this file: never index into a field of `graph`,
  * `sequential_metadata` or a stage without first proving its shape. Malformed
  * input must produce a typed issue, never a throw.
+ *
+ * Corollary, learned the hard way: prove that shape in ONE place. "Is this entry
+ * a stage definition?" was written out three times at three strictnesses and had
+ * already drifted apart within a single PR. Use `isStageDefinition` and consume
+ * `NormalisedStage`; do not re-derive either.
  */
 
 import type { Graph, StageDefinition, GraphNode, GraphEdge } from '../trust/types.js';
@@ -71,8 +76,49 @@ function asArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
 }
 
+/**
+ * A stage definition reduced to the fields this module actually uses, with the
+ * untrusted reads already done ONCE.
+ *
+ * Every consumer below takes these instead of raw `stages[]` entries, which is
+ * what makes "is this a stage definition?" a question asked in exactly one
+ * place. Passing raw entries around is what let three copies of that question
+ * drift apart.
+ */
+export interface NormalisedStage {
+  index: number;
+  label?: string;
+  decisions: string[];
+  resolvedUncertainties: string[];
+}
+
+/**
+ * THE stage-definition predicate. One definition, used at every site.
+ *
+ * Previously this question was asked three times at three strictnesses —
+ * `readStageDefinitions` checked object/not-array/numeric/finite,
+ * `buildNodeStageMap` dropped the not-array and finite checks, and `getMaxStage`
+ * dropped the object and not-array checks. They diverged inside a single PR, and
+ * the divergence was observable: an entry `readStageDefinitions` had already
+ * REJECTED as `INVALID_STAGE_DEFINITION` could still seed the forward-reference
+ * map (fabricating a FORWARD_REFERENCE) and still raise `getMaxStage` (which
+ * feeds the `maxStage > MAX_STAGES` 400 gate and `model_card.stages`).
+ *
+ * A non-finite `index` is rejected deliberately: `NaN`/`±Infinity` make every
+ * ordering comparison below meaningless rather than merely wrong.
+ */
+export function isStageDefinition(x: unknown): x is StageDefinition {
+  return (
+    x !== null &&
+    typeof x === 'object' &&
+    !Array.isArray(x) &&
+    typeof (x as { index?: unknown }).index === 'number' &&
+    Number.isFinite((x as { index: number }).index)
+  );
+}
+
 /** Human-readable stage reference for issue messages, safe on a missing label. */
-function stageRef(stage: StageDefinition): string {
+function stageRef(stage: { index: number; label?: unknown }): string {
   const label = typeof stage.label === 'string' ? stage.label : '';
   return label ? `${stage.index} ("${label}")` : `${stage.index}`;
 }
@@ -87,13 +133,15 @@ function stageRef(stage: StageDefinition): string {
  * is still computable — the omission is reported as a warning and the list is
  * treated as empty rather than silently ignored.
  *
- * Pass `issues` only where the report should be recorded; internal re-reads
- * omit it so the same omission is not reported twice.
+ * `issues` is required. It used to be optional so that `buildNodeStageMap` could
+ * re-parse the same stages a second time without double-reporting; that second
+ * parse is gone, so whether a malformation gets reported is no longer a function
+ * of which call site remembered to pass the sink.
  */
 function readStageIdList(
   stage: StageDefinition,
   field: 'decisions' | 'resolved_uncertainties',
-  issues?: SequentialValidationIssue[]
+  issues: SequentialValidationIssue[]
 ): string[] {
   const raw = (stage as unknown as Record<string, unknown>)[field];
 
@@ -102,13 +150,13 @@ function readStageIdList(
   }
 
   if (raw === undefined || raw === null) {
-    issues?.push({
+    issues.push({
       code: 'MISSING_STAGE_ID_LIST',
       message: `Stage ${stageRef(stage)} is missing "${field}". Treating it as empty — supply "${field}" as an array of node IDs for complete sequential validation.`,
       severity: 'warning',
     });
   } else {
-    issues?.push({
+    issues.push({
       code: 'INVALID_STAGE_ID_LIST',
       message: `Stage ${stageRef(stage)} has "${field}" of type ${typeof raw}, expected an array of node IDs. Treating it as empty.`,
       severity: 'warning',
@@ -119,24 +167,19 @@ function readStageIdList(
 }
 
 /**
- * Filter `stages` down to entries that are actually stage objects, reporting
- * each reject as a typed error issue.
+ * Normalise `stages` ONCE: filter to entries that are actually stage
+ * definitions (reporting each reject as a typed error) and resolve their id
+ * lists in the same pass. Everything downstream consumes the result, so no
+ * later site re-derives either the predicate or the id lists.
  */
 function readStageDefinitions(
   rawStages: unknown[],
   issues: SequentialValidationIssue[]
-): StageDefinition[] {
-  const stages: StageDefinition[] = [];
+): NormalisedStage[] {
+  const stages: NormalisedStage[] = [];
 
   rawStages.forEach((entry, i) => {
-    const isStageObject =
-      entry !== null &&
-      typeof entry === 'object' &&
-      !Array.isArray(entry) &&
-      typeof (entry as { index?: unknown }).index === 'number' &&
-      Number.isFinite((entry as { index: number }).index);
-
-    if (!isStageObject) {
+    if (!isStageDefinition(entry)) {
       issues.push({
         code: 'INVALID_STAGE_DEFINITION',
         message: `sequential_metadata.stages[${i}] is not a valid stage definition — expected an object with a numeric "index", received ${entry === null ? 'null' : Array.isArray(entry) ? 'array' : typeof entry}.`,
@@ -145,7 +188,12 @@ function readStageDefinitions(
       return;
     }
 
-    stages.push(entry as StageDefinition);
+    stages.push({
+      index: entry.index,
+      label: typeof entry.label === 'string' ? entry.label : undefined,
+      decisions: readStageIdList(entry, 'decisions', issues),
+      resolvedUncertainties: readStageIdList(entry, 'resolved_uncertainties', issues),
+    });
   });
 
   return stages;
@@ -234,8 +282,7 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
 
   // Validate each stage definition
   for (const stage of stages) {
-    const decisions = readStageIdList(stage, 'decisions', issues);
-    const resolvedUncertainties = readStageIdList(stage, 'resolved_uncertainties', issues);
+    const { decisions, resolvedUncertainties } = stage;
 
     // Check decisions exist in graph
     for (const decisionId of decisions) {
@@ -291,7 +338,7 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
   }
 
   // Validate no forward references (edges from later stages to earlier stages)
-  const nodeStages = buildNodeStageMap(graph);
+  const nodeStages = buildNodeStageMap(graphNodes, stages);
   for (const edge of graphEdges) {
     const fromStage = nodeStages.get(edge.from);
     const toStage = nodeStages.get(edge.to);
@@ -333,28 +380,29 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
 }
 
 /**
- * Build a map from node ID to stage number
- * Uses node.stage first, then falls back to stage definitions
+ * Build a map from node ID to stage number.
+ * Uses node.stage first, then falls back to the stage definitions.
+ *
+ * Takes already-normalised stages, so it neither re-parses the id lists nor
+ * carries its own copy of the stage predicate — a stage rejected upstream is
+ * simply absent here and cannot influence the forward-reference check.
  */
-function buildNodeStageMap(graph: Graph): Map<string, number> {
+function buildNodeStageMap(
+  graphNodes: GraphNode[],
+  stages: NormalisedStage[]
+): Map<string, number> {
   const nodeStages = new Map<string, number>();
 
   // First, use explicit node.stage assignments
-  for (const node of asArray<GraphNode>(graph?.nodes)) {
+  for (const node of graphNodes) {
     if (node?.stage !== undefined) {
       nodeStages.set(node.id, node.stage);
     }
   }
 
-  // Then, fill in from stage definitions. Re-reads the id lists without an
-  // `issues` sink: any malformation here was already reported by the caller.
-  for (const stage of asArray<StageDefinition>(graph?.sequential_metadata?.stages)) {
-    if (!stage || typeof stage !== 'object' || typeof stage.index !== 'number') continue;
-    const ids = [
-      ...readStageIdList(stage, 'decisions'),
-      ...readStageIdList(stage, 'resolved_uncertainties'),
-    ];
-    for (const id of ids) {
+  // Then, fill in from stage definitions
+  for (const stage of stages) {
+    for (const id of [...stage.decisions, ...stage.resolvedUncertainties]) {
       if (!nodeStages.has(id)) {
         nodeStages.set(id, stage.index);
       }
@@ -396,8 +444,8 @@ export function isSequentialGraph(graph: Graph): boolean {
 export function getMaxStage(graph: Graph): number {
   let maxStage = 0;
 
-  for (const stage of asArray<StageDefinition>(graph?.sequential_metadata?.stages)) {
-    if (typeof stage?.index === 'number' && Number.isFinite(stage.index)) {
+  for (const stage of asArray<unknown>(graph?.sequential_metadata?.stages)) {
+    if (isStageDefinition(stage)) {
       maxStage = Math.max(maxStage, stage.index);
     }
   }

--- a/tests/sequential-stage-predicate.divergence.test.ts
+++ b/tests/sequential-stage-predicate.divergence.test.ts
@@ -1,0 +1,243 @@
+/**
+ * P1 pin: "is this entry a stage definition?" must be ONE predicate.
+ *
+ * DEFECT (structural). After #265, `sequential-validation.ts` asked that
+ * question at three sites at three different strictnesses:
+ *
+ *   | site                            | object | !Array | numeric index | finite |
+ *   |---------------------------------|--------|--------|---------------|--------|
+ *   | readStageDefinitions (:132)     |   yes  |  yes   |      yes      |  yes   |
+ *   | buildNodeStageMap    (:352)     |   yes  |  no    |      yes      |  no    |
+ *   | getMaxStage          (:400)     |   no   |  no    |      yes      |  yes   |
+ *
+ * The three drifted apart INSIDE a single PR, and the drift is observable:
+ * `readStageDefinitions` can REJECT an entry as INVALID_STAGE_DEFINITION while
+ * the other two still consume it, so a stage definition the validator has
+ * already refused goes on to influence the forward-reference map and the
+ * reported stage count.
+ *
+ * SCOPE HONESTY — read before treating this as a live bug. The two checks that
+ * differ (the array check and the finite check) cannot be tripped by a strict
+ * JSON request body: JSON has no `Infinity`/`NaN` literal, and a JSON array
+ * cannot carry a named `index` property. For every JSON-representable input the
+ * three predicates happen to AGREE today. These tests therefore construct the
+ * graph object directly, which is the honest level for the claim being pinned:
+ * `validateSequentialGraph`'s own header declares its input "UNTRUSTED JSON
+ * whatever the TypeScript types promise" and requires the function to be TOTAL,
+ * so its predicates are part of its contract independent of any one caller.
+ * This is a latent-divergence pin, not a reproduction of a user-visible 500.
+ *
+ * Each absence assertion below is paired with a POSITIVE CONTROL proving the
+ * assertion can see the thing whose absence it claims.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateSequentialGraph,
+  getMaxStage,
+  isStageDefinition,
+} from '../src/util/sequential-validation.js';
+
+/** An array that also carries a numeric `index` — an object to `typeof`, an array to `Array.isArray`. */
+function arrayWithIndexProperty(index: number, decisions: string[]): unknown {
+  const entry: unknown[] & { index?: number; decisions?: string[] } = [];
+  entry.index = index;
+  entry.decisions = decisions;
+  return entry;
+}
+
+describe('P1: one stage-definition predicate, used at every site', () => {
+  describe('a stage rejected by readStageDefinitions must not seed the forward-reference map', () => {
+    /**
+     * `buildNodeStageMap` omitted the finite check, so a stage with a
+     * non-finite `index` was refused by `readStageDefinitions` (error issue)
+     * and yet still had its `decisions` list folded into the node→stage map.
+     * `Infinity > 0` then fabricated a FORWARD_REFERENCE attributed to a stage
+     * definition the validator had already thrown away.
+     */
+    const graphWithNonFiniteStage = () =>
+      ({
+        nodes: [
+          { id: 'a', label: 'A', kind: 'decision', stage: 0 },
+          { id: 'b', label: 'B', kind: 'factor' },
+        ],
+        edges: [{ from: 'b', to: 'a', weight: 1 }],
+        sequential_metadata: {
+          is_sequential: true,
+          stages: [
+            { index: 0, label: 'first', decisions: ['a'], resolved_uncertainties: [] },
+            {
+              index: Number.POSITIVE_INFINITY,
+              label: 'bogus',
+              decisions: ['b'],
+              resolved_uncertainties: [],
+            },
+          ],
+        },
+      }) as any;
+
+    it('rejects the non-finite stage (shared precondition)', () => {
+      const result = validateSequentialGraph(graphWithNonFiniteStage());
+      expect(result.issues.map((i) => i.code)).toContain('INVALID_STAGE_DEFINITION');
+      expect(result.valid).toBe(false);
+    });
+
+    it('RED-first: emits no FORWARD_REFERENCE derived from the rejected stage', () => {
+      const result = validateSequentialGraph(graphWithNonFiniteStage());
+      // Before the fix: buildNodeStageMap accepted index=Infinity, mapped
+      // b -> Infinity, and Infinity > 0 produced a FORWARD_REFERENCE.
+      expect(result.issues.map((i) => i.code)).not.toContain('FORWARD_REFERENCE');
+    });
+
+    it('POSITIVE CONTROL: a genuine forward reference in the same shape IS reported', () => {
+      // Identical graph, except the second stage is well-formed (index 1) and
+      // `b` really does sit at a later stage than its edge target. If the
+      // assertion above could not see a FORWARD_REFERENCE at all, this fails.
+      const graph = {
+        nodes: [
+          { id: 'a', label: 'A', kind: 'decision', stage: 0 },
+          { id: 'b', label: 'B', kind: 'factor' },
+        ],
+        edges: [{ from: 'b', to: 'a', weight: 1 }],
+        sequential_metadata: {
+          is_sequential: true,
+          stages: [
+            { index: 0, label: 'first', decisions: ['a'], resolved_uncertainties: [] },
+            { index: 1, label: 'second', decisions: ['b'], resolved_uncertainties: [] },
+          ],
+        },
+      } as any;
+
+      const result = validateSequentialGraph(graph);
+      expect(result.issues.map((i) => i.code)).toContain('FORWARD_REFERENCE');
+    });
+  });
+
+  describe('a stage rejected by readStageDefinitions must not raise getMaxStage', () => {
+    /**
+     * `getMaxStage` omitted both the object and the array check, so an array
+     * entry carrying `index: 7` was refused by `readStageDefinitions` and yet
+     * still set the maximum stage — which feeds the `maxStage > MAX_STAGES`
+     * 400 gate and `model_card.stages` on both analysis routes.
+     */
+    const graphWithArrayStage = () =>
+      ({
+        nodes: [{ id: 'a', label: 'A', kind: 'decision', stage: 0 }],
+        edges: [],
+        sequential_metadata: {
+          is_sequential: true,
+          stages: [
+            { index: 0, label: 'first', decisions: ['a'], resolved_uncertainties: [] },
+            arrayWithIndexProperty(7, ['a']),
+          ],
+        },
+      }) as any;
+
+    it('rejects the array stage entry (shared precondition)', () => {
+      const result = validateSequentialGraph(graphWithArrayStage());
+      const invalid = result.issues.filter((i) => i.code === 'INVALID_STAGE_DEFINITION');
+      expect(invalid).toHaveLength(1);
+      expect(invalid[0].message).toContain('received array');
+    });
+
+    it('RED-first: getMaxStage ignores the rejected array entry', () => {
+      // Before the fix: 7.
+      expect(getMaxStage(graphWithArrayStage())).toBe(0);
+    });
+
+    it('POSITIVE CONTROL: getMaxStage does report a legitimately high stage index', () => {
+      const graph = {
+        nodes: [{ id: 'a', label: 'A', kind: 'decision', stage: 0 }],
+        edges: [],
+        sequential_metadata: {
+          is_sequential: true,
+          stages: [
+            { index: 0, label: 'first', decisions: ['a'], resolved_uncertainties: [] },
+            { index: 7, label: 'seventh', decisions: [], resolved_uncertainties: [] },
+          ],
+        },
+      } as any;
+      expect(getMaxStage(graph)).toBe(7);
+    });
+  });
+
+  describe('isStageDefinition is the single exported predicate', () => {
+    it('accepts an object with a finite numeric index', () => {
+      expect(isStageDefinition({ index: 0 })).toBe(true);
+      expect(isStageDefinition({ index: 3, label: 'x' })).toBe(true);
+      expect(isStageDefinition({ index: -1 })).toBe(true); // out-of-range is a separate issue code
+    });
+
+    it('rejects every non-stage shape the three old sites disagreed about', () => {
+      expect(isStageDefinition(null)).toBe(false);
+      expect(isStageDefinition(undefined)).toBe(false);
+      expect(isStageDefinition(42)).toBe(false);
+      expect(isStageDefinition('stage')).toBe(false);
+      expect(isStageDefinition([])).toBe(false);
+      expect(isStageDefinition({})).toBe(false);
+      expect(isStageDefinition({ index: '0' })).toBe(false);
+      expect(isStageDefinition({ index: Number.NaN })).toBe(false);
+      expect(isStageDefinition({ index: Number.POSITIVE_INFINITY })).toBe(false);
+      expect(isStageDefinition(arrayWithIndexProperty(3, []))).toBe(false);
+    });
+  });
+
+  describe('normalising once removes the double-parse, not the single report', () => {
+    /**
+     * `readStageIdList` used to take an optional `issues` sink, and
+     * `buildNodeStageMap` re-parsed the same stages a second time WITHOUT it
+     * purely so the same omission was not reported twice. After normalisation
+     * there is one parse and no optional parameter, so this count is now
+     * structural rather than a convention a future editor must remember.
+     */
+    it('reports each missing stage id list exactly once', () => {
+      const graph = {
+        nodes: [
+          { id: 'd1', label: 'D1', kind: 'decision', stage: 0 },
+          { id: 'd2', label: 'D2', kind: 'decision', stage: 1 },
+        ],
+        edges: [],
+        sequential_metadata: {
+          is_sequential: true,
+          // Two stages, each omitting BOTH declared id lists -> 4 warnings, no more.
+          stages: [
+            { index: 0, label: 'first', decision_node_id: 'd1' },
+            { index: 1, label: 'second', decision_node_id: 'd2' },
+          ],
+        },
+      } as any;
+
+      const result = validateSequentialGraph(graph);
+      const missing = result.issues.filter((i) => i.code === 'MISSING_STAGE_ID_LIST');
+      expect(missing).toHaveLength(4);
+
+      // One per (stage, field) pair, and each names its own field. The message
+      // format is: `Stage 0 ("first") is missing "decisions". ...`
+      const keys = missing.map((i) => {
+        const m = /^Stage (.+?) is missing "(\w+)"\./.exec(i.message);
+        expect(m, `unparseable MISSING_STAGE_ID_LIST message: ${i.message}`).not.toBeNull();
+        return `${m![1]}|${m![2]}`;
+      });
+      expect([...new Set(keys)].sort()).toEqual([
+        '0 ("first")|decisions',
+        '0 ("first")|resolved_uncertainties',
+        '1 ("second")|decisions',
+        '1 ("second")|resolved_uncertainties',
+      ]);
+    });
+
+    it('reports each wrong-typed stage id list exactly once', () => {
+      const graph = {
+        nodes: [{ id: 'd1', label: 'D1', kind: 'decision', stage: 0 }],
+        edges: [],
+        sequential_metadata: {
+          is_sequential: true,
+          stages: [{ index: 0, label: 'first', decisions: 'd1', resolved_uncertainties: { a: 1 } }],
+        },
+      } as any;
+
+      const result = validateSequentialGraph(graph);
+      expect(result.issues.filter((i) => i.code === 'INVALID_STAGE_ID_LIST')).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## P1 — one stage-definition predicate, normalised once

Follow-up hygiene on #265. #265's actual fix (making `validateSequentialGraph` total, killing the `TypeError: stage.decisions is not iterable` 500) was at the right altitude and is untouched here. This is about what ended up sitting beside it.

### The finding, verified at the bytes on `eceb6bb`

"Is this entry a stage definition?" was written out three times at three different strictnesses:

| site | object | `!Array` | numeric index | finite |
|---|---|---|---|---|
| `readStageDefinitions` (`:132`) | yes | yes | yes | yes |
| `buildNodeStageMap` (`:352`) | yes | **no** | yes | **no** |
| `getMaxStage` (`:400`) | **no** | **no** | yes | yes |

They diverged inside #265 itself, and the divergence is observable rather than cosmetic: an entry `readStageDefinitions` has already **rejected** as `INVALID_STAGE_DEFINITION` could still be consumed by the other two — seeding the node→stage map (fabricating a `FORWARD_REFERENCE` attributed to a discarded stage) and raising `getMaxStage`, which feeds the `maxStage > MAX_STAGES` 400 gate and `model_card.stages`.

### Scope honesty — this is latent, not a live 500

The two clauses that differed (the array check and the finite check) **cannot be tripped by a strict JSON request body**: JSON has no `Infinity`/`NaN` literal, and a JSON array cannot carry a named `index` property. For every JSON-representable input the three predicates agreed. So this is a latent-divergence fix — the next edit to any one site is what makes it bite. The tests construct the graph object directly, which is the honest level for the claim: this file's own header declares its input "UNTRUSTED JSON whatever the TypeScript types promise" and requires the function to be TOTAL, so its predicates are contract independent of any one caller.

### Change

- **`export function isStageDefinition(x: unknown): x is StageDefinition`** — the one predicate, used at all three sites.
- **`readStageDefinitions` now returns `NormalisedStage[]`** (`{index, label, decisions, resolvedUncertainties}`), resolving the id lists in the same pass; `buildNodeStageMap` consumes those.

That single move deletes:
- the optional `issues?` parameter on `readStageIdList` — whether a malformation got **reported** depended on which call site remembered to pass the sink;
- the second parse of the same stages (`:353-355`);
- the "omit `issues` on re-reads" convention a future editor had to remember (`:349-350`);
- `buildNodeStageMap`'s copy of the predicate.

`asArray<T>` is reused 8× and is the right call — unchanged.

### Behaviour delta

- **`errors[0]` is provably unchanged.** It is the only thing all four consuming routes read for their 400, and the error sequence (`INVALID_STAGE_DEFINITION`, `NON_CONTIGUOUS_STAGES`, `MISSING_DECISION_NODE`, …) is identical: `readStageDefinitions` still runs before the contiguity check, and the newly-relocated id-list issues are warning-severity.
- Warning-severity id-list issues now appear **earlier** in `issues[]`, interleaved per stage rather than in a later pass. Checked: no test in the repo is order-sensitive on this branch (the one `issues[0]` assertion, `tests/sequential-validation.test.ts:50`, is on the no-`sequential_metadata` early-return branch).

### Evidence

**RED-first** (probe run against unmodified `eceb6bb` src):
```
FAIL  RED-first: emits no FORWARD_REFERENCE derived from the rejected stage
      expected [ 'INVALID_STAGE_DEFINITION', 'FORWARD_REFERENCE' ] to not include 'FORWARD_REFERENCE'
FAIL  RED-first: getMaxStage ignores the rejected array entry
      expected 7 to be +0
```
Both positive controls passed in the same run — a genuine `FORWARD_REFERENCE` **is** reported, and `getMaxStage` **does** report a legitimately high index — so neither absence assertion is vacuous.

**Mutation check** — throwaway worktree at a uniquely-named path **outside** the repo root, `node_modules` symlinked, each anchor asserted present before the write, worktree removed before the gate run:

| mutation | tests killed | control |
|---|---|---|
| A: `getMaxStage` reverts to its old loose predicate | 1 (`getMaxStage` pin) | positive control still passed |
| B: drop the `Number.isFinite` clause | 3 (precondition + `FORWARD_REFERENCE` pin + matrix) | — |
| C: drop the `!Array.isArray` clause | 3 (precondition + `getMaxStage` pin + matrix) | — |

Every clause of the unified predicate is load-bearing and observed by a test.

**Gate** — `npm test` (build + vitest + fixtures + OpenAPI + loadcheck), the repo's own gate:
- baseline `eceb6bb`: `563 files / 5953 passed, 29 skipped` → exit 0
- this branch: `563 files / 5963 passed, 29 skipped` → **exit 0**
- delta `+1 file / +10 tests` = exactly the additions in this PR; zero pre-existing tests changed, none deleted, no baseline bumped.
- `npm run typecheck` → exit 0. `eslint` on the changed file introduces **no new warning** (the one `edgeMap` unused-var warning is pre-existing at `eceb6bb`, verified by linting the stashed tree; eslint is not in the gate).
- Pre-push validation (6 checks) PASSED.

### Known root cause — NOT addressed here, needs a separate lane

There is **no runtime schema for `sequential_metadata`**. `StageDefinition` is a bare TS interface at `src/trust/types.ts:663`, and **`@talchain/schemas` 0.22.0 declares no `sequential_metadata`/`StageDefinition` at all** (zero hits across `dist/` and `json-schema/`), so the analysis routes cast `req.body as …` with no validation — which is the only reason any of these hand-rolled predicates exist. Fixing it properly is a contract addition plus a re-vendor across four repos. Out of scope for this PR by design.

### Calibration

These routes are **not on the live user path**: `validateSequentialGraph` has exactly four callers, all `/v1/analysis/*` + `/v1/explain/policy`, and `/v1/run` (the route CEE actually calls) never imports it. This is proportionate hygiene on a dormant cluster.

**Do not merge** — `staging` is unprotected (protection API returns 404), so the merge *is* the gate. Review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
