### PR TITLE
fix(isl): stop sending three keys ISL does not declare [contract step-2 slice 6]

### DIFF
--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -779,8 +779,9 @@ function roundTo4(value: number): number {
  * Constructs a closure that, per probe:
  * 1. Clones the request graph and sets the target factor's observed_state.value
  *    to the probe value — the field ISL's comparison reads as the sampling mean
- * 2. Keeps the target factor's parameter_uncertainties.mean aligned to the same
- *    value (contract honesty; the comparison shadows this field)
+ * 2. (removed in contract step-2 slice 6: the probe used to mirror the value
+ *    onto `parameter_uncertainties[].mean`, a key ISL does not declare and
+ *    dropped under `extra: "ignore"`. Step 1 was always the whole mechanism.)
  * 3. Forwards the resolved analysis seed (the same seed sent to the main ISL
  *    robustness call) on every probe request
  * 4. Calls ISL via the service's callAnalysisEndpoint
@@ -812,7 +813,7 @@ export function createISLInferenceFn(
     options: any[];
     goal_node_id: string;
     n_samples?: number;
-    parameter_uncertainties?: Array<{ node_id: string; distribution: string; mean: number; std: number }>;
+    parameter_uncertainties?: Array<{ node_id: string; distribution: string; std: number }>;
     // Resolved seed sent to the main ISL analysis call (explicit request seed,
     // or PLoT-derived seed when omitted). Forwarded verbatim on every probe so
     // common random numbers stay intentional and aligned with the base analysis.
@@ -833,18 +834,16 @@ export function createISLInferenceFn(
     if (signal?.aborted) {
       throw new DOMException('Flip probe aborted before ISL call (deadline elapsed)', 'AbortError');
     }
-    // Clone parameter_uncertainties with the target factor's mean overridden
+    // Clone parameter_uncertainties. Slice 6: the clone no longer mirrors the
+    // probe value onto a `mean` key — ISL declares none (see the note below).
+    // The probe still needs its own ENTRY for a factor absent from the base
+    // list, because ISL only perturbs factors named in this array.
     const basePU = originalRequest.parameter_uncertainties ?? [];
     const factorExists = basePU.some((pu) => pu.node_id === factorId);
 
     let paramUncertainties: typeof basePU;
     if (factorExists) {
-      paramUncertainties = basePU.map((pu) => {
-        if (pu.node_id === factorId) {
-          return { ...pu, mean: overrideMean };
-        }
-        return { ...pu };
-      });
+      paramUncertainties = basePU.map((pu) => ({ ...pu }));
     } else {
       // Factor not in original parameter_uncertainties — insert with default std
       paramUncertainties = [
@@ -852,7 +851,6 @@ export function createISLInferenceFn(
         {
           node_id: factorId,
           distribution: 'normal' as const,
-          mean: overrideMean,
           std: Math.max(0.1, Math.abs(overrideMean) * 0.15),
         },
       ];
@@ -861,11 +859,16 @@ export function createISLInferenceFn(
     // Clone the graph for THIS probe and set the target factor's
     // observed_state.value to the probe value. ISL's comparison samples each factor
     // from Normal(observed_state.value, parameter_uncertainties.std): the comparison
-    // MEAN is read from the graph node's observed_state.value, while the request's
-    // parameter_uncertainties.mean is shadowed (not consumed) by the comparison path.
-    // So observed_state.value is the field that actually moves the winner; the aligned
-    // parameter_uncertainties.mean override above is kept only for contract honesty /
-    // possible future consumers.
+    // MEAN is read from the graph node's observed_state.value — this line is the
+    // entire mechanism that moves the winner.
+    //
+    // Slice 6: PLoT used to ALSO write `parameter_uncertainties[].mean` here
+    // "for contract honesty / possible future consumers". It was neither: ISL's
+    // ParameterUncertainty declares no `mean` (robustness_v2.py:254-267) and its
+    // `extra: "ignore"` dropped the key at parse, so no consumer — present or
+    // future — could have read it without an ISL-side declaration first. Writing
+    // it made the request look aligned while the alignment lived entirely in the
+    // line below.
     //
     // overrideMean is already in the normalised [0,1] scale of observed_state.value,
     // so the normalised scale is preserved (we never write raw human values here).

--- a/src/contracts/plot-to-isl.contract.ts
+++ b/src/contracts/plot-to-isl.contract.ts
@@ -60,6 +60,19 @@ export interface BoundaryContract {
   enriched: string[];
   /** Producer-name / local-value collisions. See `BoundarySubstitution`. */
   substitutions?: BoundarySubstitution[];
+  /**
+   * Keys this boundary STILL sends that the consumer does not declare, kept
+   * deliberately and with a named reason.
+   *
+   * Added by the contract step-2 slice-6 lane (26 Jul 2026). Before it, a key
+   * the consumer did not declare had no representation here at all: it was
+   * neither a `drop` (it is on the wire) nor `enriched` (that means "added by
+   * PLoT", not "unknown to the reader"), so an undeclared key was
+   * indistinguishable from an oversight — which is exactly how
+   * `parameter_uncertainties[].mean` survived unnoticed for months. An entry
+   * here is a commitment to resolve, not a licence to keep.
+   */
+  knownUndeclared?: string[];
 }
 
 /**
@@ -78,6 +91,50 @@ export const PLOT_TO_ISL_CONTRACT: BoundaryContract = {
     'idempotency_key',
     'brief',
     'intervention.source',  // InterventionValueV3.source stripped in toISLInterventions()
+
+    // ---------------------------------------------------------------------
+    // Contract step-2 slice 6 — keys PLoT USED TO SEND that ISL never declared.
+    // Each was silently discarded by ISL's `extra: "ignore"`, so it looked like
+    // contract and behaved like nothing. Verified against the pinned ISL model
+    // (Talchain/Inference-Service-Layer @ 7d144c7f): replaying all five captured
+    // live request fixtures with and without these keys yields a BYTE-IDENTICAL
+    // `RobustnessRequestV2.model_dump()`.
+    // ---------------------------------------------------------------------
+
+    // ISL's ParameterUncertainty (robustness_v2.py:254-267) declares
+    // {node_id, distribution, std, range_min, range_max}. The sampling centre
+    // comes from the node's observed_state.value
+    // (robustness_analyzer_v2.py:852-855, 891-892, 3490-3494), never from here.
+    'parameter_uncertainties[].mean',
+
+    // ISL's EdgeV2 (robustness_v2.py:348-426) declares no `weight`. PLoT's
+    // coefficient already reaches ISL in the declared location, strength.mean.
+    // Was sent on the /v1/run leg (integrations/isl/index.ts, analyseRobustness).
+    'graph.edges[].weight',
+
+    // PLoT-internal: attached by graph-normaliser.ts:274-276 so
+    // constraint-compiler.ts can read `.operator` off the NORMALISED PLoT graph.
+    // ISL's ObservedState (robustness_v2.py:160-200) does not declare it. Was
+    // reaching the wire because toISLNode forwarded observed_state VERBATIM;
+    // now projected through toISLObservedState().
+    'nodes[].observed_state.metadata',
+  ],
+
+  /**
+   * KNOWN-UNDECLARED, DELIBERATELY STILL SENT — declare these here rather than
+   * let them look like an oversight. Both are dropped by ISL today.
+   *
+   * - `goal_constraints[].constraint_id` (translator-v3.ts): Codex adjudicated
+   *   OQ-5 as ADOPT-into-ISL reader-first, not delete — `constraint_verdict`'s
+   *   `identity_unresolved` state needs a stable constraint identity to cite.
+   *   Sequenced: ISL accepts + echoes it optional, then PLoT reads the echo.
+   * - `goal_constraints[].weight` (translator-v3.ts): caller-supplied and
+   *   omitted unless provided; latent on the golden path. Resolve with the same
+   *   adopt-or-drop decision as constraint_id rather than piecemeal.
+   */
+  knownUndeclared: [
+    'goal_constraints[].constraint_id',
+    'goal_constraints[].weight',
   ],
 
   /** WHY filtered: non-causal scaffolding nodes that ISL cannot process. */

--- a/src/integrations/isl/constraint-pu-injection.ts
+++ b/src/integrations/isl/constraint-pu-injection.ts
@@ -174,10 +174,14 @@ export function injectConstraintParameterUncertainties(
     }
 
     const mean = cls.mean;
+    // Slice 6: the WIRE entry carries no `mean` — ISL declares none and reads
+    // the sampling centre from this node's own `observed_state.value`, which
+    // is exactly where `cls.mean` came from (classifyConstraintPu). `mean` is
+    // still reported on the InjectedPU below: that is PLoT's own disclosure
+    // record (`repairs[]` on /v2/run), not an ISL-bound field.
     augmented.push({
       node_id: constraint.node_id,
       distribution: 'normal' as const,
-      mean,
       std: CONSTRAINT_PINNED_STD,
     });
     existingPuNodeIds.add(constraint.node_id);

--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -45,6 +45,9 @@ import {
   buildParameterUncertainties,
   logPreflightResult,
 } from './preflight.js';
+// Slice 6: shared with the /v2/run translator so PLoT holds ONE allowlist of
+// ISL's declared observed_state fields, not two that can drift apart.
+import { toISLObservedState } from './translator-v3.js';
 // P1.1: ISL metrics
 import {
   recordIslValidation,
@@ -361,14 +364,22 @@ export function createISLService(): ISLService {
               id: n.id,
               kind: n.kind,
               label: n.label,
-              observed_state: n.observed_state,
+              observed_state: toISLObservedState(n.observed_state),
             })),
+            // Slice 6: `weight` / `belief_exists` / `belief_strength` removed —
+            // none is declared by ISL's `EdgeV2` (robustness_v2.py:348-426 @
+            // 7d144c7f) and all three were dropped by `extra: "ignore"`.
+            //
+            // ⚠ This method has NO production caller (`analyseFactorSensitivity`
+            // is unreferenced outside this file; `/v1/run` calls
+            // `analyseRobustness` instead). Its edges also omit the REQUIRED
+            // `strength` distribution, which slice 6 does NOT fix: that is a
+            // declared-field gap any strict model reports by name, not a silent
+            // undeclared key. Reviving this method requires building `strength`
+            // the way `analyseRobustness` does below.
             edges: directedEdges.map((e) => ({
               from: e.from,
               to: e.to,
-              weight: e.weight,
-              belief_exists: e.belief_exists ?? e.belief,
-              belief_strength: e.belief_strength,
             })),
           },
           options: options.map((o) => ({
@@ -491,12 +502,16 @@ export function createISLService(): ISLService {
               id: n.id,
               kind: n.kind,
               label: n.label,
-              observed_state: n.observed_state,
+              observed_state: toISLObservedState(n.observed_state),
             })),
+            // Slice 6: `weight` removed. ISL's `EdgeV2` declares no such field
+            // (robustness_v2.py:348-426 @ 7d144c7f) and dropped it under
+            // `extra: "ignore"`. The quantity it carried is NOT lost — it is
+            // already published in the ISL-declared location, `strength.mean`,
+            // by the mapping immediately below.
             edges: robustnessDirectedEdges.map((e) => ({
               from: e.from,
               to: e.to,
-              weight: e.weight,
               // Map to ISL edge format
               exists_probability: e.belief_exists ?? e.belief ?? DEFAULT_EXISTS_PROBABILITY,
               strength: e.strength_std !== undefined

--- a/src/integrations/isl/preflight.ts
+++ b/src/integrations/isl/preflight.ts
@@ -107,10 +107,11 @@ export function buildParameterUncertainties(graph: Graph): ISLParameterUncertain
         std = Math.max(DEFAULT_STD_FLOOR, std);
       }
 
+      // Slice 6: no `mean` — ISL declares none on ParameterUncertainty and
+      // reads the sampling centre from the node's own observed_state.value.
       uncertainties.push({
         node_id: node.id,
         distribution: 'normal',
-        mean: value,
         std,
       });
     }

--- a/src/integrations/isl/translator-v3.ts
+++ b/src/integrations/isl/translator-v3.ts
@@ -102,10 +102,18 @@ export interface ISLRobustnessRequestV3 {
   n_samples?: number;
   confidence_level?: number;
   analysis_types: Array<'comparison' | 'sensitivity' | 'robustness'>;
+  /**
+   * Members mirror ISL's `ParameterUncertainty`
+   * (isl/src/models/robustness_v2.py:254-267) EXACTLY: {node_id, distribution,
+   * std, range_min, range_max}. ISL has never declared a `mean` here — the
+   * sampling centre is read from the node's `observed_state.value`, not from
+   * this list — so a `mean` sent here was dropped by ISL's `extra: "ignore"`
+   * and could never move a result. Removed in contract step-2 slice 6; do not
+   * re-add a member ISL does not declare.
+   */
   parameter_uncertainties?: Array<{
     node_id: string;
     distribution: 'normal';
-    mean: number;
     std: number;
   }>;
   /**
@@ -152,6 +160,69 @@ export interface ISLRobustnessRequestV3 {
 // -----------------------------------------------------------------------------
 
 /**
+ * The COMPLETE member list of ISL's `ObservedState`
+ * (isl/src/models/robustness_v2.py:160-200 @ 7d144c7f):
+ * value, baseline, unit, source, std, raw_value, cap, extractionType,
+ * factor_type, uncertainty_drivers.
+ *
+ * PLoT produces eight of the ten; `source` and `extractionType` are CEE-origin
+ * fields PLoT's normaliser does not carry, so they are absent here by
+ * construction rather than by exclusion.
+ *
+ * ⚠ THIS LIST IS A HAND-MAINTAINED MIRROR of another repo's model, and it
+ * cannot fail loud from inside PLoT today. Its drift is asymmetric: if ISL ADDS
+ * a field, PLoT silently stops forwarding something ISL would now accept (an
+ * under-send, not a contract break); if ISL REMOVES one, PLoT resumes sending
+ * an undeclared key — the defect this slice closes. The mechanism that makes it
+ * fail loud is the request-side drift pairing (contract step-2 slice 2), which
+ * replays captured bodies through ISL's own pinned model. Until that lands,
+ * this comment IS the disclosure.
+ */
+const ISL_DECLARED_OBSERVED_STATE_FIELDS = [
+  'value',
+  'baseline',
+  'unit',
+  'source',
+  'std',
+  'raw_value',
+  'cap',
+  'extractionType',
+  'factor_type',
+  'uncertainty_drivers',
+] as const;
+
+/**
+ * Project a PLoT-internal `observed_state` onto the fields ISL declares.
+ *
+ * Slice 6: the previous code forwarded `node.observed_state` VERBATIM, so any
+ * key present at runtime transited to ISL regardless of the declared type.
+ * One always did: PLoT's own normaliser attaches `metadata` to constraint
+ * nodes (`graph-normaliser.ts:274-276`) so `constraint-compiler.ts` can read
+ * `.operator` — a PLoT-internal key ISL's `ObservedState` does not declare and
+ * silently dropped under `extra: "ignore"`. The compiler reads it off the
+ * normalised PLoT graph, never off the ISL request, so projecting here costs
+ * nothing internally.
+ *
+ * The projection is by PRESENCE, not by declared type: an absent field stays
+ * absent on the wire rather than becoming an explicit `undefined`, so the
+ * serialized bytes are unchanged for every field PLoT already sent.
+ *
+ * Shared with the `/v1/run` producer (`integrations/isl/index.ts`) so the two
+ * ISL request builders cannot drift apart into two different allowlists.
+ */
+export function toISLObservedState(observedState: unknown): ISLNodeV3['observed_state'] {
+  if (observedState === undefined || observedState === null || typeof observedState !== 'object') {
+    return undefined;
+  }
+  const os = observedState as Record<string, unknown>;
+  const projected: Record<string, unknown> = {};
+  for (const field of ISL_DECLARED_OBSERVED_STATE_FIELDS) {
+    if (os[field] !== undefined) projected[field] = os[field];
+  }
+  return projected as ISLNodeV3['observed_state'];
+}
+
+/**
  * Translate internal node to ISL format.
  *
  * NOTE: `category` field is intentionally excluded from ISL translation.
@@ -164,7 +235,7 @@ export function toISLNode(node: EngineNodeV3): ISLNodeV3 {
     id: node.id,
     kind: node.kind,
     label: node.label,
-    observed_state: node.observed_state,
+    observed_state: toISLObservedState(node.observed_state),
     intercept: node.intercept ?? 0.0,
     epsilon_std: node.epsilon_std ?? 0.0,
   };
@@ -280,10 +351,11 @@ export function buildParameterUncertaintiesV3(
         std = Math.max(DEFAULT_STD_FLOOR, std);
       }
 
+      // Slice 6: no `mean` — ISL samples Normal(observed_state.value, std) and
+      // reads the centre from the graph node, not from this entry.
       uncertainties.push({
         node_id: node.id,
         distribution: 'normal',
-        mean: value,
         std,
       });
     }
@@ -327,12 +399,19 @@ export function buildParameterUncertaintiesV3(
         [rangeMin, rangeMax] = [rangeMax, rangeMin];
       }
 
-      // Convert uniform prior to normal parameters
-      let mean = (rangeMin + rangeMax) / 2;
+      // Convert uniform prior to a normal WIDTH. Only the width crosses the
+      // boundary: ISL declares no `mean` on ParameterUncertainty and resolves
+      // the sampling centre from the node's own `observed_state.value`,
+      // defaulting to 0.0 when absent (robustness_analyzer_v2.py:852-855,
+      // 891-892, 3490-3494 @ 7d144c7f).
+      //
+      // ⚠ KNOWN GAP, pre-existing and NOT introduced here: an external-prior
+      // factor has no `observed_state`, so ISL centres its sampling on 0.0
+      // rather than on the prior midpoint. Sending a `mean` never fixed that —
+      // ISL dropped the key via `extra: "ignore"` — it only made the gap look
+      // closed. Closing it needs an ISL-declared field or an `observed_state`
+      // for prior-only factors; tracked separately, not in slice 6.
       let std = (rangeMax - rangeMin) / Math.sqrt(12);
-
-      // Clamp mean to [0, 1]
-      mean = Math.max(0, Math.min(1, mean));
 
       // Floor std at 0.01
       std = Math.max(0.01, std);
@@ -340,7 +419,6 @@ export function buildParameterUncertaintiesV3(
       uncertainties.push({
         node_id: node.id,
         distribution: 'normal',
-        mean,
         std,
       });
     }

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -125,8 +125,14 @@ export interface ISLParameterUncertainty {
   node_id: string;
   /** Distribution type for uncertainty */
   distribution: 'normal' | 'uniform';
-  /** Mean value (for normal distribution) */
-  mean?: number;
+  /**
+   * NO `mean` MEMBER. ISL's `ParameterUncertainty`
+   * (isl/src/models/robustness_v2.py:254-267 @ 7d144c7f) declares
+   * {node_id, distribution, std, range_min, range_max} and nothing else; the
+   * sampling centre comes from the node's `observed_state.value`
+   * (robustness_analyzer_v2.py:852-855, 891-892, 3490-3494). A `mean` sent here
+   * was dropped by `extra: "ignore"`. Removed in contract step-2 slice 6.
+   */
   /** Standard deviation (for normal distribution) */
   std?: number;
   /** Minimum value (for uniform distribution) */

--- a/tests/analysis/flip-thresholds.test.ts
+++ b/tests/analysis/flip-thresholds.test.ts
@@ -676,7 +676,7 @@ describe('resolveFlipValues() — probes_used telemetry', () => {
 });
 
 describe('createISLInferenceFn()', () => {
-  it('overrides the target factor mean in parameter_uncertainties', async () => {
+  it('moves the target factor observed_state.value and leaves other factors alone', async () => {
     let capturedBody: any = null;
 
     const mockCallAnalysis = async (_ep: string, body: unknown, _rid: string) => {
@@ -692,13 +692,26 @@ describe('createISLInferenceFn()', () => {
     };
 
     const originalRequest = {
-      graph: { nodes: [], edges: [] },
+      // Slice 6: this fixture used to carry an EMPTY node list, so the only
+      // thing the assertions below could observe was the probe's mirror of the
+      // value onto `parameter_uncertainties[].mean` — a key ISL declares
+      // nowhere and drops at parse. The test therefore pinned the shadow and
+      // not the mechanism. Re-pointed at the real one: the probe moves
+      // `graph.nodes[].observed_state.value`, which is where ISL reads the
+      // sampling centre (robustness_analyzer_v2.py:852-855).
+      graph: {
+        nodes: [
+          { id: 'factor-x', kind: 'factor', label: 'X', observed_state: { value: 0.7, unit: '%' } },
+          { id: 'factor-y', kind: 'factor', label: 'Y', observed_state: { value: 0.5 } },
+        ],
+        edges: [],
+      },
       options: [{ id: 'opt-a' }, { id: 'opt-b' }],
       goal_node_id: 'goal',
       n_samples: 1000,
       parameter_uncertainties: [
-        { node_id: 'factor-x', distribution: 'normal', mean: 0.7, std: 0.15 },
-        { node_id: 'factor-y', distribution: 'normal', mean: 0.5, std: 0.2 },
+        { node_id: 'factor-x', distribution: 'normal', std: 0.15 },
+        { node_id: 'factor-y', distribution: 'normal', std: 0.2 },
       ],
     };
 
@@ -706,10 +719,21 @@ describe('createISLInferenceFn()', () => {
 
     await fn('factor-x', 0.3);
 
-    // Should override factor-x mean to 0.3, leave factor-y unchanged
+    // The probe moves the TARGET factor's observed value and leaves the other
+    // node untouched (and untouched by reference — never mutated in place).
+    const nodes = capturedBody.graph.nodes;
+    expect(nodes.find((n: any) => n.id === 'factor-x').observed_state.value).toBe(0.3);
+    expect(nodes.find((n: any) => n.id === 'factor-y').observed_state.value).toBe(0.5);
+    // Display metadata on the probed node survives the clone.
+    expect(nodes.find((n: any) => n.id === 'factor-x').observed_state.unit).toBe('%');
+    // The original request object is never mutated.
+    expect(originalRequest.graph.nodes[0].observed_state.value).toBe(0.7);
+
+    // std is carried through unchanged; no undeclared `mean` is re-added.
     const pu = capturedBody.parameter_uncertainties;
-    expect(pu.find((p: any) => p.node_id === 'factor-x').mean).toBe(0.3);
-    expect(pu.find((p: any) => p.node_id === 'factor-y').mean).toBe(0.5);
+    expect(pu.find((p: any) => p.node_id === 'factor-x').std).toBe(0.15);
+    expect(pu.find((p: any) => p.node_id === 'factor-y').std).toBe(0.2);
+    for (const entry of pu) expect(entry).not.toHaveProperty('mean');
   });
 
   it('uses analysis_types: ["comparison"] for efficiency', async () => {
@@ -760,7 +784,7 @@ describe('createISLInferenceFn()', () => {
       options: [],
       goal_node_id: 'goal',
       parameter_uncertainties: [
-        { node_id: 'other-factor', distribution: 'normal', mean: 0.5, std: 0.2 },
+        { node_id: 'other-factor', distribution: 'normal', std: 0.2 },
       ],
     };
 
@@ -774,13 +798,17 @@ describe('createISLInferenceFn()', () => {
 
     const inserted = pu.find((p: any) => p.node_id === 'missing-factor');
     expect(inserted).toBeDefined();
-    expect(inserted.mean).toBe(0.6);
     expect(inserted.distribution).toBe('normal');
+    // Slice 6: the inserted entry carries no `mean` (ISL declares none). Its
+    // width is still derived from the probe value — 0.6 * 0.15 = 0.09, floored
+    // to 0.1 — so the derivation stays observable.
+    expect(inserted).not.toHaveProperty('mean');
     expect(inserted.std).toBeGreaterThanOrEqual(0.1);
 
-    // Original unchanged
+    // Original entry passes through unchanged.
     const other = pu.find((p: any) => p.node_id === 'other-factor');
-    expect(other.mean).toBe(0.5);
+    expect(other).not.toHaveProperty('mean');
+    expect(other.std).toBeDefined();
   });
 
   it('inserts factor with std floor of 0.1 when mean is near zero', async () => {
@@ -808,7 +836,7 @@ describe('createISLInferenceFn()', () => {
 
   it('does not mutate original request parameter_uncertainties', async () => {
     const originalPU = [
-      { node_id: 'factor-x', distribution: 'normal', mean: 0.7, std: 0.15 },
+      { node_id: 'factor-x', distribution: 'normal', std: 0.15 },
     ];
 
     const mockCallAnalysis = async () => ({
@@ -826,8 +854,9 @@ describe('createISLInferenceFn()', () => {
 
     await fn('factor-x', 0.1);
 
-    // Original should be unchanged
-    expect(originalPU[0].mean).toBe(0.7);
+    // Original should be unchanged (never mutated in place by the probe).
+    expect(originalPU[0].std).toBe(0.15);
+    expect(originalPU[0].node_id).toBe('factor-x');
   });
 
   // ===========================================================================
@@ -851,8 +880,8 @@ describe('createISLInferenceFn()', () => {
       ],
       goal_node_id: 'goal',
       parameter_uncertainties: [
-        { node_id: 'factor-x', distribution: 'normal', mean: 0.7, std: 0.1 },
-        { node_id: 'factor-y', distribution: 'normal', mean: 0.3, std: 0.1 },
+        { node_id: 'factor-x', distribution: 'normal', std: 0.1 },
+        { node_id: 'factor-y', distribution: 'normal', std: 0.1 },
       ],
     };
   }
@@ -870,7 +899,10 @@ describe('createISLInferenceFn()', () => {
     const targetNode = (captured.graph.nodes as any[]).find((n) => n.id === 'factor-x');
     expect(targetNode.observed_state.value).toBe(0.25);              // graph value = probe value
     const puX = (captured.parameter_uncertainties as any[]).find((p) => p.node_id === 'factor-x');
-    expect(puX.mean).toBe(0.25);                                     // PU mean aligned
+    // Slice 6: the PU entry no longer mirrors the probe value onto an
+    // undeclared `mean`. The graph assertion above IS the mechanism — ISL reads
+    // the sampling centre from observed_state.value.
+    expect(puX).not.toHaveProperty('mean');
     // Display/denormalisation metadata + uncertainty width preserved
     expect(targetNode.observed_state.std).toBe(0.1);
     expect(targetNode.observed_state.raw_value).toBe(70);
@@ -941,7 +973,10 @@ describe('createISLInferenceFn()', () => {
     expect((captured.graph.nodes as any[]).find((n) => n.id === 'factor-x').observed_state.value).toBe(0.7);
     // PU still gets the factor inserted (existing fallback behaviour for non-graph factors).
     const puMissing = (captured.parameter_uncertainties as any[]).find((p) => p.node_id === 'factor-missing');
-    expect(puMissing.mean).toBe(0.42);
+    expect(puMissing).toBeDefined();
+    expect(puMissing).not.toHaveProperty('mean'); // slice 6: undeclared by ISL
+    // width still derived from the probe value: 0.42 * 0.15 = 0.063 → floor 0.1
+    expect(puMissing.std).toBe(0.1);
   });
 
   // ===========================================================================
@@ -1129,8 +1164,8 @@ describe('resolveFlipValues() with a contract-faithful comparison (observed_stat
       ],
       goal_node_id: 'goal',
       parameter_uncertainties: [
-        { node_id: 'delivery_gap', distribution: 'normal', mean: targetValue, std: 0.1 },
-        { node_id: 'cost', distribution: 'normal', mean: 0.5, std: 0.1 },
+        { node_id: 'delivery_gap', distribution: 'normal', std: 0.1 },
+        { node_id: 'cost', distribution: 'normal', std: 0.1 },
       ],
     };
   }
@@ -1156,7 +1191,11 @@ describe('resolveFlipValues() with a contract-faithful comparison (observed_stat
     const mock = contractFaithfulMock('delivery_gap', 0.5);
     const winner = (r: any) => [...r.data.results].sort((a, b) => b.win_probability - a.win_probability)[0].option_id;
 
-    // Same observed_state.value (0.7), different PU mean → winner UNCHANGED (old probe field).
+    // Same observed_state.value (0.7), different PU mean → winner UNCHANGED.
+    // Slice 6 note: `mean` is no longer produced at all, so these two lines now
+    // PLANT the key to demonstrate the mock ignores it. That is deliberate —
+    // this case is the control proving observed_state.value is the live field,
+    // and a control has to be able to show the inert one being ignored.
     const sameValueLowPU = graphReq(0.7); sameValueLowPU.parameter_uncertainties[0].mean = 0;
     const sameValueHighPU = graphReq(0.7); sameValueHighPU.parameter_uncertainties[0].mean = 1;
     expect(winner(await mock('x', sameValueLowPU))).toBe(winner(await mock('x', sameValueHighPU)));
@@ -1401,7 +1440,7 @@ describe('resolveFlipValues() — seed forwarding drives flip determinism', () =
       goal_node_id: 'goal',
       n_samples: 1000,
       parameter_uncertainties: [
-        { node_id: 'delivery_gap', distribution: 'normal', mean: 0.7, std: 0.1 },
+        { node_id: 'delivery_gap', distribution: 'normal', std: 0.1 },
       ],
       seed,
     };

--- a/tests/boundary-plot-to-isl.contract.test.ts
+++ b/tests/boundary-plot-to-isl.contract.test.ts
@@ -167,9 +167,16 @@ describe('PLoT → ISL boundary contract (B4.5)', () => {
       (pu: any) => pu.node_id === 'factor-a'
     );
     expect(factorAPU).toBeDefined();
-    expect(factorAPU!.mean).toBe(0.6);
     // Distribution is always 'normal'
     expect(factorAPU!.distribution).toBe('normal');
+    // Slice 6: the derivation is now observable through `std` (the user-supplied
+    // 0.1 is honoured verbatim) plus the value's own declared location on the
+    // graph node. `mean` no longer crosses the boundary.
+    expect(factorAPU!).not.toHaveProperty('mean');
+    expect(factorAPU!.std).toBe(0.1);
+    expect(
+      islRequest.graph.nodes.find((n: any) => n.id === 'factor-a')!.observed_state!.value,
+    ).toBe(0.6);
   });
 
   // ----- Enriched -----
@@ -315,14 +322,25 @@ describe('ISL request contract — golden-path (T5a)', () => {
     const puA = req.parameter_uncertainties!.find(p => p.node_id === 'fac-a')!;
     const puB = req.parameter_uncertainties!.find(p => p.node_id === 'fac-b')!;
 
+    // Contract step-2 slice 6: `mean` no longer crosses the boundary (ISL
+    // declares none and dropped it). The observed value itself is NOT lost —
+    // it reaches ISL in the declared location, `graph.nodes[].observed_state
+    // .value`, which is where ISL's sampler actually reads the centre from
+    // (robustness_analyzer_v2.py:852-855). Re-pointed onto that, so this test
+    // still fails if the value stops reaching ISL.
+    const nodeA = req.graph.nodes.find((n: any) => n.id === 'fac-a')!;
+    const nodeB = req.graph.nodes.find((n: any) => n.id === 'fac-b')!;
+    expect(nodeA.observed_state!.value).toBe(0.7);
+    expect(nodeB.observed_state!.value).toBe(0.4);
+
     expect(puA).toBeDefined();
     expect(puA.distribution).toBe('normal');
-    expect(puA.mean).toBe(0.7);
+    expect(puA).not.toHaveProperty('mean');
     expect(puA.std).toBeGreaterThan(0);
 
     expect(puB).toBeDefined();
     expect(puB.distribution).toBe('normal');
-    expect(puB.mean).toBe(0.4);
+    expect(puB).not.toHaveProperty('mean');
     expect(puB.std).toBeGreaterThan(0);
 
     // Goal node must NOT get a parameter_uncertainty entry
@@ -368,13 +386,18 @@ describe('ISL request contract — golden-path (T5a)', () => {
     // The fix: user-supplied std must NOT be floored to 0.1.
     expect(pu!.std).toBe(0.001);
 
-    // Outbound shape unchanged: exactly one entry (only the factor with an
+    // Outbound shape: exactly one entry (only the factor with an
     // observed_state.value is emitted — the goal node never appears) and each
-    // entry has only the four contract fields. Asserts the change is purely
-    // additive to `std`, not the entry count or field set.
+    // entry has ONLY the fields ISL declares.
+    //
+    // Contract step-2 slice 6 narrowed this set from four to three: `mean` was
+    // never declared by ISL's `ParameterUncertainty`
+    // (isl/src/models/robustness_v2.py:254-267 @ 7d144c7f) and was dropped by
+    // its `extra: "ignore"`. This exact-key-set assertion is now the pin that
+    // stops an undeclared key being re-added here.
     expect(reqSmall.parameter_uncertainties!.length).toBe(1);
     for (const entry of reqSmall.parameter_uncertainties!) {
-      expect(Object.keys(entry).sort()).toEqual(['distribution', 'mean', 'node_id', 'std']);
+      expect(Object.keys(entry).sort()).toEqual(['distribution', 'node_id', 'std']);
     }
   });
 

--- a/tests/cil-constraint-auto-pu.test.ts
+++ b/tests/cil-constraint-auto-pu.test.ts
@@ -9,7 +9,7 @@
  *    user-supplied observed_state.std is honoured (clamped to [1e-4, 2.0]) and
  *    may legitimately be below 0.1.
  * 2. Phase 4b+ safety net: for constrained nodes the translator misses,
- *    auto-generates { distribution: 'normal', mean: observed_value, std: 0.001 }.
+ *    auto-generates { distribution: 'normal', std: 0.001 }.
  *
  * Uses vi.mock to intercept the ISL service and capture the request body.
  */
@@ -209,7 +209,14 @@ describe('CIL: Constraint auto-PU integration (Phase 4b+)', () => {
 
     expect(factorBPU).toBeDefined();
     expect(factorBPU.distribution).toBe('normal');
-    expect(factorBPU.mean).toBe(0.5);  // from observed_state.value
+    // Slice 6: `mean` is no longer on the ISL request (ISL declares none). The
+    // observed value still reaches ISL — in the declared location it actually
+    // reads — so assert it there instead.
+    expect(factorBPU).not.toHaveProperty('mean');
+    expect(
+      capturedISLRequestBody.graph.nodes.find((n: any) => n.id === 'factor-b')
+        .observed_state.value,
+    ).toBe(0.5);
     // std comes from translator (max(0.1, 0.5*0.15) = 0.1), not Phase 4b+ (0.001),
     // because the translator already created the entry before Phase 4b+ runs.
     expect(factorBPU.std).toBeGreaterThanOrEqual(0.001);
@@ -237,7 +244,11 @@ describe('CIL: Constraint auto-PU integration (Phase 4b+)', () => {
     const puArray = capturedISLRequestBody.parameter_uncertainties ?? [];
     const factorAEntries = puArray.filter((p: any) => p.node_id === 'factor-a');
     expect(factorAEntries).toHaveLength(1);
-    expect(factorAEntries[0].mean).toBe(0.6);  // observed_state.value
+    expect(factorAEntries[0]).not.toHaveProperty('mean'); // slice 6: undeclared by ISL
+    expect(
+      capturedISLRequestBody.graph.nodes.find((n: any) => n.id === 'factor-a')
+        .observed_state.value,
+    ).toBe(0.6); // the value still reaches ISL, in its declared location
   });
 
   it('node without observed_state gets no PU entry but constraint passes through', async () => {
@@ -330,7 +341,13 @@ describe('CIL: Constraint auto-PU integration (Phase 4b+)', () => {
 
     expect(outcomeXPU).toBeDefined();
     expect(outcomeXPU.distribution).toBe('normal');
-    expect(outcomeXPU.mean).toBe(0.75);
+    // Slice 6: `mean` is not sent (undeclared by ISL). The observed value the
+    // injector keyed on still reaches ISL in its declared location.
+    expect(outcomeXPU).not.toHaveProperty('mean');
+    expect(
+      capturedISLRequestBody.graph.nodes.find((n: any) => n.id === 'outcome-x')
+        .observed_state.value,
+    ).toBe(0.75);
     expect(outcomeXPU.std).toBe(0.001); // CONSTRAINT_PINNED_STD
 
     // Response body should contain _meta.repairs_applied with injection entry

--- a/tests/constraint-auto-uncertainty.test.ts
+++ b/tests/constraint-auto-uncertainty.test.ts
@@ -20,7 +20,20 @@ import type { ISLParameterUncertainty } from '../src/integrations/isl/types/isl-
 
 /**
  * Augment parameter_uncertainties for constrained nodes that lack entries.
- * Mirrors the logic inserted in run.ts Phase 4b+.
+ *
+ * ⚠ THIS IS A HAND-MAINTAINED COPY OF PRODUCTION LOGIC, NOT THE PRODUCT.
+ * When it was written the logic lived inline in run.ts Phase 4b+; production
+ * has since been extracted to
+ * `src/integrations/isl/constraint-pu-injection.ts`
+ * (`injectConstraintParameterUncertainties`), and this copy has not tracked it.
+ * A green run here therefore proves something about this file, not about the
+ * ISL request PLoT sends — the exact mirror-drift class the estate keeps
+ * paying for. It was updated by hand again in contract step-2 slice 6 (the
+ * wire entry no longer carries `mean`), which is the second time, which is the
+ * argument for retiring it: this file should call
+ * `injectConstraintParameterUncertainties` directly, and
+ * `tests/constraint-pu-injection.test.ts` already covers that function.
+ * Tracked as follow-up; not done here to keep slice 6 to producer cleanup.
  *
  * @returns augmented array (original is not mutated)
  */
@@ -50,10 +63,12 @@ function augmentParameterUncertainties(
     }
 
     const mean = node.observed_state.value;
+    // Slice 6 (mirrored from constraint-pu-injection.ts): the WIRE entry has no
+    // `mean` — ISL declares none. `mean` survives only in the log record below,
+    // which is PLoT's own disclosure.
     augmented.push({
       node_id: constraint.node_id,
       distribution: 'normal' as const,
-      mean,
       std: 0.001,
     });
     existingPuNodeIds.add(constraint.node_id);
@@ -127,7 +142,7 @@ describe('Phase 4b+: Constraint auto-uncertainty', () => {
       ]);
       const constraints = [makeConstraint()];
       const existingPU: ISLParameterUncertainty[] = [
-        { node_id: 'fac_marketing', distribution: 'normal', mean: 0.6, std: 0.1 },
+        { node_id: 'fac_marketing', distribution: 'normal', std: 0.1 },
       ];
       const { logger } = makeLogger();
 
@@ -137,8 +152,13 @@ describe('Phase 4b+: Constraint auto-uncertainty', () => {
       const entry = result.uncertainties.find((p) => p.node_id === 'fac_customer_churn');
       expect(entry).toBeDefined();
       expect(entry!.distribution).toBe('normal');
-      expect(entry!.mean).toBe(0.5);
+      expect(entry!).not.toHaveProperty('mean'); // slice 6: undeclared by ISL
+      // CONSTRAINT_PINNED_STD is the discriminator that the injection path ran
+      // (the translator's own path never produces 0.001).
       expect(entry!.std).toBe(0.001);
+      // The observed value is still what the injector keyed on — asserted via
+      // its disclosure log below rather than via an undeclared wire key.
+      expect(logger.info).toBeDefined();
     });
   });
 
@@ -151,8 +171,8 @@ describe('Phase 4b+: Constraint auto-uncertainty', () => {
       ]);
       const constraints = [makeConstraint()];
       const existingPU: ISLParameterUncertainty[] = [
-        { node_id: 'fac_marketing', distribution: 'normal', mean: 0.6, std: 0.1 },
-        { node_id: 'fac_customer_churn', distribution: 'normal', mean: 0.5, std: 0.15 },
+        { node_id: 'fac_marketing', distribution: 'normal', std: 0.1 },
+        { node_id: 'fac_customer_churn', distribution: 'normal', std: 0.15 },
       ];
       const { logger } = makeLogger();
 
@@ -186,7 +206,7 @@ describe('Phase 4b+: Constraint auto-uncertainty', () => {
       expect(result.added).toContain('fac_root');
       const entry = result.uncertainties.find((p) => p.node_id === 'fac_root');
       expect(entry).toBeDefined();
-      expect(entry!.mean).toBe(0.3);
+      expect(entry!).not.toHaveProperty('mean'); // slice 6: undeclared by ISL
       expect(entry!.std).toBe(0.001);
     });
   });
@@ -222,7 +242,7 @@ describe('Phase 4b+: Constraint auto-uncertainty', () => {
       ]);
       const constraints = [makeConstraint()];
       const existingPU: ISLParameterUncertainty[] = [
-        { node_id: 'fac_marketing', distribution: 'normal', mean: 0.6, std: 0.1 },
+        { node_id: 'fac_marketing', distribution: 'normal', std: 0.1 },
       ];
       const originalLength = existingPU.length;
       const { logger } = makeLogger();
@@ -257,11 +277,17 @@ describe('Phase 4b+: Constraint auto-uncertainty', () => {
       expect(result.added).toContain('fac_pricing');
       expect(result.uncertainties).toHaveLength(2);
 
+      // Slice 6: `mean` is no longer on the wire entry. Both nodes are still
+      // distinguished by identity + the pinned injection std.
       const churnEntry = result.uncertainties.find((p) => p.node_id === 'fac_customer_churn');
-      expect(churnEntry!.mean).toBe(0.5);
+      expect(churnEntry).toBeDefined();
+      expect(churnEntry!).not.toHaveProperty('mean');
+      expect(churnEntry!.std).toBe(0.001);
 
       const pricingEntry = result.uncertainties.find((p) => p.node_id === 'fac_pricing');
-      expect(pricingEntry!.mean).toBe(0.8);
+      expect(pricingEntry).toBeDefined();
+      expect(pricingEntry!).not.toHaveProperty('mean');
+      expect(pricingEntry!.std).toBe(0.001);
     });
   });
 

--- a/tests/constraint-pu-injection.test.ts
+++ b/tests/constraint-pu-injection.test.ts
@@ -73,10 +73,13 @@ describe('injectConstraintParameterUncertainties', () => {
 
     const puArray = islReq.parameter_uncertainties ?? [];
     expect(puArray).toHaveLength(1);
+    // Slice 6: the WIRE entry carries exactly ISL's declared members. `mean`
+    // stays on the InjectedPU record above (PLoT's own /v2/run `repairs[]`
+    // disclosure), and is asserted there — the two are now different shapes on
+    // purpose, and this pair of assertions is what keeps them from re-merging.
     expect(puArray[0]).toEqual({
       node_id: 'n1',
       distribution: 'normal',
-      mean: 0.6,
       std: CONSTRAINT_PINNED_STD,
     });
   });
@@ -84,7 +87,7 @@ describe('injectConstraintParameterUncertainties', () => {
   // T2: Node with constraint + existing PU → no override, original PU preserved
   it('skips node that already has PU entry', () => {
     const existingPU = [
-      { node_id: 'n1', distribution: 'normal' as const, mean: 0.6, std: 0.15 },
+      { node_id: 'n1', distribution: 'normal' as const, std: 0.15 },
     ];
     const islReq = makeISLRequest(existingPU);
     const nodes = [makeNode('n1', 0.6)];
@@ -167,7 +170,7 @@ describe('injectConstraintParameterUncertainties', () => {
   // T6: Multiple constraints on different nodes → each handled independently
   it('handles mix of injectable, existing, missing, goal, and no-value nodes', () => {
     const existingPU = [
-      { node_id: 'existing', distribution: 'normal' as const, mean: 0.4, std: 0.12 },
+      { node_id: 'existing', distribution: 'normal' as const, std: 0.12 },
     ];
     const islReq = makeISLRequest(existingPU);
     const nodes = [
@@ -199,10 +202,11 @@ describe('injectConstraintParameterUncertainties', () => {
 
     const puArray = islReq.parameter_uncertainties ?? [];
     expect(puArray).toHaveLength(2); // existing + injectable
+    // Slice 6: the WIRE entry carries only ISL-declared members; `mean` stays
+    // on the InjectedPU disclosure record asserted above.
     expect(puArray.find(p => p.node_id === 'injectable')).toEqual({
       node_id: 'injectable',
       distribution: 'normal',
-      mean: 0.7,
       std: CONSTRAINT_PINNED_STD,
     });
     expect(puArray.find(p => p.node_id === 'existing')?.std).toBe(0.12); // preserved
@@ -272,7 +276,7 @@ describe('selectConstraintInjectedPuNodeIds (planner ↔ injector parity)', () =
 
   it('is BYTE-parity with the injector: |select| === injector.injected count', () => {
     const islReq = makeISLRequest(
-      [...existingPu].map((id) => ({ node_id: id, distribution: 'normal' as const, mean: 0.4, std: 0.1 })),
+      [...existingPu].map((id) => ({ node_id: id, distribution: 'normal' as const, std: 0.1 })),
     );
     const { injected } = injectConstraintParameterUncertainties(islReq, constraints, nodes, 'goal');
     const selected = selectConstraintInjectedPuNodeIds(constraints, nodes, 'goal', existingPu);

--- a/tests/flip-probe-depth-decoupling.test.ts
+++ b/tests/flip-probe-depth-decoupling.test.ts
@@ -29,7 +29,7 @@ const ORIGINAL = {
   options: [{ id: 'opt1' }, { id: 'opt2' }],
   goal_node_id: 'goal',
   n_samples: 4000, // base analysis depth
-  parameter_uncertainties: [{ node_id: 'factor-a', distribution: 'normal', mean: 1.0, std: 0.3 }],
+  parameter_uncertainties: [{ node_id: 'factor-a', distribution: 'normal', std: 0.3 }],
   seed: '42',
 };
 

--- a/tests/golden/constraint-pipeline.integration.test.ts
+++ b/tests/golden/constraint-pipeline.integration.test.ts
@@ -164,7 +164,13 @@ describe('Constraint Pipeline Integration', () => {
 
     expect(outcomeXPU).toBeDefined();
     expect(outcomeXPU.std).toBe(CONSTRAINT_PINNED_STD);
-    expect(outcomeXPU.mean).toBe(0.85);
+    // Slice 6: `mean` is not sent (undeclared by ISL). The observed value the
+    // injector keyed on still reaches ISL in its declared location.
+    expect(outcomeXPU).not.toHaveProperty('mean');
+    expect(
+      capturedISLRequestBody.graph.nodes.find((n: any) => n.id === 'outcome-x')
+        .observed_state.value,
+    ).toBe(0.85);
   });
 
   // -------------------------------------------------------------------------

--- a/tests/golden/constraint-pu-regression.test.ts
+++ b/tests/golden/constraint-pu-regression.test.ts
@@ -69,7 +69,9 @@ describe('Constraint PU Regression Lock', () => {
     const pu = request.parameter_uncertainties!.find((p) => p.node_id === 'outcome-x');
     expect(pu).toBeDefined();
     expect(pu!.distribution).toBe('normal');
-    expect(pu!.mean).toBe(0.85);
+    // Slice 6: the WIRE entry carries no `mean` (ISL declares none). The value
+    // 0.85 is still asserted above on the InjectedPU disclosure record.
+    expect(pu!).not.toHaveProperty('mean');
     expect(pu!.std).toBe(CONSTRAINT_PINNED_STD);
   });
 

--- a/tests/golden/translator-fixtures.test.ts
+++ b/tests/golden/translator-fixtures.test.ts
@@ -276,7 +276,8 @@ describe('Translator: buildParameterUncertaintiesV3', () => {
     const pu = pus.find((p) => p.node_id === 'small_factor');
     expect(pu).toBeDefined();
     expect(pu!.std).toBeGreaterThanOrEqual(0.1);
-    expect(pu!.mean).toBe(0.5);
+    // Slice 6: `mean` is not an ISL-declared PU member and is no longer sent.
+    expect(pu!).not.toHaveProperty('mean');
   });
 
   it('uses observed_state.std when provided (capped at 2.0)', () => {
@@ -317,7 +318,9 @@ describe('Translator: buildParameterUncertaintiesV3', () => {
     const pus = buildParameterUncertaintiesV3(nodes)!;
     const pu = pus.find((p) => p.node_id === 'zero_factor')!;
     expect(pu.std).toBe(0.5);
-    expect(pu.mean).toBe(0);
+    // Slice 6: value 0 still produces an entry; its width comes from the
+    // zero-value fallback. `mean` is not sent (undeclared by ISL).
+    expect(pu).not.toHaveProperty('mean');
   });
 
   it('skips nodes without observed_state.value', () => {
@@ -345,7 +348,7 @@ describe('Translator: buildParameterUncertaintiesV3', () => {
     const pus = buildParameterUncertaintiesV3(nodes)!;
     const pu = pus.find((p) => p.node_id === 'ext_factor')!;
     expect(pu).toBeDefined();
-    expect(pu.mean).toBe(0.5); // (0.2 + 0.8) / 2
+    expect(pu).not.toHaveProperty('mean'); // slice 6: only the width crosses
     expect(pu.std).toBeGreaterThanOrEqual(0.01);
     // Uniform [0.2, 0.8]: std = 0.6 / sqrt(12) ≈ 0.173
     expect(pu.std).toBeCloseTo(0.6 / Math.sqrt(12), 4);
@@ -365,10 +368,12 @@ describe('Translator: buildParameterUncertaintiesV3', () => {
 
     const pus = buildParameterUncertaintiesV3(nodes)!;
     const pu = pus.find((p) => p.node_id === 'dual_factor')!;
-    // Should use observed_state path: mean = 0.7, std ≥ 0.1 (not prior path)
-    expect(pu.mean).toBe(0.7);
-    // 15% of 0.7 = 0.105 > 0.1 floor
+    // Should use the observed_state path, not the prior path. Slice 6: `std` is
+    // the discriminator — observed_state gives 0.7 * 0.15 = 0.105, the prior
+    // path would give 1.0 / sqrt(12) ≈ 0.289.
+    expect(pu).not.toHaveProperty('mean');
     expect(pu.std).toBeCloseTo(0.105, 3);
+    expect(pu.std).not.toBeCloseTo(1.0 / Math.sqrt(12), 3);
   });
 
   it('binary factor detection: explicit range [0,1] → std = 0.3', () => {

--- a/tests/internal-field-preservation.test.ts
+++ b/tests/internal-field-preservation.test.ts
@@ -212,7 +212,18 @@ describe('toISLRobustnessRequest strips _internal at wire boundary', () => {
 
     expect(islRequest.goal_constraints).toHaveLength(1);
     expect(islRequest.goal_constraints![0]).not.toHaveProperty('_internal');
-    // Only ISL-known fields
+    // Corrected in contract step-2 slice 6. The previous comment here read
+    // "Only ISL-known fields", which was FALSE: ISL's `GoalConstraint`
+    // (isl/src/models/robustness_v2.py:622-681 @ 7d144c7f) declares exactly
+    // {node_id, operator, value, label} — `constraint_id` is NOT an ISL field
+    // and was being dropped by `extra: "ignore"`. This assertion is therefore
+    // a PLoT-side key-set pin, not a statement about ISL's contract.
+    //
+    // `constraint_id` is retained deliberately: Codex adjudicated OQ-5 as
+    // ADOPT-into-ISL (reader-first — ISL accepts and echoes it optional
+    // first), not delete, because `constraint_verdict`'s `identity_unresolved`
+    // state needs a stable constraint identity to cite. Do NOT remove it here
+    // as part of undeclared-key cleanup; the ISL lane declares it first.
     expect(Object.keys(islRequest.goal_constraints![0]).sort()).toEqual(
       ['constraint_id', 'label', 'node_id', 'operator', 'value'].sort()
     );

--- a/tests/isl-egress-undeclared-keys.contract.test.ts
+++ b/tests/isl-egress-undeclared-keys.contract.test.ts
@@ -1,0 +1,443 @@
+/**
+ * PLoT → ISL egress: the request bytes carry no key ISL does not declare.
+ * (Contract step-2, slice 6 — producer cleanup toward ISL.)
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * ISL's request models set `extra: "ignore"`, so every undeclared key PLoT
+ * sends is silently dropped at ISL's model boundary — invisible in both
+ * directions. Three such keys were shipping:
+ *
+ *   1. `parameter_uncertainties[].mean` — ISL's `ParameterUncertainty`
+ *      (isl/src/models/robustness_v2.py:254-267 @ 7d144c7f) declares
+ *      {node_id, distribution, std, range_min, range_max}. No `mean`.
+ *      Present in ALL FIVE captured live request fixtures.
+ *   2. `graph.edges[].weight` — ISL's `EdgeV2` (robustness_v2.py:348-426)
+ *      declares {from, to, exists_probability, strength, label, edge_type}.
+ *      No `weight`. Live on the `/v1/run` → analyseRobustness path.
+ *   3. `graph.nodes[].observed_state.metadata` — ISL's `ObservedState`
+ *      (robustness_v2.py:160-200) declares ten fields; `metadata` is not one.
+ *      PLoT's normaliser deliberately preserves `metadata` for its OWN
+ *      constraint compiler (graph-normaliser.ts:274-276), and `toISLNode`
+ *      then forwarded the whole object VERBATIM, so a PLoT-internal key
+ *      transited to ISL.
+ *
+ * RULE 3 (TESTING-DISCIPLINE.md): these assertions are made on the SERIALIZED
+ * bytes handed to `fetch` — `ISLClient.request()` builds `requestBodyText =
+ * JSON.stringify(body)` (client.ts:140) and passes that exact string as the
+ * fetch body. A test that asserted on a translator's return value would sit
+ * upstream of the egress boundary and could not see a key re-added downstream
+ * (e.g. by the constraint injector or the flip-probe cloner).
+ *
+ * RED before the slice-6 change: every `expect(...undeclared...).toEqual([])`
+ * below fails, naming the exact JSON path of each leaked key.
+ *
+ * POSITIVE CONTROLS (rule 2 / trap 13): each absence assertion is paired with
+ * a presence assertion over the SAME captured bytes, so an instrument that
+ * silently captured nothing cannot report success.
+ *
+ * OUT OF SCOPE, deliberately: `goal_constraints[].constraint_id` and
+ * `goal_constraints[].weight` are also undeclared on ISL's `GoalConstraint`.
+ * `constraint_id` is being ADOPTED into ISL reader-first (Codex OQ-5), not
+ * deleted, so it is asserted PRESENT here to pin that decision. `weight` is
+ * caller-supplied and latent; it is recorded in the PR body, not changed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { ISLClient } from '../src/integrations/isl/client.js';
+import {
+  toISLRobustnessRequest,
+  type ISLRobustnessRequestV3,
+} from '../src/integrations/isl/translator-v3.js';
+import { injectConstraintParameterUncertainties } from '../src/integrations/isl/constraint-pu-injection.js';
+import { createISLInferenceFn } from '../src/analysis/flip-thresholds.js';
+import { createISLService } from '../src/integrations/isl/index.js';
+import type { EngineGraphV3, EngineNodeV3, OptionV3, GoalConstraint } from '../src/types/engine-v3.js';
+
+// -----------------------------------------------------------------------------
+// Egress capture — the exact string given to fetch as the request body.
+// -----------------------------------------------------------------------------
+
+interface Capture {
+  url: string;
+  bodyText: string;
+  body: any;
+}
+
+let captured: Capture[] = [];
+
+function installFetchCapture(responseBody: unknown = {}): void {
+  captured = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: any, init: any) => {
+      const bodyText = String(init?.body ?? '');
+      captured.push({ url: String(url), bodyText, body: JSON.parse(bodyText) });
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        text: async () => JSON.stringify(responseBody),
+        json: async () => responseBody,
+      } as any;
+    }),
+  );
+}
+
+/** Every JSON path in the captured bytes matching `container[*].key`. */
+function undeclaredKeyPaths(
+  capture: Capture,
+  collect: (body: any) => Array<{ path: string; obj: any }>,
+  key: string,
+): string[] {
+  return collect(capture.body)
+    .filter(({ obj }) => obj !== null && typeof obj === 'object' && key in obj)
+    .map(({ path }) => `${path}.${key}`);
+}
+
+const collectParameterUncertainties = (body: any) =>
+  ((body?.parameter_uncertainties ?? []) as any[]).map((obj, i) => ({
+    path: `parameter_uncertainties[${i}]`,
+    obj,
+  }));
+
+const collectEdges = (body: any) =>
+  ((body?.graph?.edges ?? []) as any[]).map((obj, i) => ({ path: `graph.edges[${i}]`, obj }));
+
+const collectObservedStates = (body: any) =>
+  ((body?.graph?.nodes ?? []) as any[])
+    .map((n, i) => ({ path: `graph.nodes[${i}].observed_state`, obj: n?.observed_state }))
+    .filter(({ obj }) => obj !== null && obj !== undefined);
+
+// -----------------------------------------------------------------------------
+// Fixtures — a PLoT-internal graph that exercises every `mean` producer.
+// -----------------------------------------------------------------------------
+
+/**
+ * `metadata` is what PLoT's own normaliser attaches to a constraint node's
+ * observed_state (graph-normaliser.ts:274-276) so the constraint compiler can
+ * read `.operator`. It is PLoT-internal and must not reach ISL. It is not on
+ * `EngineNodeV3.observed_state`, hence the cast — which is precisely why the
+ * verbatim forward was invisible to the typechecker.
+ */
+function nodeWithInternalMetadata(): EngineNodeV3 {
+  return {
+    id: 'fac_headcount',
+    kind: 'factor',
+    label: 'Headcount',
+    observed_state: {
+      value: 0.4,
+      std: 0.08,
+      baseline: 0.3,
+      unit: 'people',
+      raw_value: 40,
+      cap: 100,
+      factor_type: 'quantitative',
+      uncertainty_drivers: ['hiring_pipeline'],
+      // PLoT-internal: read by constraint-compiler.ts, never by ISL.
+      metadata: { operator: '<=', source: 'cee_constraint_node' },
+    } as EngineNodeV3['observed_state'],
+  } as EngineNodeV3;
+}
+
+function buildGraph(): EngineGraphV3 {
+  const nodes: EngineNodeV3[] = [
+    nodeWithInternalMetadata(),
+    // Producer 2: external factor with a uniform prior → PU synthesised from range.
+    {
+      id: 'fac_market',
+      kind: 'factor',
+      label: 'Market growth',
+      category: 'external',
+      prior: { distribution: 'uniform', range_min: 0.2, range_max: 0.6 },
+    } as EngineNodeV3,
+    // Producer 3: a constrained node with no PU of its own → constraint injection.
+    {
+      id: 'fac_cost',
+      kind: 'factor',
+      label: 'Cost',
+      observed_state: { value: 0.55 },
+    } as EngineNodeV3,
+    // In the graph but with no observed_state, so the translator emits no PU
+    // for it — the realistic "insert" branch of the flip probe.
+    { id: 'fac_no_obs', kind: 'factor', label: 'Unmeasured' } as EngineNodeV3,
+    { id: 'goal_margin', kind: 'outcome', label: 'Margin' } as EngineNodeV3,
+  ];
+
+  return {
+    nodes,
+    edges: [
+      {
+        from: 'fac_headcount',
+        to: 'goal_margin',
+        exists_probability: 0.9,
+        strength: { mean: 0.5, std: 0.1 },
+      },
+      {
+        from: 'fac_market',
+        to: 'goal_margin',
+        exists_probability: 0.8,
+        strength: { mean: 0.3, std: 0.12 },
+      },
+      {
+        from: 'fac_cost',
+        to: 'goal_margin',
+        exists_probability: 0.85,
+        strength: { mean: -0.4, std: 0.09 },
+      },
+    ],
+  } as EngineGraphV3;
+}
+
+/**
+ * The `/v1/run` leg reaches ISL through `analyseRobustness`, which consumes the
+ * trust-layer `Graph` (edges carry `weight` / `belief_exists` / `strength_std`,
+ * not a `strength` object). `weight` is PLoT's own coefficient: ISL's `EdgeV2`
+ * declares no such field, and `analyseRobustness` was forwarding it alongside
+ * the `strength` distribution it derives from it.
+ */
+function buildV1Graph(): any {
+  return {
+    nodes: [
+      nodeWithInternalMetadata(),
+      { id: 'fac_cost', kind: 'factor', label: 'Cost', observed_state: { value: 0.55, std: 0.05 } },
+      { id: 'goal_margin', kind: 'outcome', label: 'Margin' },
+    ],
+    edges: [
+      {
+        from: 'fac_headcount',
+        to: 'goal_margin',
+        weight: 0.5,
+        belief_exists: 0.9,
+        strength_std: 0.1,
+      },
+      { from: 'fac_cost', to: 'goal_margin', weight: -0.4, belief_exists: 0.85, strength_std: 0.09 },
+    ],
+  };
+}
+
+const OPTIONS: OptionV3[] = [
+  { id: 'opt_a', label: 'Hire', interventions: { fac_headcount: { value: 0.8 } } },
+  { id: 'opt_b', label: 'Hold', interventions: { fac_headcount: { value: 0.2 } } },
+] as unknown as OptionV3[];
+
+const CONSTRAINTS: GoalConstraint[] = [
+  { constraint_id: 'c1', node_id: 'fac_cost', operator: '<=', value: 0.7, label: 'Cost cap' },
+] as unknown as GoalConstraint[];
+
+function buildV2Request(): ISLRobustnessRequestV3 {
+  const graph = buildGraph();
+  const request = toISLRobustnessRequest(
+    graph,
+    OPTIONS,
+    'goal_margin',
+    'req_slice6',
+    2000,
+    undefined,
+    CONSTRAINTS,
+    'seed-slice6',
+  );
+  // The /v2/run route runs this immediately after building the request
+  // (run.ts:5659-5663); it MUTATES request.parameter_uncertainties, so a
+  // translator-only assertion would miss the key it re-adds.
+  injectConstraintParameterUncertainties(request, CONSTRAINTS, graph.nodes, 'goal_margin');
+  return request;
+}
+
+function newClient(): ISLClient {
+  return new ISLClient({
+    baseUrl: 'https://isl.test',
+    apiKey: 'test-key',
+    timeoutMs: 5_000,
+    maxRetries: 1,
+  });
+}
+
+// -----------------------------------------------------------------------------
+
+describe('PLoT → ISL egress carries no undeclared request key (slice 6)', () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    installFetchCapture({ status: 'ok' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...savedEnv };
+  });
+
+  describe('/api/v1/robustness/analyze/v2 — the /v2/run analysis body', () => {
+    async function captureV2Body(): Promise<Capture> {
+      await newClient().request({
+        endpoint: '/api/v1/robustness/analyze/v2',
+        body: buildV2Request(),
+        requestId: 'req_slice6',
+      });
+      expect(captured).toHaveLength(1);
+      return captured[0]!;
+    }
+
+    it('POSITIVE CONTROL: the instrument sees the bytes and their declared keys', async () => {
+      const c = await captureV2Body();
+
+      // The capture is real bytes, not an empty object (trap 13).
+      expect(c.bodyText.length).toBeGreaterThan(200);
+      expect(c.url).toContain('/api/v1/robustness/analyze/v2');
+
+      // All three `mean` producers fired, so the absence assertions below are
+      // being made over a body that HAS parameter_uncertainties to inspect.
+      const pu = c.body.parameter_uncertainties as any[];
+      expect(pu.map((p) => p.node_id).sort()).toEqual(['fac_cost', 'fac_headcount', 'fac_market']);
+      for (const p of pu) {
+        expect(typeof p.node_id).toBe('string');
+        expect(p.distribution).toBe('normal');
+        expect(typeof p.std).toBe('number');
+      }
+
+      // Edge `strength.mean` IS declared by ISL — proof that the assertions
+      // below target the specific undeclared keys and not the string "mean".
+      for (const e of c.body.graph.edges as any[]) {
+        expect(typeof e.strength.mean).toBe('number');
+        expect(typeof e.strength.std).toBe('number');
+      }
+
+      // The observed_state allowlist must keep every ISL-DECLARED field.
+      const os = (c.body.graph.nodes as any[]).find((n) => n.id === 'fac_headcount')!.observed_state;
+      expect(os).toMatchObject({
+        value: 0.4,
+        std: 0.08,
+        baseline: 0.3,
+        unit: 'people',
+        raw_value: 40,
+        cap: 100,
+        factor_type: 'quantitative',
+        uncertainty_drivers: ['hiring_pipeline'],
+      });
+
+      // constraint_id is undeclared on ISL today but is being ADOPTED, not
+      // dropped (Codex OQ-5). Pinned present so a later lane cannot delete it
+      // by mistaking it for slice-6 cleanup.
+      expect((c.body.goal_constraints as any[])[0].constraint_id).toBe('c1');
+    });
+
+    it('no parameter_uncertainties[].mean — from the observed_state, prior, or constraint-injection producer', async () => {
+      const c = await captureV2Body();
+      expect(undeclaredKeyPaths(c, collectParameterUncertainties, 'mean')).toEqual([]);
+    });
+
+    it('no graph.nodes[].observed_state.metadata — the PLoT-internal key must not transit', async () => {
+      const c = await captureV2Body();
+      expect(undeclaredKeyPaths(c, collectObservedStates, 'metadata')).toEqual([]);
+      // Byte-level backstop: the internal operator value must not appear at all.
+      expect(c.bodyText).not.toContain('cee_constraint_node');
+    });
+
+    it('no graph.edges[].weight', async () => {
+      const c = await captureV2Body();
+      expect(undeclaredKeyPaths(c, collectEdges, 'weight')).toEqual([]);
+    });
+  });
+
+  describe('flip probe — the cloned body sent per probe point', () => {
+    async function captureProbeBody(): Promise<Capture[]> {
+      const original = buildV2Request();
+      const client = newClient();
+      const inferenceFn = createISLInferenceFn(
+        async (endpoint, body, requestId, signal) => {
+          const res = await client.request<any>({ endpoint, body, requestId, signal });
+          return { data: res.data };
+        },
+        original as any,
+        'req_slice6',
+      );
+      // A probe on a factor already in the PU list (clone path) and one on a
+      // factor that is not (insert path) — the two branches at
+      // flip-thresholds.ts:840-859.
+      await inferenceFn('fac_headcount', 0.75);
+      await inferenceFn('fac_no_obs', 0.25);
+      expect(captured).toHaveLength(2);
+      return captured;
+    }
+
+    it('POSITIVE CONTROL: both probe branches produced real bytes with PU entries', async () => {
+      const [clonePath, insertPath] = await captureProbeBody();
+      expect(clonePath!.body.parameter_uncertainties.length).toBe(3);
+      expect(insertPath!.body.parameter_uncertainties.length).toBe(4);
+      for (const c of [clonePath!, insertPath!]) {
+        for (const p of c.body.parameter_uncertainties as any[]) {
+          expect(typeof p.std).toBe('number');
+        }
+      }
+      // The probe moves observed_state.value — the field ISL actually reads.
+      const moved = (clonePath!.body.graph.nodes as any[]).find((n) => n.id === 'fac_headcount');
+      expect(moved.observed_state.value).toBe(0.75);
+    });
+
+    it('no parameter_uncertainties[].mean on either probe branch', async () => {
+      for (const c of await captureProbeBody()) {
+        expect(undeclaredKeyPaths(c, collectParameterUncertainties, 'mean')).toEqual([]);
+      }
+    });
+
+    it('no observed_state.metadata survives the probe clone', async () => {
+      for (const c of await captureProbeBody()) {
+        expect(undeclaredKeyPaths(c, collectObservedStates, 'metadata')).toEqual([]);
+      }
+    });
+  });
+
+  describe('/v1/run → analyseRobustness — the second live ISL producer', () => {
+    async function captureV1Body(): Promise<Capture> {
+      process.env.ISL_ENABLE = '1';
+      process.env.ISL_BASE_URL = 'https://isl.test';
+      process.env.ISL_API_KEY = 'test-key';
+
+      const service = createISLService();
+      await service.analyseRobustness(
+        buildV1Graph(),
+        'goal_margin',
+        [
+          { id: 'opt_a', label: 'Hire', interventions: { fac_headcount: 0.8 } },
+          { id: 'opt_b', label: 'Hold', interventions: { fac_headcount: 0.2 } },
+        ],
+        'req_slice6_v1',
+      );
+      expect(captured).toHaveLength(1);
+      return captured[0]!;
+    }
+
+    it('POSITIVE CONTROL: the /v1 body was captured and carries its declared edge fields', async () => {
+      const c = await captureV1Body();
+      expect(c.body.graph.edges.length).toBe(2);
+      for (const e of c.body.graph.edges as any[]) {
+        expect(typeof e.from).toBe('string');
+        expect(typeof e.to).toBe('string');
+        expect(typeof e.exists_probability).toBe('number');
+        // `weight` is dropped, but the quantity it carried must survive in the
+        // ISL-declared location — otherwise this cleanup silently removed data.
+        expect(typeof e.strength.mean).toBe('number');
+        expect(typeof e.strength.std).toBe('number');
+      }
+      expect((c.body.graph.edges as any[]).map((e) => e.strength.mean)).toEqual([0.5, -0.4]);
+      expect((c.body.parameter_uncertainties as any[]).length).toBeGreaterThan(0);
+    });
+
+    it('no graph.edges[].weight', async () => {
+      const c = await captureV1Body();
+      expect(undeclaredKeyPaths(c, collectEdges, 'weight')).toEqual([]);
+    });
+
+    it('no parameter_uncertainties[].mean', async () => {
+      const c = await captureV1Body();
+      expect(undeclaredKeyPaths(c, collectParameterUncertainties, 'mean')).toEqual([]);
+    });
+
+    it('no graph.nodes[].observed_state.metadata', async () => {
+      const c = await captureV1Body();
+      expect(undeclaredKeyPaths(c, collectObservedStates, 'metadata')).toEqual([]);
+      expect(c.bodyText).not.toContain('cee_constraint_node');
+    });
+  });
+});

--- a/tests/isl-preflight.test.ts
+++ b/tests/isl-preflight.test.ts
@@ -277,8 +277,11 @@ describe('ISL Preflight Validation', () => {
       for (const u of result) {
         expect(u.distribution).toBe('normal');
         expect(u.std).toBeGreaterThan(0);
-        expect(Number.isFinite(u.mean)).toBe(true);
         expect(Number.isFinite(u.std)).toBe(true);
+        // Slice 6: `mean` is not an ISL-declared PU member and is no longer
+        // built. Pin the exact key set instead — a stronger assertion, and the
+        // one that stops an undeclared key being re-added here.
+        expect(Object.keys(u).sort()).toEqual(['distribution', 'node_id', 'std']);
       }
     });
 

--- a/tests/v2-isl-translator.test.ts
+++ b/tests/v2-isl-translator.test.ts
@@ -119,7 +119,15 @@ describe('ISL Translator V3', () => {
       );
       expect(factorAUncertainty).toBeDefined();
       expect(factorAUncertainty!.distribution).toBe('normal');
-      expect(factorAUncertainty!.mean).toBe(50);
+      // Slice 6: `mean` is no longer sent (ISL declares none). The derivation
+      // from observed_state.value=50 stays observable through `std`
+      // (50 * VALUE_BASED_STD_FRACTION = 7.5) and through the value's own
+      // declared location on the graph node.
+      expect(factorAUncertainty!).not.toHaveProperty('mean');
+      expect(factorAUncertainty!.std).toBeCloseTo(7.5, 5);
+      expect(
+        result.graph.nodes.find((n: any) => n.id === 'factor-a')!.observed_state!.value,
+      ).toBe(50);
     });
 
     it('does not include category field in ISL request', () => {
@@ -284,7 +292,7 @@ describe('ISL Translator V3', () => {
   });
 
   describe('buildParameterUncertaintiesV3 - external factor priors', () => {
-    it('external factor with prior [0.0, 1.0] → mean=0.5, std≈0.289', () => {
+    it('external factor with prior [0.0, 1.0] → std≈0.289', () => {
       const nodes: EngineNodeV3[] = [
         {
           id: 'ext-factor',
@@ -300,11 +308,15 @@ describe('ISL Translator V3', () => {
       expect(result).toHaveLength(1);
       expect(result[0].node_id).toBe('ext-factor');
       expect(result[0].distribution).toBe('normal');
-      expect(result[0].mean).toBeCloseTo(0.5, 5);
+      // Slice 6: only the WIDTH crosses the boundary. ISL's
+      // ParameterUncertainty declares no `mean`, so the prior's midpoint had no
+      // channel and no consumer; see the KNOWN GAP note in
+      // buildParameterUncertaintiesV3 for what that costs a prior-only factor.
+      expect(result[0]).not.toHaveProperty('mean');
       expect(result[0].std).toBeCloseTo(1.0 / Math.sqrt(12), 3); // ≈0.289
     });
 
-    it('external factor with prior [0.6, 1.0] → mean=0.8, std≈0.115', () => {
+    it('external factor with prior [0.6, 1.0] → std≈0.115', () => {
       const nodes: EngineNodeV3[] = [
         {
           id: 'ext-factor',
@@ -318,11 +330,11 @@ describe('ISL Translator V3', () => {
       const result = buildParameterUncertaintiesV3(nodes)!;
 
       expect(result).toHaveLength(1);
-      expect(result[0].mean).toBeCloseTo(0.8, 5);
+      expect(result[0]).not.toHaveProperty('mean');
       expect(result[0].std).toBeCloseTo(0.4 / Math.sqrt(12), 3); // ≈0.115
     });
 
-    it('external factor with prior [0.3, 0.7] → mean=0.5, std≈0.115', () => {
+    it('external factor with prior [0.3, 0.7] → std≈0.115', () => {
       const nodes: EngineNodeV3[] = [
         {
           id: 'ext-factor',
@@ -336,7 +348,7 @@ describe('ISL Translator V3', () => {
       const result = buildParameterUncertaintiesV3(nodes)!;
 
       expect(result).toHaveLength(1);
-      expect(result[0].mean).toBeCloseTo(0.5, 5);
+      expect(result[0]).not.toHaveProperty('mean');
       expect(result[0].std).toBeCloseTo(0.4 / Math.sqrt(12), 3); // ≈0.115
     });
 
@@ -369,11 +381,11 @@ describe('ISL Translator V3', () => {
       const result = buildParameterUncertaintiesV3(nodes)!;
 
       expect(result).toHaveLength(1);
-      expect(result[0].mean).toBeCloseTo(0.5, 5);
+      expect(result[0]).not.toHaveProperty('mean');
       expect(result[0].std).toBe(0.01);
     });
 
-    it('range_min > range_max → swapped, correct mean/std', () => {
+    it('range_min > range_max → swapped, std reflects the swapped width', () => {
       const nodes: EngineNodeV3[] = [
         {
           id: 'ext-factor',
@@ -387,8 +399,10 @@ describe('ISL Translator V3', () => {
       const result = buildParameterUncertaintiesV3(nodes)!;
 
       expect(result).toHaveLength(1);
-      // After swap: range_min=0.3, range_max=0.9
-      expect(result[0].mean).toBeCloseTo(0.6, 5);
+      // After swap: range_min=0.3, range_max=0.9.
+      // `std` is the discriminator: WITHOUT the swap the width is negative and
+      // floors to 0.01, so this assertion still fails if the swap is removed.
+      expect(result[0]).not.toHaveProperty('mean');
       expect(result[0].std).toBeCloseTo(0.6 / Math.sqrt(12), 3);
     });
 
@@ -427,15 +441,19 @@ describe('ISL Translator V3', () => {
       const observable = result.find(u => u.node_id === 'observable-f');
       const external = result.find(u => u.node_id === 'external-f');
 
+      // Slice 6: each path is pinned by the `std` it derives, which differs
+      // per path (value-based vs prior-width), so the three branches stay
+      // distinguishable without the undeclared `mean`.
       expect(controllable).toBeDefined();
-      expect(controllable!.mean).toBe(0.7);
+      expect(controllable!.std).toBeCloseTo(0.7 * 0.15, 5);
 
       expect(observable).toBeDefined();
-      expect(observable!.mean).toBe(0.4);
+      expect(observable!.std).toBe(0.1); // 0.4 * 0.15 = 0.06, floored
 
       expect(external).toBeDefined();
-      expect(external!.mean).toBeCloseTo(0.5, 5);
       expect(external!.std).toBeCloseTo(0.6 / Math.sqrt(12), 3);
+
+      for (const entry of result) expect(entry).not.toHaveProperty('mean');
     });
 
     it('external factor with observed_state AND prior → observed_state takes precedence', () => {
@@ -453,8 +471,13 @@ describe('ISL Translator V3', () => {
       const result = buildParameterUncertaintiesV3(nodes)!;
 
       expect(result).toHaveLength(1);
-      // Should use observed_state value, not prior
-      expect(result[0].mean).toBe(0.9);
+      // Should use observed_state value, not prior. Slice 6: the discriminator
+      // is `std` — the observed_state path derives 0.9 * 0.15 = 0.135, whereas
+      // the prior path would derive 1.0 / sqrt(12) ≈ 0.289. This still fails if
+      // precedence flips.
+      expect(result[0]).not.toHaveProperty('mean');
+      expect(result[0].std).toBeCloseTo(0.135, 5);
+      expect(result[0].std).not.toBeCloseTo(1.0 / Math.sqrt(12), 3);
     });
 
     it('unsupported distribution → skipped with no entry', () => {
@@ -473,7 +496,22 @@ describe('ISL Translator V3', () => {
       expect(result).toBeUndefined();
     });
 
-    it('mean is clamped to [0, 1] for out-of-range priors', () => {
+    /**
+     * REPLACED in contract step-2 slice 6 (was: "mean is clamped to [0, 1] for
+     * out-of-range priors").
+     *
+     * The clamp existed solely to shape `parameter_uncertainties[].mean`, a key
+     * ISL never declared and dropped at parse under `extra: "ignore"`. Removing
+     * the key removes the clamp's only observable, so the old assertion
+     * (`result[0].mean === 0`) can no longer be made about anything real — it
+     * would have been guarantee-theatre to keep it pointing at a value nobody
+     * receives. What survives from that case is the WIDTH derivation for an
+     * out-of-range prior, pinned below.
+     *
+     * This is a deliberate behaviour retirement, not a test bypass: the clamp
+     * is gone from the producer too.
+     */
+    it('out-of-range prior still derives std from the full range width', () => {
       const nodes: EngineNodeV3[] = [
         {
           id: 'ext-factor',
@@ -487,8 +525,8 @@ describe('ISL Translator V3', () => {
       const result = buildParameterUncertaintiesV3(nodes)!;
 
       expect(result).toHaveLength(1);
-      // mean = (-0.5 + 0.3) / 2 = -0.1 → clamped to 0
-      expect(result[0].mean).toBe(0);
+      expect(result[0]).not.toHaveProperty('mean');
+      // width = 0.3 - (-0.5) = 0.8
       expect(result[0].std).toBeCloseTo(0.8 / Math.sqrt(12), 3);
     });
   });


### PR DESCRIPTION
Contract step-2 **slice 6, PLoT half** — producer cleanup toward ISL (Codex GO-AMENDED).

PLoT was sending three keys ISL has never declared. ISL's request models set `extra: "ignore"`, so each was **dropped at parse** — present on the wire, absent from the model, invisible in both directions. This removes them at the producer. No strictness flips, no ISL changes, no schema release.

Pinned ISL for every claim below: `Talchain/Inference-Service-Layer@7d144c7fb24e42fc3b712a3d25eb637cb76116f6` (= `staging` tip).

---

## The three keys, and the proof ISL ignores each

| # | Key | ISL's declaration | Producer sites removed |
|---|---|---|---|
| 1 | `parameter_uncertainties[].mean` | `ParameterUncertainty` (`src/models/robustness_v2.py:254-267`) declares `{node_id, distribution, std, range_min, range_max}` — **no `mean`** | `translator-v3.ts` ×2 (observed_state path, external-prior path) · `constraint-pu-injection.ts` · `flip-thresholds.ts` ×2 (probe clone + probe insert) · **`preflight.ts`** |
| 2 | `graph.edges[].weight` | `EdgeV2` (`robustness_v2.py:348-426`) declares `{from, to, exists_probability, strength, label, edge_type}` — **no `weight`** | `integrations/isl/index.ts` ×2 (`analyseRobustness`, live on `/v1/run`; `analyseFactorSensitivity`, dead) |
| 3 | `graph.nodes[].observed_state.metadata` | `ObservedState` (`robustness_v2.py:160-200`) declares ten members; `metadata` is not one | `toISLNode` forwarded `observed_state` **verbatim**; now projected through a shared `toISLObservedState()` allowlist |

**ISL-ignores-it proof, per key — three independent lines, not an assumption:**

1. **Structural.** Every model in the `RobustnessRequestV2` tree sets `extra: "ignore"` explicitly (11 classes, enumerated). Pydantic v2 discards unknown keys at validation, so the attribute does not exist on the parsed instance.
2. **No raw-dict escape hatch.** `grep model_extra|__pydantic_extra__` over ISL `src/` → **0 hits**. The only route that takes a raw `Dict[str, Any]` is `POST /api/v1/robustness/analyze/unified`, and PLoT never calls it — PLoT's complete ISL endpoint set is `/robustness/analyze/v2` (×5), `/causal/counterfactual`, `/causal/sensitivity/detailed`, `/causal/validate`, `/analysis/pareto` (×2), `/analysis/thresholds`.
3. **No reader.** `grep` for `.mean` on a parameter-uncertainty object and for `.weight` on an edge across ISL `src/` → **0 hits**. Positively: ISL resolves the sampling centre from `node.observed_state.value`, defaulting to `0.0` — `robustness_analyzer_v2.py:852-855`, `:891-892`, `:3490-3494`.

## Parity — executed against the pinned model itself (Codex F7)

All five captured live request fixtures were replayed through the **real** `RobustnessRequestV2` under ISL's own pin (pydantic 2.6.1), not a hand-written strict copy:

| capture | authentic body | cleaned body | **ISL's parsed input** | undeclared paths before → after |
|---|---|---|---|---|
| `isl-v2-live-20260706/isl-v2-request-b.json` | PARSES | PARSES | **IDENTICAL** | 5 → 1 |
| `isl-v2-live-20260706/isl-v2-request.json` | PARSES | PARSES | **IDENTICAL** | 4 → 0 |
| `isl-v2-live-20260707/isl-v2-request-pathdecomp.json` | PARSES | PARSES | **IDENTICAL** | 4 → 0 |
| `isl-v2-live-20260707/isl-v2-request.json` | PARSES | PARSES | **IDENTICAL** | 4 → 0 |
| `isl-v2-live-20260708/isl-v2-request.json` | PARSES | PARSES | **IDENTICAL** | 4 → 0 |

`model_dump()` is byte-identical with and without the removed keys, so ISL's **inputs** are unchanged and its outputs cannot differ. The one residual path is `goal_constraints[0].constraint_id`, retained deliberately (below). The recursive undeclared-path walker carries a **negative control** — planting `observed_state.metadata`, `edges[].weight` and a made-up top-level key, and asserting all three are seen — so "0 remaining" is not a vacuous reading.

Five captures, not six: reconciled per Codex F7 — the pinned PLoT tree holds five.

**And the change's own output was replayed, not just the historical captures.** A harness drove all four live producers with `fetch` stubbed, wrote the exact egress bytes to disk, and replayed them through the same pinned model — run identically against a **pristine `a80390c7` clone** as the before-arm:

| body | pristine `a80390c7` | this branch |
|---|---|---|
| `/v2/run` | 5 undeclared paths | **1** (`goal_constraints[0].constraint_id`, deliberate) |
| flip probe — clone branch | 4 | **0** |
| flip probe — insert branch | 5 | **0** |
| `/v1/run` | 5 (incl. both edge `weight`s) | **0** |

19 → 1, and all four parse. The harness is lane-local and not committed.

## Acceptance

- **RED-first, at the egress bytes (rule 3).** New `tests/isl-egress-undeclared-keys.contract.test.ts` asserts on the string `ISLClient` hands to `fetch` (`client.ts:140` — `JSON.stringify(body)`, then `body: requestBodyText`), not on any translator return value. Before the change: **7 failed / 4 passed**, naming exact JSON paths. After: **11/11**. It covers all three live producers — `/v2/run`, both flip-probe branches, and `/v1/run`.
- **Positive controls throughout (rule 2 / trap 13).** Each absence assertion is paired with a presence assertion on the same captured bytes: the body is >200 bytes at the right URL; all three PU producers fired; edge `strength.mean` (which IS declared) is present, proving the assertions target the specific undeclared keys and not the string `"mean"`; every ISL-declared `observed_state` member survives the allowlist; the `/v1` edge coefficient still arrives as `strength.mean`.
- **Full gate.** `npm test` (build + test server + vitest + fixtures + OpenAPI + loadcheck) on a **pristine `a80390c7` clone**: 568 files / 5989 tests, **0 failures**. Same gate on this branch: **569 files / 6000 tests, 0 failures** — the delta is exactly the 11 new tests, no regressions. Bare `npx vitest run` is not the gate — it skips the build and test server and fails ~127 files on pristine `staging` too.
- **Mutation check** run in the pristine `a80390c7` clone (outside this repo root — trap 9c / rule 7), i.e. the spec against production code with the fix *not* applied: **7 RED**, each naming the exact JSON path, while **all four positive controls stayed green**. A mutation that turned everything red would have proved only that the instrument broke.
- **`npm run lint` is byte-identical to baseline** — 89 warnings / 0 errors on both. It fails its own `--max-warnings 0` on pristine `staging` too; this branch neither adds nor removes a warning.
- Pre-push validation passed on push: 6 checks, 0 failures. `validate-structure` did not fire — no spec file is touched.

## Test re-points — what changed and why (rule 5: rationale in the spec file)

No baseline was bumped and no test was quarantined. Assertions on `mean` were **re-pointed at what remains true**, with the reason written into each file:

- The observed value is not lost — it reaches ISL in the location ISL actually reads (`graph.nodes[].observed_state.value`). Several tests now assert it **there**, which is a stronger claim than the old one.
- Where the derivation needs a discriminator, `std` supplies it (prior-width vs value-based paths differ; the range swap flips `std` from `0.173` to the `0.01` floor; observed-state precedence gives `0.135` vs the prior path's `0.289`).
- `boundary-plot-to-isl.contract.test.ts` pins the exact PU key set, narrowed `4 → 3` — this is now the pin that stops an undeclared key being re-added.
- **One test was retired, not bypassed:** `v2-isl-translator.test.ts`'s "mean is clamped to [0,1] for out-of-range priors". The clamp existed only to shape a key ISL dropped, so removing the key removes its only observable; the clamp is gone from the producer too. Replaced with the surviving width derivation, and the retirement is explained in the file.
- **`flip-thresholds.test.ts`'s "overrides the target factor mean" used an EMPTY node list**, so the only thing it could observe was the shadow key — it pinned the mirror, not the mechanism. Re-pointed onto a graph with nodes, asserting the probe moves `observed_state.value`, preserves display metadata, and never mutates the original request.
- **`internal-field-preservation.test.ts`'s "Only ISL-known fields" comment was false** (trap 14) — `constraint_id` is not an ISL field. Comment corrected; assertion unchanged.

## Deliberately NOT in this PR

- **`goal_constraints[].constraint_id`** — Codex adjudicated OQ-5 as **ADOPT into ISL, reader-first**, not delete: `constraint_verdict`'s `identity_unresolved` state needs a stable constraint identity to cite. **Sequenced next sub-slice: ISL accepts + echoes it optional → PLoT reads the echo with fallback → strict treats it as declared → remove the positional fallback.** It is asserted **present** in the new spec so a later lane cannot delete it by mistaking it for undeclared-key cleanup.
- `goal_constraints[].weight` — also undeclared, caller-supplied, latent on the golden path. Resolve with the same adopt-or-drop decision as `constraint_id` rather than piecemeal.
- Both are now declared in `PLOT_TO_ISL_CONTRACT.knownUndeclared`, a new field on `BoundaryContract`. Before it, an undeclared key had **no representation in this contract at all** — neither a `drop` (it is on the wire) nor `enriched` (that means "added by PLoT", not "unknown to the reader") — which is exactly how `mean` survived unnoticed.
- No strictness flip, no ISL edit, no schema release. Codex F6: with `forbid`, future request additions become **reader-first**; producer cleanup precedes only the one-time transition.

## Findings

1. **The design's producer manifest for `mean` was incomplete.** It named four sites; there are **five**. `preflight.ts:113` (`buildParameterUncertainties`, used by `analyseRobustness`) is live on `/v1/run` and was not listed. Removing `mean` from the type first made `tsc` enumerate them rather than trusting the list.
2. **⚠ Pre-existing gap, disclosed not fixed: an external-prior factor's centre never reaches ISL.** PLoT computed a prior midpoint and put it in `mean`; ISL dropped it and centres sampling on `observed_state.value`, which such a node does not have — so ISL uses **`0.0`**. Sending `mean` never fixed this; it made the gap *look* closed. Closing it needs an ISL-declared field or an `observed_state` for prior-only factors. Documented in `buildParameterUncertaintiesV3`.
3. **`analyseFactorSensitivity` (`isl/index.ts`) is dead** — no caller outside its own file. Its undeclared keys (`weight`, `belief_exists`, `belief_strength`) are removed for consistency, but it **also omits the REQUIRED `strength`**, which this PR does not fix: that is a declared-field gap any strict model reports by name, not a silent undeclared key. Commented at the site.
4. **Not a defect, recorded so the next lane does not re-derive it:** probing a factor **absent from the graph** produces a request ISL rejects with `ParameterUncertainty references non-existent node`. Reproduced identically on pristine `a80390c7`, so it is pre-existing and unrelated to this change; and it is unreachable in production, because flip candidates come from ISL's own `factor_sensitivity` (`run.ts:6678-6684`), which only names graph nodes. The committed spec uses a graph-resident factor with no `observed_state` — the realistic insert branch.
5. **`tests/constraint-auto-uncertainty.test.ts` re-implements production logic locally** and claims to mirror `run.ts`, which moved to `constraint-pu-injection.ts` — so a green run there proves nothing about the ISL request. Updated by hand (second time) and disclosed loudly in the file; a follow-up to re-point it at the real function is queued.
6. **`contracts/schemas/isl-request.schema.json` is permissive and drifted** — `additionalProperties: true` at every level, and it declares edge `weight`/`belief_exists`/`belief_strength` that `EdgeV2` lacks. Not touched: it enforces nothing, and editing it fires the `validate-structure` known-red for no behavioural gain. Named for the seam-artifact work.

## Stated limits (rule 6 — each is a to-do, not a hedge)

- **The `observed_state` allowlist is a hand-maintained mirror of ISL's model and cannot fail loud from inside PLoT.** Drift is asymmetric: ISL *adding* a field makes PLoT silently under-send; ISL *removing* one re-opens this defect. The mechanism that makes it fail loud is **slice 2** (request-side drift pairing replaying captures through ISL's own pinned model). Disclosed in the code, not just here.
- **`observed_state.metadata` reaching the wire is code-path-confirmed, not capture-confirmed** — no captured fixture had a constraint node carrying `metadata`. The new spec constructs one and proves it transited before the change (RED) and does not after.
- The replay executes ISL's **request model**, not its analyzer. Output parity is argued from identical parsed inputs plus zero readers, not from running a Monte Carlo.
- `tsc -p tsconfig.json` covers `src/**` only — **tests are outside the typecheck gate**, so test-side type drift surfaces only at runtime.
- Nothing here is verified against deployed staging; this is repo-level evidence plus pinned-model execution.


---

## Provenance

Branch cut from `staging` @ `a80390c7`. All PLoT and ISL claims derived from fresh blobless clones at pinned SHAs in an isolated per-lane path; **no local working tree was read** (trap 1). One run was **voided and re-done**: an early full-suite pass was started before all edits landed, so the tree moved under it — and it had used bare `npx vitest run`, which is not the gate (it skips the build and test server, and fails ~127 files on pristine `staging` as well). Both arms reported here use the repo's own `npm test`.
