### PR TITLE
fix(sequential): stop #265 blocking inputs that used to return 200 [C6]

### DIFF
--- a/src/routes/v1/analysis-sequential.ts
+++ b/src/routes/v1/analysis-sequential.ts
@@ -187,11 +187,23 @@ export async function registerSequentialAnalysisRoute(app: FastifyInstance) {
         }
       }
 
-      // Get discount factor
-      const discountFactor =
+      // Get discount factor.
+      //
+      // Read as a number even when the client sent a numeric string. Without
+      // this the raw string reached `Math.pow` (which coerced it silently), the
+      // ISL request body, and `model_card.discount_factor` — whose declared type
+      // is `number` — so the response echoed `"0.95"` while the accompanying
+      // COERCED_DISCOUNT_FACTOR warning said it had been read as `0.95`. The
+      // response must not say two different things about one value.
+      // `validateSequentialGraph` has already blocked a non-coercible
+      // `sequential_metadata.default_discount_factor`; the range check below
+      // still guards the top-level `discount_factor`, which nothing validates.
+      const rawDiscountFactor =
         body.discount_factor ??
         body.graph.sequential_metadata?.default_discount_factor ??
         1.0;
+      const discountFactor =
+        typeof rawDiscountFactor === 'number' ? rawDiscountFactor : Number(rawDiscountFactor);
 
       if (discountFactor < 0 || discountFactor > 1) {
         return replyWithAppError(reply, {

--- a/src/util/sequential-validation.ts
+++ b/src/util/sequential-validation.ts
@@ -32,6 +32,17 @@
  * - `INVALID_STAGE_DEFINITION` (error): A `stages[]` entry is not a stage object
  * - `MISSING_STAGE_ID_LIST` (warning): Stage omits `decisions`/`resolved_uncertainties`
  * - `INVALID_STAGE_ID_LIST` (warning): Stage id list present but not an array
+ * - `COERCED_DISCOUNT_FACTOR` (warning): Discount factor sent as a numeric string
+ *
+ * ## Blocking is a wire contract — check the pre-#265 behaviour before widening it
+ *
+ * All four routes block on ANY error-severity issue, so raising a code from
+ * warning to error, or adding an error for a shape that previously passed, turns
+ * a 200 into a 400 for every client sending that shape. #265 did this to
+ * `INVALID_DISCOUNT_FACTOR` (a JSON-string discount factor had returned 200 with
+ * the CORRECT result, coerced by JS) and, by adding the policy-tree gate at all,
+ * to every pre-existing error code on that route. Neither was covered by a test.
+ * Before changing a severity here, measure the previous behaviour at the route.
  *
  * ## This function must be TOTAL
  *
@@ -69,6 +80,22 @@ export interface SequentialValidationResult {
 /** Total array read — untrusted input may put anything here. */
 function asArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
+}
+
+/**
+ * A numeric string read as a number, else `undefined`.
+ *
+ * Deliberately narrow: only a string whose whole trimmed content is a finite
+ * numeric literal. `''`, `'  '`, `'abc'`, booleans, objects and arrays are NOT
+ * coercible — `Number('')` is 0 and `Number(true)` is 1, and accepting either
+ * would invent a value the client never sent.
+ */
+function coerceNumericString(value: unknown): number | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (trimmed === '') return undefined;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 /** Human-readable stage reference for issue messages, safe on a missing label. */
@@ -275,17 +302,32 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
     nodesByStage.set(stage.index, stageNodeIds);
   }
 
-  // Validate node stage assignments match stage definitions
-  for (const node of graphNodes) {
-    if (node.stage !== undefined) {
-      const stageDef = stages.find((s) => s.index === node.stage);
-      if (!stageDef) {
-        issues.push({
-          code: 'INVALID_NODE_STAGE',
-          message: `Node "${node.id}" has stage ${node.stage} but no stage definition exists for that index.`,
-          severity: 'error',
-          affected_ids: [node.id],
-        });
+  // Validate node stage assignments match stage definitions.
+  //
+  // Skipped when the stage list is known-incomplete. `readStageDefinitions` drops
+  // entries it rejects, so every node pointing at a dropped index would report
+  // INVALID_NODE_STAGE — restating a consequence of the one real fault with the
+  // wrong subject. A single bad entry with three nodes at that stage produced
+  // three misattributed errors on top of the INVALID_STAGE_DEFINITION that
+  // already named the actual cause. Derived from the two lengths, not tracked in
+  // a counter that could drift.
+  //
+  // This does not weaken the verdict: the rejected definition is itself
+  // error-severity, so the request is blocked either way. Once the definitions
+  // are fixed, a genuinely orphaned node surfaces on the next call.
+  const stageListIncomplete = stages.length !== rawStages.length;
+  if (!stageListIncomplete) {
+    for (const node of graphNodes) {
+      if (node.stage !== undefined) {
+        const stageDef = stages.find((s) => s.index === node.stage);
+        if (!stageDef) {
+          issues.push({
+            code: 'INVALID_NODE_STAGE',
+            message: `Node "${node.id}" has stage ${node.stage} but no stage definition exists for that index.`,
+            severity: 'error',
+            affected_ids: [node.id],
+          });
+        }
       }
     }
   }
@@ -306,20 +348,44 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
     }
   }
 
-  // Validate discount factor if present
-  const discountFactor = graph.sequential_metadata.default_discount_factor;
-  if (discountFactor !== undefined && discountFactor !== null) {
-    if (typeof discountFactor !== 'number' || !Number.isFinite(discountFactor)) {
+  // Validate discount factor if present.
+  //
+  // #265 added the `typeof !== 'number'` test at error severity, which turned a
+  // JSON-string discount factor into a 400 on both full-validation routes.
+  // Measured against 04f6dbac, `default_discount_factor: "0.95"` previously
+  // returned 200 with overall_expected_value 6066 — byte-equal to the numeric
+  // 0.95 control, because JS coerced the string in the comparisons and again in
+  // the arithmetic. The client got the right answer. A numeric string is a
+  // client-serialisation artefact, not a semantic error, so it is coerced back —
+  // but the coercion is now DISCLOSED instead of happening by accident.
+  //
+  // Non-coercible values (`'abc'`, `true`, `{}`, `''`) stay error-severity on
+  // purpose: pre-#265 they returned 200 carrying `overall_expected_value: null`
+  // or a boolean silently read as 1. #265's block is better than that silence.
+  const rawDiscountFactor = graph.sequential_metadata.default_discount_factor;
+  if (rawDiscountFactor !== undefined && rawDiscountFactor !== null) {
+    const isNumber = typeof rawDiscountFactor === 'number' && Number.isFinite(rawDiscountFactor);
+    const coerced = isNumber ? undefined : coerceNumericString(rawDiscountFactor);
+    const discountFactor = isNumber ? (rawDiscountFactor as number) : coerced;
+
+    if (discountFactor === undefined) {
       issues.push({
         code: 'INVALID_DISCOUNT_FACTOR',
-        message: `Discount factor must be a number between 0 and 1, received ${typeof discountFactor}.`,
+        message: `Discount factor must be a number between 0 and 1, received ${typeof rawDiscountFactor}.`,
         severity: 'error',
       });
     } else if (discountFactor < 0 || discountFactor > 1) {
+      // Coercion is not permission: "1.5" must fail exactly as 1.5 does.
       issues.push({
         code: 'INVALID_DISCOUNT_FACTOR',
         message: `Discount factor must be between 0 and 1, got ${discountFactor}.`,
         severity: 'error',
+      });
+    } else if (coerced !== undefined) {
+      issues.push({
+        code: 'COERCED_DISCOUNT_FACTOR',
+        message: `Discount factor was sent as a string ("${String(rawDiscountFactor)}"), not a number. Reading it as ${coerced} — send a JSON number to remove this warning.`,
+        severity: 'warning',
       });
     }
   }

--- a/tests/sequential-265-behaviour-change.regression.test.ts
+++ b/tests/sequential-265-behaviour-change.regression.test.ts
@@ -1,0 +1,343 @@
+/**
+ * C6: the 200 -> 400 behaviour changes #265 shipped without test cover.
+ *
+ * #265's gate is "any issue with `severity === 'error'`", which reaches the
+ * PRE-EXISTING error codes (NON_CONTIGUOUS_STAGES, MISSING_DECISION_NODE,
+ * MISSING_UNCERTAINTY_NODE, INVALID_NODE_STAGE, INVALID_DISCOUNT_FACTOR), not
+ * only the four new malformation codes. Its own two new 400 tests exercise
+ * exactly one input — `stages = 'not-an-array'`. Everything else below was
+ * uncovered.
+ *
+ * Measured pre-#265 (04f6dbac) vs post-#265 (eceb6bb), same probe, both routes,
+ * in a worktree per revision:
+ *
+ *   sequential_metadata.default_discount_factor    PRE                POST
+ *   "0.95"                        200  ev=6066     400 INVALID_DISCOUNT_FACTOR
+ *   "abc"                         200  ev=null     400 INVALID_DISCOUNT_FACTOR
+ *   true                          200  ev=6221.5   400 INVALID_DISCOUNT_FACTOR
+ *   {}                            200  ev=null     400 INVALID_DISCOUNT_FACTOR
+ *   null                          200  ev=6221.5   200                (unchanged)
+ *   0.95  (control)               200  ev=6066     200  ev=6066       (unchanged)
+ *
+ * The decisive row is the first: `"0.95"` produced ev=6066 pre-#265, BYTE-EQUAL
+ * to the numeric 0.95 control. JS coerced the string in the `< 0 / > 1`
+ * comparisons and again in the arithmetic, so the client got the RIGHT answer.
+ * #265 turned that into a 400. A numeric string is a client-serialisation
+ * artefact, not a semantic error, so this test pins it back to 200 — but now
+ * with the coercion DISCLOSED as a warning instead of happening silently.
+ *
+ * `"abc"`, `true` and `{}` are deliberately NOT restored. Pre-#265 they returned
+ * 200 carrying `overall_expected_value: null` or an accidental
+ * boolean-to-1 coercion — silent garbage. #265's 400 is strictly better there,
+ * so it stays, and this file is where that choice is written down.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { registerSequentialAnalysisRoute } from '../src/routes/v1/analysis-sequential.js';
+import { registerPolicyTreeRoute } from '../src/routes/v1/analysis-policy-tree.js';
+import { validateSequentialGraph } from '../src/util/sequential-validation.js';
+
+const NODES = [
+  { id: 'd1', label: 'D1', kind: 'decision', stage: 0 },
+  { id: 'o1a', label: 'O1a', kind: 'option', stage: 0, value: 60 },
+  { id: 'o1b', label: 'O1b', kind: 'option', stage: 0, value: 40 },
+  { id: 'd2', label: 'D2', kind: 'decision', stage: 1 },
+  { id: 'o2a', label: 'O2a', kind: 'option', stage: 1, value: 70 },
+  { id: 'out', label: 'Out', kind: 'outcome', stage: 1, value: 100 },
+];
+const EDGES = [
+  { from: 'o1a', to: 'out', weight: 0.6 },
+  { from: 'o2a', to: 'out', weight: 0.7 },
+];
+const GOOD_STAGES = [
+  { index: 0, label: 's0', decisions: ['d1'], resolved_uncertainties: [] },
+  { index: 1, label: 's1', decisions: ['d2'], resolved_uncertainties: [] },
+];
+
+function payloadWithDiscount(default_discount_factor: unknown) {
+  return {
+    graph: {
+      nodes: NODES,
+      edges: EDGES,
+      sequential_metadata: { is_sequential: true, stages: GOOD_STAGES, default_discount_factor },
+    },
+    outcome_node: 'out',
+  };
+}
+
+const BOTH_FULL_VALIDATION_ROUTES = ['/v1/analysis/sequential', '/v1/analysis/policy-tree'];
+
+describe('C6: #265 behaviour changes on previously-200 inputs', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await registerSequentialAnalysisRoute(app);
+    await registerPolicyTreeRoute(app);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  beforeEach(() => {
+    process.env.ENABLE_SEQUENTIAL_ANALYSIS = '1';
+    delete process.env.ISL_SEQUENTIAL_ENABLE;
+    delete process.env.ISL_POLICY_TREE_ENABLE;
+    delete process.env.ISL_ENABLE;
+  });
+
+  // ===========================================================================
+  // (a) a numeric-string discount factor must not block
+  // ===========================================================================
+  describe('(a) a coercible numeric-string default_discount_factor', () => {
+    it('RED-first: does not block either route', async () => {
+      for (const url of BOTH_FULL_VALIDATION_ROUTES) {
+        const res = await app.inject({ method: 'POST', url, payload: payloadWithDiscount('0.95') });
+        // Before this fix: 400 INVALID_DISCOUNT_FACTOR on both.
+        expect(res.statusCode, `${url} must not block on "0.95"`).toBe(200);
+      }
+    });
+
+    it('RED-first: yields the SAME analysis as the equivalent number', async () => {
+      // Restoring the status code is not enough — the answer has to be the one
+      // the client used to get. Pre-#265 this was ev=6066 either way.
+      const asString = await app.inject({
+        method: 'POST',
+        url: '/v1/analysis/sequential',
+        payload: payloadWithDiscount('0.95'),
+      });
+      const asNumber = await app.inject({
+        method: 'POST',
+        url: '/v1/analysis/sequential',
+        payload: payloadWithDiscount(0.95),
+      });
+
+      expect(asString.statusCode).toBe(200);
+      expect(asNumber.statusCode).toBe(200);
+
+      const s = JSON.parse(asString.payload);
+      const n = JSON.parse(asNumber.payload);
+      expect(s.analysis.overall_expected_value).toBe(n.analysis.overall_expected_value);
+      expect(typeof n.analysis.overall_expected_value).toBe('number');
+      expect(Number.isFinite(n.analysis.overall_expected_value)).toBe(true);
+
+      // RED-first: the response must not say two different things about one
+      // value. `model_card.discount_factor` is declared `number`, but the raw
+      // string used to be echoed straight through — so the card read "0.95"
+      // while the COERCED_DISCOUNT_FACTOR warning said it was read as 0.95.
+      expect(s.model_card.discount_factor).toBe(0.95);
+      expect(typeof s.model_card.discount_factor).toBe('number');
+    });
+
+    it('POSITIVE CONTROL: the discount factor actually affects the result', async () => {
+      // Without this, the equality above could hold because the discount factor
+      // is ignored entirely — the assertion would pass while proving nothing.
+      const discounted = await app.inject({
+        method: 'POST',
+        url: '/v1/analysis/sequential',
+        payload: payloadWithDiscount(0.5),
+      });
+      const undiscounted = await app.inject({
+        method: 'POST',
+        url: '/v1/analysis/sequential',
+        payload: payloadWithDiscount(1),
+      });
+
+      const a = JSON.parse(discounted.payload).analysis.overall_expected_value;
+      const b = JSON.parse(undiscounted.payload).analysis.overall_expected_value;
+      expect(a).not.toBe(b);
+    });
+
+    it('RED-first: the coercion is DISCLOSED, not silent', async () => {
+      // Pre-#265 the string was coerced by accident with no signal at all. The
+      // 200 comes back, but the client is told the field was not a number.
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/analysis/sequential',
+        payload: payloadWithDiscount('0.95'),
+      });
+      const issues = JSON.parse(res.payload).validation.issues;
+      const coerced = issues.find((i: any) => i.code === 'COERCED_DISCOUNT_FACTOR');
+      expect(coerced).toBeDefined();
+      expect(coerced.severity).toBe('warning');
+      expect(coerced.message).toContain('string');
+    });
+
+    it('POSITIVE CONTROL: a plain number is not reported as coerced', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/analysis/sequential',
+        payload: payloadWithDiscount(0.95),
+      });
+      const issues = JSON.parse(res.payload).validation.issues;
+      expect(issues.map((i: any) => i.code)).not.toContain('COERCED_DISCOUNT_FACTOR');
+      expect(issues).toEqual([]);
+    });
+
+    it('a numeric string OUT of range still blocks, like the number would', () => {
+      // Coercion is not permission: "1.5" must fail exactly as 1.5 does.
+      for (const v of ['1.5', '-0.1']) {
+        const r = validateSequentialGraph({
+          nodes: NODES,
+          edges: EDGES,
+          sequential_metadata: {
+            is_sequential: true,
+            stages: GOOD_STAGES,
+            default_discount_factor: v,
+          },
+        } as any);
+        const err = r.issues.find((i) => i.code === 'INVALID_DISCOUNT_FACTOR');
+        expect(err, `"${v}" must still be rejected`).toBeDefined();
+        expect(err!.severity).toBe('error');
+      }
+    });
+
+    it('non-coercible values are DELIBERATELY still blocked (documented choice)', async () => {
+      // Pre-#265 these returned 200 with overall_expected_value: null (or a
+      // boolean silently coerced to 1). That silence is worse than a 400, so
+      // #265's block is kept here on purpose rather than restored.
+      for (const bad of ['abc', true, {}, [], '', '  ']) {
+        const res = await app.inject({
+          method: 'POST',
+          url: '/v1/analysis/sequential',
+          payload: payloadWithDiscount(bad),
+        });
+        expect(res.statusCode, `${JSON.stringify(bad)} must block`).toBe(400);
+        expect(JSON.parse(res.payload).code).toBe('INVALID_DISCOUNT_FACTOR');
+      }
+    });
+
+    it('null and undefined remain accepted, as before and after #265', async () => {
+      for (const v of [null, undefined]) {
+        const res = await app.inject({
+          method: 'POST',
+          url: '/v1/analysis/sequential',
+          payload: payloadWithDiscount(v),
+        });
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(res.payload).validation.issues).toEqual([]);
+      }
+    });
+  });
+
+  // ===========================================================================
+  // (b) a rejected stage entry must not cascade into N misattributed errors
+  // ===========================================================================
+  describe('(b) a rejected stage definition must not cascade INVALID_NODE_STAGE', () => {
+    /** `index: '1'` is dropped by readStageDefinitions; 3 nodes still point at stage 1. */
+    const graphWithDroppedStage = () =>
+      ({
+        nodes: NODES,
+        edges: EDGES,
+        sequential_metadata: {
+          is_sequential: true,
+          stages: [
+            GOOD_STAGES[0],
+            { index: '1', label: 's1', decisions: ['d2'], resolved_uncertainties: [] },
+          ],
+        },
+      }) as any;
+
+    it('RED-first: reports the rejected definition, not one error per orphaned node', () => {
+      const r = validateSequentialGraph(graphWithDroppedStage());
+      const codes = r.issues.map((i) => i.code);
+
+      expect(codes).toContain('INVALID_STAGE_DEFINITION');
+      // Before the fix: three INVALID_NODE_STAGE errors (d2, o2a, out), all of
+      // them restating a consequence of the one real fault.
+      expect(codes).not.toContain('INVALID_NODE_STAGE');
+    });
+
+    it('POSITIVE CONTROL: INVALID_NODE_STAGE still fires when the stage list is intact', () => {
+      // Suppression must be conditional on the list being known-incomplete. With
+      // every entry well-formed, a node pointing at an undefined stage is a real
+      // and correctly-attributed error.
+      const r = validateSequentialGraph({
+        nodes: [...NODES, { id: 'orphan', label: 'Orphan', kind: 'factor', stage: 9 }],
+        edges: EDGES,
+        sequential_metadata: { is_sequential: true, stages: GOOD_STAGES },
+      } as any);
+
+      const issue = r.issues.find((i) => i.code === 'INVALID_NODE_STAGE');
+      expect(issue).toBeDefined();
+      expect(issue!.affected_ids).toEqual(['orphan']);
+      expect(r.valid).toBe(false);
+    });
+
+    it('still blocks — suppressing the cascade must not unblock the request', async () => {
+      // The rejected definition is itself error-severity, so the 400 stands.
+      for (const url of BOTH_FULL_VALIDATION_ROUTES) {
+        const res = await app.inject({
+          method: 'POST',
+          url,
+          payload: { graph: graphWithDroppedStage(), outcome_node: 'out' },
+        });
+        expect(res.statusCode, url).toBe(400);
+        expect(JSON.parse(res.payload).code, url).toBe('INVALID_STAGE_DEFINITION');
+      }
+    });
+  });
+
+  // ===========================================================================
+  // the policy-tree gate widening #265 shipped uncovered
+  // ===========================================================================
+  describe('policy-tree now blocks on PRE-EXISTING error codes too (intended, was uncovered)', () => {
+    /**
+     * #265 added the gate at analysis-policy-tree.ts:263. Before it, the route
+     * discarded `validation` entirely and returned 200 on EVERY validation
+     * error. So this is a wide status change for that route — intended, matching
+     * the contract table this module has always published, but #265's only 400
+     * tests used `stages = 'not-an-array'`. These pin the rest of the surface so
+     * the next person can see what the gate actually covers.
+     */
+    const cases: Array<[string, unknown]> = [
+      [
+        'NON_CONTIGUOUS_STAGES',
+        [
+          { index: 0, label: 's0', decisions: [], resolved_uncertainties: [] },
+          { index: 5, label: 's5', decisions: [], resolved_uncertainties: [] },
+        ],
+      ],
+      [
+        'MISSING_DECISION_NODE',
+        [{ index: 0, label: 's0', decisions: ['nope'], resolved_uncertainties: [] }],
+      ],
+      [
+        'MISSING_UNCERTAINTY_NODE',
+        [{ index: 0, label: 's0', decisions: [], resolved_uncertainties: ['nope'] }],
+      ],
+    ];
+
+    it.each(cases)('policy-tree blocks with %s', async (code, stages) => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/analysis/policy-tree',
+        payload: {
+          graph: { nodes: NODES, edges: EDGES, sequential_metadata: { is_sequential: true, stages } },
+          outcome_node: 'out',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.payload).code).toBe(code);
+    });
+
+    it('POSITIVE CONTROL: a well-formed graph is not blocked by that gate', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/analysis/policy-tree',
+        payload: {
+          graph: {
+            nodes: NODES,
+            edges: EDGES,
+            sequential_metadata: { is_sequential: true, stages: GOOD_STAGES },
+          },
+          outcome_node: 'out',
+        },
+      });
+      expect(res.statusCode).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## C6 — #265 blocks inputs that previously returned 200

#265's gate is **"any issue with `severity === 'error'`"**, which reaches the *pre-existing* codes (`NON_CONTIGUOUS_STAGES`, `MISSING_DECISION_NODE`, `MISSING_UNCERTAINTY_NODE`, `INVALID_NODE_STAGE`, `INVALID_DISCOUNT_FACTOR`), not only the four new malformation codes. Its own two new 400 tests exercise exactly one input — `stages = 'not-an-array'` — so the rest of the widened surface shipped uncovered.

### Measurement, not inference

Same probe, both routes, a **worktree per revision** — pre-#265 `04f6dbac` vs post-#265 `eceb6bb`:

| `sequential_metadata.default_discount_factor` | PRE | POST |
|---|---|---|
| `"0.95"` | **200**, `ev=6066` | **400** `INVALID_DISCOUNT_FACTOR` |
| `"abc"` | 200, `ev=null` | 400 `INVALID_DISCOUNT_FACTOR` |
| `true` | 200, `ev=6221.538` | 400 `INVALID_DISCOUNT_FACTOR` |
| `{}` | 200, `ev=null` | 400 `INVALID_DISCOUNT_FACTOR` |
| `null` | 200, `ev=6221.538` | 200 *(unchanged)* |
| `0.95` (control) | 200, `ev=6066` | 200, `ev=6066` *(unchanged)* |

The decisive row is the first. `"0.95"` returned **`ev=6066`, byte-equal to the numeric `0.95` control** — JS coerced the string in the `< 0 / > 1` comparisons and again in the arithmetic, so the client got the *right answer*. #265 turned that into a 400. The change is wider than the four input shapes above suggest: `/v1/analysis/sequential` was affected too, via its **pre-existing** gate at `:178`, not just the new policy-tree one.

### (a) Restore the numeric string — but disclose the coercion

A numeric string is a client-serialisation artefact, not a semantic error, so it is read as a number again and the request succeeds. The coercion is now **disclosed** as a `COERCED_DISCOUNT_FACTOR` warning instead of happening by accident. **Coercion is not permission:** `"1.5"` still fails exactly as `1.5` does.

`'abc'`, `true`, `{}`, `''`, `'  '` **stay error-severity on purpose.** Pre-#265 they returned 200 carrying `overall_expected_value: null`, or a boolean silently read as `1` — #265's block is *better* than that silence, so it is kept rather than restored, and that judgement is now written down in a test instead of implied. `coerceNumericString` is deliberately narrow for this reason: `Number('')` is `0` and `Number(true)` is `1`, and accepting either would invent a value the client never sent.

Also normalised at `analysis-sequential.ts:191`: the raw string previously reached `Math.pow`, the **ISL request body**, and `model_card.discount_factor` — whose declared type is `number` — so the response echoed `"0.95"` while the new warning said it had been read as `0.95`. A response must not say two different things about one value.

### (b) Correction — the reported mechanism does not hold

> *claimed:* a dropped stage entry cascades into `INVALID_NODE_STAGE`, "converting a previously-degraded-but-200 policy tree into a 400"

**Probed per input, that is not what happens:**

| `stages` entry | PRE-#265 | POST-#265 |
|---|---|---|
| `{label:'junk'}` (no index) | sequential **400** `NON_CONTIGUOUS_STAGES` / policy-tree 200 | 400 `INVALID_STAGE_DEFINITION` |
| `{index:'1'}` | sequential **400** `NON_CONTIGUOUS_STAGES` / policy-tree 200 | 400 `INVALID_STAGE_DEFINITION` |
| `42` / `null` / `[]` | **500** both | 400 `INVALID_STAGE_DEFINITION` |

1. On `/v1/analysis/sequential` there is **no 200 → 400** at all — every JSON-reachable bad entry already returned 400 (via `NON_CONTIGUOUS_STAGES`, because the un-filtered `stageIndices` contained a non-integer) or 500.
2. The 200 → 400 on `/v1/analysis/policy-tree` is caused by #265 **adding the gate at all** — the route previously discarded `validation` and returned 200 on *every* validation error — not by the cascade.
3. The cascade **changes no status**: `errors[0]`, the only issue any route reports, is always the `INVALID_STAGE_DEFINITION`, which is pushed first. Verified — one bad entry with three nodes at that stage yields `INVALID_STAGE_DEFINITION, INVALID_NODE_STAGE×3` with `errors[0].code === 'INVALID_STAGE_DEFINITION'`.

So the sub-claim that survives is the one about *quality*: those three `INVALID_NODE_STAGE` errors restate a consequence of the one real fault with the wrong subject, and `issues[]` **is** surfaced on the wire. Suppressed when the stage list is known-incomplete, **derived from the two lengths** rather than a counter that could drift. Not a weakening — the rejected definition is itself error-severity so the 400 stands, and a positive control proves `INVALID_NODE_STAGE` still fires whenever the stage list is intact.

**The real gap was cover for the policy-tree gate widening.** Three pre-existing error codes are now pinned on that route (`NON_CONTIGUOUS_STAGES`, `MISSING_DECISION_NODE`, `MISSING_UNCERTAINTY_NODE`) with a positive control that a well-formed graph is not blocked. That widening is *intended* — it matches the contract table this module has always published — it was simply untested.

### Evidence

**RED-first**, against unmodified `eceb6bb`: **4 failed | 11 passed**
```
× (a) RED-first: does not block either route          → expected 400 to be 200
× (a) RED-first: yields the SAME analysis as the equivalent number → expected 400 to be 200
× (a) RED-first: the coercion is DISCLOSED, not silent
× (b) RED-first: reports the rejected definition, not one error per orphaned node
      → expected [ 'INVALID_STAGE_DEFINITION', …(3) ] to not include 'INVALID_NODE_STAGE'
```
Every positive control passed in that same run — including *"the discount factor actually affects the result"* (`0.5` vs `1` give different `ev`), without which the same-answer equality could hold because the factor was ignored entirely, and *"`INVALID_NODE_STAGE` still fires when the stage list is intact"*.

**Mutation check** — throwaway worktree, uniquely-named path **outside** the repo root, each anchor asserted present before the write, worktree removed before the gate run. Each mutation kills only its own target:

| mutation | tests killed |
|---|---|
| A: remove the numeric-string coercion (restore #265's blanket block) | 3 |
| B: keep the coercion, drop the disclosure warning | 1 (disclosure) |
| C: un-suppress the `INVALID_NODE_STAGE` cascade | 1 (cascade) |
| D: revert the `model_card` numeric normalisation | 1 (same-answer) |

**Gate** — `npm test`, the repo's own gate:
- baseline `eceb6bb`: `562 files / 5953 passed, 29 skipped` → exit 0
- this branch, run 1: **1 failed** — `tests/stream.real.limited.test.ts`, `TypeError: fetch failed` / `ECONNRESET` on `${BASE}/stream`. Unrelated: that file has **zero** references to `sequential` or `discount`, and my diff touches neither streaming nor the server. Reported rather than hidden.
- this branch, run 2: **exit 0**, `563 files / 5968 passed, 29 skipped` → `+1 file / +15 tests`, exactly this PR's additions. Flake confirmed.
- `npm run typecheck` → exit 0. Pre-push validation (6 checks) PASSED. No test deleted, no baseline bumped.

### Sequencing

Branched from `staging` at `eceb6bb`, like the sibling PRs. Both this and #266 touch `src/util/sequential-validation.ts`; the hunks are in different regions (this one: the discount-factor block and the node-stage loop; #266: the stage predicate and `buildNodeStageMap`) so any conflict is textual and small. **Merge this one first** — it is a live behaviour change, the others are hygiene.

**Do not merge without review** — `staging` is unprotected (protection API returns 404), so the merge *is* the gate.

### Calibration

Still a dormant cluster: `validateSequentialGraph` has four callers, all `/v1/analysis/*` + `/v1/explain/policy`, and `/v1/run` (what CEE actually calls) never imports it. So this restores correctness for a client that does not exist yet — worth doing because the regression was undisclosed, not because anyone is hitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
