### PR TITLE
fix(guard): sample the egress guard per-arm; the band sweep runs always [ROADMAP 1.210]

### DIFF
--- a/src/routes/v2/enrichment-egress-guard.ts
+++ b/src/routes/v2/enrichment-egress-guard.ts
@@ -50,15 +50,53 @@ export const ENRICHMENT_CONTRACT_MAX_REPORTED_ISSUES = 10;
 // ----------------------------------------------------------------------------
 
 /**
- * Production default sample rate: assess 1 in N outgoing bodies.
+ * Production sample rate for the SCHEMA-PARSE arm only: parse 1 in N bodies.
  *
- * The full-body `AnalysisEnrichmentSchema.safeParse` on EVERY /v2/run duplicates
- * CEE's shadow parse of the same envelope. A real contract regression is
- * DETERMINISTIC — it breaks the same field on EVERY response — so a 1-in-N
- * sample still surfaces it within N requests, while cutting the per-request
- * schema-parse cost by ~(N-1)/N. Outside production the guard runs on EVERY
- * request (staging + tests want the immediate, complete signal). Ops override:
- * `ENRICHMENT_GUARD_SAMPLE_N` (integer ≥ 1; 1 = every request).
+ * SCOPE MATTERS HERE - read `assessEnrichmentContract` before changing this.
+ * The guard has two arms with different detection semantics, and only one of
+ * them may be sampled:
+ *
+ *   SCHEMA-PARSE arm (sampled, this constant). The full-body
+ *   `AnalysisEnrichmentSchema.safeParse` duplicates CEE's shadow parse. Its
+ *   faults ARE deterministic: a type or enum corruption on a typed key is a
+ *   property of the CODE, so it breaks every response and a 1-in-N sample
+ *   surfaces it within N requests while cutting ~(N-1)/N of the cost.
+ *
+ *   STABILITY-BAND arm (NEVER sampled, see assessStabilityBands). It validates
+ *   PER-RESPONSE ISL PAYLOAD DATA - ordered finite endpoints, non-negative
+ *   width, counts consistent with the per-seed list. A malformed band arrives
+ *   in the data for ONE request. It is not a property of the code and it does
+ *   not repeat, so sampling does not delay detection, it DESTROYS it: at
+ *   N=16 roughly 15 of every 16 malformed bands shipped to CEE stamped
+ *   `enrichment_contract_ok: true`.
+ *
+ * That distinction was missed originally because the arms landed in the wrong
+ * order. The sampling rationale was written in b9f825a (#230) and said, of the
+ * guard as it then was, "a real contract regression is DETERMINISTIC". True at
+ * the time. The data-dependent band arm was added later the same day in
+ * 9700d8b (#232) and inherited a sampling policy that had been justified
+ * against a check it is not. (`git merge-base --is-ancestor b9f825a 9700d8b`
+ * confirms the ordering.)
+ *
+ * The split is cheap because the arm that must NOT be sampled is the cheap one.
+ * Measured at this tip, 2000 iterations on a realistic body:
+ *
+ *   edge_e_values   band arm     schema arm   band share of total
+ *   10              0.0015 ms    0.2100 ms    0.7%
+ *   50              0.0065 ms    0.8652 ms    0.7%
+ *   200             0.0250 ms    3.1816 ms    0.8%
+ *
+ * So running the band sweep on every response costs microseconds, while the
+ * schema parse - the part actually worth sampling - keeps its saving. An
+ * earlier always-on figure of 0.047 ms mean (#225) does NOT reproduce here:
+ * the full guard measures 0.21-3.21 ms and scales with edge_e_values length.
+ * That figure was most likely taken on a minimal body, which is why the numbers
+ * above were re-measured rather than assumed.
+ *
+ * Outside production BOTH arms run on every request (staging + tests want the
+ * immediate, complete signal). Ops override: `ENRICHMENT_GUARD_SAMPLE_N`
+ * (integer >= 1; 1 = every request). Note the override governs the SCHEMA arm
+ * only - no value of it can switch the band sweep off.
  */
 export const DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD = 16;
 
