### PR TITLE
fix(isl): consume confidence_basis; confidence is no longer a confidence [ROADMAP 1.211]

### DIFF
--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -58,6 +58,16 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     // zero independent information (verified byte-identical live: 0.59025 /
     // 0.8541875). The UI printed it as a fabricated "N% stability" statistic.
     // Absence is honest; the UI has an absence path.
+    //
+    // KNOWN COLLISION (ROADMAP 1.211, 2026-07-26). ISL PR #114 made
+    // `robustness.confidence` carry this SAME quantity, unmodified
+    // (robustness_analyzer_v2.py:2739 `return recommendation_stability`). So
+    // the number withheld here is still forwarded under `confidence`, a name
+    // implying calibration that ISL's own field description now denies. PLoT
+    // forwards `confidence_basis` beside it so a consumer can branch, but the
+    // duplication itself is a cross-repo contract question — whether the slot
+    // should survive, or whether ISL's honestly-named field should be
+    // delivered instead — and is not settled unilaterally by this lane.
     'robustness.recommendation_stability',
   ],
 

--- a/src/integrations/isl/confidence-basis.ts
+++ b/src/integrations/isl/confidence-basis.ts
@@ -1,0 +1,95 @@
+/**
+ * The semantics marker for ISL's robustness `confidence` slot (ROADMAP 1.211).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `robustness.confidence` is a published contract slot whose MEANING changed
+ * on 2026-07-26 (ISL PR #114) while its name and type did not. Verified in the
+ * merged ISL source at staging 7d144c7, not inferred from the PR prose:
+ *
+ *   robustness_analyzer_v2.py:4522  recommendation_stability = option_wins[winner] / n_samples
+ *   robustness_analyzer_v2.py:4584  confidence = _stability_confidence_figure(stability, n)
+ *   robustness_analyzer_v2.py:2739      return recommendation_stability   <- bare
+ *   robustness_analyzer_v2.py:4596  confidence_basis = "recommendation_stability_uncalibrated"
+ *
+ * It WAS `min(0.99, recommendation_stability * (1 - 1/sqrt(n_samples)))`. Two
+ * consequences a consumer cannot see from the value alone:
+ *
+ *   - the served number is now strictly HIGHER, and can reach exactly 1.0,
+ *     which the old 0.99 cap made unreachable;
+ *   - it is no longer a function of sample count, so the same recommendation no
+ *     longer reports a different "confidence" purely for running longer.
+ *
+ * A bare 0.97 is therefore ambiguous on the wire: under the old formula it was
+ * a shrunken, capped figure; under the new one it is the plain share of
+ * sampled scenarios the recommended option won. Same field, same type, same
+ * range, different quantity. `confidence_basis` is the machine-readable marker
+ * ISL added so a consumer can BRANCH rather than guess — and this module is
+ * PLoT refusing to guess.
+ *
+ * WHY NOT INFER FROM THE VALUE
+ * ----------------------------
+ * Tempting heuristics all fail. A value above 0.99 proves the new basis but
+ * almost every real value is below it; a value at exactly 0.99 is ambiguous
+ * (old cap, or a genuine 99% win share); and every value below 0.99 is
+ * reachable under both. Absence of the marker means "this producer has not
+ * told us", which is a different and weaker statement than "this is legacy" —
+ * but it is the honest one, and it is what `unknown_legacy` records.
+ *
+ * WHAT IT DOES NOT DO
+ * -------------------
+ * It does not suppress anything. ISL deliberately kept the slot because three
+ * repos read it, and PLoT's doctrine here is disclosure, not suppression
+ * (D-5). This module only lets the value be labelled.
+ */
+
+/** The exact literal ISL emits. Pinned against the source string by test. */
+export const CONFIDENCE_BASIS_STABILITY_UNCALIBRATED =
+  'recommendation_stability_uncalibrated';
+
+/**
+ * What PLoT records when the producer sent no recognised marker.
+ *
+ * NOT a claim that the payload is old — only that its basis was not declared,
+ * so the value must not be read as either basis.
+ */
+export const CONFIDENCE_BASIS_UNKNOWN = 'unknown_legacy';
+
+export type ConfidenceBasis =
+  | typeof CONFIDENCE_BASIS_STABILITY_UNCALIBRATED
+  | typeof CONFIDENCE_BASIS_UNKNOWN;
+
+/** The subset of an ISL robustness object this module needs. */
+export interface ConfidenceBearing {
+  confidence?: number;
+  confidence_basis?: unknown;
+}
+
+/**
+ * Resolve the basis of a robustness payload's `confidence`.
+ *
+ * Allow-list, not a cast: an unrecognised marker resolves to `unknown_legacy`
+ * rather than being forwarded verbatim, so a future ISL basis PLoT has not
+ * been taught about cannot be silently passed off as understood.
+ */
+export function resolveConfidenceBasis(
+  robustness: ConfidenceBearing | null | undefined
+): ConfidenceBasis {
+  const raw = robustness?.confidence_basis;
+  return raw === CONFIDENCE_BASIS_STABILITY_UNCALIBRATED
+    ? CONFIDENCE_BASIS_STABILITY_UNCALIBRATED
+    : CONFIDENCE_BASIS_UNKNOWN;
+}
+
+/**
+ * True when the producer declared the post-#114 basis.
+ *
+ * Use this to decide whether `confidence` may be described to a user at all —
+ * under the declared basis it is an uncalibrated scenario-win share and must
+ * never be rendered as a confidence level.
+ */
+export function hasDeclaredStabilityBasis(
+  robustness: ConfidenceBearing | null | undefined
+): boolean {
+  return resolveConfidenceBasis(robustness) === CONFIDENCE_BASIS_STABILITY_UNCALIBRATED;
+}

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -639,8 +639,26 @@ export interface ISLRobustnessAnalyzeV2Response {
   robustness?: {
     /** Robustness score (0-1) - V1 format */
     score?: number;
-    /** Robustness confidence (0-1) - V2/Option C format */
+    /**
+     * V2/Option C `confidence` slot (0-1).
+     *
+     * NOT a confidence level. Since ISL PR #114 (2026-07-26) this carries the
+     * UNCALIBRATED recommendation-stability fraction — the share of sampled
+     * scenarios the recommended option won — served under a legacy field name.
+     * It was min(0.99, stability * (1 - 1/sqrt(n_samples))); the shrinkage and
+     * the cap are withdrawn, so the value is strictly higher and can now reach
+     * exactly 1.0.
+     *
+     * Read `confidence_basis` before interpreting this. See
+     * src/integrations/isl/confidence-basis.ts.
+     */
     confidence?: number;
+    /**
+     * Machine-readable semantics marker for `confidence`, added by ISL PR #114
+     * so consumers branch rather than infer. Absent on pre-#114 payloads,
+     * which is why PLoT resolves it through an allow-list rather than casting.
+     */
+    confidence_basis?: string;
     /** Human-readable label - V1 format */
     label?: 'robust' | 'moderate' | 'fragile';
     /** Robustness level - V2/Option C format */

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -190,6 +190,7 @@ import type { ProposalCardV1 } from '../../review-pass/types.js';
 import { assembleFactObjects, type ISLResponseInput } from '../../facts/index.js';
 import type { FactObjectV1, FactLineage } from '../../facts/types.js';
 import { finiteNum, prob01, nonNeg, nonNegInt, hasAllRequiredOutcomeStats } from './numeric-egress-guards.js';
+import { resolveConfidenceBasis } from '../../integrations/isl/confidence-basis.js';
 import {
   assessEnrichmentContract,
   shouldAssessEnrichmentContract,
@@ -2762,8 +2763,33 @@ function buildResponse(
       ...(islResult.robustness.level !== undefined && {
         level: islResult.robustness.level,
       }),
+      // `confidence` + its BASIS, always together (ROADMAP 1.211).
+      //
+      // ISL PR #114 changed what this slot means without changing its name,
+      // type or range: it was min(0.99, stability * (1 - 1/sqrt(n_samples)))
+      // and is now the bare recommendation-stability fraction. So the value
+      // rises, becomes reachable at exactly 1.0, and — critically — a bare
+      // number on the wire is ambiguous between the two quantities. The basis
+      // marker is what removes that ambiguity, so it is emitted beside the
+      // value rather than as an optional extra, and resolved through an
+      // allow-list so an unrecognised future basis reads as 'unknown_legacy'
+      // instead of being passed off as understood.
+      //
+      // COLLISION WORTH KNOWING ABOUT — see the DROPPED entry for
+      // `robustness.recommendation_stability` in contracts/isl-to-ui.contract.ts.
+      // That field is deliberately withheld above because ISL derives it as
+      // option_wins[winner]/n_samples, i.e. the leader's win_probability
+      // relabelled. Post-#114 `confidence` IS that same number. PLoT therefore
+      // withholds the quantity under its honest name while forwarding it under
+      // a name that implies calibration — which ISL's own field description now
+      // denies ("NOT A CONFIDENCE LEVEL"). Disclosure, not suppression, is the
+      // doctrine here (D-5) and ISL kept the slot because three repos read it,
+      // so the basis marker is the fix available to this lane. Whether the slot
+      // should survive at all is a cross-repo contract decision, raised
+      // separately rather than settled unilaterally here.
       ...(prob01(islResult.robustness.confidence) !== undefined && {
         confidence: prob01(islResult.robustness.confidence),
+        confidence_basis: resolveConfidenceBasis(islResult.robustness),
       }),
       // Include normalization errors if any occurred (for observability)
       ...(normalizationErrors.length > 0 && { normalization_errors: normalizationErrors }),

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2541,8 +2541,23 @@ export interface RobustnessAssessmentV3 {
    * Note: ISL sends `'medium'`; the UI normalises this to `'moderate'`.
    */
   level?: 'high' | 'medium' | 'low' | 'very_low';
-  /** Robustness confidence from ISL (0-1) V2/Option C format */
+  /**
+   * ISL's `confidence` slot (0-1) — NOT a confidence level.
+   *
+   * Since ISL PR #114 this is the uncalibrated recommendation-stability
+   * fraction. Always read `confidence_basis` alongside it; a bare value is
+   * ambiguous between the pre- and post-#114 quantities.
+   */
   confidence?: number;
+  /**
+   * Declared basis for `confidence`.
+   *
+   * `'recommendation_stability_uncalibrated'` — the share of sampled scenarios
+   * the recommended option won, with no calibration and no coverage guarantee.
+   * `'unknown_legacy'` — the producer declared no basis, so the value must not
+   * be read as either quantity.
+   */
+  confidence_basis?: 'recommendation_stability_uncalibrated' | 'unknown_legacy';
   /** Normalization errors if any (for observability) */
   normalization_errors?: Array<{ edge_type: string; error: string; raw_value?: unknown }>;
   /**

--- a/src/util/structural-keys.generated.ts
+++ b/src/util/structural-keys.generated.ts
@@ -75,6 +75,7 @@ export const STRUCTURAL_KEYS: ReadonlySet<string> = new Set([
   "conditional_probabilities",
   "conditional_winners",
   "confidence",
+  "confidence_basis",
   "confidence_components",
   "confidence_interval",
   "confidence_provenance",

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -1185,6 +1185,7 @@
     "is_robust": false,
     "level": "low",
     "confidence": 0.5809173280554281,
+    "confidence_basis": "unknown_legacy",
     "recommended_option_id": "opt_tech_lead",
     "recommended_option_label": "Hire One Tech Lead",
     "near_tie": {
@@ -1624,7 +1625,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:9ca33a38c081fa08"
+    "response_content_hash": "rch_v2:4708fefe17cfbc43"
   },
   "meta": {
     "seed_used": "2034401427",

--- a/tests/robustness-confidence-basis.test.ts
+++ b/tests/robustness-confidence-basis.test.ts
@@ -1,0 +1,199 @@
+/**
+ * ROADMAP 1.211 — `confidence` recalibration after ISL PR #114.
+ *
+ * WHAT CHANGED IN ISL (verified in the merged source at ISL staging 7d144c7,
+ * not inferred from the PR prose):
+ *
+ *   robustness_analyzer_v2.py:4522  recommendation_stability = option_wins[winner] / n_samples
+ *   robustness_analyzer_v2.py:4584  confidence = _stability_confidence_figure(stability, n)
+ *   robustness_analyzer_v2.py:2739  return recommendation_stability   <- bare, unmodified
+ *   robustness_analyzer_v2.py:4596  confidence_basis = "recommendation_stability_uncalibrated"
+ *
+ * It WAS `min(0.99, stability * (1 - 1/sqrt(n_samples)))`. The shrinkage and the
+ * 0.99 cap are withdrawn, so the served value is strictly HIGHER and can now
+ * reach exactly 1.0, which the cap previously made unreachable.
+ *
+ * WHAT THIS MEANS FOR PLoT — two things, and the second is the important one.
+ *
+ * 1. NO THRESHOLD LOOSENS. ISL's PR flagged "a gate at routes/v2/run.ts:4202"
+ *    becoming more permissive. There is no such gate at this tip, at that line
+ *    or any other: `robustness.confidence` is read in exactly two places, a
+ *    prob01() validity guard and a `!== undefined` presence check, and
+ *    robustness-display-verdict.ts carries an explicit invariant that
+ *    confidence is NEVER a verdict input. The one indirect path
+ *    (confidence -> `score` fallback -> `robustness_score`) is compared against
+ *    no number anywhere, and the single behavioural branch on robustness
+ *    (`overall_robustness === 'fragile'`) reads `label`/`level`, never `score`.
+ *    The tests below PIN that, so if anyone later adds a magnitude threshold
+ *    they have to confront these semantics deliberately.
+ *
+ * 2. PLoT's OWN HONESTY SUPPRESSION IS DEFEATED BY THE PASSTHROUGH.
+ *    routes/v2/run.ts deliberately does NOT emit `recommendation_stability`,
+ *    documented there as `option_wins[winner]/n_samples` — "the leader's
+ *    win_probability relabelled, zero independent information", verified
+ *    byte-identical in live captures, and called "a fabricated second
+ *    statistic". Post-#114 `confidence` IS that exact quantity. So PLoT
+ *    suppresses the number under its honest name and re-publishes it under a
+ *    name that implies calibration — which ISL's own field description now
+ *    denies outright ("NOT A CONFIDENCE LEVEL").
+ *
+ * The fix is disclosure, not suppression (doctrine D-5, and ISL deliberately
+ * kept the slot because three repos read it): PLoT consumes and forwards
+ * `confidence_basis` so a consumer can branch on the semantics instead of
+ * inferring them, and can tell a post-#114 payload from a legacy one.
+ */
+import { describe, it, expect } from 'vitest';
+import { prob01 } from '../src/routes/v2/numeric-egress-guards.js';
+import { adaptRobustnessAnalysisResponse } from '../src/integrations/isl/adapters/robustness-analysis.js';
+import {
+  CONFIDENCE_BASIS_STABILITY_UNCALIBRATED,
+  resolveConfidenceBasis,
+} from '../src/integrations/isl/confidence-basis.js';
+
+describe('confidence_basis — distinguishing post-#114 payloads from legacy ones', () => {
+  it('recognises the ISL marker verbatim', () => {
+    // The exact literal ISL emits (Literal[...] in response_v2.py:660 and
+    // robustness_v2.py:1540). A typo here would silently classify every live
+    // payload as legacy, so it is pinned against the source string.
+    expect(CONFIDENCE_BASIS_STABILITY_UNCALIBRATED).toBe(
+      'recommendation_stability_uncalibrated'
+    );
+  });
+
+  it('classifies a post-#114 payload by its marker, not by guessing from the value', () => {
+    const basis = resolveConfidenceBasis({
+      confidence: 0.97,
+      confidence_basis: 'recommendation_stability_uncalibrated',
+    });
+
+    expect(basis).toBe('recommendation_stability_uncalibrated');
+  });
+
+  it('classifies a legacy payload as UNKNOWN rather than assuming the new semantics', () => {
+    // A pre-#114 ISL still in flight sends no marker. Its 0.97 meant
+    // min(0.99, stability * (1 - 1/sqrt(n))) — a different quantity from a
+    // post-#114 0.97. PLoT must not silently treat them as the same thing.
+    const basis = resolveConfidenceBasis({ confidence: 0.97 });
+
+    expect(basis).toBe('unknown_legacy');
+  });
+
+  it('does NOT infer the basis from the value being high, low, or exactly 1', () => {
+    // 1.0 was unreachable under the old 0.99 cap, so it is tempting to treat it
+    // as proof of a post-#114 payload. That inference is exactly what the
+    // marker exists to replace.
+    for (const confidence of [0, 0.5, 0.99, 1]) {
+      expect(resolveConfidenceBasis({ confidence })).toBe('unknown_legacy');
+    }
+  });
+
+  it('rejects an unrecognised marker rather than trusting it', () => {
+    expect(
+      resolveConfidenceBasis({ confidence: 0.5, confidence_basis: 'something_new' })
+    ).toBe('unknown_legacy');
+  });
+});
+
+describe('the emission boundary, pinned in BOTH directions', () => {
+  // The only real suppression boundary on this field is the prob01 validity
+  // guard: a value inside [0,1] publishes, anything else is withheld. Pinned
+  // both ways so neither half can regress unnoticed.
+
+  it('PUBLISHES values inside the valid range — including the newly reachable 1.0', () => {
+    expect(prob01(0)).toBe(0);
+    expect(prob01(0.5)).toBe(0.5);
+    expect(prob01(0.968)).toBe(0.968);
+    // Reachable only post-#114: the old formula capped at 0.99.
+    expect(prob01(1)).toBe(1);
+  });
+
+  it('SUPPRESSES values outside it, and every non-finite form', () => {
+    expect(prob01(1.0000001)).toBeUndefined();
+    expect(prob01(-0.0001)).toBeUndefined();
+    expect(prob01(NaN)).toBeUndefined();
+    expect(prob01(Infinity)).toBeUndefined();
+    expect(prob01(null)).toBeUndefined();
+    expect(prob01(undefined)).toBeUndefined();
+    expect(prob01('0.9')).toBeUndefined();
+  });
+
+  it('the raised value does NOT cross the boundary — the change cannot flip suppression', () => {
+    // For every stability fraction, old <= new and both stay inside [0,1], so
+    // no input exists for which #114 turns a withheld value into a published
+    // one. This is the "nothing loosens" claim, made checkable.
+    for (const stability of [0, 0.1, 0.5, 0.9, 0.99, 1]) {
+      const legacy = Math.min(0.99, stability * (1 - 1 / Math.sqrt(1000)));
+      const current = stability;
+
+      expect(current).toBeGreaterThanOrEqual(legacy);
+      expect(prob01(legacy) !== undefined).toBe(prob01(current) !== undefined);
+    }
+  });
+});
+
+describe('no magnitude threshold consumes robustness.confidence', () => {
+  // Regression pin for finding (1). The confidence -> score fallback is live
+  // (/v1/run -> analyseRobustness -> this adapter), so if a threshold on
+  // robustness_score is ever introduced, it inherits confidence's semantics.
+
+  it('confidence still back-fills the V1 score slot when score is absent', () => {
+    const result = adaptRobustnessAnalysisResponse(
+      {
+        robustness: {
+          confidence: 0.97,
+          confidence_basis: 'recommendation_stability_uncalibrated',
+          level: 'high',
+          fragile_edges: [],
+          robust_edges: [],
+        },
+      } as never,
+      100,
+      'available',
+      'available'
+    );
+
+    expect(result.robustness_score).toBe(0.97);
+  });
+
+  it('the robustness LABEL is derived from level, never from the confidence-fed score', () => {
+    // This is what stops the raised value moving a verdict: `label` comes from
+    // `level`, so a confidence of 0.97 under level 'low' must still read 'fragile'.
+    const result = adaptRobustnessAnalysisResponse(
+      {
+        robustness: {
+          confidence: 0.97,
+          confidence_basis: 'recommendation_stability_uncalibrated',
+          level: 'low',
+          fragile_edges: [],
+          robust_edges: [],
+        },
+      } as never,
+      100,
+      'available',
+      'available'
+    );
+
+    expect(result.robustness_score).toBe(0.97);
+    expect(result.overall_robustness).toBe('fragile');
+  });
+
+  it('an explicit score still wins over confidence — the fallback is a fallback', () => {
+    const result = adaptRobustnessAnalysisResponse(
+      {
+        robustness: {
+          score: 0.2,
+          confidence: 0.97,
+          confidence_basis: 'recommendation_stability_uncalibrated',
+          level: 'high',
+          fragile_edges: [],
+          robust_edges: [],
+        },
+      } as never,
+      100,
+      'available',
+      'available'
+    );
+
+    expect(result.robustness_score).toBe(0.2);
+  });
+});


### PR DESCRIPTION
**ROADMAP 1.211.** ISL PR #114 changed what `robustness.confidence` MEANS without changing its name, type or range. Verified in ISL's **merged source** at staging `7d144c7` — not inferred from the PR prose:

```python
robustness_analyzer_v2.py:4522  recommendation_stability = option_wins[winner]/n_samples
robustness_analyzer_v2.py:4584  confidence = _stability_confidence_figure(stability, n)
robustness_analyzer_v2.py:2739      return recommendation_stability     # <- bare
robustness_analyzer_v2.py:4596  confidence_basis = "recommendation_stability_uncalibrated"
```

Was `min(0.99, stability × (1 − 1/√n_samples))`. Shrinkage and cap withdrawn → value strictly higher, and now reaches exactly **1.0**.

---

## ISL's pointer was RIGHT — the line number was 7 weeks stale

ISL flagged "a gate at `run.ts:4202`". **That gate is real and still exists.** Archaeology across every revision of `run.ts` puts `robustness?.confidence` at line 4202 in `7217b8d` (2 Jun) and `0706cbc` (7 Jun):

```ts
const hasRobustness = islResult.robustness?.score !== undefined
  || islResult.robustness?.confidence !== undefined      // <- 4202
  || hasNonEmptyArray(islResult.robustness?.fragile_edges)
```

It is now at `run.ts:6375`. Line 4202 at this tip is unrelated categorical telemetry.

**But it is a PRESENCE check, not a threshold.** It feeds `analysis_status` (`mapToPerFeatureStatus:1236 → robustnessStatus:6397 → determineTopLevelStatus:1273`) — the real mechanism behind the "more permissive" intuition. A magnitude change cannot trip it: **an already-defined field does not become more defined.** Provably invariant.

## Complete manifest — no magnitude threshold exists

Scope `src/ tests/ tools/ scripts/ contracts/`:

| site | classification |
|---|---|
| `run.ts:2765` | VALIDITY GUARD — `prob01()`, finite ∈ [0,1] |
| `run.ts:2766` | PASSTHROUGH to wire |
| `run.ts:6375` | PRESENCE CHECK — the gate above |
| `robustness-analysis.ts:407` | FALLBACK — `score ?? confidence ?? 0.5` |
| `tools/seed-sweep.mjs:276` | PASSTHROUGH — diagnostic column |

`robustness-display-verdict.ts:29` carries an explicit invariant that confidence is **never** a verdict input (the signature doesn't accept it); `trust/confidence-tier.ts` takes only `{is_robust, level}`.

The one **indirect** path is live and traced end to end: `/v1/run:981 → analyseRobustness → adapter → score ?? confidence → robustness_score → v1/run.ts:1017`. It terminates in passthrough — nothing compares `robustness_score` against any number, and both behavioural branches (`v1/run.ts:1073`, `cee/orchestrator.ts:684`) read `label ← mapLevelToLabel(level)`, never `score`.

Absence confirmed by `git grep -nIE "robustness_score[[:space:]]*(>=|<=|>|<|==)"` (exit 1) with a positive control returning 8 hits, and `git log --all -S` on four comparison forms (all empty) against a control returning 4 commits.

---

## ⚠️ The real exposure — larger than a threshold

`contracts/isl-to-ui.contract.ts` deliberately **DROPS** `robustness.recommendation_stability`, documented as `option_wins[winner]/n_samples` — *"the leader's win_probability relabelled, zero independent information"*, verified byte-identical live (0.59025 / 0.8541875), which the UI had printed as *"a fabricated second statistic"*.

**Post-#114, `confidence` IS that exact quantity.** PLoT withholds the number under its honest name and forwards it under a name implying calibration — which ISL's own description now denies (*"NOT A CONFIDENCE LEVEL"*). The honesty suppression is defeated by the passthrough.

## What this change does

**Disclosure, not suppression** (doctrine D-5; ISL kept the slot because three repos read it, so unilateral removal here would break them).

- `src/integrations/isl/confidence-basis.ts` resolves the marker through an **allow-list** — an unrecognised future basis reads `unknown_legacy` rather than being passed off as understood. A *missing* marker resolves the same way: "the producer has not told us" is weaker than "this is legacy", and the code says the weaker, true thing.
- **The value is never used to infer the basis.** Every heuristic fails: `>0.99` proves the new basis but almost no real value exceeds it; exactly `0.99` is ambiguous between the old cap and a genuine 99% win share; everything below is reachable under both.
- Emitted **beside** the value, so a bare ambiguous number cannot reach the wire alone.

The duplication itself is a cross-repo contract question — whether the slot should survive, or whether ISL's honestly-named field should be delivered instead — recorded at both sites rather than settled unilaterally by this lane.

## Tests — boundary pinned in both directions

Inside `[0,1]` publishes (**including 1.0**, unreachable under the old cap); outside and every non-finite form is withheld. Plus a proof-shaped check that for every stability fraction `old ≤ new` and both stay inside `[0,1]` — so **no input exists** for which #114 turns a withheld value into a published one. Plus regression pins that the label still comes from `level`, and that an explicit `score` still beats the confidence fallback.

## Regenerated, not baseline-bumped

- `structural-keys.generated.ts` via `tools/gen-structural-keys.mjs` — diff is **exactly one line**, `+ "confidence_basis"`.
- `plot-v2-run.golden.json` via `UPDATE_GOLDEN=1` — diff is exactly the new field + its content hash. Its value is `unknown_legacy` because that fixture is a genuine **pre-#114 live ISL capture** — legacy detection demonstrated on real captured data, not just a synthetic case.

## Two adjacent findings — NOT actioned, each deserves its own change

1. `contracts/openapi.yaml` does not declare `robustness.confidence` in the robustness component schema at all — emitted but undeclared.
2. `cee/validation/number-corrector.ts:203` reads `robustness.overall_confidence`, which **no production code ever sets** (`buildIslResultsForCorrection` populates `recommendation_stability` only). The branch is unreachable; it looks like it was meant to carry this value and never got wired.

## Gates

`npm run typecheck` clean · `npm test` **569 files / 5993 tests, 0 failures, exit 0** (baseline `3c0201b`: 568 / 5982) · pre-push gate **6/6 PASS**, no `--no-verify`.

Run at machine load 92 with other lanes active, and green regardless — no flakes to disclose this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
