### PR TITLE
fix(isl): degrade to a typed unknown when ISL data is absent, never to a verdict or a number

### DIFF
--- a/src/integrations/isl/adapters/validation.ts
+++ b/src/integrations/isl/adapters/validation.ts
@@ -38,8 +38,15 @@ const CONFIDENCE_MAP: Record<ISLValidationResponse['robustness'], PLoTValidation
  * ```
  */
 export function adaptValidationResponse(isl: ISLValidationResponse): PLoTValidationResult {
-  // Map ISL status to PLoT status
-  const status = STATUS_MAP[isl.status] || 'uncertain';
+  // Map ISL status to PLoT status.
+  //
+  // The fallback arm is reached only when ISL sends a status outside its three
+  // DECLARED values — i.e. undeclared wire data we cannot interpret. It used to
+  // default to 'uncertain', which is a scientific verdict PLoT would then have
+  // attributed to ISL: the same fabrication class as the 404 fallback below,
+  // just triggered by an unrecognised value instead of a missing response.
+  // An uninterpretable status is a non-result, so it degrades to 'unavailable'.
+  const status = STATUS_MAP[isl.status] || 'unavailable';
 
   // Map robustness to confidence
   const confidence = CONFIDENCE_MAP[isl.robustness] || 'medium';
@@ -104,14 +111,33 @@ function generateValidationReasoning(isl: ISLValidationResponse): string {
 }
 
 /**
- * Create a fallback validation result when ISL is unavailable
+ * Create a fallback validation result when ISL produced no validation.
  *
- * @param reason - Why fallback is being used
- * @returns Fallback validation result
+ * TYPED REFUSAL, NOT A VERDICT (ROADMAP 1.240). This returns
+ * `status: 'unavailable'` — a value ISL can never produce — so no consumer can
+ * mistake "we did not get an answer" for "the answer is uncertain".
+ *
+ * It previously returned `status: 'uncertain'`, and routes/v1/run.ts rendered
+ * that as a user-facing critique reading "ISL validation reports partial
+ * identifiability", tagged `source: 'isl'`. ISL had returned 404 (its
+ * `causal_router` is not mounted) and computed nothing; the user was told a
+ * substantive scientific claim about their own graph on behalf of a service
+ * that was never reached. The one honest token — 'ISL validation unavailable' —
+ * was demoted into `suggested_action`, where it read as advice rather than as
+ * the retraction it actually was.
+ *
+ * `confidence: 'low'` is retained only because the field is required by the
+ * interface; with `status: 'unavailable'` it carries no claim about the graph.
+ * Do NOT reintroduce a verdict here for any failure mode — 404, timeout, 5xx
+ * and circuit-breaker trips are all non-results and all take this path.
+ *
+ * @param reason - Why fallback is being used (surfaced as explanation.reasoning,
+ *                 for operators; never rendered as a finding about the graph)
+ * @returns Typed-unavailable validation result
  */
 export function createFallbackValidation(reason: string): PLoTValidationResult {
   return {
-    status: 'uncertain',
+    status: 'unavailable',
     confidence: 'low',
     explanation: {
       summary: 'ISL validation unavailable',

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -573,8 +573,24 @@ export interface ISLConstraintResult {
   threshold: number;
   value?: number;
   prob_satisfied: number;
-  failure_margin_median?: number;
-  near_miss_fraction?: number;
+  /**
+   * Median failure margin, NORMALISED, as ISL sends it.
+   *
+   * `| null` is MEASURED, not defensive — the deployed service sends the key
+   * with a null value for an absent margin (same wire as `constraint_id` above;
+   * `exclude_none=True` does not reach inside this object). Declaring it
+   * `number | undefined` was a compile-time fiction that cost us a real defect:
+   * both denormalisation sites guarded with `!== undefined`, so `null` passed,
+   * `null * rangeWidth` evaluated to 0, and a FABRICATED MEASURED ZERO breach
+   * margin shipped to egress — while the comment above that code claimed the
+   * zero-fabrication had already been killed.
+   *
+   * Keep the `| null`. It is what makes `fmm * rangeWidth` a type error, so the
+   * only way to compute with this value is to validate it first (nonNeg()).
+   */
+  failure_margin_median?: number | null;
+  /** Near-miss rate in [0,1]. Nullable on the wire for the same reason. */
+  near_miss_fraction?: number | null;
   binding?: boolean;
 }
 

--- a/src/integrations/isl/types/plot-types.ts
+++ b/src/integrations/isl/types/plot-types.ts
@@ -9,8 +9,26 @@
  * PLoT validation result (transformed from ISL)
  */
 export interface PLoTValidationResult {
-  /** Identifiability status */
-  status: 'identifiable' | 'uncertain' | 'cannot_identify';
+  /**
+   * Identifiability status.
+   *
+   * `identifiable` / `uncertain` / `cannot_identify` are SCIENTIFIC VERDICTS —
+   * each asserts something substantive about the user's graph, and each may be
+   * set ONLY from a validation ISL actually computed.
+   *
+   * `unavailable` is NOT a verdict. It is the typed refusal PLoT degrades to
+   * when no validation was obtained (ISL disabled, unmounted route → 404,
+   * timeout, 5xx, circuit-breaker trip). It exists precisely so a non-result
+   * cannot be mistaken for `uncertain`: the fallback previously returned
+   * `uncertain`, which routes/v1/run.ts rendered as "ISL validation reports
+   * partial identifiability" tagged `source: 'isl'` — a claim about the user's
+   * graph attributed to a service that returned 404 (ROADMAP 1.240).
+   *
+   * Consumers MUST NOT collapse `unavailable` into any verdict branch — not
+   * into `uncertain`, and not into "not identifiable" via a
+   * `status === 'identifiable'` boolean.
+   */
+  status: 'identifiable' | 'uncertain' | 'cannot_identify' | 'unavailable';
   /** Confidence in the validation */
   confidence: 'high' | 'medium' | 'low';
   /** Valid adjustment sets */

--- a/src/routes/v1/run.ts
+++ b/src/routes/v1/run.ts
@@ -79,6 +79,24 @@ function transformValidationToEnrichment(
 ): CausalValidationEnrichment | undefined {
   if (!validation) return undefined;
 
+  // ROADMAP 1.240 sibling, same defect species, different channel.
+  //
+  // `identifiable` below is computed as `status === 'identifiable'`, so an
+  // UNAVAILABLE validation used to serialise as `identifiable: false` — a
+  // fabricated boolean verdict ("the causal effect is NOT identifiable")
+  // derived from the absence of an answer. It rode the PLoT→CEE enrichment
+  // payload, which is an untyped `z.record` passthrough, so no schema
+  // downstream would ever have rejected it.
+  //
+  // `CausalValidationEnrichment.identifiable` is REQUIRED and boolean, so the
+  // block cannot express "unknown"; honest absence is therefore to omit the
+  // block entirely. `causal_validation` is already optional on the enrichment,
+  // and the machine-readable signal that ISL degraded is carried separately by
+  // `isl_degraded` (source !== 'isl'), so nothing is lost by omitting it — the
+  // user-facing ISL_VALIDATION_UNAVAILABLE critique carries the explicit
+  // unknown.
+  if (validation.status === 'unavailable') return undefined;
+
   // Extract confounders from issues if present
   const confounders: string[] = [];
   const warnings: string[] = [];
@@ -1052,6 +1070,37 @@ export async function registerRunRoute(app: FastifyInstance) {
             source: 'isl' as const,
             message: 'ISL validation reports partial identifiability; results may rely on stronger assumptions.',
             suggested_action: isl_validation.explanation?.summary,
+          });
+        } else if (isl_validation.status === 'unavailable') {
+          // ROADMAP 1.240 — the typed refusal, NOT a verdict.
+          //
+          // No validation was obtained (ISL disabled, unmounted route → 404,
+          // timeout, 5xx, or breaker trip). Before this branch existed the
+          // fallback's 'uncertain' fell into the arm above and told the user
+          // "ISL validation reports partial identifiability" with
+          // source:'isl' — a scientific claim about their graph attributed to
+          // a service that computed nothing.
+          //
+          // Deliberate choices:
+          //  - source:'engine'. PLoT is reporting its OWN inability to reach
+          //    ISL. Nothing here may be attributed to ISL.
+          //  - OBSERVATION/INFO. An unchecked property is not a detected
+          //    problem; grading it WARNING would be a different fabrication
+          //    (implying something was found).
+          //  - Stated positively rather than omitted. Silence would leave the
+          //    user believing identifiability WAS checked and cleared, which
+          //    is the same lie by another route.
+          //  - The raw failure reason stays in explanation.reasoning (for
+          //    operators) and is deliberately NOT interpolated into the
+          //    user-facing message or suggested_action, which would leak ISL
+          //    internals to the caller.
+          (critique as any[]).push({
+            code: CRITIQUE_CODES.ISL_VALIDATION_UNAVAILABLE,
+            severity: 'OBSERVATION',
+            semantic_severity: 'INFO',
+            source: 'engine' as const,
+            message: 'Causal identifiability was not checked: the inference service returned no validation result. No identifiability claim is made either way.',
+            suggested_action: 'Re-run once the inference service is available if you need an identifiability check.',
           });
         }
 

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -2013,14 +2013,21 @@ function buildConstraintFields(
   // failure_margin_median is a distance (delta), so scale by range width (same as std).
   // Use flatMap to preserve index for stable constraint_id resolution while filtering.
   const constraintDiagnostics: ConstraintDiagnostic[] = islConstraints.flatMap((c, idx) => {
-    if (c.failure_margin_median === undefined && c.near_miss_fraction === undefined && c.binding === undefined) {
+    // Absence test must be NULL-AWARE. ISL sends `failure_margin_median: null`
+    // / `near_miss_fraction: null` (measured — see ISLConstraintResult), and
+    // `null === undefined` is false, so an all-absent row used to survive this
+    // guard and emit with a fabricated `binding: false`.
+    if (c.failure_margin_median == null && c.near_miss_fraction == null && c.binding === undefined) {
       return [];
     }
     const constraintId = resolveConstraintId(c, idx);
-    // Absent ≠ zero: keep undefined undefined (kill the `?? 0` fabrication). A
-    // binding-only row (both margins absent) now emits with NO fabricated
-    // margins — the defect that manufactured false "hard-step" evidence.
-    let failureMarginMedian = c.failure_margin_median;
+    // Absent ≠ zero — and on this wire "absent" is spelled `null`, not
+    // `undefined`. VALIDATE BEFORE DENORMALISING: the guard used to run AFTER
+    // the multiply, so `null * rangeWidth` had already collapsed to 0 and
+    // nonNeg(0) then blessed it as a measured zero-margin breach. nonNeg()
+    // rejects null/undefined/NaN/±Infinity/negatives up front, so only a real
+    // measurement ever reaches the arithmetic.
+    let failureMarginMedian = nonNeg(c.failure_margin_median);
 
     if (failureMarginMedian !== undefined && constraintNormRanges) {
       const range = constraintNormRanges.get(constraintId);
@@ -2040,6 +2047,11 @@ function buildConstraintFields(
     // near_miss_fraction is a rate in [0,1]. Same bounds as the per-option
     // constraint_margins path. The fields are optional on
     // ConstraintDiagnostic, so a spread omits them when undefined.
+    //
+    // near_miss_fraction was never exposed to the null defect: prob01() runs
+    // BEFORE any arithmetic touches it, and prob01 rejects null. That ordering
+    // is now what the margin does too — this second nonNeg only re-checks the
+    // DENORMALISED product (a finite × finite can still overflow to Infinity).
     const nearMissFraction = prob01(c.near_miss_fraction);
     failureMarginMedian = nonNeg(failureMarginMedian);
     return [{
@@ -2448,7 +2460,13 @@ function buildResponse(
           // recorded ranges; clamp-precision (below) deliberately does NOT
           // (Codex F1: the ranges map is absent whenever the constraint value
           // was already in [0,1], but the intervention can still have clamped).
-          let fmm = c.failure_margin_median;
+          // VALIDATE BEFORE DENORMALISING — identical ordering fix to the
+          // top-level constraint_diagnostics path above. ISL sends `null` for
+          // an absent margin; the old `!== undefined` guard let it through and
+          // `null * rangeWidth` became a fabricated measured 0, which then also
+          // unlocked the margin_precision block below and shipped a precision
+          // claim ('exact') about a margin that was never computed.
+          let fmm = nonNeg(c.failure_margin_median);
           if (fmm !== undefined && constraintNormRanges) {
             const range = constraintNormRanges.get(cid);
             if (range) {

--- a/src/trust/critique-codes.ts
+++ b/src/trust/critique-codes.ts
@@ -27,11 +27,19 @@ export const CRITIQUE_CODES = {
   MISSING_COMPETITOR_RESPONSE: 'MISSING_COMPETITOR_RESPONSE',
   PSYCHOLOGICAL_THRESHOLD: 'PSYCHOLOGICAL_THRESHOLD',
 
-  // ISL validation issues
+  // ISL validation issues.
+  // These four are FINDINGS — each reports something ISL actually computed and
+  // is emitted with source:'isl'. Never emit one from a fallback.
   ISL_CANNOT_IDENTIFY: 'ISL_CANNOT_IDENTIFY',
   ISL_UNCERTAIN: 'ISL_UNCERTAIN',
   ISL_ISSUE: 'ISL_ISSUE',
   ISL_FRAGILE: 'ISL_FRAGILE',
+
+  // ISL availability notice — NOT a finding (ROADMAP 1.240).
+  // Emitted with source:'engine' because it is PLoT reporting its own inability
+  // to obtain a validation, not ISL reporting anything. This is the explicit
+  // unknown that replaced a fabricated ISL_UNCERTAIN on a 404/timeout/5xx.
+  ISL_VALIDATION_UNAVAILABLE: 'ISL_VALIDATION_UNAVAILABLE',
 
   // CEE weight/belief issues
   CEE_UNIFORM_WEIGHTS: 'CEE_UNIFORM_WEIGHTS',

--- a/tests/constraint-margin-null-not-zero.test.ts
+++ b/tests/constraint-margin-null-not-zero.test.ts
@@ -344,6 +344,98 @@ describe('INSTANCE B — a wire `null` margin must never become a measured zero'
   });
 
   // =========================================================================
+  // The ABSENCE TEST itself had to become null-aware, or it fabricates a
+  // DIFFERENT field. Pinned separately because reverting only this hunk left
+  // every other assertion in this file green (trap 11: a fix whose revert
+  // turns nothing red is unpinned).
+  // =========================================================================
+
+  describe('an all-absent constraint row is dropped, not emitted with a fabricated binding:false', () => {
+    /**
+     * ISL sends every margin as null AND omits `binding`. The old guard tested
+     * `=== undefined` on the two margins, so null failed it, the row survived,
+     * and `binding: c.binding ?? false` then asserted the constraint is NOT the
+     * binding limiter — a verdict nobody computed. `binding` is required on
+     * ConstraintDiagnostic, so the only honest option is to emit no row.
+     */
+    function allAbsentRow(probSatisfied: number) {
+      return {
+        constraints: [
+          {
+            constraint_id: CONSTRAINT_ID,
+            node_id: 'fac_cost',
+            operator: '<=',
+            value: 50000,
+            prob_satisfied: probSatisfied,
+            failure_margin_median: null,
+            near_miss_fraction: null,
+            // `binding` deliberately OMITTED — nothing to report at all.
+          },
+        ],
+        joint_probability: probSatisfied,
+      };
+    }
+
+    it('emits no constraint_diagnostics row at all', async () => {
+      mockConstraintAnalysisByOption = {
+        opt_under: allAbsentRow(1.0),
+        opt_just_over: allAbsentRow(0.0),
+      };
+
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      expect(
+        diagnosticEntry(body),
+        'nothing was measured for this constraint, so no diagnostic may be asserted about it',
+      ).toBeUndefined();
+    });
+
+    it('never claims binding:false for a constraint ISL said nothing about', async () => {
+      mockConstraintAnalysisByOption = {
+        opt_under: allAbsentRow(1.0),
+        opt_just_over: allAbsentRow(0.0),
+      };
+
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      const fabricated = (body.constraint_diagnostics ?? []).filter(
+        (d: any) => d.binding === false,
+      );
+      expect(fabricated, 'binding:false is a verdict, not a default').toEqual([]);
+    });
+
+    it('POSITIVE CONTROL — a row carrying only `binding` IS still emitted', async () => {
+      // Guards against over-correction: a binding-only row is a real ISL
+      // finding (the constraint IS the limiter) and must survive, with no
+      // fabricated margins attached.
+      const bindingOnly = {
+        constraints: [
+          {
+            constraint_id: CONSTRAINT_ID,
+            node_id: 'fac_cost',
+            operator: '<=',
+            value: 50000,
+            prob_satisfied: 0.0,
+            failure_margin_median: null,
+            near_miss_fraction: null,
+            binding: true,
+          },
+        ],
+        joint_probability: 0.0,
+      };
+      mockConstraintAnalysisByOption = { opt_under: bindingOnly, opt_just_over: bindingOnly };
+
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+      const diag = diagnosticEntry(body);
+
+      expect(diag, 'a genuine binding finding must reach egress').toBeDefined();
+      expect(diag.binding).toBe(true);
+      expect(diag.failure_margin_median).toBeUndefined();
+      expect(diag.near_miss_fraction).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
   // The ASYMMETRY, pinned — near_miss_fraction is already safe, and WHY.
   // =========================================================================
 

--- a/tests/constraint-margin-null-not-zero.test.ts
+++ b/tests/constraint-margin-null-not-zero.test.ts
@@ -1,0 +1,393 @@
+/**
+ * INSTANCE B — a fabricated "measured zero" breach margin from a wire `null`.
+ * ============================================================================
+ * Found by the #276 lane, flagged not fixed; verified here at the bytes.
+ *
+ * THE DEFECT. The deployed ISL sends `failure_margin_median: null` for an
+ * absent margin — MEASURED, not assumed, and recorded in PLoT's own source:
+ *
+ *   src/integrations/isl/types/isl-types.ts:558-563
+ *     "The route serialises with `exclude_none=True`, but that does not reach
+ *      inside this object: `failure_margin_median` and `near_miss_fraction`
+ *      come back null on the same wire too."
+ *
+ * The interface nevertheless declared `failure_margin_median?: number` — a
+ * compile-time fiction over untrusted wire data. Both denormalisation sites
+ * then guarded with `!== undefined`:
+ *
+ *     let fmm = c.failure_margin_median;              // null
+ *     if (fmm !== undefined && constraintNormRanges) {  // null !== undefined → TRUE
+ *       fmm = fmm * rangeWidth;                         // null * 60000 === 0
+ *     }
+ *     fmm = nonNeg(fmm);                                // nonNeg(0) === 0 → PASSES
+ *
+ * — so an absent margin shipped as `failure_margin_median: 0`: a PRECISE,
+ * MEASURED-LOOKING zero meaning "this option breaches by exactly nothing".
+ *
+ * WHY THIS IS THE SHARPEST FORM. The comment directly above that code claims
+ * the fabrication is already dead:
+ *
+ *     "Absent ≠ zero: keep undefined undefined (kill the `?? 0` fabrication)."
+ *
+ * It killed the `?? 0` — for `undefined`, a shape ISL does not send. The live
+ * `null` walked straight past it. tests/constraint-margin-plumbing.test.ts
+ * pins "missing margin is DISTINGUISHABLE from a zero margin" using
+ * `undefined`, so the existing control passed while the live shape fabricated.
+ * A control pinned to a shape the producer never emits is a control that tests
+ * nothing (the estate's trap-12b, in the data plane).
+ *
+ * WHAT THE FABRICATED ZERO COSTS. The plumbing suite's own header records that
+ * fabricated zeros from the earlier `?? 0` were read by a live probe as
+ * positive evidence that "the constraint signal is a hard step, ranking by
+ * degree of breach is impossible" — a false architectural conclusion that was
+ * written into a design plan. This is that same defect, resurrected in the
+ * shape ISL actually sends.
+ *
+ * ASYMMETRY (deliberately pinned below): `near_miss_fraction: null` is SAFE,
+ * because it goes through `prob01()` BEFORE any arithmetic and prob01 rejects
+ * null. Only `failure_margin_median` is coerced before it is guarded. The
+ * general bug is the ORDER — validate, then compute — not the field.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+import { prob01, nonNeg } from '../src/routes/v2/numeric-egress-guards.js';
+
+/** option_id → constraint_analysis (undefined entry = ISL sent none for it). */
+let mockConstraintAnalysisByOption: Record<string, any> = {};
+
+function buildMockOption(opt: any, idx: number) {
+  const analysis = mockConstraintAnalysisByOption[opt.id];
+  return {
+    option_id: opt.id,
+    outcome: {
+      mean: 0.7 - idx * 0.1,
+      std: 0.1,
+      p10: 0.5,
+      p50: 0.7,
+      p90: 0.9,
+      n_samples: 1000,
+      n_valid_samples: 1000,
+      validity_ratio: 1.0,
+    },
+    rank: idx + 1,
+    win_probability: 0.3,
+    status: 'computed',
+    ...(analysis !== undefined && { constraint_analysis: analysis }),
+  };
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable',
+      confidence: 'high',
+      adjustment_sets: [],
+      minimal_set: [],
+      backdoor_paths: [],
+      issues: [],
+      explanation: { summary: 'Mock validation', reasoning: 'Test' },
+      source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      options: options.map(buildMockOption),
+      edges: [],
+      edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [],
+      value_of_information: [],
+      factors_provenance: 'unavailable' as const,
+      factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const,
+      robustness_score: 0.8,
+      fragile_edges: [],
+      robust_edges: [],
+      latency_ms: 50,
+      source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    return {
+      data: {
+        options: options.map(buildMockOption),
+        edges: [],
+        factors: [],
+        value_of_information: [],
+        overall_robustness: 'robust',
+        robustness_score: 0.8,
+        fragile_edges: [],
+        robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+/**
+ * `fac_cost` carries an explicit cap, so its normalisation range is [0, 60000]
+ * from a PRODUCER-DECLARED scale. That is what makes `constraintNormRanges`
+ * populated and `rangeWidth = 60000 > 0` — i.e. the denormalisation multiply
+ * actually RUNS. Without it the null would never be coerced and this suite
+ * would pass vacuously.
+ */
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Programme value', observed_state: { value: 0.4 } },
+    { id: 'fac_cost', kind: 'factor', label: 'First-year cost', observed_state: { value: 40000, cap: 60000, unit: '£' } },
+  ],
+  edges: [{ from: 'fac_cost', to: 'goal', strength: { mean: -0.5, std: 0.1 } }],
+};
+
+const OPTIONS = [
+  { id: 'opt_under', label: 'Under budget', interventions: { fac_cost: 38000 } },
+  { id: 'opt_just_over', label: 'Just over budget', interventions: { fac_cost: 52000 } },
+];
+
+const CONSTRAINT_ID = 'c_cost_cap';
+const GOAL_CONSTRAINTS = [
+  { constraint_id: CONSTRAINT_ID, node_id: 'fac_cost', operator: '<=', value: 50000, label: 'First-year cost cap', unit: '£' },
+];
+
+const BASE_PAYLOAD = { graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '42' };
+
+/**
+ * An ISL constraint row in the shape the DEPLOYED service actually sends.
+ * `margin`/`nearMiss` are written VERBATIM — pass `null` to reproduce the live
+ * wire, a number for the positive control. Note the fields are always PRESENT
+ * (that is the point: ISL sends the key with a null value, it does not omit it).
+ */
+function islConstraintVerbatim(probSatisfied: number, margin: unknown, nearMiss: unknown) {
+  return {
+    constraints: [
+      {
+        constraint_id: CONSTRAINT_ID,
+        node_id: 'fac_cost',
+        operator: '<=',
+        value: 50000,
+        prob_satisfied: probSatisfied,
+        failure_margin_median: margin,
+        near_miss_fraction: nearMiss,
+        binding: true,
+      },
+    ],
+    joint_probability: probSatisfied,
+  };
+}
+
+async function runAnalysis(app: FastifyInstance, payload: object): Promise<any> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v2/run',
+    headers: { 'Content-Type': 'application/json' },
+    payload,
+  });
+  expect(res.statusCode).toBe(200);
+  return res.json();
+}
+
+function marginEntry(body: any, optionId: string): any {
+  const entry = (body.option_comparison ?? []).find((o: any) => o.option_id === optionId);
+  expect(entry, `option_comparison entry for ${optionId}`).toBeDefined();
+  return (entry.constraint_margins ?? []).find((m: any) => m.constraint_id === CONSTRAINT_ID);
+}
+
+function diagnosticEntry(body: any): any {
+  return (body.constraint_diagnostics ?? []).find((d: any) => d.constraint_id === CONSTRAINT_ID);
+}
+
+describe('INSTANCE B — a wire `null` margin must never become a measured zero', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  beforeEach(() => {
+    mockConstraintAnalysisByOption = {};
+  });
+
+  // =========================================================================
+  // POSITIVE CONTROLS FIRST — prove the harness can SEE a real margin.
+  // Every absence assertion below is vacuous without these (trap 13).
+  // =========================================================================
+
+  describe('positive controls — a genuine numeric margin still flows, denormalised', () => {
+    it('a real failure_margin_median reaches egress in user units', async () => {
+      mockConstraintAnalysisByOption = {
+        opt_under: islConstraintVerbatim(1.0, null, null),
+        opt_just_over: islConstraintVerbatim(0.0, 0.03333, 1.0),
+      };
+
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+      const entry = marginEntry(body, 'opt_just_over');
+
+      expect(entry, 'the breaching option must carry its margin entry').toBeDefined();
+      // 0.03333 × rangeWidth(60000) ≈ £2,000 over the £50,000 cap.
+      expect(entry.failure_margin_median).toBeCloseTo(2000, 0);
+      expect(entry.near_miss_fraction).toBe(1.0);
+    });
+
+    it('a real margin also reaches the top-level constraint_diagnostics', async () => {
+      mockConstraintAnalysisByOption = {
+        opt_under: islConstraintVerbatim(0.0, 0.03333, 1.0),
+        opt_just_over: islConstraintVerbatim(0.0, 0.03333, 1.0),
+      };
+
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+      const diag = diagnosticEntry(body);
+
+      expect(diag, 'top-level diagnostics must carry the constraint').toBeDefined();
+      expect(diag.failure_margin_median).toBeCloseTo(2000, 0);
+      expect(diag.near_miss_fraction).toBe(1.0);
+    });
+  });
+
+  // =========================================================================
+  // RED — the defect.
+  // =========================================================================
+
+  describe('RED: failure_margin_median: null (the live ISL shape)', () => {
+    beforeEach(() => {
+      mockConstraintAnalysisByOption = {
+        opt_under: islConstraintVerbatim(1.0, null, null),
+        opt_just_over: islConstraintVerbatim(0.0, null, null),
+      };
+    });
+
+    it('per-option constraint_margins emits NO failure_margin_median — not 0', async () => {
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+      const entry = marginEntry(body, 'opt_just_over');
+
+      if (entry !== undefined) {
+        expect(
+          Object.prototype.hasOwnProperty.call(entry, 'failure_margin_median'),
+          'ISL sent null (= not computed). A fabricated 0 reads as "breaches by exactly nothing".',
+        ).toBe(false);
+        expect(entry.failure_margin_median).not.toBe(0);
+      }
+    });
+
+    it('per-option margin_precision is absent too — it is a claim ABOUT a margin that does not exist', async () => {
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+      const entry = marginEntry(body, 'opt_just_over');
+
+      if (entry !== undefined) {
+        expect(entry.margin_precision).toBeUndefined();
+      }
+    });
+
+    it('top-level constraint_diagnostics emits NO failure_margin_median — not 0', async () => {
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+      const diag = diagnosticEntry(body);
+
+      if (diag !== undefined) {
+        expect(
+          Object.prototype.hasOwnProperty.call(diag, 'failure_margin_median'),
+          'a null margin must be an honest omission, never a measured zero',
+        ).toBe(false);
+        expect(diag.failure_margin_median).not.toBe(0);
+      }
+    });
+
+    it('the whole response body contains no fabricated zero margin anywhere', async () => {
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+
+      // Scope: the serialised response. Claim type: no `failure_margin_median`
+      // key anywhere carries the value 0 or null. Catches any THIRD site the
+      // two named above miss.
+      const offenders: string[] = [];
+      const walk = (node: any, path: string): void => {
+        if (node === null || typeof node !== 'object') return;
+        if (Array.isArray(node)) {
+          node.forEach((v, i) => walk(v, `${path}[${i}]`));
+          return;
+        }
+        for (const [k, v] of Object.entries(node)) {
+          if (k === 'failure_margin_median' && (v === 0 || v === null)) {
+            offenders.push(`${path}.${k} = ${JSON.stringify(v)}`);
+          }
+          walk(v, `${path}.${k}`);
+        }
+      };
+      walk(body, '$');
+
+      expect(offenders, 'no site may emit a fabricated/serialised-null margin').toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  // The ASYMMETRY, pinned — near_miss_fraction is already safe, and WHY.
+  // =========================================================================
+
+  describe('near_miss_fraction: null is already safe (guard runs BEFORE arithmetic)', () => {
+    it('emits no near_miss_fraction for a null, and never a 0', async () => {
+      mockConstraintAnalysisByOption = {
+        opt_under: islConstraintVerbatim(1.0, null, null),
+        opt_just_over: islConstraintVerbatim(0.0, 0.03333, null),
+      };
+
+      const body = await runAnalysis(app, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+      const entry = marginEntry(body, 'opt_just_over');
+
+      expect(entry).toBeDefined();
+      expect(entry.near_miss_fraction).toBeUndefined();
+      // The margin on the SAME row is genuine and must survive — this is what
+      // makes the assertion above a real discrimination and not blanket
+      // suppression of the row.
+      expect(entry.failure_margin_median).toBeCloseTo(2000, 0);
+    });
+  });
+
+  // =========================================================================
+  // GENERAL-SHAPE GUARD — the `!== undefined` bug class, not just this field.
+  // =========================================================================
+
+  describe('guard: null must not survive any numeric coercion in the changed paths', () => {
+    it('the egress guards themselves reject null (and undefined), never returning 0', () => {
+      expect(nonNeg(null)).toBeUndefined();
+      expect(nonNeg(undefined)).toBeUndefined();
+      expect(prob01(null)).toBeUndefined();
+      expect(prob01(undefined)).toBeUndefined();
+      // The trap: nonNeg ACCEPTS a real 0, so it can never undo a coercion
+      // that already happened upstream. Ordering is the whole fix.
+      expect(nonNeg(0)).toBe(0);
+    });
+
+    it('documents the coercion that made this a defect: null is not undefined, and multiplies to 0', () => {
+      const wireValue: any = null;
+      expect(wireValue !== undefined).toBe(true);        // the guard that failed
+      expect(wireValue * 60000).toBe(0);                 // the fabrication
+      expect(nonNeg(wireValue * 60000)).toBe(0);         // and nonNeg blesses it
+      // Whereas validating FIRST refuses it outright:
+      expect(nonNeg(wireValue)).toBeUndefined();
+    });
+  });
+});

--- a/tests/isl-adapters.test.ts
+++ b/tests/isl-adapters.test.ts
@@ -169,14 +169,58 @@ describe('Validation Adapter', () => {
   });
 
   describe('createFallbackValidation', () => {
-    it('creates uncertain status fallback', () => {
+    /**
+     * UPDATED (ROADMAP 1.240). This test previously asserted
+     * `status === 'uncertain'` — it PINNED THE DEFECT. 'uncertain' is the same
+     * value ISL's `partially_identifiable` maps to, so routes/v1/run.ts could
+     * not tell a real verdict from a non-result and rendered "ISL validation
+     * reports partial identifiability" with source:'isl' on a 404.
+     *
+     * Corrected at the source rather than absorbed into a baseline: the
+     * fallback must be a TYPED REFUSAL that no verdict branch can consume.
+     */
+    it('returns a typed unavailable status — never a verdict', () => {
       const result = createFallbackValidation('ISL timeout');
 
-      expect(result.status).toBe('uncertain');
+      expect(result.status).toBe('unavailable');
       expect(result.confidence).toBe('low');
       expect(result.explanation.summary).toContain('unavailable');
       expect(result.explanation.reasoning).toBe('ISL timeout');
       expect(result.source).toBe('engine_fallback');
+    });
+
+    it('is distinguishable from every status ISL can actually return', () => {
+      const fallback = createFallbackValidation('404 Not Found');
+      const islVerdicts = (['identifiable', 'partially_identifiable', 'not_identifiable'] as const).map(
+        (status) =>
+          adaptValidationResponse({
+            status,
+            robustness: 'high',
+            adjustment_sets: [],
+            minimal_adjustment_set: [],
+            suggestions: [],
+          }).status,
+      );
+
+      expect(islVerdicts).not.toContain(fallback.status);
+    });
+  });
+
+  describe('adaptValidationResponse — an UNDECLARED ISL status is not a verdict either', () => {
+    it('maps an unrecognised status to unavailable, not to uncertain', () => {
+      // Undeclared wire data: ISL sent something outside its three declared
+      // values. The old default was 'uncertain' — a scientific verdict
+      // manufactured from a value PLoT could not interpret, and then attributed
+      // to ISL. Same fabrication class as the 404 fallback.
+      const result = adaptValidationResponse({
+        status: 'some_future_status' as never,
+        robustness: 'high',
+        adjustment_sets: [],
+        minimal_adjustment_set: [],
+        suggestions: [],
+      });
+
+      expect(result.status).toBe('unavailable');
     });
   });
 });

--- a/tests/isl-validation-unavailable-no-fabricated-verdict.test.ts
+++ b/tests/isl-validation-unavailable-no-fabricated-verdict.test.ts
@@ -1,0 +1,338 @@
+/**
+ * INSTANCE A — a fabricated SCIENTIFIC VERDICT when ISL returned nothing.
+ * ============================================================================
+ * ROADMAP 1.240. Evidence: parallel-briefs/ISL-UNMOUNTED-ROUTES-LIVE-PROBE-2026-07-27.md
+ * (live-probed against isl-staging @7d144c7f, deployed == pinned confirmed).
+ *
+ * THE DEFECT. ISL does not mount `causal_router`, so POST /api/v1/causal/validate
+ * returns 404 (byte-identical to the negative control; `GET` on a mounted sibling
+ * returns 405, so the 404 is genuinely an unmounted path). PLoT's validateCausal
+ * catches that and returns `createFallbackValidation(...)`, which used
+ * `status: 'uncertain'`. That status is indistinguishable from ISL's own
+ * `partially_identifiable`, so routes/v1/run.ts pushed a user-facing critique:
+ *
+ *     source:  'isl'
+ *     message: 'ISL validation reports partial identifiability; results may
+ *               rely on stronger assumptions.'
+ *
+ * ISL computed NOTHING. The user was told a substantive scientific claim about
+ * their own graph, attributed to a service that returned 404. The only honest
+ * token — 'ISL validation unavailable' — was demoted into `suggested_action`,
+ * where it reads as advice rather than as the retraction it actually is.
+ *
+ * THE RULE (A1 ruling): when upstream data is absent, PLoT degrades to a typed
+ * refusal or an explicit unknown — never to a number and never to a verdict.
+ *
+ * WHY THE TIMEOUT CASE IS TESTED SEPARATELY AND IS THE LOAD-BEARING ONE.
+ * Mounting causal_router would make the 404 critique stop appearing while
+ * leaving the defect intact for the next timeout, 5xx or circuit-breaker trip.
+ * The timeout case survives any future mounting decision, so it — not the 404 —
+ * is what keeps this pin honest. Both are asserted below.
+ *
+ * SEAM. These drive the REAL ISLClient (global fetch stubbed at the wire), the
+ * REAL error mapping, the REAL validateCausal catch, the REAL fallback and the
+ * REAL /v1/run consumer. Nothing between the HTTP status and the response body
+ * is mocked, so the pin cannot pass by testing a mock's idea of a 404.
+ *
+ * POSITIVE CONTROLS. A genuine ISL 200 must STILL produce the real
+ * `source: 'isl'` critique for partially_identifiable and not_identifiable, and
+ * must still populate the enrichment. Over-suppression is an equal failure: a
+ * fix that silences ISL's real scientific verdicts is not a fix.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+import { createServer } from '../src/createServer.js';
+import { resetISLService } from '../src/integrations/isl/index.js';
+
+const ISL_VALIDATE_PATH = '/api/v1/causal/validate';
+
+/** A graph with a confounder, so /v1/run has something to validate. */
+const PAYLOAD = {
+  graph: {
+    nodes: [
+      { id: 'A', label: 'Input' },
+      { id: 'B', label: 'Output' },
+      { id: 'C', label: 'Confounder' },
+    ],
+    edges: [
+      { from: 'A', to: 'B', weight: 0.5 },
+      { from: 'C', to: 'A', weight: 0.4 },
+      { from: 'C', to: 'B', weight: 0.4 },
+    ],
+  },
+  seed: 123,
+  outcome_node: 'B',
+  detail_level: 'standard',
+};
+
+/** ISL's real 404 body, copied from the live probe (§1 of the brief). */
+const ISL_404_BODY = JSON.stringify({ detail: 'Not Found' });
+
+type WireBehaviour =
+  | { kind: 'http'; status: number; body: string }
+  | { kind: 'abort' }
+  | { kind: 'ok'; body: unknown };
+
+/** What the stubbed wire does for /api/v1/causal/validate on the next call. */
+let validateBehaviour: WireBehaviour = { kind: 'http', status: 404, body: ISL_404_BODY };
+
+let realFetch: typeof globalThis.fetch;
+
+function jsonResponse(status: number, body: string): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * Stub ONLY the ISL wire. Everything else (including the test's own requests,
+ * which use app.inject and never touch fetch) is untouched.
+ */
+function installWireStub(): void {
+  realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: any, init?: any) => {
+    const url = String(typeof input === 'string' ? input : input?.url ?? input);
+
+    if (url.includes(ISL_VALIDATE_PATH)) {
+      const behaviour = validateBehaviour;
+      if (behaviour.kind === 'abort') {
+        // What a real per-attempt timeout looks like to ISLClient: an
+        // AbortError, which client.ts maps to ISLTimeoutError.
+        const err = new Error('The operation was aborted');
+        err.name = 'AbortError';
+        throw err;
+      }
+      if (behaviour.kind === 'http') {
+        return jsonResponse(behaviour.status, behaviour.body);
+      }
+      return jsonResponse(200, JSON.stringify(behaviour.body));
+    }
+
+    // Every OTHER ISL endpoint (robustness/analyze/v2 etc.) fails closed with a
+    // 404 so this suite isolates the validation path.
+    return jsonResponse(404, ISL_404_BODY);
+  }) as typeof globalThis.fetch;
+}
+
+/** A genuine ISL 200 validation response, in ISL's declared shape. */
+function islValidationBody(status: 'identifiable' | 'partially_identifiable' | 'not_identifiable') {
+  return {
+    status,
+    robustness: 'high',
+    adjustment_sets: [['C']],
+    minimal_adjustment_set: ['C'],
+    suggestions: [],
+  };
+}
+
+function critiqueItems(body: any): any[] {
+  expect(Array.isArray(body.critique), 'response must carry a critique array').toBe(true);
+  return body.critique as any[];
+}
+
+/** Every critique item attributed to ISL. */
+function islAttributed(body: any): any[] {
+  return critiqueItems(body).filter((c) => c.source === 'isl');
+}
+
+describe('INSTANCE A — ISL validation absent must not fabricate an identifiability verdict', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    // Enable ISL so validateCausal actually reaches the (stubbed) wire, rather
+    // than short-circuiting on `ISL not enabled` — which would make every
+    // assertion below pass for the wrong reason.
+    process.env.ISL_ENABLE = '1';
+    process.env.ISL_BASE_URL = 'http://isl.invalid';
+    process.env.ISL_API_KEY = 'test-key';
+    // NOTE: `maxRetries` is really max ATTEMPTS — client.ts loops
+    // `attempt <= maxRetries`, so 0 runs the body zero times and never reaches
+    // fetch. 1 = exactly one attempt, no backoff.
+    process.env.ISL_MAX_RETRIES = '1';
+    resetISLService();
+
+    installWireStub();
+    app = await createServer();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    globalThis.fetch = realFetch;
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    delete process.env.ISL_ENABLE;
+    delete process.env.ISL_BASE_URL;
+    delete process.env.ISL_API_KEY;
+    delete process.env.ISL_MAX_RETRIES;
+    resetISLService();
+  });
+
+  beforeEach(() => {
+    validateBehaviour = { kind: 'http', status: 404, body: ISL_404_BODY };
+  });
+
+  afterEach(() => {
+    delete process.env.TEST_ISL_MODE;
+  });
+
+  async function run(): Promise<any> {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: PAYLOAD,
+    });
+    expect(res.statusCode).toBe(200);
+    return res.json();
+  }
+
+  // =========================================================================
+  // POSITIVE CONTROL FIRST — prove the harness can SEE the real critique.
+  // Without this, every absence assertion below would be vacuous (trap 13).
+  // =========================================================================
+
+  describe('positive controls — a genuine ISL result still speaks for ISL', () => {
+    it('a real partially_identifiable 200 STILL produces the source:isl partial-identifiability critique', async () => {
+      validateBehaviour = { kind: 'ok', body: islValidationBody('partially_identifiable') };
+
+      const body = await run();
+      const isl = islAttributed(body);
+
+      const partial = isl.find((c) =>
+        String(c.message).includes('partial identifiability'),
+      );
+      expect(
+        partial,
+        'a genuine ISL partially_identifiable must still be reported as ISL\'s own finding — ' +
+          'over-suppression is an equal failure to fabrication',
+      ).toBeDefined();
+      expect(partial.code).toBe('ISL_UNCERTAIN');
+      expect(partial.source).toBe('isl');
+    });
+
+    it('a real not_identifiable 200 STILL produces the source:isl BLOCKER', async () => {
+      validateBehaviour = { kind: 'ok', body: islValidationBody('not_identifiable') };
+
+      const body = await run();
+      const isl = islAttributed(body);
+
+      const blocker = isl.find((c) => c.code === 'ISL_CANNOT_IDENTIFY');
+      expect(blocker, 'a genuine ISL not_identifiable must still block').toBeDefined();
+      expect(blocker.severity).toBe('BLOCKER');
+      expect(blocker.source).toBe('isl');
+    });
+
+    it('a real identifiable 200 reaches the enrichment as identifiable:true', async () => {
+      validateBehaviour = { kind: 'ok', body: islValidationBody('identifiable') };
+
+      const body = await run();
+
+      expect(body.enrichment?.causal_validation).toBeDefined();
+      expect(body.enrichment.causal_validation.identifiable).toBe(true);
+      expect(body.isl_validation?.source).toBe('isl');
+    });
+  });
+
+  // =========================================================================
+  // RED — the defect itself.
+  // =========================================================================
+
+  describe('RED: ISL 404 (unmounted causal_router) must not become a verdict', () => {
+    it('emits NO source:isl critique at all', async () => {
+      const body = await run();
+
+      expect(
+        islAttributed(body),
+        'ISL returned 404 and computed nothing, so NOTHING may be attributed to it',
+      ).toEqual([]);
+    });
+
+    it('never claims partial identifiability', async () => {
+      const body = await run();
+
+      const messages = critiqueItems(body).map((c) => String(c.message ?? ''));
+      expect(
+        messages.some((m) => m.includes('partial identifiability')),
+        'a 404 must not manufacture an identifiability claim about the user\'s graph',
+      ).toBe(false);
+      expect(
+        critiqueItems(body).some((c) => c.code === 'ISL_UNCERTAIN'),
+      ).toBe(false);
+      expect(
+        critiqueItems(body).some((c) => c.code === 'ISL_CANNOT_IDENTIFY'),
+      ).toBe(false);
+    });
+
+    it('carries a TYPED unavailable marker instead — an explicit unknown, not silence', async () => {
+      const body = await run();
+
+      // The status itself is the typed marker: a distinct value that cannot be
+      // confused with any verdict ISL can return.
+      expect(body.isl_validation?.status).toBe('unavailable');
+      expect(body.isl_validation?.source).toBe('engine_fallback');
+
+      const notice = critiqueItems(body).find(
+        (c) => c.code === 'ISL_VALIDATION_UNAVAILABLE',
+      );
+      expect(
+        notice,
+        'the user must be told identifiability was NOT checked — silence is a different dishonesty',
+      ).toBeDefined();
+      expect(notice.source).not.toBe('isl');
+      expect(notice.severity).toBe('OBSERVATION');
+      expect(String(notice.message)).not.toContain('partial identifiability');
+    });
+
+    it('emits NO causal_validation enrichment block — never a fabricated identifiable:false', async () => {
+      const body = await run();
+
+      // transformValidationToEnrichment computed `identifiable: status === 'identifiable'`,
+      // so an unavailable validation shipped `identifiable: false` into the
+      // PLoT->CEE enrichment payload — which is an untyped z.record passthrough,
+      // so nothing downstream would have caught it.
+      expect(body.enrichment?.causal_validation).toBeUndefined();
+    });
+  });
+
+  describe('RED: an ISL TIMEOUT must not become a verdict either (survives any mounting decision)', () => {
+    beforeEach(() => {
+      validateBehaviour = { kind: 'abort' };
+    });
+
+    it('emits NO source:isl critique', async () => {
+      const body = await run();
+      expect(islAttributed(body)).toEqual([]);
+    });
+
+    it('never claims partial identifiability, and marks the result unavailable', async () => {
+      const body = await run();
+
+      const messages = critiqueItems(body).map((c) => String(c.message ?? ''));
+      expect(messages.some((m) => m.includes('partial identifiability'))).toBe(false);
+      expect(body.isl_validation?.status).toBe('unavailable');
+      expect(
+        critiqueItems(body).some((c) => c.code === 'ISL_VALIDATION_UNAVAILABLE'),
+      ).toBe(true);
+      expect(body.enrichment?.causal_validation).toBeUndefined();
+    });
+  });
+
+  describe('RED: an ISL 5xx must not become a verdict either', () => {
+    beforeEach(() => {
+      validateBehaviour = { kind: 'http', status: 503, body: '{"detail":"Service Unavailable"}' };
+    });
+
+    it('emits NO source:isl critique and marks the result unavailable', async () => {
+      const body = await run();
+
+      expect(islAttributed(body)).toEqual([]);
+      expect(body.isl_validation?.status).toBe('unavailable');
+      expect(body.enrichment?.causal_validation).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
One slice, one defect species: **PLoT fabricates values and verdicts when upstream data is absent.** Two independently-found instances, both in the same file region, fixed together because fixing one and leaving the other leaves the class open.

The rule applied throughout (A1 ruling, adopted from the live-probe lane): **when upstream data is absent, PLoT degrades to a typed refusal or an explicit unknown — never to a number and never to a verdict.**

---

## Instance A — a fabricated scientific verdict on a 404

ROADMAP 1.240. Evidence: `parallel-briefs/ISL-UNMOUNTED-ROUTES-LIVE-PROBE-2026-07-27.md` (live-probed against `isl-staging` @`7d144c7f`, deployed == pinned confirmed), independently corroborated by this repo's own `tests/fixtures/isl-pinned/PIN.json` (`unmounted_at_this_pin`).

ISL does not mount `causal_router`, so `POST /api/v1/causal/validate` returns 404. `validateCausal` caught that and returned `createFallbackValidation(...)` with `status: 'uncertain'` — the *same value* ISL's `partially_identifiable` maps to. `routes/v1/run.ts` could therefore not distinguish a verdict from a non-result, and pushed:

```
source:  'isl'
message: 'ISL validation reports partial identifiability; results may rely on stronger assumptions.'
```

ISL computed nothing. The user was told a substantive scientific claim about their own graph, attributed to a service that returned 404. The only honest token — `'ISL validation unavailable'` — was demoted into `suggested_action`, where it read as advice rather than as the retraction it was.

**Fix**

- `PLoTValidationResult.status` gains `'unavailable'` — a value ISL can never produce, so a non-result cannot be mistaken for a verdict. All failure modes take it: 404, timeout, 5xx, breaker trip, ISL-disabled.
- `/v1/run` emits `ISL_VALIDATION_UNAVAILABLE` — `OBSERVATION`/`INFO`, `source: 'engine'`, because PLoT is reporting its *own* inability to reach ISL. Stated positively rather than omitted: silence would leave the user believing identifiability was checked and cleared, which is the same lie by another route. The raw failure reason stays in `explanation.reasoning` for operators and is deliberately not interpolated into user-facing text.
- `adaptValidationResponse`'s unknown-status default was `|| 'uncertain'` — a verdict manufactured from undeclared wire data. Now `|| 'unavailable'`.
- **Sibling found in the same data path, different channel:** `transformValidationToEnrichment` computed `identifiable: status === 'identifiable'`, so an unavailable validation shipped `identifiable: false` into the PLoT→CEE enrichment — an untyped `z.record` passthrough nothing downstream would reject. It now omits the block; `isl_degraded` already carries the machine signal.

**Deliberately not fixed by mounting the ISL router.** That would make the fabricated critique stop appearing while leaving it intact for the next timeout or 5xx. The timeout and 5xx cases are pinned separately for exactly that reason — they survive any future mounting decision.

---

## Instance B — a fabricated "measured zero" breach margin

Found by the #276 lane, flagged not fixed; verified here at the bytes.

The deployed ISL sends `failure_margin_median: null` — measured, and recorded in PLoT's own source (`isl-types.ts`: *"`failure_margin_median` and `near_miss_fraction` come back null on the same wire too"*). The interface nevertheless declared `?: number`. Both denormalisation sites guarded with `!== undefined`:

```ts
let fmm = c.failure_margin_median;                 // null
if (fmm !== undefined && constraintNormRanges) {   // null !== undefined → TRUE
  fmm = fmm * rangeWidth;                          // null * 60000 === 0
}
fmm = nonNeg(fmm);                                 // nonNeg(0) === 0 → PASSES
```

An absent margin shipped as `failure_margin_median: 0` — a precise, measured-looking zero meaning *"this option breaches by exactly nothing"*. It also unlocked `margin_precision: 'exact'`: a precision claim about a margin that was never computed.

**The comment directly above that code claimed the fabrication was already dead** — *"Absent ≠ zero: keep undefined undefined (kill the `?? 0` fabrication)"*. It killed `?? 0` for `undefined`, a shape ISL does not send.

**Fix**

- `ISLConstraintResult` now declares both margin fields `number | null`, matching what the service measurably sends. This is what makes `fmm * rangeWidth` a **compile error**, so validate-before-compute is enforced by the compiler rather than by memory — derived, not mirrored.
- Both sites `nonNeg()` **before** denormalising. Ordering is the whole fix: `nonNeg` accepts a real `0`, so it can never undo a coercion already performed.
- The absence test is now null-aware, so an all-absent row no longer emits a fabricated `binding: false`.

`near_miss_fraction` was never exposed — `prob01()` runs before any arithmetic and rejects null. That asymmetry is pinned, because the general bug is the **order**, not the field.

---

## Evidence

**RED-first at the seam.** Instance A drives the *real* `ISLClient` with the wire stubbed at `fetch`, so the real error mapping, the real fallback and the real consumer all run — nothing between the HTTP status and the response body is mocked.

**Positive controls, and they earned their keep.** A genuine ISL 200 must still produce the real `source:'isl'` critique and the real denormalised margin; over-suppression is an equal failure. One control caught that an earlier draft never reached the wire at all: `ISL_MAX_RETRIES=0` means *zero attempts* (`client.ts` loops `attempt <= maxRetries`), so every assertion would have passed vacuously against the ISL-disabled path.

**Mutation-checked**, in a worktree outside the repo root (trap 9c), removed before the gate run:

| Mutant | Result |
|---|---|
| A1 · fallback back to `status:'uncertain'` | **7 red** (positive controls hold) |
| A2 · restore the `identifiable:false` enrichment | **3 red** — failure prints `{ identifiable: false }` |
| A3 · delete the `ISL_VALIDATION_UNAVAILABLE` branch | **2 red** |
| B1 · revert diagnostics ordering | **`tsc` TS18047** *and* **2 red** |
| B2 · revert per-option ordering | **`tsc` TS18047** *and* **3 red** |
| B3 · revert the null-aware absence guard | **2 red** |

B3 initially turned **nothing** red — the hardening was unpinned. Rather than ship it on trust, a pin was added (including a positive control that a genuine binding-only row still reaches egress) and the mutant re-run.

**One existing test pinned the defect** and was corrected at source, not absorbed into a baseline: `tests/isl-adapters.test.ts` asserted `createFallbackValidation(...).status === 'uncertain'`.

---

## Siblings found and reported, not fixed

Same species — fabricate a number when upstream data is absent — but **outside the two data paths in scope**. Note these use `??`, which handles `null` correctly, so they are *not* instances of the `!== undefined` bug; they are the broader class.

| Site | Fabrication | Reachability |
|---|---|---|
| `adapters/robustness-enrichment.ts:181` | `sensitivity_score ?? sensitivity ?? 0` → "this factor has zero sensitivity". Both fields are optional. | **Live.** `buildRobustnessDataForCee` ← `routes/v2/run.ts:6488` — the deployed CEE path, into the untyped `z.record` enrichment. The file's own docstring notes it *"differs from V2 run transform which preserves undefined for UI-facing responses"* — the honest shape exists on one channel and the fabricated one on the other. |
| `adapters/robustness-analysis.ts:407` | `score ?? confidence ?? 0.5` → a fabricated midpoint robustness score. | `/v1/run` only — latent-armed, same class as Instance A. |
| `adapters/robustness-analysis.ts:233` | `switch_probability ?? 1` → fabricated **certainty**. | `/v1/run` only. Same file already types this field `number \| null` elsewhere. |

**Two control-scope gaps** (the reason this survived so long):

- `tests/gates/numeric-safety-deep-scan.test.ts` feeds `NaN`/`±Infinity` but never `null` — the estate's numeric-safety gate is blind to the exact shape ISL actually sends.
- `tests/constraint-margin-plumbing.test.ts` pins *"missing margin is DISTINGUISHABLE from a zero margin"* using `undefined`. It passed throughout while the live `null` fabricated. A control pinned to a shape the producer never emits tests nothing.

---

## The three dead producers: proof delivered, deletion deliberately **not** in this PR

Deadness is **proven and complete**. Scope: `src/`, `lib/`, `tools/`, `scripts/`, `contracts/` at `c79c63c1`. Claim type: *no call site exists*.

| Producer | Non-test references | Call sites |
|---|---|---|
| `computeCounterfactual` | interface decl `isl/index.ts:127`, impl `:310` | **0** |
| `analyseFactorSensitivity` | decl `:147`, impl `:336`, 2 comments, 1 comment in `run.ts` | **0** |
| `analyseSensitivity` | decl `:120`, impl `:270`, 2 comments in `run.ts` | **0** |

**But the deletion is not cheap, and it is not this PR's slice.** `tests/isl-request-drift-pairing.contract.test.ts:387` enforces

```ts
expect(Object.keys(TRANSCRIPT.egress).sort()).toEqual(PRODUCERS.map(p => p.name).sort());
```

so removing a producer requires regenerating `tests/fixtures/isl-pinned/replay-transcript.json` through the Python replay driver against a **fresh ISL clone at `0316098b`** with pydantic 2.6.1 / numpy / pydantic_settings — plus deleting three committed egress fixtures, three `ENDPOINT_MANIFEST` rows, two FINDINGS tests, and the orphaned adapters. That instrument was re-pinned by #276 hours ago, and it is the very thing that *proves* these producers are broken.

Bundling ~500 lines of contract-instrument churn into a trust-fix PR would violate this repo's own "never bundle unrelated edits" rule and would bury the RED/mutation evidence above. **Recommend it as its own slice** with the transcript regeneration explicitly in scope.

---

## Gate

Repo's authoritative gate (`npm test` → `tools/run-all-tests.js`), pristine baseline derived on `c79c63c1` in the same clone.

| | Test files | Tests |
|---|---|---|
| Pristine baseline `c79c63c1` | 570 passed, 4 skipped (574) | 6070 passed, 29 skipped (6110) |
| This branch | 572 passed, 4 skipped (576) | 6094 passed, 29 skipped (6134) |

Delta `+2` files / `+24` tests = the two new suites (10 + 12) plus 2 added to `isl-adapters.test.ts`. **Zero pre-existing tests broken.** `npx tsc --noEmit` clean.

**Stated limits.** No change to the ISL request/response *shape*, so the `0316098b` drift pin is untouched and stays honest. `staging` is unprotected (`gh api …/branches/staging/protection` → HTTP 404 "Branch not protected"), so this PR's review plus the gate run above **is** the gate. Instance A's reachability caveat is inherited from the probe lane unchanged: latent on the deployed default path (CEE never calls `/v1/run`; the UI bakes `VITE_ENABLE_LEGACY_DIRECT_RUN:"false"`) but **armed** by `localStorage['feature.legacyDirectRun']`. Instance B's per-option path is reachable on the live `/v2/run` → CEE path whenever a constraint carries a recorded normalisation range. The dev surfaces sharing the httpV1 adapter (`PlcLab`, `SandboxV1`, `PlotShowcase`, `EngineAuditPanel`) were not individually traced — that limit is carried over from the probe lane, not re-derived here.