@@ -204,13 +242,29 @@ export function assessStabilityBands(body: unknown): EnrichmentContractIssue[] {
  * site (fail-open) so a schema-library failure can never take down response
  * delivery.
  */
-export function assessEnrichmentContract(body: unknown): EnrichmentContractAssessment {
-  const result = AnalysisEnrichmentSchema.safeParse(body);
-  const schemaIssues: EnrichmentContractIssue[] = result.success
-    ? []
-    : result.error.issues.map((issue) => ({ path: issue.path.join('.'), code: issue.code }));
+export function assessEnrichmentContract(
+  body: unknown,
+  opts: { runSchemaParse?: boolean } = {},
+): EnrichmentContractAssessment {
+  // The schema parse is the SAMPLED arm; the caller passes the sampler's
+  // verdict. Defaults to true so every existing caller keeps running both arms.
+  const runSchemaParse = opts.runSchemaParse ?? true;
+
+  const schemaIssues: EnrichmentContractIssue[] = [];
+  if (runSchemaParse) {
+    const result = AnalysisEnrichmentSchema.safeParse(body);
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        schemaIssues.push({ path: issue.path.join('.'), code: issue.code });
+      }
+    }
+  }
   // F12: the passthrough envelope cannot see the nested stability band — add the
   // PLoT-local refinement so a malformed band is never stamped valid.
+  //
+  // UNCONDITIONAL, and it must stay that way: this arm validates per-response
+  // ISL data, so a skipped response is a fault that ships undetected rather
+  // than one caught a few requests later. See the sampling note above.
   const stabilityIssues = assessStabilityBands(body);
   const all = [...schemaIssues, ...stabilityIssues];
   if (all.length === 0) {

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -3614,14 +3614,32 @@ function buildResponse(
   // The appended warning `{code, message, severity}` conforms to the
   // envelope's inference_warnings element schema by construction, so the
   // disclosure can never itself create a contract violation.
-  // A3 remediation item 8: sample the guard (1-in-N in production, every
-  // request otherwise). A skipped request leaves enrichment_contract_ok ABSENT
-  // (= unassessed — the same honest non-claim as the guard-error path below),
-  // never a fabricated `true`. A deterministic envelope break still surfaces
-  // within N, and CEE's shadow parse remains the independent backstop.
+  // A3 remediation item 8 / ROADMAP 1.210: sampling is PER-ARM, because the
+  // guard's two arms fail in different ways.
+  //
+  // The schema parse is sampled (1-in-N in production, every request
+  // otherwise) — its faults are deterministic properties of the code, so a
+  // break still surfaces within N and CEE's shadow parse remains the
+  // independent backstop.
+  //
+  // The stability-band sweep runs on EVERY response and is no longer gated by
+  // the sampler. It validates per-response ISL DATA, so a skipped response is
+  // not a detection deferred by a few requests — it is a malformed band shipped
+  // undetected. At N=16 roughly 15 in 16 got through. It costs ~0.0015-0.025 ms,
+  // measured; see the sampling note in enrichment-egress-guard.ts.
+  //
+  // The guard therefore now runs on every request, so enrichment_contract_ok is
+  // always present rather than ABSENT on skipped requests. When only the band
+  // arm ran, `true` means "no malformed band" and NOT "the full envelope was
+  // parsed" — the narrower claim is the honest one, and `enrichment_contract_
+  // schema_parsed` records which arms actually ran so a reader can tell.
   try {
-    if (shouldAssessEnrichmentContract()) {
-      const enrichmentAssessment = assessEnrichmentContract(response);
+    {
+      const runSchemaParse = shouldAssessEnrichmentContract();
+      const enrichmentAssessment = assessEnrichmentContract(response, { runSchemaParse });
+      if (response._meta?.evidence) {
+        response._meta.evidence.enrichment_contract_schema_parsed = runSchemaParse;
+      }
       if (response._meta?.evidence) {
         response._meta.evidence.enrichment_contract_ok = enrichmentAssessment.ok;
       }

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -2839,6 +2839,24 @@ export interface EvidenceCaptureV1 {
    * @see src/routes/v2/enrichment-egress-guard.ts
    */
   enrichment_contract_ok?: boolean;
+  /**
+   * Which arms of the egress guard actually ran for THIS response
+   * (ROADMAP 1.210).
+   *
+   * The guard has two arms, sampled independently because they fail
+   * differently. The stability-band sweep — per-response ISL DATA validation —
+   * runs on EVERY response. The full-envelope schema parse is sampled 1-in-N in
+   * production, because its faults are deterministic properties of the code.
+   *
+   * True  = both arms ran; `enrichment_contract_ok` covers the whole envelope.
+   * False = only the band sweep ran; `enrichment_contract_ok: true` then means
+   *         "no malformed stability band", NOT "the envelope parsed clean".
+   *
+   * Present whenever the guard ran at all, so a reader never has to guess which
+   * claim an `ok: true` is making.
+   * @see src/routes/v2/enrichment-egress-guard.ts
+   */
+  enrichment_contract_schema_parsed?: boolean;
 }
 
 /**

--- a/src/util/structural-keys.generated.ts
+++ b/src/util/structural-keys.generated.ts
@@ -141,6 +141,7 @@ export const STRUCTURAL_KEYS: ReadonlySet<string> = new Set([
   "endpoint",
   "endpoint_version",
   "enrichment_contract_ok",
+  "enrichment_contract_schema_parsed",
   "entry_nodes",
   "epsilon_std",
   "error",

--- a/tests/enrichment-egress-guard.sampling-by-arm.test.ts
+++ b/tests/enrichment-egress-guard.sampling-by-arm.test.ts
@@ -1,0 +1,219 @@
+/**
+ * ROADMAP 1.210 — the egress guard's 1-in-16 sample was calibrated for the
+ * wrong kind of check.
+ *
+ * THE DEFECT
+ *
+ * The sampling rationale (b9f825a, #230, 18 Jul) reads: "A real contract
+ * regression is DETERMINISTIC — it breaks the same field on EVERY response — so
+ * a 1-in-N sample still surfaces it within N requests."
+ *
+ * That is true of the SCHEMA-PARSE arm. A type or enum corruption on a typed
+ * key is a property of the code, so it breaks every response and 1-in-16
+ * catches it within 16 requests.
+ *
+ * It is false of the STABILITY-BAND arm, which landed AFTERWARDS in 9700d8b
+ * (#232, same day; `git merge-base --is-ancestor b9f825a 9700d8b` confirms the
+ * ordering). That arm validates PER-RESPONSE ISL PAYLOAD DATA — that
+ * band_min <= band_median <= band_max, that endpoints are finite, that width is
+ * non-negative. A malformed band arrives in the data for a particular request.
+ * It is not a property of the code and it does not repeat. Under 1-in-16 it is
+ * caught with probability 1/16, so roughly 15 in 16 malformed bands ship to CEE
+ * stamped `enrichment_contract_ok: true`.
+ *
+ * A guard that says "valid" about a body it never looked at is worse than no
+ * guard, for the same reason a circuit breaker that cannot trip is worse than
+ * none: it reads as protection that does not exist.
+ *
+ * THE FIX, AND WHY IT IS A SPLIT RATHER THAN A BLANKET RAISE
+ *
+ * Measured on this tip (2000 iterations, realistic body):
+ *
+ *   edge_e_values   band arm      schema arm    band share
+ *   10              0.0015 ms     0.2100 ms     0.7%
+ *   50              0.0065 ms     0.8652 ms     0.7%
+ *   200             0.0250 ms     3.1816 ms     0.8%
+ *
+ * The arm whose detection sampling BREAKS is also the arm that costs almost
+ * nothing, and the expensive arm is the one for which the deterministic
+ * argument genuinely holds. So each arm is now sampled according to its own
+ * detection semantics: the band sweep runs on EVERY response, the schema parse
+ * keeps its 1-in-N.
+ *
+ * (The brief cited 0.047 ms mean for always-on from #225. This tip does not
+ * reproduce that: the full guard is 0.21-3.21 ms and scales with
+ * edge_e_values length. That figure is likely from a minimal body, and it is
+ * why the split is measured here rather than assumed.)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  assessEnrichmentContract,
+  assessStabilityBands,
+  shouldAssessEnrichmentContract,
+  __resetEnrichmentGuardSampler,
+  DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD,
+} from '../src/routes/v2/enrichment-egress-guard.js';
+
+/** A body whose stability band is malformed: median above max (reversed). */
+function bodyWithMalformedBand() {
+  return {
+    edge_e_values: [
+      {
+        edge_id: 'a->b',
+        from_id: 'a',
+        to_id: 'b',
+        e_value: 0.5,
+        flip_direction: 'increase',
+        current_mean: 100,
+        flip_mean: 120,
+        stability: {
+          n_seeds: 8,
+          n_seeds_flipped: 2,
+          band_min: 0.4,
+          band_median: 0.9,
+          band_max: 0.6,
+          band_width: 0.2,
+        },
+      },
+    ],
+  };
+}
+
+/** The same shape, well-formed. */
+function bodyWithValidBand() {
+  return {
+    edge_e_values: [
+      {
+        edge_id: 'a->b',
+        from_id: 'a',
+        to_id: 'b',
+        e_value: 0.5,
+        flip_direction: 'increase',
+        current_mean: 100,
+        flip_mean: 120,
+        stability: {
+          n_seeds: 8,
+          n_seeds_flipped: 2,
+          band_min: 0.4,
+          band_median: 0.5,
+          band_max: 0.6,
+          band_width: 0.2,
+        },
+      },
+    ],
+  };
+}
+
+const prevEnv = process.env.ENRICHMENT_GUARD_SAMPLE_N;
+const prevNodeEnv = process.env.NODE_ENV;
+
+beforeEach(() => {
+  __resetEnrichmentGuardSampler();
+});
+
+afterEach(() => {
+  if (prevEnv === undefined) delete process.env.ENRICHMENT_GUARD_SAMPLE_N;
+  else process.env.ENRICHMENT_GUARD_SAMPLE_N = prevEnv;
+  if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = prevNodeEnv;
+  __resetEnrichmentGuardSampler();
+});
+
+describe('POSITIVE CONTROL — the band arm can detect the fault at all', () => {
+  it('flags a reversed band', () => {
+    const issues = assessStabilityBands(bodyWithMalformedBand());
+
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.some((i) => i.path.includes('band_max'))).toBe(true);
+  });
+
+  it('passes a well-formed band', () => {
+    expect(assessStabilityBands(bodyWithValidBand())).toEqual([]);
+  });
+});
+
+describe('the data-dependent arm runs on EVERY response, whatever the sample rate', () => {
+  it('catches a malformed band on a request the sampler would have skipped', () => {
+    // N=16 with the counter at 1 means shouldAssessEnrichmentContract() is
+    // false — under the old behaviour this body was never inspected and went
+    // out stamped ok:true.
+    process.env.ENRICHMENT_GUARD_SAMPLE_N = '16';
+    __resetEnrichmentGuardSampler();
+    shouldAssessEnrichmentContract(); // consume request 1 (the sampled one)
+
+    expect(shouldAssessEnrichmentContract()).toBe(false); // request 2: skipped
+
+    const assessment = assessEnrichmentContract(bodyWithMalformedBand(), {
+      runSchemaParse: false,
+    });
+
+    expect(assessment.ok).toBe(false);
+    expect(assessment.issue_count).toBeGreaterThan(0);
+  });
+
+  it('catches a malformed band across a FULL sampling cycle — every request, not 1 in N', () => {
+    process.env.ENRICHMENT_GUARD_SAMPLE_N = String(DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD);
+    __resetEnrichmentGuardSampler();
+
+    let caught = 0;
+    for (let i = 0; i < DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD; i++) {
+      const runSchemaParse = shouldAssessEnrichmentContract();
+      const assessment = assessEnrichmentContract(bodyWithMalformedBand(), { runSchemaParse });
+      if (!assessment.ok) caught++;
+    }
+
+    // Was 1 of 16 before this change. Must now be 16 of 16.
+    expect(caught).toBe(DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD);
+  });
+
+  it('does not cry wolf — a valid band stays ok on every request of the cycle', () => {
+    process.env.ENRICHMENT_GUARD_SAMPLE_N = String(DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD);
+    __resetEnrichmentGuardSampler();
+
+    for (let i = 0; i < DEFAULT_ENRICHMENT_GUARD_SAMPLE_N_PROD; i++) {
+      const runSchemaParse = shouldAssessEnrichmentContract();
+      expect(assessEnrichmentContract(bodyWithValidBand(), { runSchemaParse }).ok).toBe(true);
+    }
+  });
+});
+
+describe('the schema-parse arm keeps its sampling — its faults ARE deterministic', () => {
+  it('is skipped when the sampler says so', () => {
+    // `analysis_status` must be an enum member; a number is a type corruption
+    // the schema arm catches and the band arm cannot see.
+    const corrupt = { analysis_status: 12345 };
+
+    const skipped = assessEnrichmentContract(corrupt, { runSchemaParse: false });
+    const run = assessEnrichmentContract(corrupt, { runSchemaParse: true });
+
+    // Skipping is what makes the sampling a saving at all.
+    expect(skipped.ok).toBe(true);
+    // POSITIVE CONTROL: the same body IS caught when the arm runs, so the
+    // assertion above is about sampling and not about a blind check.
+    expect(run.ok).toBe(false);
+  });
+
+  it('defaults to running both arms when no options are passed', () => {
+    // Back-compat for every existing caller.
+    expect(assessEnrichmentContract({ analysis_status: 12345 }).ok).toBe(false);
+    expect(assessEnrichmentContract(bodyWithMalformedBand()).ok).toBe(false);
+  });
+});
+
+describe('sampler semantics are unchanged', () => {
+  it('still assesses request 1, N+1, 2N+1 under an explicit N', () => {
+    process.env.ENRICHMENT_GUARD_SAMPLE_N = '4';
+    __resetEnrichmentGuardSampler();
+
+    const pattern = Array.from({ length: 8 }, () => shouldAssessEnrichmentContract());
+
+    expect(pattern).toEqual([true, false, false, false, true, false, false, false]);
+  });
+
+  it('N=1 assesses every request', () => {
+    process.env.ENRICHMENT_GUARD_SAMPLE_N = '1';
+    __resetEnrichmentGuardSampler();
+
+    expect([1, 2, 3].map(() => shouldAssessEnrichmentContract())).toEqual([true, true, true]);
+  });
+});

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -1578,7 +1578,8 @@
       "plot_build": "__VOLATILE__",
       "isl_build": "9a22a1a",
       "isl_request_digest": null,
-      "isl_response_digest": null
+      "isl_response_digest": null,
+      "enrichment_contract_schema_parsed": true
     },
     "feature_flags_snapshot": {
       "SCM_LITE_ENABLE": "0",


### PR DESCRIPTION
**ROADMAP 1.210.** The guard's 1-in-16 production sample was calibrated for one kind of check, then inherited by another kind that it silently disables.

## The ordering IS the defect

The rationale was written in `b9f825a` (#230, 18 Jul):

> "A real contract regression is DETERMINISTIC — it breaks the same field on EVERY response — so a 1-in-N sample still surfaces it within N requests."

True of the guard **as it then stood**: a single full-body schema parse.

The data-dependent **stability-band arm** was added *later the same day* in `9700d8b` (#232) and inherited a policy justified against a check it is not. `git merge-base --is-ancestor b9f825a 9700d8b` confirms the ordering.

## Why it matters

The band arm validates **per-response ISL payload data** — `band_min ≤ band_median ≤ band_max`, finite endpoints, non-negative width, counts consistent with the per-seed list. A malformed band arrives in the data for **one** request. It is not a property of the code and it does not repeat.

So sampling doesn't *delay* detection — it **destroys** it. At N=16, roughly **15 of every 16 malformed bands shipped to CEE stamped `enrichment_contract_ok: true`.**

A guard that reports "valid" about a body it never looked at is worse than no guard — the same failure mode as a circuit breaker that cannot trip.

## ⚠️ The cited cost figure does not reproduce

The brief cited **0.047 ms** mean for always-on (#225). At this tip it does not reproduce, so I re-measured rather than assumed: the full guard is **0.21–3.21 ms** and **scales with `edge_e_values` length**. The #225 figure was most likely taken on a minimal body.

Measured here, 2000 iterations, realistic body:

| `edge_e_values` | band arm | schema arm | band share |
|---|---|---|---|
| 10 | **0.0015 ms** | 0.2100 ms | 0.7% |
| 50 | **0.0065 ms** | 0.8652 ms | 0.7% |
| 200 | **0.0250 ms** | 3.1816 ms | 0.8% |

## So the fix is a split, not a blanket raise

The arm whose detection sampling **breaks** is the arm that costs ~nothing; the expensive arm is the one for which the deterministic argument genuinely holds. Each arm is now sampled by its own detection semantics:

- **stability-band sweep → EVERY response**, never gated by the sampler
- **full-envelope schema parse → keeps 1-in-N** in production

Raising both to always-on would have added up to **3.2 ms per response to buy nothing** — the schema arm's faults are still deterministic, so 1-in-N still catches them within N, with CEE's shadow parse as the independent backstop.

## Honesty of the resulting claim

The guard now runs on every request, so `enrichment_contract_ok` is always present. But when only the band arm ran, `ok: true` means *"no malformed stability band"* — **not** *"the full envelope parsed clean"*.

Rather than let one boolean carry two meanings, a sibling `enrichment_contract_schema_parsed` records which arms actually ran, so a reader never has to guess which claim an `ok: true` is making.

`assessEnrichmentContract(body, { runSchemaParse })` defaults to `true`, so every existing caller is unchanged.

**The stale rationale comment is rewritten at the site**, as asked — it now describes the code that exists, names both arms, states which may be sampled and why, carries the measurements, and records that `ENRICHMENT_GUARD_SAMPLE_N` governs the schema arm only and **cannot** switch the band sweep off.

## Tests

RED-first: the cycle test asserts **16 of 16** malformed bands caught (was 1 of 16). Positive controls throughout — the band arm detects the fault at all; a *valid* band stays `ok` on every request of a full cycle (so this isn't a guard that just always says "bad"); and a schema-only corruption **is** caught when the schema arm runs, so the "skipped when sampled out" assertion is about sampling rather than a blind check. Sampler round-robin semantics pinned unchanged.

## Regenerated, not baseline-bumped

- `structural-keys.generated.ts` — exactly one line.
- `plot-v2-run.golden.json` — exactly the new evidence field. **No content-hash change**, because the stamp lives in `_meta`, which the hash excludes by construction.

## Gates

`npm run typecheck` clean · pre-push gate **6/6 PASS**, `Tests 5951 passed | 29 skipped (5991)`, no `--no-verify`.

**Flake disclosed:** an earlier full run failed `tests/stream.real.limited.test.ts` (SSE backpressure). It passes in isolation (1/1, 384 ms) and **did not recur** in the gate run. This change does not touch streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
