### PR TITLE
fix(explain-policy): a malformed policy_tree is a typed 400, never a 500 [1.229]

### DIFF
--- a/src/routes/v1/explain-policy.ts
+++ b/src/routes/v1/explain-policy.ts
@@ -107,7 +107,140 @@ async function callCeeExplainPolicy(
 }
 
 /**
+ * Validate the untrusted `policy_tree` down to the fields this handler reads.
+ *
+ * ## Why this exists
+ *
+ * The route casts `req.body as ExplainPolicyRequest` and previously validated
+ * only that `policy_tree`, `policy_tree.nodes` and `policy_tree.root_id` were
+ * *truthy*. Everything below that was read as if the TypeScript types were
+ * enforced at the wire, and they are not: a node without `children` reached
+ * `n.children.length` and the resulting TypeError surfaced to callers as an
+ * opaque 500 "Something went wrong". Reproduced live on staging build
+ * `220739b` with `{"policy_tree":{"root_id":"r","depth":2,"nodes":[{"id":"r"}]}}`.
+ *
+ * This is the same defect class PR #265 fixed for `sequential_metadata`.
+ * That fix made `validateSequentialGraph` total; `policy_tree` was left
+ * unhardened, and this route also re-reads `sequential_metadata.stages`
+ * directly (see `readStageLabels`), on a path the validator does not cover.
+ *
+ * ## The rule for anyone editing this file
+ *
+ * Every field of `policy_tree` or `graph` that the handler reads must either
+ * be validated here (typed 400) or be read totally (no throw, no fabricated
+ * output) at the point of use. Malformed input must produce an honest
+ * envelope, never a 500.
+ *
+ * Load-bearing fields are validated because the analysis is genuinely
+ * uncomputable without them:
+ * - `nodes[].stage`          — the grouping key, and a required response field
+ * - `nodes[].expected_value` — arithmetic input; also `.toFixed()` in the output
+ * - `nodes[].children`       — the sole terminal-node discriminator
+ * Cosmetic fields (`type`, `label`, `action`, `policy_summary`) are read
+ * totally instead, so a request that succeeds today keeps succeeding.
+ */
+function validatePolicyTreeShape(
+  policyTree: IslPolicyTreeResponse
+): { code: string; field: string; message: string } | null {
+  if (!Array.isArray(policyTree.nodes)) {
+    return {
+      code: 'INVALID_POLICY_TREE',
+      field: 'policy_tree.nodes',
+      message: `policy_tree.nodes must be an array of policy tree nodes, received ${policyTree.nodes === null ? 'null' : typeof policyTree.nodes}.`,
+    };
+  }
+
+  for (let i = 0; i < policyTree.nodes.length; i++) {
+    const node = policyTree.nodes[i] as unknown;
+
+    if (node === null || typeof node !== 'object' || Array.isArray(node)) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}]`,
+        message: `policy_tree.nodes[${i}] is not a policy tree node — expected an object, received ${node === null ? 'null' : Array.isArray(node) ? 'array' : typeof node}.`,
+      };
+    }
+
+    const n = node as Record<string, unknown>;
+
+    if (typeof n.id !== 'string' || n.id.length === 0) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}].id`,
+        message: `policy_tree.nodes[${i}] is missing a non-empty string "id".`,
+      };
+    }
+
+    if (typeof n.stage !== 'number' || !Number.isFinite(n.stage)) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}].stage`,
+        message: `policy_tree.nodes[${i}] ("${n.id}") has "stage" of type ${n.stage === null ? 'null' : typeof n.stage}, expected a finite number. Stage explanations are grouped by this value.`,
+      };
+    }
+
+    if (typeof n.expected_value !== 'number' || !Number.isFinite(n.expected_value)) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}].expected_value`,
+        message: `policy_tree.nodes[${i}] ("${n.id}") has "expected_value" of type ${n.expected_value === null ? 'null' : typeof n.expected_value}, expected a finite number. Risk and rationale figures are computed from it.`,
+      };
+    }
+
+    if (!Array.isArray(n.children)) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}].children`,
+        message: `policy_tree.nodes[${i}] ("${n.id}") has "children" of type ${n.children === null ? 'null' : typeof n.children}, expected an array of child node IDs. Terminal nodes are identified by an empty "children" array.`,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Read stage labels from `graph.sequential_metadata.stages` without trusting
+ * its shape.
+ *
+ * `validateSequentialGraph` is total and rejects a malformed `stages` with a
+ * typed 400 — but only when the graph declares `is_sequential: true` (or a
+ * node carries `stage`). A graph with `is_sequential: false` and a malformed
+ * `stages` skips that validator entirely and used to reach `for...of` on a
+ * non-iterable here. Labels are cosmetic, so a malformed entry is skipped
+ * rather than refused: this path must not invent a refusal the validator
+ * itself would not raise.
+ */
+function readStageLabels(graph: ExplainPolicyRequest['graph']): Map<number, string> {
+  const stageLabels = new Map<number, string>();
+  const rawStages: unknown = graph?.sequential_metadata?.stages;
+
+  if (!Array.isArray(rawStages)) return stageLabels;
+
+  for (const stage of rawStages) {
+    if (stage === null || typeof stage !== 'object') continue;
+    const { index, label } = stage as { index?: unknown; label?: unknown };
+    if (typeof index !== 'number' || !Number.isFinite(index)) continue;
+    if (typeof label !== 'string' || label.length === 0) continue;
+    stageLabels.set(index, label);
+  }
+
+  return stageLabels;
+}
+
+/** Describe a decision node without emitting "undefined" into user-facing prose. */
+function decisionText(node: PolicyTreeNode): string {
+  if (typeof node.action === 'string' && node.action.length > 0) return node.action;
+  if (typeof node.label === 'string' && node.label.length > 0) return node.label;
+  return node.id;
+}
+
+/**
  * Extract stage explanations from policy tree
+ *
+ * Precondition: `tree` has passed `validatePolicyTreeShape`, so `nodes` is an
+ * array of objects with finite `stage` and `expected_value`. `graph` is NOT
+ * validated — read it totally.
  */
 function extractStageExplanations(
   tree: IslPolicyTreeResponse,
@@ -124,13 +257,8 @@ function extractStageExplanations(
   const stages = [...nodesByStage.keys()].sort((a, b) => a - b);
   const stageExplanations: CeePolicyExplanation['stage_explanations'] = [];
 
-  // Get stage labels from graph metadata
-  const stageLabels = new Map<number, string>();
-  if (graph.sequential_metadata?.stages) {
-    for (const stage of graph.sequential_metadata.stages) {
-      stageLabels.set(stage.index, stage.label);
-    }
-  }
+  // Get stage labels from graph metadata (untrusted — see readStageLabels)
+  const stageLabels = readStageLabels(graph);
 
   for (const stageIndex of stages) {
     const stageNodes = nodesByStage.get(stageIndex) ?? [];
@@ -144,11 +272,12 @@ function extractStageExplanations(
     );
 
     if (bestDecision) {
+      const action = decisionText(bestDecision);
       stageExplanations.push({
         stage: stageIndex,
         stage_label: stageLabel,
-        explanation: `At ${stageLabel}, the optimal action is ${bestDecision.action ?? bestDecision.label}.`,
-        key_decision: bestDecision.action ?? bestDecision.label,
+        explanation: `At ${stageLabel}, the optimal action is ${action}.`,
+        key_decision: action,
         rationale: `Expected value: ${bestDecision.expected_value.toFixed(2)}`,
       });
     }
@@ -159,19 +288,25 @@ function extractStageExplanations(
 
 /**
  * Generate local fallback explanation when CEE is unavailable
+ *
+ * Precondition: `policyTree` has passed `validatePolicyTreeShape`.
  */
 function generateFallbackExplanation(
   policyTree: IslPolicyTreeResponse,
   graph: ExplainPolicyRequest['graph']
 ): CeePolicyExplanation {
-  const rootNode = policyTree.nodes.find((n) => n.id === policyTree.root_id);
   const stageExplanations = extractStageExplanations(policyTree, graph);
 
-  // Generate summary
+  // Generate summary. `policy_summary` is declared required but is not
+  // validated at the wire; interpolating it unchecked emitted the literal
+  // string "undefined", or dropped `explanation.summary` from the response
+  // entirely (JSON.stringify omits undefined) — a required response field
+  // silently absent. Read it totally instead.
+  const treeSummary = typeof policyTree.policy_summary === 'string' ? policyTree.policy_summary : '';
   const summary =
     stageExplanations.length > 0
-      ? `This policy consists of ${stageExplanations.length} sequential decisions. ${policyTree.policy_summary}`
-      : policyTree.policy_summary;
+      ? `This policy consists of ${stageExplanations.length} sequential decisions. ${treeSummary}`.trim()
+      : treeSummary;
 
   // Identify risks from low expected value paths
   const risks: string[] = [];
@@ -259,6 +394,27 @@ export async function registerExplainPolicyRoute(app: FastifyInstance) {
           }
           sequentialWarnings.push(issue.message);
         }
+      }
+
+      // Validate the policy tree down to the fields the handler reads. Without
+      // this, a node missing `children` reached `n.children.length` and 500'd.
+      //
+      // Deliberately the LAST validator: a body that is malformed in both its
+      // graph and its policy_tree keeps reporting the graph code it reported
+      // before this change (e.g. INVALID_STAGE_DEFINITION, pinned by #265's
+      // live evidence). This check therefore only ever converts a 500 into a
+      // 400 — it never renames a 400 that callers already receive.
+      //
+      // It runs before the CEE call so the route answers a malformed tree the
+      // same way whoever narrates it — CEE or the local fallback.
+      const treeIssue = validatePolicyTreeShape(body.policy_tree);
+      if (treeIssue) {
+        return replyWithAppError(reply, {
+          type: 'BAD_INPUT',
+          statusCode: 400,
+          message: `Policy tree validation failed: ${treeIssue.message}`,
+          fields: { field: treeIssue.field, code: treeIssue.code },
+        });
       }
 
       // Call CEE if enabled

--- a/tests/explain-policy-malformed-tree.regression.test.ts
+++ b/tests/explain-policy-malformed-tree.regression.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Regression pin: POST /v1/explain/policy must be TOTAL on a malformed
+ * `policy_tree` — a typed 400, never a 500.
+ *
+ * DEFECT (found live on staging build `220739b`, 26 Jul 2026, and reproduced
+ * offline here): the route validated only that `policy_tree`,
+ * `policy_tree.nodes` and `policy_tree.root_id` were *truthy*, then cast
+ * `req.body`. `generateFallbackExplanation` ran
+ * `policyTree.nodes.filter((n) => n.children.length === 0)` on the result, so a
+ * node without a `children` array — a shape the route's own validation
+ * accepted — threw `TypeError: Cannot read properties of undefined (reading
+ * 'length')`, surfacing to callers as an opaque 500 "Something went wrong".
+ *
+ * The live probe's own "well-formed control" 500'd for exactly this reason:
+ * `{"policy_tree":{"root_id":"r","depth":2,"nodes":[{"id":"r"}]}}` has no
+ * `children` on its single node. Every captured 500 on this route shares that
+ * one cause; the payloads below are the captured bytes, verbatim.
+ *
+ * Same defect class as PR #265, which made `validateSequentialGraph` total for
+ * `sequential_metadata`. `policy_tree` was left unhardened, and this route also
+ * re-reads `sequential_metadata.stages` directly — on a path #265's validator
+ * does not cover (see the `is_sequential: false` cases below).
+ *
+ * WHAT EACH BLOCK PROVES
+ * - "captured live payloads": the exact reported defect, 500 -> typed 400.
+ * - "additional throw sites": four further unguarded reads on the same
+ *   untrusted body, each 500 before this change.
+ * - "throw eliminated without a new refusal": shapes that threw but must not
+ *   become refusals — the graph declares itself non-sequential, so stage
+ *   labels are cosmetic.
+ * - "positive controls": a well-formed request still returns a complete 200,
+ *   and a previously-observed 400 code is unchanged.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { registerExplainPolicyRoute } from '../src/routes/v1/explain-policy.js';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = Fastify({ logger: false });
+  await registerExplainPolicyRoute(app);
+  await app.ready();
+});
+
+afterAll(async () => {
+  if (app) await app.close();
+});
+
+beforeEach(() => {
+  // The fallback path is the one that crashed; keep CEE off so it is exercised.
+  delete process.env.CEE_EXPLAIN_POLICY_ENABLE;
+  delete process.env.CEE_ORCHESTRATOR_ENABLED;
+});
+
+async function post(payload: unknown) {
+  const res = await app.inject({ method: 'POST', url: '/v1/explain/policy', payload: payload as any });
+  return { statusCode: res.statusCode, body: JSON.parse(res.payload) };
+}
+
+/** A tree that satisfies every field the handler reads. */
+function wellFormedTree() {
+  return {
+    root_id: 'root',
+    depth: 1,
+    terminal_count: 1,
+    policy_summary: 'Launch Now (EV: 100)',
+    nodes: [
+      { id: 'root', type: 'decision', label: 'Start', stage: 0, expected_value: 100, children: ['d1'] },
+      { id: 'd1', type: 'decision', label: 'Launch Now', stage: 0, action: 'launch', expected_value: 100, children: [] },
+    ],
+  };
+}
+
+function wellFormedGraph() {
+  return {
+    nodes: [
+      { id: 'launch', label: 'Launch Decision', kind: 'decision', stage: 0 },
+      { id: 'outcome', label: 'Revenue', kind: 'outcome', stage: 1 },
+    ],
+    edges: [{ from: 'launch', to: 'outcome' }],
+    sequential_metadata: {
+      is_sequential: true,
+      stages: [
+        { index: 0, label: 'Launch', decisions: ['launch'], resolved_uncertainties: [] },
+        { index: 1, label: 'Outcome', decisions: [], resolved_uncertainties: [] },
+      ],
+    },
+  };
+}
+
+/**
+ * The captured staging payloads, byte-for-byte from
+ * `acceptance-evidence/owed-acceptances-2026-07-26/raw/plot265-P{0,5,6}-*.request.json`.
+ * All three carry the same `policy_tree`; they differ only in the
+ * `sequential_metadata` shape the prior lane was probing.
+ */
+const CAPTURED_500S: Array<[string, unknown]> = [
+  [
+    'P0 — the probe\'s own "well-formed" control',
+    { policy_tree: { root_id: 'r', depth: 2, nodes: [{ id: 'r' }] }, graph: { nodes: [{ id: 'n1', stage: 0 }, { id: 'n2', stage: 1 }], edges: [], sequential_metadata: { is_sequential: true, stages: [{ index: 0, decisions: ['n1'], resolved_uncertainties: [] }, { index: 1, decisions: ['n2'], resolved_uncertainties: [] }] } } },
+  ],
+  [
+    'P5 — stages omit their id lists',
+    { policy_tree: { root_id: 'r', depth: 2, nodes: [{ id: 'r' }] }, graph: { nodes: [{ id: 'n1', stage: 0 }, { id: 'n2', stage: 1 }], edges: [], sequential_metadata: { is_sequential: true, stages: [{ index: 0 }, { index: 1 }] } } },
+  ],
+  [
+    'P6 — a stage id list is the wrong type',
+    { policy_tree: { root_id: 'r', depth: 2, nodes: [{ id: 'r' }] }, graph: { nodes: [{ id: 'n1', stage: 0 }, { id: 'n2', stage: 1 }], edges: [], sequential_metadata: { is_sequential: true, stages: [{ index: 0, decisions: 'n1', resolved_uncertainties: [] }, { index: 1, decisions: ['n2'], resolved_uncertainties: [] }] } } },
+  ],
+];
+
+describe('POST /v1/explain/policy — captured live 500s become typed 400s', () => {
+  /**
+   * The captured node `{"id":"r"}` omits all three load-bearing fields
+   * (`stage`, `expected_value`, `children`). Only `children` threw at runtime —
+   * the other two were read totally — so the reported field here is `stage`,
+   * the first the validator rejects on, while the `children` throw is pinned in
+   * isolation in the next block. Reporting the first failure per node matches
+   * the route's existing one-field-per-envelope style.
+   */
+  it.each(CAPTURED_500S)('%s', async (_name, payload) => {
+    const { statusCode, body } = await post(payload);
+
+    // RED before the fix: 500, TypeError reading 'length' of undefined.
+    expect(statusCode).not.toBe(500);
+    expect(statusCode).toBe(400);
+
+    // Honest envelope, not a generic BAD_INPUT: names the code, the exact
+    // node, and the field that could not be read.
+    expect(body.code).toBe('INVALID_POLICY_TREE_NODE');
+    expect(body.field).toBe('policy_tree.nodes[0].stage');
+    expect(body.message).toContain('nodes[0]');
+    expect(body.retryable).toBe(false);
+    expect(body.error.type).toBe('BAD_INPUT');
+  });
+
+  it('all three captured payloads fail on the same node for the same reason', async () => {
+    // They differ only in sequential_metadata; the policy_tree is identical, so
+    // a divergent verdict here would mean the tree check is order-dependent.
+    const fields = await Promise.all(
+      CAPTURED_500S.map(async ([, p]) => (await post(p)).body.field)
+    );
+    expect(new Set(fields).size).toBe(1);
+    expect(fields[0]).toBe('policy_tree.nodes[0].stage');
+  });
+
+  it('the captured node still fails once stage and expected_value are supplied — children was the throw', async () => {
+    // Walks the captured payload up to well-formed one field at a time. The
+    // last thing standing is `children`, i.e. the exact 500 reported live.
+    const base = { root_id: 'r', depth: 2, policy_summary: 's' };
+    const graph = { nodes: [], edges: [] };
+
+    const afterStage = await post({ policy_tree: { ...base, nodes: [{ id: 'r', stage: 0 }] }, graph });
+    expect(afterStage.body.field).toBe('policy_tree.nodes[0].expected_value');
+
+    const afterEv = await post({ policy_tree: { ...base, nodes: [{ id: 'r', stage: 0, expected_value: 1 }] }, graph });
+    expect(afterEv.body.field).toBe('policy_tree.nodes[0].children');
+
+    const complete = await post({
+      policy_tree: { ...base, nodes: [{ id: 'r', stage: 0, expected_value: 1, children: [] }] },
+      graph,
+    });
+    expect(complete.statusCode).toBe(200);
+  });
+});
+
+describe('POST /v1/explain/policy — the other unguarded reads of the same untrusted body', () => {
+  /**
+   * Each entry threw before this change. The first is the reported defect in
+   * isolation; the rest are throw sites reachable from the same route with no
+   * additional malformation elsewhere in the body.
+   */
+  const cases: Array<[string, unknown, string, string]> = [
+    [
+      'a node omits children (the reported defect, isolated)',
+      { policy_tree: { root_id: 'r', depth: 1, policy_summary: 's', nodes: [{ id: 'r', type: 'outcome', label: 'R', stage: 0, expected_value: 1 }] }, graph: { nodes: [], edges: [] } },
+      'INVALID_POLICY_TREE_NODE',
+      'policy_tree.nodes[0].children',
+    ],
+    [
+      'children is present but not an array (silently mis-classified as non-terminal before)',
+      { policy_tree: { root_id: 'r', depth: 1, policy_summary: 's', nodes: [{ id: 'r', type: 'outcome', label: 'R', stage: 0, expected_value: 1, children: 'x' }] }, graph: { nodes: [], edges: [] } },
+      'INVALID_POLICY_TREE_NODE',
+      'policy_tree.nodes[0].children',
+    ],
+    [
+      'nodes is truthy but not an array (nodes.find is not a function)',
+      { policy_tree: { root_id: 'r', depth: 1, policy_summary: 's', nodes: { a: 1 } }, graph: { nodes: [], edges: [] } },
+      'INVALID_POLICY_TREE',
+      'policy_tree.nodes',
+    ],
+    [
+      'a node entry is null (reading id of null)',
+      { policy_tree: { root_id: 'r', depth: 1, policy_summary: 's', nodes: [null] }, graph: { nodes: [], edges: [] } },
+      'INVALID_POLICY_TREE_NODE',
+      'policy_tree.nodes[0]',
+    ],
+    [
+      'a decision node omits expected_value (expected_value.toFixed is not a function)',
+      { policy_tree: { root_id: 'r', depth: 1, policy_summary: 's', nodes: [{ id: 'r', type: 'decision', label: 'R', stage: 0, children: [] }] }, graph: { nodes: [], edges: [] } },
+      'INVALID_POLICY_TREE_NODE',
+      'policy_tree.nodes[0].expected_value',
+    ],
+    [
+      'a node omits stage — the grouping key, and a required response field',
+      { policy_tree: { root_id: 'r', depth: 1, policy_summary: 's', nodes: [{ id: 'r', type: 'outcome', label: 'R', expected_value: 1, children: [] }] }, graph: { nodes: [], edges: [] } },
+      'INVALID_POLICY_TREE_NODE',
+      'policy_tree.nodes[0].stage',
+    ],
+  ];
+
+  it.each(cases)('%s -> typed 400', async (_name, payload, code, field) => {
+    const { statusCode, body } = await post(payload);
+    expect(statusCode).not.toBe(500);
+    expect(statusCode).toBe(400);
+    expect(body.code).toBe(code);
+    expect(body.field).toBe(field);
+  });
+
+  it('the message names the offending node by id and index, not just the field', async () => {
+    const { body } = await post({
+      policy_tree: {
+        root_id: 'a',
+        depth: 1,
+        policy_summary: 's',
+        nodes: [
+          { id: 'a', type: 'decision', label: 'A', stage: 0, expected_value: 1, children: ['b'] },
+          { id: 'b', type: 'outcome', label: 'B', stage: 1, expected_value: 2 },
+        ],
+      },
+      graph: { nodes: [], edges: [] },
+    });
+    expect(body.field).toBe('policy_tree.nodes[1].children');
+    expect(body.message).toContain('nodes[1]');
+    expect(body.message).toContain('"b"');
+  });
+});
+
+describe('POST /v1/explain/policy — throws eliminated without inventing a refusal', () => {
+  /**
+   * `validateSequentialGraph` is total, but it is only reached when the graph
+   * declares itself sequential. With `is_sequential: false` the route used to
+   * read `sequential_metadata.stages` directly and throw. Stage labels are
+   * cosmetic, so these must succeed, not refuse.
+   */
+  const nonSequential = (stages: unknown) => ({
+    policy_tree: {
+      root_id: 'r',
+      depth: 1,
+      policy_summary: 'summary',
+      nodes: [{ id: 'r', type: 'decision', label: 'R', stage: 0, expected_value: 5, children: [] }],
+    },
+    graph: { nodes: [{ id: 'a' }], edges: [], sequential_metadata: { is_sequential: false, stages } },
+  });
+
+  it('stages is not an array (was: stages is not iterable)', async () => {
+    const { statusCode, body } = await post(nonSequential({ bad: true }));
+    expect(statusCode).toBe(200);
+    expect(body.schema).toBe('explain_policy.v1');
+    // Label unavailable -> falls back to the generated label, not a crash.
+    expect(body.explanation.stage_explanations[0].stage_label).toBe('Stage 0');
+  });
+
+  it('a stages entry is null (was: reading index of null)', async () => {
+    const { statusCode } = await post(nonSequential([null]));
+    expect(statusCode).toBe(200);
+  });
+
+  it('policy_summary is absent — summary is a string, never the literal "undefined"', async () => {
+    // Before: `explanation.summary` was `undefined`, so JSON.stringify dropped
+    // a required response field entirely.
+    const tree = wellFormedTree() as Record<string, unknown>;
+    delete tree.policy_summary;
+    const { statusCode, body } = await post({ policy_tree: tree, graph: wellFormedGraph() });
+
+    expect(statusCode).toBe(200);
+    expect('summary' in body.explanation).toBe(true);
+    expect(typeof body.explanation.summary).toBe('string');
+    expect(body.explanation.summary).not.toContain('undefined');
+  });
+
+  it('a decision node without a label falls back to its id, not "undefined"', async () => {
+    const tree = wellFormedTree();
+    delete (tree.nodes[0] as Record<string, unknown>).label;
+    delete (tree.nodes[1] as Record<string, unknown>).label;
+    delete (tree.nodes[1] as Record<string, unknown>).action;
+    const { statusCode, body } = await post({ policy_tree: tree, graph: wellFormedGraph() });
+
+    expect(statusCode).toBe(200);
+    expect(JSON.stringify(body.explanation)).not.toContain('undefined');
+  });
+});
+
+describe('POST /v1/explain/policy — positive controls', () => {
+  it('a well-formed request still returns a complete 200 explanation', async () => {
+    const { statusCode, body } = await post({ policy_tree: wellFormedTree(), graph: wellFormedGraph() });
+
+    expect(statusCode).toBe(200);
+    expect(body.schema).toBe('explain_policy.v1');
+    expect(body.provenance).toBe('plot_fallback');
+
+    // Non-vacuous: the explanation carries real, derived content — this is what
+    // proves the guards did not turn a working route into a refusal machine.
+    expect(body.explanation.summary).toBe(
+      'This policy consists of 1 sequential decisions. Launch Now (EV: 100)'
+    );
+    expect(body.explanation.stage_explanations).toHaveLength(1);
+    expect(body.explanation.stage_explanations[0]).toMatchObject({
+      stage: 0,
+      stage_label: 'Launch',
+      key_decision: 'Start',
+      rationale: 'Expected value: 100.00',
+    });
+    expect(body.explanation.assumptions.length).toBeGreaterThan(0);
+  });
+
+  it('a tree with no nodes is still accepted (unchanged behaviour)', async () => {
+    const { statusCode, body } = await post({
+      policy_tree: { root_id: 'root', nodes: [], depth: 0, terminal_count: 0, policy_summary: 'Empty policy' },
+      graph: { nodes: [], edges: [] },
+    });
+    expect(statusCode).toBe(200);
+    expect(body.explanation.summary).toBe('Empty policy');
+  });
+
+  it('the terminal-node risk finding still fires when it should', async () => {
+    // Two terminals, one far below average -> the risks list must say so.
+    const { statusCode, body } = await post({
+      policy_tree: {
+        root_id: 'root',
+        depth: 1,
+        terminal_count: 2,
+        policy_summary: 'Mixed outcomes',
+        nodes: [
+          { id: 'root', type: 'decision', label: 'Start', stage: 0, expected_value: 50, children: ['hi', 'lo'] },
+          { id: 'hi', type: 'outcome', label: 'Good', stage: 1, expected_value: 100, children: [] },
+          { id: 'lo', type: 'outcome', label: 'Bad', stage: 1, expected_value: 1, children: [] },
+        ],
+      },
+      graph: { nodes: [], edges: [] },
+    });
+
+    expect(statusCode).toBe(200);
+    expect(body.explanation.risks.join(' ')).toContain('below-average');
+  });
+
+  it('PRESERVATION CONTROL: a graph-side 400 keeps the code it returned before', async () => {
+    // #265's own live evidence pins this payload to INVALID_STAGE_DEFINITION.
+    // Its policy_tree is malformed too, so this asserts the new validator runs
+    // last and never renames a 400 callers already receive.
+    // (Not RED-first: this must pass both before and after the change.)
+    const { statusCode, body } = await post({
+      policy_tree: { root_id: 'r', depth: 2, nodes: [{ id: 'r' }] },
+      graph: {
+        nodes: [{ id: 'n1', stage: 0 }, { id: 'n2', stage: 1 }],
+        edges: [],
+        sequential_metadata: { is_sequential: true, stages: [{ decision_node_id: 'n1', timing: 't0' }, { decision_node_id: 'n2', timing: 't1' }] },
+      },
+    });
+
+    expect(statusCode).toBe(400);
+    expect(body.code).toBe('INVALID_STAGE_DEFINITION');
+    expect(body.field).toBe('graph.sequential_metadata');
+  });
+
+  it('the pre-existing presence checks are unchanged', async () => {
+    expect((await post({ graph: { nodes: [], edges: [] } })).statusCode).toBe(400);
+    expect(
+      (await post({ policy_tree: { root_id: 'root', nodes: [], depth: 0, terminal_count: 0, policy_summary: 'x' } }))
+        .statusCode
+    ).toBe(400);
+  });
+});


### PR DESCRIPTION
## The defect

`POST /v1/explain/policy` returns **500** on staging build `220739b` for any `policy_tree` whose nodes omit `children`. Found live by the owed-acceptances lane (26 Jul); raw captures in `acceptance-evidence/owed-acceptances-2026-07-26/raw/plot265-P{0,5,6}-*`.

The route validated only that `policy_tree`, `policy_tree.nodes` and `policy_tree.root_id` were **truthy**, then cast `req.body`. Everything below that was read as if the TypeScript types were enforced at the wire. They are not.

**Same defect class as #265**, which made `validateSequentialGraph` total for `sequential_metadata`. `policy_tree` was left unhardened.

## Root causes, at file:line (all reproduced offline against the captured bytes)

| # | `src/routes/v1/explain-policy.ts` (pre-change lines) | Throw | Reached by |
|---|---|---|---|
| 1 | `:178` `policyTree.nodes.filter(n => n.children.length === 0)` | `Cannot read properties of undefined (reading 'length')` | **the reported 500** — a node with no `children` |
| 2 | `:167` `policyTree.nodes.find(...)` | `nodes.find is not a function` | `nodes` truthy but not an array |
| 3 | `:119` `node.stage` | `reading 'stage' of null` | a `null` entry in `nodes[]` |
| 4 | `:152` `bestDecision.expected_value.toFixed(2)` | `reading 'toFixed' of undefined` | a `type:'decision'` node with no numeric `expected_value` |
| 5 | `:130` `for (const stage of graph.sequential_metadata.stages)` | `stages is not iterable` / `reading 'index' of null` | **`is_sequential: false`** — the one path `validateSequentialGraph` never sees |

Row 5 is worth naming: **#265 made the validator total, but this route reads the same untrusted `stages` field a second time, directly**, and that second read is skipped past whenever the graph declares itself non-sequential. A total validator does not make a route total.

## The theory was correct, and there is no second defect

The lane's `.children` lead is confirmed at the bytes. The probe's own **"well-formed control" 500s for exactly the same reason** — its node `{"id":"r"}` has no `children` (nor `stage`, nor `expected_value`). It was never well-formed by the handler's real requirements. All three captured 500s carry an identical `policy_tree` and fail identically; a genuinely well-formed payload returned 200 **before** this change and still does, byte-identically.

## The fix

`validatePolicyTreeShape()` returns typed 400s per the existing convention, naming the node index and the exact field:

- `INVALID_POLICY_TREE` — `nodes` is not an array
- `INVALID_POLICY_TREE_NODE` — an entry is not an object, or a **load-bearing** field is missing / wrong-typed

Load-bearing = the analysis is genuinely uncomputable without it: `stage` (grouping key, and a required response field), `expected_value` (arithmetic + `.toFixed`), `children` (the sole terminal-node discriminator). Rejecting is the honest answer — the alternative is guessing terminal-ness and emitting fabricated risk claims.

Cosmetic fields are made **total** instead, so nothing that succeeds today starts refusing:
- `readStageLabels()` — guards the unvalidated `stages` re-read; a bad entry is skipped, not refused (labels are cosmetic, and this path must not invent a refusal `validateSequentialGraph` itself would not raise)
- `decisionText()` — `action ?? label ?? id`, so prose never contains `undefined`
- `policy_summary` read as a string — previously `explanation.summary` could be `undefined`, and `JSON.stringify` then **dropped a required response field entirely**

### One ordering decision, deliberately

`validatePolicyTreeShape` runs as the **last** validator, after the sequential check. A body malformed in both its graph and its tree therefore keeps the graph code it returned before — e.g. the #265 payload still answers `INVALID_STAGE_DEFINITION`, pinned by a preservation control in the tests. **The invariant this buys: this change only ever converts a 500 into a 400. It never renames a 400 a caller already receives.**

## Verification

**RED-first, mutation-checked.** New tests run against unfixed `origin/staging` (`220739b`) in a throwaway worktree **outside the repo root**: **16 of 21 fail** — `expected 500 not to be 500` on every captured payload and every derived throw site. The 5 that pass are exactly the positive/preservation controls, which must pass both ways by construction. Worktree removed before any gate ran.

**Positive control is non-vacuous:** a well-formed request returns 200 with asserted content — `summary`, one `stage_explanation` with `stage_label: 'Launch'`, `rationale: 'Expected value: 100.00'` — plus a separate control proving the terminal-node **risk finding still fires** when it should. The guards did not turn a working route into a refusal machine.

**Authoritative gate** (`bash scripts/pre-push-validate.sh`): **6/6 PASS**, `5989 passed | 29 skipped`, 0 failures. `npx tsc --noEmit` clean; `eslint --max-warnings 0` clean on both changed files.

## Stated limits

- **Not live-verified.** Everything here is offline reproduction against the captured bytes plus the full suite. The staging behaviour change is unproven until this deploys.
- **Behaviour change beyond pure 500-elimination, disclosed:** three shapes that returned **200** now return **400** — `children` present but not an array (previously silently mis-classified as non-terminal), a node with no `stage` (previously emitted a response object missing the required `stage` field), and a node with non-numeric `expected_value` on a non-decision node (previously NaN-poisoned the risk average and silently suppressed the finding). Each was already producing a contract-invalid or fabricated result.
- **Validation runs before the CEE call**, so a malformed tree is refused even when `CEE_EXPLAIN_POLICY_ENABLE` is on and CEE would have narrated it. Judged correct — the tree is forwarded to CEE verbatim — but it is a change to the CEE-enabled path, which was **not** exercised live (the captured probes all took the fallback path).
- **No caller manifest was run.** The route does not appear in `/health` `top_routes`, but "no production caller" is not claimed. Treated as live throughout.
- Unchanged: auth, route registration, the #269 refusal pattern on other routes, and the OpenAPI spec (this route has no spec entry, so `validate-structure` has an empty spec delta).
- The one dead local removed (`rootNode`, assigned and never read) was itself throw site #2; it is gone rather than guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
