### PR TITLE
fix(isl): close the fabricate-on-absence CLASS — teach the numeric-safety gate about null

### DIFF
--- a/src/integrations/isl/adapters/robustness-analysis.ts
+++ b/src/integrations/isl/adapters/robustness-analysis.ts
@@ -17,7 +17,7 @@ import type {
   NormalizedEdgeInfo,
   EdgeNormalizationError,
 } from '../types/plot-types.js';
-import { isFiniteNumber } from '../../../util/numeric.js';
+import { isFiniteNumber, finiteNum } from '../../../util/numeric.js';
 
 // -----------------------------------------------------------------------------
 // Edge ID Parsing Helpers
@@ -81,6 +81,24 @@ function normalizeFragileEdge(edge: ISLFragileEdgeInfo): NormalizedEdgeInfo {
 /**
  * Normalize a robust edge from ISL format to consistent object shape.
  * ISL returns robust_edges as strings in "from->to" format.
+ *
+ * NO switch_probability IS EMITTED (ROADMAP 1.240, sibling 3).
+ * This used to hardcode `switch_probability: 1` with the comment "Robust edges
+ * have 100% stability". A bare `"from->to"` string carries NO measurement at
+ * all, so the 1 was manufactured from nothing — and it was manufactured under
+ * the WRONG NAME: `switch_probability` is the probability that flipping the
+ * edge switches the recommended option (`normalizeFragileEdge` feeds exactly
+ * this field to `classifyEdgeSeverity` and to the doctrine-013 `visible` gate,
+ * where HIGHER means MORE fragile). "100% stability" would be
+ * switch_probability ≈ 0. The fabricated value was therefore not merely absent
+ * data rendered as a number, it was absent data rendered as the maximum of the
+ * inverted scale.
+ *
+ * `NormalizedEdgeInfo.switch_probability` is already optional and
+ * `NormalizedEdgeInfoV3` documents it as "omitted when the source edge carries
+ * no switch_probability", so omission is what the published contract already
+ * describes. `normalizeFragileEdge`'s legacy-string arm made the same choice
+ * for the same reason.
  */
 function normalizeRobustEdge(edgeId: string): NormalizedEdgeInfo {
   const parsed = parseEdgeId(edgeId);
@@ -88,7 +106,6 @@ function normalizeRobustEdge(edgeId: string): NormalizedEdgeInfo {
     edge_id: edgeId,
     from_id: parsed.from,
     to_id: parsed.to,
-    switch_probability: 1, // Robust edges have 100% stability
   };
 }
 
@@ -222,7 +239,12 @@ export function normalizeRobustEdges(
         result.edges.push(normalizeRobustEdge(edge));
         continue;
       }
-      // Object format (fallback - treat like fragile but with switch_probability=1)
+      // Object format (fallback). switch_probability is FORWARDED when ISL
+      // measured it and OMITTED otherwise (ROADMAP 1.240, sibling 3) — it used
+      // to end `?? 1`, fabricating maximum switch probability from an absent
+      // field, on the inverted scale described in normalizeRobustEdge above.
+      // `isFiniteNumber` also rejects null/NaN/±Infinity, so this arm now
+      // matches normalizeFragileEdge's admission rule exactly.
       if (typeof edge === 'object' && edge !== null && 'edge_id' in edge) {
         const objEdge = edge as ISLFragileEdgeInfo;
         const parsed = parseEdgeId(objEdge.edge_id);
@@ -230,7 +252,9 @@ export function normalizeRobustEdges(
           edge_id: objEdge.edge_id,
           from_id: objEdge.from_id ?? parsed.from,
           to_id: objEdge.to_id ?? parsed.to,
-          switch_probability: objEdge.switch_probability ?? 1,
+          ...(isFiniteNumber(objEdge.switch_probability)
+            ? { switch_probability: objEdge.switch_probability }
+            : {}),
         });
         continue;
       }
@@ -403,9 +427,31 @@ export function adaptRobustnessAnalysisResponse(
   const robustResult = normalizeRobustEdges(rawRobustness.robust_edges as unknown[], requestId);
   const normalizationErrors = [...fragileResult.errors, ...robustResult.errors];
 
+  // ROADMAP 1.240, sibling 2 — the two fabrications that used to live here.
+  //
+  //   score: rawRobustness.score ?? rawRobustness.confidence ?? 0.5
+  //   label: rawRobustness.label ?? mapLevelToLabel(rawRobustness.level)
+  //
+  // `??` handles null correctly, so this was never the `!== undefined` bug —
+  // it is the broader class: a plausible substitute standing in for a
+  // measurement that does not exist. The `0.5` published "we assessed this
+  // decision as exactly half robust" and the label default published
+  // 'moderate' — `mapLevelToLabel`'s `default:` arm returns 'moderate' for
+  // undefined, so an ISL response carrying NEITHER `label` NOR `level` was
+  // rendered as a moderate-robustness VERDICT about the user's graph. That is
+  // the same species as the 'uncertain' identifiability verdict a 404 used to
+  // produce (Instance A) — a verdict manufactured from silence — and it is the
+  // worse of the two here, because a label is read as a conclusion where a
+  // score is read as a statistic.
+  //
+  // Both now degrade to absence. `finiteNum` also rejects NaN/±Infinity, and
+  // `mapLevelToLabel` is only consulted when `level` is actually present, so
+  // its 'moderate' default can no longer be reached from absent data.
   const robustness = {
-    score: rawRobustness.score ?? rawRobustness.confidence ?? 0.5,
-    label: rawRobustness.label ?? mapLevelToLabel(rawRobustness.level),
+    score: finiteNum(rawRobustness.score ?? rawRobustness.confidence),
+    label: rawRobustness.label ?? (rawRobustness.level !== undefined && rawRobustness.level !== null
+      ? mapLevelToLabel(rawRobustness.level)
+      : undefined),
     fragile_edges: fragileResult.edges,
     robust_edges: robustResult.edges,
   };
@@ -424,9 +470,13 @@ export function adaptRobustnessAnalysisResponse(
     factors_provenance: factors.length > 0 ? 'isl:/api/v1/robustness/analyze/v2' : 'unavailable',
     factor_sensitivity_status: factorStatus,
 
-    // Robustness
-    overall_robustness: robustness.label,
-    robustness_score: robustness.score,
+    // Robustness. Both fields are OMITTED when ISL measured neither — never
+    // substituted (see the block above). `overall_robustness` was already
+    // consumed absence-safely by the only caller: routes/v1/run.ts guards the
+    // CEE payload with `hasRobustness = isl_sensitivity?.overall_robustness
+    // !== undefined` and gates its ISL_FRAGILE critique on `=== 'fragile'`.
+    ...(robustness.label !== undefined && { overall_robustness: robustness.label }),
+    ...(robustness.score !== undefined && { robustness_score: robustness.score }),
     fragile_edges: robustness.fragile_edges,
     robust_edges: robustness.robust_edges,
 
@@ -468,9 +518,14 @@ export function createFallbackRobustnessAnalysis(
     factors_provenance: 'unavailable',
     factor_sensitivity_status: factorStatus,
 
-    // Robustness - default moderate
-    overall_robustness: 'moderate',
-    robustness_score: 0.5,
+    // Robustness — OMITTED, not "default moderate" (ROADMAP 1.240).
+    // This is the ISL-unavailable path: nothing was computed, so there is no
+    // robustness verdict and no robustness score to report. It used to return
+    // `overall_robustness: 'moderate', robustness_score: 0.5`, which is
+    // Instance A's defect in the robustness channel — a fabricated assessment
+    // of the user's graph, indistinguishable from a genuine ISL 'moderate'.
+    // `source: 'unavailable'` below is the machine-readable refusal; absence of
+    // the two fields is the honest human-readable one.
     fragile_edges: [],
     robust_edges: [],
 

--- a/src/integrations/isl/adapters/robustness-analysis.ts
+++ b/src/integrations/isl/adapters/robustness-analysis.ts
@@ -82,23 +82,47 @@ function normalizeFragileEdge(edge: ISLFragileEdgeInfo): NormalizedEdgeInfo {
  * Normalize a robust edge from ISL format to consistent object shape.
  * ISL returns robust_edges as strings in "from->to" format.
  *
- * NO switch_probability IS EMITTED (ROADMAP 1.240, sibling 3).
- * This used to hardcode `switch_probability: 1` with the comment "Robust edges
- * have 100% stability". A bare `"from->to"` string carries NO measurement at
- * all, so the 1 was manufactured from nothing — and it was manufactured under
- * the WRONG NAME: `switch_probability` is the probability that flipping the
- * edge switches the recommended option (`normalizeFragileEdge` feeds exactly
- * this field to `classifyEdgeSeverity` and to the doctrine-013 `visible` gate,
- * where HIGHER means MORE fragile). "100% stability" would be
- * switch_probability ≈ 0. The fabricated value was therefore not merely absent
- * data rendered as a number, it was absent data rendered as the maximum of the
- * inverted scale.
+ * ⚠ KNOWN LIVE FABRICATION, BLOCKED ON A CROSS-REPO CONTRACT CHANGE
+ * (ROADMAP 1.240, sibling 3 — the string arm).
  *
- * `NormalizedEdgeInfo.switch_probability` is already optional and
- * `NormalizedEdgeInfoV3` documents it as "omitted when the source edge carries
- * no switch_probability", so omission is what the published contract already
- * describes. `normalizeFragileEdge`'s legacy-string arm made the same choice
- * for the same reason.
+ * `switch_probability: 1` below is MANUFACTURED. A bare `"from->to"` string
+ * carries no measurement at all, and the 1 is manufactured under the WRONG
+ * NAME: `switch_probability` is the probability that flipping the edge
+ * switches the recommended option — `normalizeFragileEdge` feeds exactly this
+ * field to `classifyEdgeSeverity` and to the doctrine-013 `visible` gate,
+ * where HIGHER means MORE fragile. "100% stability" would be
+ * switch_probability ≈ 0. So this is absent data rendered as the MAXIMUM of an
+ * INVERTED scale.
+ *
+ * IT IS NOT FIXED HERE, AND THE REASON IS THE FINDING. Omitting it (attempted
+ * and measured in this lane) makes every /v2/run response fail its own egress
+ * contract:
+ *
+ *   @talchain/schemas (vendored 0.22.0) boundary/enrichment.js:269
+ *     EnrichmentRobustnessEdgeSchema = z.object({ …
+ *       switch_probability: z.number(),      // REQUIRED
+ *
+ * That schema covers `robust_edges` as well as `fragile_edges`, CEE persists
+ * this body verbatim and shadow-validates it against the same schema, and the
+ * producer-side guard (routes/v2/enrichment-egress-guard.ts) stamps
+ * `_meta.evidence.enrichment_contract_ok: false` plus a user-visible
+ * ENRICHMENT_CONTRACT_MISMATCH warning on EVERY response. Measured: 4 issue
+ * paths, one per robust edge, on the golden fixture.
+ *
+ * NOTE THE SKEW THIS EXPOSES (hazard 1). PLoT's own published type already
+ * says the honest thing — `NormalizedEdgeInfoV3.switch_probability?: number`,
+ * documented "OPTIONAL: omitted when the source edge carries no
+ * switch_probability" (types/engine-v3.ts:2454) — and `normalizeFragileEdge`
+ * already omits it on that basis. The shared schema disagrees, so the
+ * divergence is LATENT for fragile edges today and would become universal for
+ * robust edges. Fixing it unilaterally in PLoT would trade a wrong number for
+ * a standing false alarm on a fail-open guard, which is the broken-alarm trap.
+ *
+ * REQUIRED TO CLOSE: relax the field in olumi-schemas to
+ * `switch_probability: z.number().optional()` (matching what PLoT already
+ * publishes), release, re-pin the vendored tarball here, THEN delete the
+ * fabrication below. The gate case is present and skipped in
+ * tests/gates/numeric-safety-deep-scan.test.ts §D3 with this same reason.
  */
 function normalizeRobustEdge(edgeId: string): NormalizedEdgeInfo {
   const parsed = parseEdgeId(edgeId);
@@ -106,6 +130,7 @@ function normalizeRobustEdge(edgeId: string): NormalizedEdgeInfo {
     edge_id: edgeId,
     from_id: parsed.from,
     to_id: parsed.to,
+    switch_probability: 1, // FABRICATED — see the blocker above. Do not read as a measurement.
   };
 }
 

--- a/src/integrations/isl/adapters/robustness-enrichment.ts
+++ b/src/integrations/isl/adapters/robustness-enrichment.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types/plot-types.js';
 import type { ISLFactorSensitivityItem } from '../types/isl-types.js';
 import { sanitiseIslVoi } from '../../../lib/evpi-emission.js';
+import { finiteNum } from '../../../util/numeric.js';
 import { sortByFragility } from './robustness-analysis.js';
 
 // =============================================================================
@@ -167,23 +168,36 @@ export function enrichRobustEdge(
  * Enrich factor sensitivity with labels from the graph.
  *
  * Handles both canonical (sensitivity_score) and legacy (sensitivity) fields
- * from ISL response. Defaults to 0 when neither is present because the
- * output type (EnrichedFactorSensitivity) requires a numeric sensitivity
- * value for CEE consumption. This differs from V2 run transform which
- * preserves undefined for UI-facing responses.
+ * from ISL response.
+ *
+ * ABSENT SENSITIVITY IS OMITTED, NEVER ZERO (ROADMAP 1.240, sibling 1).
+ * This used to end `?? 0`, justified by "the output type requires a numeric
+ * sensitivity value for CEE consumption". That is the fabricate-to-keep-the-
+ * shape move the standing ruling forbids: a factor ISL said nothing about was
+ * relabelled as a factor ISL had measured to have ZERO influence on the
+ * decision — the strongest possible negative claim, manufactured from silence.
+ * The file's own docstring conceded the divergence ("differs from V2 run
+ * transform which preserves undefined for UI-facing responses"): the honest
+ * shape already existed on one channel and the fabricated one on the other.
+ *
+ * The type requirement was the tail wagging the dog, so the TYPE moved:
+ * `EnrichedFactorSensitivity.sensitivity` is now optional and this builder
+ * omits it. `finiteNum` (not `!= null`) is the guard, so NaN/±Infinity are
+ * treated as unmeasured too — the same admission rule the sibling ISL surfaces
+ * already apply. A genuine measured `0` still passes through unchanged.
  */
 export function enrichFactorSensitivity(
   factor: ISLFactorSensitivityItem,
   graph: EngineGraphV3
 ): EnrichedFactorSensitivity {
-  // Schema v2.6 canonical field is 'sensitivity_score'; legacy used 'sensitivity'
-  // Support both for backward compatibility, defaulting to 0 if neither present
-  const sensitivityValue = factor.sensitivity_score ?? factor.sensitivity ?? 0;
+  // Schema v2.6 canonical field is 'sensitivity_score'; legacy used 'sensitivity'.
+  // `??` already handles null correctly; what was wrong was the final `?? 0`.
+  const sensitivityValue = finiteNum(factor.sensitivity_score ?? factor.sensitivity);
 
   return {
     factor_id: factor.node_id,
     factor_label: getNodeLabel(graph, factor.node_id),
-    sensitivity: sensitivityValue,
+    ...(sensitivityValue !== undefined && { sensitivity: sensitivityValue }),
     // Forward-safe internal hardening: apply the non-negative VOI contract
     // (Howard 1966) on this enrichment builder for consistency with the three
     // sibling surfaces that already sanitise ISL VOI — `mapIslFactorEntry`

--- a/src/integrations/isl/types/plot-types.ts
+++ b/src/integrations/isl/types/plot-types.ts
@@ -57,8 +57,15 @@ export interface PLoTValidationResult {
  * PLoT sensitivity result (transformed from ISL)
  */
 export interface PLoTSensitivityResult {
-  /** Overall model robustness */
-  overall_robustness: 'robust' | 'moderate' | 'fragile';
+  /**
+   * Overall model robustness — a VERDICT.
+   *
+   * OPTIONAL (ROADMAP 1.240, sibling 2): absent when nothing was assessed.
+   * The `/v1/run` builder populates it from
+   * `PLoTRobustnessAnalysisResult.overall_robustness`, which is itself now
+   * omitted rather than defaulted to 'moderate'.
+   */
+  overall_robustness?: 'robust' | 'moderate' | 'fragile';
   /** Parameters sorted by sensitivity */
   sensitive_parameters: Array<{
     parameter: string;
@@ -219,10 +226,25 @@ export interface PLoTRobustnessAnalysisResult {
   factor_sensitivity_status: 'available' | 'skipped_no_factor_values' | 'skipped_no_parameter_uncertainties' | 'failed';
 
   // ============ Robustness ============
-  /** Overall robustness assessment */
-  overall_robustness: 'robust' | 'moderate' | 'fragile';
-  /** Robustness score (0-1) */
-  robustness_score: number;
+  /**
+   * Overall robustness assessment — a VERDICT about the user's graph.
+   *
+   * OPTIONAL (ROADMAP 1.240, sibling 2). Emitted only when ISL supplied
+   * `robustness.label`, or a `robustness.level` this adapter can map. It was
+   * required, and `adaptRobustnessAnalysisResponse` met that requirement by
+   * falling through `mapLevelToLabel(undefined)` → 'moderate', so an ISL
+   * response carrying neither field published a moderate-robustness verdict
+   * PLoT had invented. Absent means "not assessed"; it must never be widened
+   * back to a required field, and consumers must not default it.
+   */
+  overall_robustness?: 'robust' | 'moderate' | 'fragile';
+  /**
+   * Robustness score (0-1).
+   *
+   * OPTIONAL for the same reason — it used to end `?? 0.5`, publishing a
+   * precise-looking midpoint for a quantity ISL never measured.
+   */
+  robustness_score?: number;
   /**
    * Edges identified as fragile - normalized to consistent object shape.
    * Contains edge_id, from_id, to_id, and optional switch_probability.
@@ -230,7 +252,11 @@ export interface PLoTRobustnessAnalysisResult {
   fragile_edges: NormalizedEdgeInfo[];
   /**
    * Edges identified as robust - normalized to consistent object shape.
-   * Contains edge_id, from_id, to_id (switch_probability defaults to 1.0).
+   * Contains edge_id, from_id, to_id, and `switch_probability` ONLY when ISL
+   * measured one. It formerly "defaulted to 1.0"; ISL sends robust_edges as
+   * bare `"from->to"` strings that carry no measurement, and 1.0 is the
+   * maximum of an INVERTED scale (switch_probability high = fragile), so the
+   * default was both fabricated and backwards. See normalizeRobustEdge.
    */
   robust_edges: NormalizedEdgeInfo[];
 
@@ -267,10 +293,15 @@ export interface PLoTFactorSensitivityResult {
   factors: FactorSensitivityEntry[];
   /** Value of information for each factor */
   value_of_information: VOIEntry[];
-  /** Overall robustness assessment from factor analysis */
-  robustness_label: 'robust' | 'moderate' | 'fragile';
-  /** Robustness score (0-1) */
-  robustness_score: number;
+  /**
+   * Overall robustness assessment from factor analysis — a VERDICT.
+   * OPTIONAL (ROADMAP 1.240, sibling 2); omitted when ISL assessed nothing.
+   * This object IS emitted on the `/v1/run` response (`isl_factor_sensitivity`),
+   * so a fabricated label here was user-visible.
+   */
+  robustness_label?: 'robust' | 'moderate' | 'fragile';
+  /** Robustness score (0-1). OPTIONAL for the same reason. */
+  robustness_score?: number;
   /** ISL latency in milliseconds */
   latency_ms: number;
   /** Source of the result */
@@ -326,8 +357,20 @@ export interface EnrichedFactorSensitivity {
   factor_id: string;
   /** Human-readable factor label */
   factor_label: string;
-  /** Sensitivity score */
-  sensitivity: number;
+  /**
+   * Sensitivity score, as ISL measured it.
+   *
+   * OPTIONAL — omitted when ISL supplied neither `sensitivity_score` nor the
+   * legacy `sensitivity`, or supplied a non-finite one. It was REQUIRED, and
+   * that requirement was the entire justification for `enrichFactorSensitivity`
+   * ending `?? 0`: a factor ISL said nothing about was published as a factor
+   * measured to have zero influence (ROADMAP 1.240, sibling 1). A required
+   * numeric field on data that can legitimately be absent is a standing
+   * instruction to fabricate, so the field moved rather than the honesty.
+   *
+   * Consumers must treat absence as "not measured", never as 0.
+   */
+  sensitivity?: number;
   /** Value of information */
   value_of_information?: number;
   /** Direction of impact */

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -14,6 +14,7 @@
  */
 
 import type { EngineNodeV3, OptionV3, InterventionValueV3, OutcomeStatsV3, RepairRecord } from '../types/engine-v3.js';
+import { finiteNum } from '../util/numeric.js';
 
 // -----------------------------------------------------------------------------
 // Types
@@ -812,20 +813,35 @@ export function needsNormalisation(options: OptionV3[]): boolean {
  * ISL option result with outcome data.
  * Matches the shape returned by ISL /api/v1/robustness/analyze/v2
  */
+/**
+ * ISL option result AS IT ARRIVES ON THE WIRE.
+ *
+ * Every numeric slot is `| null` because that is what the deployed service
+ * measurably sends for an absent value (same wire fact recorded for
+ * `failure_margin_median` / `near_miss_fraction` in
+ * src/integrations/isl/types/isl-types.ts — `exclude_none=True` on the route
+ * does not reach inside these nested objects). Declaring them bare `number`
+ * was a compile-time fiction over untrusted wire data, and it cost a live
+ * defect: see denormaliseOptionResult below.
+ *
+ * Keep the `| null`. It is what makes `opt.outcome.std * rangeWidth` a type
+ * error, so the only way to compute with these values is to validate them
+ * first — derived, not remembered.
+ */
 interface ISLOptionResult {
   option_id?: string;
   id?: string;
-  expected_outcome?: number;
-  confidence_interval?: [number, number];
+  expected_outcome?: number | null;
+  confidence_interval?: [number | null, number | null];
   outcome?: {
-    mean: number;
-    std?: number;
-    p10: number;
-    p50: number;
-    p90: number;
-    n_samples?: number;
-    n_valid_samples?: number;
-    validity_ratio?: number;
+    mean: number | null;
+    std?: number | null;
+    p10: number | null;
+    p50: number | null;
+    p90: number | null;
+    n_samples?: number | null;
+    n_valid_samples?: number | null;
+    validity_ratio?: number | null;
   };
   [key: string]: unknown;
 }
@@ -879,6 +895,35 @@ export function denormaliseISLResult(
 
 /**
  * Denormalise a single option result.
+ *
+ * VALIDATE BEFORE DENORMALISING (ROADMAP 1.240 — found by the absence-shape
+ * arm of tests/gates/numeric-safety-deep-scan.test.ts).
+ *
+ * This function used to compute unconditionally:
+ *
+ *     mean: denormaliseValue(opt.outcome.mean, range)   // null → null*w + min
+ *     std:  opt.outcome.std !== undefined ? opt.outcome.std * rangeWidth : undefined
+ *
+ * Both fabricate on the shape ISL actually sends. `denormaliseValue(null, …)`
+ * evaluates `null * rangeWidth + min` === `min`, so an outcome ISL did not
+ * compute was published as a PRECISE MEASURED OUTCOME sitting exactly at the
+ * bottom of the goal range — "this option achieves the worst possible result".
+ * And `std !== undefined` is the identical guard #277 removed from
+ * buildConstraintFields: `null !== undefined` is true, so `null * rangeWidth`
+ * collapsed to a measured standard deviation of 0, i.e. perfect certainty.
+ *
+ * The fabricated stats are all finite and in range, so every downstream
+ * finiteness and range check passed them, `hasAllRequiredOutcomeStats` returned
+ * true, and `option_comparison_status` reported a confident 'computed'. This is
+ * on the LIVE /v2/run → CEE path.
+ *
+ * Note the asymmetry that hid it: `undefined` and a MISSING KEY both produce
+ * `NaN` here, which the egress guards already reject, so the defect was
+ * invisible to every absence test written with those two shapes. Only `null`
+ * — the shape the wire actually carries — coerces to a plausible number.
+ *
+ * `finiteNum` rejects null/undefined/NaN/±Infinity, so only a real measurement
+ * reaches the arithmetic and an absent one stays absent.
  */
 function denormaliseOptionResult(
   opt: ISLOptionResult,
@@ -886,31 +931,42 @@ function denormaliseOptionResult(
 ): ISLOptionResult {
   const denormalised: ISLOptionResult = { ...opt };
 
+  /** Denormalise only a genuine measurement; absence stays absent. */
+  const dn = (v: unknown): number | undefined => {
+    const n = finiteNum(v);
+    return n === undefined ? undefined : denormaliseValue(n, range);
+  };
+
   // Denormalise expected_outcome
-  if (typeof opt.expected_outcome === 'number') {
-    denormalised.expected_outcome = denormaliseValue(opt.expected_outcome, range);
+  const expected = dn(opt.expected_outcome);
+  if (expected !== undefined) {
+    denormalised.expected_outcome = expected;
   }
 
-  // Denormalise confidence_interval
+  // Denormalise confidence_interval. Both bounds must be measured — half a
+  // denormalised interval is not an interval, and substituting one bound
+  // manufactures a width.
   if (Array.isArray(opt.confidence_interval) && opt.confidence_interval.length === 2) {
-    denormalised.confidence_interval = [
-      denormaliseValue(opt.confidence_interval[0], range),
-      denormaliseValue(opt.confidence_interval[1], range),
-    ];
+    const lo = dn(opt.confidence_interval[0]);
+    const hi = dn(opt.confidence_interval[1]);
+    denormalised.confidence_interval = lo !== undefined && hi !== undefined
+      ? [lo, hi]
+      : undefined;
   }
 
   // Denormalise full outcome stats
   if (opt.outcome && typeof opt.outcome === 'object') {
     const rangeWidth = range.max - range.min;
+    const std = finiteNum(opt.outcome.std);
 
     denormalised.outcome = {
       ...opt.outcome,
-      mean: denormaliseValue(opt.outcome.mean, range),
-      p10: denormaliseValue(opt.outcome.p10, range),
-      p50: denormaliseValue(opt.outcome.p50, range),
-      p90: denormaliseValue(opt.outcome.p90, range),
-      // Scale std by range width
-      std: opt.outcome.std !== undefined ? opt.outcome.std * rangeWidth : undefined,
+      mean: dn(opt.outcome.mean) ?? null,
+      p10: dn(opt.outcome.p10) ?? null,
+      p50: dn(opt.outcome.p50) ?? null,
+      p90: dn(opt.outcome.p90) ?? null,
+      // Scale std by range width — only when std was actually measured.
+      std: std !== undefined ? std * rangeWidth : undefined,
     };
   }
 

--- a/src/trust/types.ts
+++ b/src/trust/types.ts
@@ -132,8 +132,17 @@ export interface EdgeSensitivityEnrichment {
  * Updated to use /api/v1/robustness/analyze/v2 with analysis_types: ['comparison', 'sensitivity', 'robustness']
  */
 export interface SensitivityAnalysisEnrichment {
-  /** Overall model robustness assessment */
-  overall_robustness: 'robust' | 'moderate' | 'fragile';
+  /**
+   * Overall model robustness assessment — a VERDICT about the user's graph.
+   *
+   * OPTIONAL (ROADMAP 1.240, sibling 2). Emitted only when a robustness label
+   * was actually assessed; the upstream adapter used to default it to
+   * 'moderate' when ISL sent neither `label` nor `level`. `robustness_score`
+   * below was already optional, so the pair is now consistent. The documented
+   * consumer pattern (`?.overall_robustness === 'fragile'`, line ~210) is
+   * absence-safe; consumers must not substitute a default.
+   */
+  overall_robustness?: 'robust' | 'moderate' | 'fragile';
   /** Robustness score (0-1) */
   robustness_score?: number;
   /** Combined edges sorted by sensitivity (highest elasticity from existence or magnitude) */

--- a/tests/constraint-margin-plumbing.test.ts
+++ b/tests/constraint-margin-plumbing.test.ts
@@ -191,8 +191,42 @@ const GOAL_CONSTRAINTS = [
 
 const BASE_PAYLOAD = { graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '42' };
 
-/** ISL constraint row for one option. Margin fields OMITTED when not supplied. */
-function islConstraint(probSatisfied: number, margin?: number, nearMiss?: number) {
+/**
+ * ISL constraint row for one option.
+ *
+ * ABSENCE SHAPE (re-pointed, ROADMAP 1.240). This helper used to express
+ * absence ONLY by omitting the key, and the "missing margin is DISTINGUISHABLE
+ * from a zero margin" pin below was written against that shape. It passed
+ * throughout the period in which the LIVE shape — `failure_margin_median:
+ * null` — was fabricating a measured zero at egress (#277 Instance B). A
+ * control pinned to a shape the producer does not emit tests nothing.
+ *
+ * `absentAs` now selects which shape absence takes:
+ *   'null'    — WHAT ISL ACTUALLY SENDS. Verified at the wire by the #276 lane
+ *               and recorded in src/integrations/isl/types/isl-types.ts. This
+ *               is the DEFAULT, so the pin now defends the live shape.
+ *   'missing' — also wire-reachable (ISL's `exclude_none=True` elsewhere), kept
+ *               as a second arm rather than replaced.
+ *
+ * There is deliberately NO `undefined` arm: JSON cannot carry `undefined`, so
+ * no ISL response can produce one here. The in-process `undefined` shape is
+ * covered at the adapter seam in tests/gates/numeric-safety-deep-scan.test.ts.
+ */
+type AbsentAs = 'null' | 'missing';
+
+function islConstraint(
+  probSatisfied: number,
+  margin?: number,
+  nearMiss?: number,
+  absentAs: AbsentAs = 'null',
+) {
+  const marginField = margin !== undefined
+    ? { failure_margin_median: margin }
+    : (absentAs === 'null' ? { failure_margin_median: null } : {});
+  const nearMissField = nearMiss !== undefined
+    ? { near_miss_fraction: nearMiss }
+    : (absentAs === 'null' ? { near_miss_fraction: null } : {});
+
   return {
     constraints: [
       {
@@ -200,8 +234,8 @@ function islConstraint(probSatisfied: number, margin?: number, nearMiss?: number
         operator: '<=',
         value: 50000,
         prob_satisfied: probSatisfied,
-        ...(margin !== undefined && { failure_margin_median: margin }),
-        ...(nearMiss !== undefined && { near_miss_fraction: nearMiss }),
+        ...marginField,
+        ...nearMissField,
       },
     ],
     joint_probability: probSatisfied,
@@ -299,41 +333,48 @@ describe('B4/L2 constraint eligibility gate + graded breach margins', () => {
       expect(body.approximate).toBe(body.analysis_status === 'partial');
     });
 
-    it('a MISSING margin is DISTINGUISHABLE from a zero margin', async () => {
-      // opt_under: ISL sent NO margin fields (it satisfies the constraint).
-      // opt_just_over: ISL sent an explicit ZERO margin.
-      // These two must NOT render identically. This is the pin for the defect
-      // that fabricated positive evidence for a false conclusion.
-      mockConstraintAnalysisByOption = {
-        opt_under: islConstraint(1.0),
-        opt_just_over: islConstraint(0.0, 0, 0),
-        opt_far_over: islConstraint(0.0, 0.16667, 0.0),
-      };
-      mockWinProbabilityByOption = { opt_under: 0.5, opt_just_over: 0.3, opt_far_over: 0.2 };
+    // RE-POINTED ONTO THE LIVE SHAPE (ROADMAP 1.240). Both absence shapes ISL
+    // can actually put on the wire are now exercised. `null` is the one the
+    // deployed service sends and the one that fabricated for months while this
+    // very test passed; `missing` is the shape the test used to use, kept as a
+    // second arm rather than replaced so neither can regress.
+    for (const absentAs of ['null', 'missing'] as const) {
+      it(`a MISSING margin is DISTINGUISHABLE from a zero margin (absence sent as ${absentAs.toUpperCase()})`, async () => {
+        // opt_under: ISL sent NO margin (it satisfies the constraint).
+        // opt_just_over: ISL sent an explicit ZERO margin.
+        // These two must NOT render identically. This is the pin for the defect
+        // that fabricated positive evidence for a false conclusion.
+        mockConstraintAnalysisByOption = {
+          opt_under: islConstraint(1.0, undefined, undefined, absentAs),
+          opt_just_over: islConstraint(0.0, 0, 0, absentAs),
+          opt_far_over: islConstraint(0.0, 0.16667, 0.0, absentAs),
+        };
+        mockWinProbabilityByOption = { opt_under: 0.5, opt_just_over: 0.3, opt_far_over: 0.2 };
 
-      const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
+        const body = await runAnalysis(baseUrl, { ...BASE_PAYLOAD, goal_constraints: GOAL_CONSTRAINTS });
 
-      const underMargin = optionEntry(body, 'opt_under').constraint_margins?.find(
-        (m: any) => m.constraint_id === CONSTRAINT_ID,
-      );
-      const zeroMargin = optionEntry(body, 'opt_just_over').constraint_margins?.find(
-        (m: any) => m.constraint_id === CONSTRAINT_ID,
-      );
+        const underMargin = optionEntry(body, 'opt_under').constraint_margins?.find(
+          (m: any) => m.constraint_id === CONSTRAINT_ID,
+        );
+        const zeroMargin = optionEntry(body, 'opt_just_over').constraint_margins?.find(
+          (m: any) => m.constraint_id === CONSTRAINT_ID,
+        );
 
-      expect(zeroMargin, 'explicit-zero option must carry a margin entry').toBeDefined();
-      expect(underMargin, 'no-margin option must still carry its entry').toBeDefined();
+        expect(zeroMargin, 'explicit-zero option must carry a margin entry').toBeDefined();
+        expect(underMargin, 'no-margin option must still carry its entry').toBeDefined();
 
-      // A real measured zero is PRESENT and equal to 0 ...
-      expect(zeroMargin).toHaveProperty('failure_margin_median');
-      expect(zeroMargin.failure_margin_median).toBe(0);
-      expect(zeroMargin).toHaveProperty('near_miss_fraction');
-      expect(zeroMargin.near_miss_fraction).toBe(0);
+        // A real measured zero is PRESENT and equal to 0 ...
+        expect(zeroMargin).toHaveProperty('failure_margin_median');
+        expect(zeroMargin.failure_margin_median).toBe(0);
+        expect(zeroMargin).toHaveProperty('near_miss_fraction');
+        expect(zeroMargin.near_miss_fraction).toBe(0);
 
-      // ... while an ABSENT measurement is ABSENT, never a fabricated 0.
-      expect(underMargin).not.toHaveProperty('failure_margin_median');
-      expect(underMargin).not.toHaveProperty('near_miss_fraction');
-      expect(underMargin.failure_margin_median).toBeUndefined();
-    });
+        // ... while an ABSENT measurement is ABSENT, never a fabricated 0.
+        expect(underMargin).not.toHaveProperty('failure_margin_median');
+        expect(underMargin).not.toHaveProperty('near_miss_fraction');
+        expect(underMargin.failure_margin_median).toBeUndefined();
+      });
+    }
 
     it('marks a CLAMPED breach magnitude as a lower bound (Finding D)', async () => {
       // opt_far_over intervenes 82000 against a cap of 60000, so its

--- a/tests/gates/numeric-safety-deep-scan.test.ts
+++ b/tests/gates/numeric-safety-deep-scan.test.ts
@@ -1,9 +1,64 @@
 /**
- * SCIENTIFIC REGRESSION GATE — WP5: Numeric safety
+ * SCIENTIFIC REGRESSION GATE — WP5: Numeric safety + ABSENCE safety
  * ----------------------------------------------------------------------------
  * Proves the public /v2/run response carries no non-finite numbers and no
  * fabricated nulls/strings even when ISL emits NaN / ±Infinity from a
  * degenerate Monte Carlo run.
+ *
+ * ============================================================================
+ * WHY THIS GATE GREW AN ABSENCE DIMENSION (ROADMAP 1.240, this lane)
+ * ============================================================================
+ * PR #277 fixed three instances of "PLoT fabricates a value or a verdict when
+ * upstream data is absent" and — more usefully — named WHY the species kept
+ * surviving. One of the two reasons was THIS FILE:
+ *
+ *     "tests/gates/numeric-safety-deep-scan.test.ts feeds NaN/±Infinity but
+ *      never null — the estate's numeric-safety gate is blind to the exact
+ *      shape ISL actually sends."
+ *
+ * That blindness is what made the class structurally invisible. Every `?? 0`,
+ * `|| default` and `!== undefined` guard that fabricates on a NULL upstream
+ * field passed this gate, because this gate never sent one. The instrument
+ * agreed with the code about which shapes exist, so it could only ever confirm
+ * what the code already assumed.
+ *
+ * The extension below feeds THREE DISTINCT ABSENCE SHAPES through the same
+ * surfaces this file already exercises with NaN/±Infinity, plus the constraint
+ * margins and the validation status where the known instances lived.
+ *
+ * REACHABILITY OF EACH SHAPE — stated, not assumed:
+ *
+ *   `null`         WIRE-REACHABLE, and MEASURED on the deployed service. ISL
+ *                  sends `constraint_id: null`, `failure_margin_median: null`,
+ *                  `near_miss_fraction: null` (captured at the wire by the #276
+ *                  lane; recorded in src/integrations/isl/types/isl-types.ts).
+ *                  This is the shape that fabricated in production code and it
+ *                  is the primary arm of every case below.
+ *
+ *   missing key    WIRE-REACHABLE. ISL's route serialises with
+ *                  `exclude_none=True`, so top-level optional fields are simply
+ *                  absent. Reads identically to `undefined` in JS, which is
+ *                  exactly why the two were conflated.
+ *
+ *   `undefined`    NOT wire-reachable — JSON has no `undefined`, so no ISL
+ *                  response can carry one. It IS reachable for IN-PROCESS
+ *                  callers of the adapters (§D below, and PLoT's own
+ *                  intermediate values), so it is exercised at the unit seam
+ *                  and deliberately NOT claimed as a wire case.
+ *
+ * WHAT THIS GATE DOES NOT REACH — stated so the coverage is not over-read:
+ *   - The HTTP wire itself. §C stimulates the validation-absent path through
+ *     the REAL `createFallbackValidation` adapter, not through a stubbed
+ *     socket. The wire → fallback leg (404 / timeout / 5xx / breaker) is
+ *     covered by tests/isl-validation-unavailable-no-fabricated-verdict.test.ts,
+ *     which stubs global fetch and drives the real ISLClient.
+ *   - `/v1/run`'s dev-only sibling surfaces (PlcLab, SandboxV1, PlotShowcase,
+ *     EngineAuditPanel) — not traced by this lane.
+ *   - `analyseSensitivity` / `analyseFactorSensitivity` /
+ *     `computeCounterfactual` and their fallbacks. #277 proved those producers
+ *     have ZERO call sites; their `?? 0.5` / `'moderate'` fabrications are the
+ *     same species but are queued for deletion as their own slice, so pinning
+ *     them here would pin code that is scheduled to disappear.
  *
  * IMPORTANT (why we scan the RAW payload, not just parsed JSON): Fastify's
  * serialiser turns NaN / ±Infinity into `null` (or string-interpolates them
@@ -106,9 +161,20 @@ function makePayload(opts: { nonFinite: boolean }) {
 
 let payloadFn = makePayload({ nonFinite: true });
 
+/**
+ * What `validateCausal` returns on the next call. Mutable so §C can swap a
+ * genuine ISL verdict for the REAL `createFallbackValidation` output without a
+ * second module mock. Default is a genuine 'identifiable' so every pre-existing
+ * assertion in this file is unaffected.
+ */
+let validateFn: () => Promise<any> = async () => ({
+  status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [],
+  backdoor_paths: [], issues: [], explanation: { summary: 'm', reasoning: 't' }, source: 'isl',
+});
+
 const svc: any = {
   isEnabled: () => true, isAvailable: async () => true,
-  validateCausal: async () => ({ status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [], explanation: { summary: 'm', reasoning: 't' }, source: 'isl' }),
+  validateCausal: async () => validateFn(),
   analyseSensitivity: async () => ({ overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' }),
   analyseRobustness: async (_g: any, _n: string, o: any[]) => payloadFn(o),
   analyseFactorSensitivity: async () => ({ factors: [], value_of_information: [], robustness_label: 'robust', robustness_score: 0.8, latency_ms: 0, source: 'unavailable' }),
@@ -384,5 +450,618 @@ describe('numeric-egress gate · a single invalid required outcome quantile omit
     const res = await run(app);
     // expected_outcome is finite but is NOT emitted in V2, so it must not rescue status.
     expect(res.json().option_comparison_status).not.toBe('computed');
+  });
+});
+
+// ===========================================================================
+// ===========================================================================
+//  ABSENCE-SHAPE COVERAGE (ROADMAP 1.240)
+//
+//  Everything below feeds `null` / missing-key / `undefined` where the blocks
+//  above feed NaN / ±Infinity. See the file header for the reachability of
+//  each shape and for what this gate does NOT reach.
+//
+//  RETRO-PROOF. This gate was run against the PRE-#277 tree (c79c63c1) in a
+//  throwaway worktree outside the repo root. §B and §C turn RED there on the
+//  three defects #277 fixed, which is the evidence that the extension is not
+//  vacuous: a gate that would not have caught the KNOWN defects cannot be
+//  trusted to catch the next one. Per-block results are recorded in the PR.
+// ===========================================================================
+// ===========================================================================
+
+/** The three absence shapes, applied to one key of an object. */
+const ABSENCE_SHAPES = ['null', 'missing', 'undefined'] as const;
+type AbsenceShape = (typeof ABSENCE_SHAPES)[number];
+
+/**
+ * Return `{ [key]: <shape> }` — or `{}` for the missing-key shape.
+ * Spread into a fixture so one matrix drives all three shapes.
+ */
+function absent(key: string, shape: AbsenceShape): Record<string, unknown> {
+  if (shape === 'missing') return {};
+  return { [key]: shape === 'null' ? null : undefined };
+}
+
+/**
+ * Collect dotted paths of every field named in `keys` that is PRESENT with a
+ * number. Used to assert that a field whose upstream was ABSENT did not
+ * reappear at egress carrying a plausible substitute (0, 0.5, 1, …).
+ *
+ * This is the assertion the NaN/Infinity blocks above could not make: a
+ * fabricated 0 is finite, in range, and serialises perfectly, so every
+ * finiteness and range check passes it through.
+ */
+function findPresentNumbers(obj: unknown, keys: Set<string>, path = '$', acc: string[] = []): string[] {
+  if (Array.isArray(obj)) {
+    obj.forEach((v, i) => findPresentNumbers(v, keys, `${path}[${i}]`, acc));
+  } else if (obj && typeof obj === 'object') {
+    for (const [k, v] of Object.entries(obj)) {
+      if (keys.has(k) && typeof v === 'number') acc.push(`${path}.${k}=${v}`);
+      findPresentNumbers(v, keys, `${path}.${k}`, acc);
+    }
+  }
+  return acc;
+}
+
+// ---------------------------------------------------------------------------
+// §A — /v2/run: the SAME option/outcome fields the NaN fixture exercises,
+//      fed the three absence shapes instead.
+//
+// HONEST NOTE ON WHAT §A PROVES. These particular fields were already guarded
+// absence-safely before #277 (`finiteNum` / `prob01` reject null as well as
+// NaN), so §A does NOT turn red on the pre-#277 tree. It is not retro-evidence;
+// it closes the SHAPE-BLINDNESS on the surface this gate already claimed to
+// cover, so a future `?? 0` added to any of these fields fails here instead of
+// shipping. §B and §C carry the retro-proof.
+// ---------------------------------------------------------------------------
+
+/** Every numeric egress key that must never be fabricated from an absent input. */
+const NEVER_FABRICATE = new Set([
+  'win_probability', 'probability_of_goal', 'expected_outcome',
+  'mean', 'std', 'p10', 'p50', 'p90', 'validity_ratio', 'n_samples', 'n_valid_samples',
+]);
+
+function makeAbsencePayload(shape: AbsenceShape) {
+  return (options: any[]) => ({
+    options: options.map((o: any, i: number) => ({
+      option_id: o.id,
+      ...absent('win_probability', shape),
+      ...absent('probability_of_goal', shape),
+      ...absent('expected_outcome', shape),
+      ...absent('confidence_interval', shape),
+      outcome: {
+        ...absent('mean', shape),
+        ...absent('std', shape),
+        ...absent('p10', shape),
+        ...absent('p50', shape),
+        ...absent('p90', shape),
+        ...absent('n_samples', shape),
+        ...absent('n_valid_samples', shape),
+        ...absent('validity_ratio', shape),
+      },
+      rank: i + 1,
+    })),
+    edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2', edge_sensitivity_status: 'available',
+    factors: [], factor_sensitivity: [], value_of_information: [],
+    factors_provenance: 'unavailable', factor_sensitivity_status: 'skipped_no_factor_values',
+    overall_robustness: 'robust',
+    ...absent('robustness_score', shape),
+    fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl',
+  });
+}
+
+for (const shape of ABSENCE_SHAPES) {
+  describe(`absence gate §A · /v2/run option outcomes absent as ${shape.toUpperCase()}`, () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      process.env.RATE_LIMIT_ENABLED = '0';
+      process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+      payloadFn = makeAbsencePayload(shape);
+      app = await createServer();
+    });
+    afterAll(async () => {
+      await app?.close();
+      delete process.env.RATE_LIMIT_ENABLED;
+      delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    });
+
+    it('no numeric-egress field is fabricated from an absent upstream value', async () => {
+      const res = await run(app);
+      expect(res.statusCode).toBe(200);
+      const oc = (res.json().option_comparison ?? []) as any[];
+      expect(oc.length, 'the gate must actually reach option_comparison').toBeGreaterThan(0);
+      // The load-bearing assertion: NOTHING numeric survives from nothing.
+      expect(findPresentNumbers(oc, NEVER_FABRICATE)).toEqual([]);
+    });
+
+    it('absent is ABSENT, never a fabricated null on a declared-numeric field', async () => {
+      const res = await run(app);
+      expect(findNullNumericFields(res.json())).toEqual([]);
+      expect(findNullProbabilityFields(res.json())).toEqual([]);
+      expect(findNonFiniteNumbers(res.json())).toEqual([]);
+    });
+
+    it('status honestly reports that nothing usable was computed', async () => {
+      const res = await run(app);
+      expect(res.json().option_comparison_status).not.toBe('computed');
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// §B — /v2/run CONSTRAINT MARGINS. This is Instance B's surface and it is the
+//      half of the retro-proof that lives on the numeric side.
+//
+// Pre-#277 the denormalisation guard was `fmm !== undefined`, so a wire `null`
+// walked past it, `null * 60000` evaluated to 0, and `nonNeg(0)` blessed the
+// result as a measured zero-margin breach — "this option breaches by exactly
+// nothing" — which additionally unlocked `margin_precision: 'exact'`, a
+// precision claim about a margin that was never computed.
+//
+// The scenario mirrors tests/constraint-margin-plumbing.test.ts (and the live
+// staging probe it was built from) because the DENORMALISATION is what does the
+// fabricating: `fac_cost` carries an explicit cap, so a normalisation range
+// exists, so the multiply actually runs. Without the cap the range map is
+// absent, the multiply is skipped, and the whole case passes vacuously.
+// ---------------------------------------------------------------------------
+
+const CONSTRAINT_GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Programme value', observed_state: { value: 0.4 } },
+    { id: 'fac_cost', kind: 'factor', label: 'First-year cost', observed_state: { value: 40000, cap: 60000, unit: '£' } },
+  ],
+  edges: [{ from: 'fac_cost', to: 'goal', strength: { mean: -0.5, std: 0.1 } }],
+};
+
+const CONSTRAINT_OPTIONS = [
+  { id: 'opt_under', label: 'Under budget', interventions: { fac_cost: 38000 } },
+  { id: 'opt_over', label: 'Over budget', interventions: { fac_cost: 52000 } },
+];
+
+const CONSTRAINT_ID = 'c_cost_cap';
+const GOAL_CONSTRAINTS = [
+  { constraint_id: CONSTRAINT_ID, node_id: 'fac_cost', operator: '<=', value: 50000, label: 'First-year cost cap', unit: '£' },
+];
+
+const CONSTRAINT_PAYLOAD = {
+  graph: CONSTRAINT_GRAPH,
+  options: CONSTRAINT_OPTIONS,
+  goal_node_id: 'goal',
+  seed: '42',
+  goal_constraints: GOAL_CONSTRAINTS,
+};
+
+/**
+ * ISL robustness payload where `opt_over` breaches and its margin fields take
+ * `shape`. `null` here is the LIVE shape (see header). `measured` is the
+ * positive control: a genuine 0.03333 must still denormalise to ≈ £2,000.
+ */
+function makeConstraintPayload(shape: AbsenceShape | 'measured') {
+  const marginFields = shape === 'measured'
+    ? { failure_margin_median: 0.03333, near_miss_fraction: 1.0 }
+    : { ...absent('failure_margin_median', shape), ...absent('near_miss_fraction', shape) };
+
+  return (options: any[]) => ({
+    options: options.map((o: any, i: number) => ({
+      option_id: o.id,
+      win_probability: o.id === 'opt_under' ? 0.7 : 0.3,
+      outcome: { mean: 0.7 - i * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1 },
+      rank: i + 1,
+      status: 'computed',
+      constraint_analysis: {
+        constraints: [
+          o.id === 'opt_under'
+            // Satisfies: ISL sends no margin at all for it, in the same shape.
+            ? { node_id: 'fac_cost', operator: '<=', value: 50000, prob_satisfied: 1.0,
+                ...(shape === 'measured' ? {} : { ...absent('failure_margin_median', shape), ...absent('near_miss_fraction', shape) }) }
+            // Breaches: prob_satisfied is real, the MARGIN is the variable.
+            : { node_id: 'fac_cost', operator: '<=', value: 50000, prob_satisfied: 0.0, ...marginFields },
+        ],
+        joint_probability: o.id === 'opt_under' ? 1.0 : 0.0,
+      },
+    })),
+    edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2', edge_sensitivity_status: 'available',
+    factors: [], factor_sensitivity: [], value_of_information: [],
+    factors_provenance: 'unavailable', factor_sensitivity_status: 'skipped_no_factor_values',
+    overall_robustness: 'robust', robustness_score: 0.8,
+    fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl',
+  });
+}
+
+async function runConstraints(app: FastifyInstance) {
+  const res = await app.inject({
+    method: 'POST', url: '/v2/run',
+    headers: { 'content-type': 'application/json' },
+    payload: CONSTRAINT_PAYLOAD,
+  });
+  expect(res.statusCode).toBe(200);
+  return res.json();
+}
+
+function marginEntry(body: any, optionId: string): any {
+  const entry = (body.option_comparison ?? []).find((o: any) => o.option_id === optionId);
+  expect(entry, `option_comparison entry for ${optionId}`).toBeDefined();
+  return (entry.constraint_margins ?? []).find((m: any) => m.constraint_id === CONSTRAINT_ID);
+}
+
+for (const shape of ABSENCE_SHAPES) {
+  describe(`absence gate §B · /v2/run constraint margins absent as ${shape.toUpperCase()}`, () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      process.env.RATE_LIMIT_ENABLED = '0';
+      process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+      payloadFn = makeConstraintPayload(shape);
+      app = await createServer();
+    });
+    afterAll(async () => {
+      await app?.close();
+      delete process.env.RATE_LIMIT_ENABLED;
+      delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    });
+
+    it('RETRO-PROOF: an absent margin never denormalises into a measured ZERO breach', async () => {
+      const body = await runConstraints(app);
+      const over = marginEntry(body, 'opt_over');
+      // The entry itself may exist (prob_satisfied IS measured); the MARGIN
+      // must not. Pre-#277 this shipped `failure_margin_median: 0`.
+      if (over !== undefined) {
+        expect(over, 'absent margin must not reappear as a number').not.toHaveProperty('failure_margin_median');
+        expect(over).not.toHaveProperty('near_miss_fraction');
+        // A precision claim about a margin that was never computed is worse
+        // than the margin itself.
+        expect(over).not.toHaveProperty('margin_precision');
+      }
+    });
+
+    it('RETRO-PROOF: no fabricated margin anywhere in the response, at any depth', async () => {
+      const body = await runConstraints(app);
+      expect(findPresentNumbers(body, new Set(['failure_margin_median', 'near_miss_fraction']))).toEqual([]);
+      expect(findNullNumericFields(body)).toEqual([]);
+      expect(findNonFiniteNumbers(body)).toEqual([]);
+    });
+
+    it('a satisfying option with no margin data carries no fabricated margin either', async () => {
+      const body = await runConstraints(app);
+      const under = marginEntry(body, 'opt_under');
+      if (under !== undefined) {
+        expect(under).not.toHaveProperty('failure_margin_median');
+        expect(under).not.toHaveProperty('near_miss_fraction');
+      }
+    });
+  });
+}
+
+describe('absence gate §B · POSITIVE CONTROL — a genuine margin still flows through unchanged', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    payloadFn = makeConstraintPayload('measured');
+    app = await createServer();
+  });
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  it('a measured 0.03333 still denormalises to ≈ £2,000 (over-suppression is an equal failure)', async () => {
+    const body = await runConstraints(app);
+    const over = marginEntry(body, 'opt_over');
+    expect(over, 'the positive control must actually reach constraint_margins — otherwise every §B absence assertion above is vacuous').toBeDefined();
+    expect(over.failure_margin_median).toBeCloseTo(2000, 0);
+    expect(over.near_miss_fraction).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §C — /v1/run VALIDATION. The verdict half of the retro-proof.
+//
+// Two defects #277 fixed live here:
+//   C1  createFallbackValidation returned status:'uncertain', which /v1/run
+//       rendered as a user-facing critique "ISL validation reports partial
+//       identifiability" tagged source:'isl' — a scientific claim about the
+//       user's graph attributed to a service that computed nothing.
+//   C2  transformValidationToEnrichment computed `identifiable: status ===
+//       'identifiable'`, so a non-result serialised as `identifiable: false`
+//       into the untyped z.record PLoT→CEE enrichment.
+//
+// C3 is the same defect reached through a NULL rather than through a missing
+// response: `STATUS_MAP[isl.status] || 'uncertain'` manufactured a verdict from
+// any undeclared wire value, and `null` is an undeclared wire value.
+//
+// SEAM. The transport is the module mock; everything from the ISL service
+// boundary inwards is real — the real createFallbackValidation, the real
+// adaptValidationResponse, the real /v1/run consumer and the real enrichment
+// builder. See the header for what this does not cover.
+// ---------------------------------------------------------------------------
+
+const { createFallbackValidation, adaptValidationResponse } =
+  await import('../../src/integrations/isl/adapters/validation.js');
+
+const V1_PAYLOAD = {
+  graph: {
+    nodes: [
+      { id: 'A', label: 'Input' },
+      { id: 'B', label: 'Output' },
+      { id: 'C', label: 'Confounder' },
+    ],
+    edges: [
+      { from: 'A', to: 'B', weight: 0.5 },
+      { from: 'C', to: 'A', weight: 0.4 },
+      { from: 'C', to: 'B', weight: 0.4 },
+    ],
+  },
+  seed: 123,
+  outcome_node: 'B',
+  detail_level: 'standard',
+};
+
+/** Critique codes that assert something ISL COMPUTED about the graph. */
+const ISL_VERDICT_CODES = new Set(['ISL_CANNOT_IDENTIFY', 'ISL_UNCERTAIN', 'ISL_ISSUE', 'ISL_FRAGILE']);
+
+async function runV1(app: FastifyInstance) {
+  const res = await app.inject({
+    method: 'POST', url: '/v1/run',
+    headers: { 'content-type': 'application/json' },
+    payload: V1_PAYLOAD,
+  });
+  expect(res.statusCode).toBe(200);
+  return res.json();
+}
+
+describe('absence gate §C1/C3 · an undeclared or absent ISL status is not a verdict (unit)', () => {
+  for (const shape of ABSENCE_SHAPES) {
+    it(`RETRO-PROOF: adaptValidationResponse with status ${shape.toUpperCase()} degrades to 'unavailable', never 'uncertain'`, () => {
+      const isl: any = { robustness: 'high', adjustment_sets: [], minimal_adjustment_set: [], suggestions: [], ...absent('status', shape) };
+      const out = adaptValidationResponse(isl);
+      // 'uncertain' is ISL's `partially_identifiable` verdict. Producing it
+      // from an absent status is manufacturing a scientific claim.
+      expect(out.status).not.toBe('uncertain');
+      expect(out.status).toBe('unavailable');
+    });
+  }
+
+  it('RETRO-PROOF: createFallbackValidation is a typed refusal, not a verdict', () => {
+    const out = createFallbackValidation('ISL returned 404 (causal_router not mounted)');
+    expect(out.status).toBe('unavailable');
+    expect(['identifiable', 'uncertain', 'cannot_identify']).not.toContain(out.status);
+  });
+
+  it('POSITIVE CONTROL: every status ISL genuinely declares still maps to its real verdict', () => {
+    const base = { robustness: 'high', adjustment_sets: [['C']], minimal_adjustment_set: ['C'], suggestions: [] };
+    expect(adaptValidationResponse({ ...base, status: 'identifiable' } as any).status).toBe('identifiable');
+    expect(adaptValidationResponse({ ...base, status: 'partially_identifiable' } as any).status).toBe('uncertain');
+    expect(adaptValidationResponse({ ...base, status: 'not_identifiable' } as any).status).toBe('cannot_identify');
+  });
+});
+
+describe('absence gate §C1/C2 · /v1/run with NO validation obtained', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    // The REAL fallback adapter is the stimulus: this is exactly what the ISL
+    // service returns on a 404 / timeout / 5xx / breaker trip.
+    validateFn = async () => createFallbackValidation('ISL unavailable (gate stimulus)');
+    payloadFn = makePayload({ nonFinite: false });
+    app = await createServer();
+  });
+  afterAll(async () => {
+    await app?.close();
+    validateFn = async () => ({
+      status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [],
+      backdoor_paths: [], issues: [], explanation: { summary: 'm', reasoning: 't' }, source: 'isl',
+    });
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  it('RETRO-PROOF C1: no critique attributes an identifiability verdict to ISL', async () => {
+    const body = await runV1(app);
+    const critiques: any[] = body.result?.critique ?? body.critique ?? [];
+    const fabricated = critiques.filter(
+      (c) => ISL_VERDICT_CODES.has(c?.code) || (c?.source === 'isl'),
+    );
+    expect(
+      fabricated,
+      `a verdict was attributed to ISL although ISL produced nothing: ${JSON.stringify(fabricated)}`,
+    ).toEqual([]);
+    // And the raw payload must not contain the fabricated sentence.
+    expect(JSON.stringify(body)).not.toContain('reports partial identifiability');
+  });
+
+  it('C1 corollary: the unknown is stated POSITIVELY, not by silence', async () => {
+    // Omitting the critique entirely would leave the user believing
+    // identifiability WAS checked and cleared — the same lie by another route.
+    const body = await runV1(app);
+    const critiques: any[] = body.result?.critique ?? body.critique ?? [];
+    const notice = critiques.find((c) => c?.code === 'ISL_VALIDATION_UNAVAILABLE');
+    expect(notice, 'the explicit unknown must be present').toBeDefined();
+    expect(notice.source, 'PLoT is reporting its OWN inability — never attributed to ISL').toBe('engine');
+  });
+
+  it('RETRO-PROOF C2: the enrichment omits causal_validation rather than shipping identifiable:false', async () => {
+    const body = await runV1(app);
+    const cv = body.enrichment?.causal_validation;
+    expect(cv ?? undefined, `enrichment carried a fabricated verdict: ${JSON.stringify(cv)}`).toBeUndefined();
+    // Defence in depth: no `identifiable` boolean anywhere in the payload.
+    expect(JSON.stringify(body)).not.toContain('"identifiable":false');
+  });
+});
+
+describe('absence gate §C · POSITIVE CONTROL — a genuine ISL verdict still reaches the user', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    validateFn = async () => adaptValidationResponse({
+      status: 'partially_identifiable', robustness: 'high',
+      adjustment_sets: [['C']], minimal_adjustment_set: ['C'], suggestions: [],
+    } as any);
+    payloadFn = makePayload({ nonFinite: false });
+    app = await createServer();
+  });
+  afterAll(async () => {
+    await app?.close();
+    validateFn = async () => ({
+      status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [],
+      backdoor_paths: [], issues: [], explanation: { summary: 'm', reasoning: 't' }, source: 'isl',
+    });
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  it('a real partially_identifiable verdict IS reported, with source:isl (over-suppression is an equal failure)', async () => {
+    const body = await runV1(app);
+    const critiques: any[] = body.result?.critique ?? body.critique ?? [];
+    const real = critiques.find((c) => c?.code === 'ISL_UNCERTAIN');
+    expect(real, 'a genuine ISL verdict must still be surfaced').toBeDefined();
+    expect(real.source).toBe('isl');
+    // ... and the availability notice must NOT be emitted alongside it.
+    expect(critiques.find((c) => c?.code === 'ISL_VALIDATION_UNAVAILABLE')).toBeUndefined();
+  });
+
+  it('a real verdict still populates the enrichment block', async () => {
+    const body = await runV1(app);
+    expect(body.enrichment?.causal_validation).toBeDefined();
+    expect(body.enrichment.causal_validation.identifiable).toBe(false); // genuine: partially_identifiable
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §D — THE THREE SIBLINGS #277 REPORTED AND DID NOT FIX (fixed by this lane).
+//
+// These use `??`, which handles `null` correctly, so they are NOT instances of
+// the `!== undefined` bug — they are the broader class: a plausible substitute
+// standing in for a measurement that does not exist. They are pinned at the
+// UNIT seam because that is the only seam that can carry the `undefined` shape
+// (JSON cannot), and because two of the three have no reachable egress reader:
+//
+//   D1  enrichFactorSensitivity — `?? 0`. `buildRobustnessDataForCee` IS called
+//       on the live /v2/run path, but the ONLY consumer of RobustnessDataForCee
+//       is buildCeeReviewRequest and it reads `fragile_edges` alone. The
+//       fabricated `sensitivity: 0` therefore had ZERO readers and never
+//       reached a wire. Fixed anyway — a value with no reader today is a value
+//       the next lane wires up believing it is measured — but pinned here
+//       rather than at egress, because there is no egress to pin.
+//   D2  adaptRobustnessAnalysisResponse — `?? 0.5` score AND the label default,
+//       which `mapLevelToLabel(undefined)` turned into a 'moderate' VERDICT.
+//       /v1/run only.
+//   D3  normalizeRobustEdges — `?? 1`, plus its string-format twin which
+//       hardcoded `switch_probability: 1` from a bare "from->to" string.
+// ---------------------------------------------------------------------------
+
+const { enrichFactorSensitivity } =
+  await import('../../src/integrations/isl/adapters/robustness-enrichment.js');
+const { adaptRobustnessAnalysisResponse, normalizeRobustEdges, createFallbackRobustnessAnalysis } =
+  await import('../../src/integrations/isl/adapters/robustness-analysis.js');
+
+const D_GRAPH: any = { nodes: [{ id: 'fac_price', label: 'Price' }], edges: [] };
+
+describe('absence gate §D1 · enrichFactorSensitivity never fabricates zero sensitivity', () => {
+  for (const shape of ABSENCE_SHAPES) {
+    it(`sensitivity is OMITTED when both source fields are ${shape.toUpperCase()}`, () => {
+      const factor: any = {
+        node_id: 'fac_price',
+        ...absent('sensitivity_score', shape),
+        ...absent('sensitivity', shape),
+      };
+      const out = enrichFactorSensitivity(factor, D_GRAPH);
+      expect(out, 'absent ≠ "measured to have zero influence"').not.toHaveProperty('sensitivity');
+    });
+  }
+
+  it('POSITIVE CONTROL: a measured value — including a genuine 0 — flows through unchanged', () => {
+    expect(enrichFactorSensitivity({ node_id: 'fac_price', sensitivity_score: 0.42 } as any, D_GRAPH).sensitivity).toBe(0.42);
+    expect(enrichFactorSensitivity({ node_id: 'fac_price', sensitivity_score: 0 } as any, D_GRAPH).sensitivity).toBe(0);
+    // legacy field still honoured
+    expect(enrichFactorSensitivity({ node_id: 'fac_price', sensitivity: 0.7 } as any, D_GRAPH).sensitivity).toBe(0.7);
+  });
+});
+
+describe('absence gate §D2 · adaptRobustnessAnalysisResponse never fabricates a robustness score or verdict', () => {
+  function islResponse(robustness: unknown) {
+    return { sensitivity: [], factor_sensitivity: [], robustness } as any;
+  }
+
+  for (const shape of ABSENCE_SHAPES) {
+    it(`robustness_score and overall_robustness are OMITTED when score/confidence/label/level are ${shape.toUpperCase()}`, () => {
+      const robustness: any = {
+        ...absent('score', shape), ...absent('confidence', shape),
+        ...absent('label', shape), ...absent('level', shape),
+        fragile_edges: [], robust_edges: [],
+      };
+      const out = adaptRobustnessAnalysisResponse(islResponse(robustness), 10, 'available', 'available');
+      expect(out, '0.5 is not a measurement').not.toHaveProperty('robustness_score');
+      expect(out, "'moderate' is a VERDICT about the user's graph").not.toHaveProperty('overall_robustness');
+    });
+  }
+
+  it('the robustness object being absent entirely is also not a verdict', () => {
+    const out = adaptRobustnessAnalysisResponse(islResponse(undefined), 10, 'available', 'available');
+    expect(out).not.toHaveProperty('robustness_score');
+    expect(out).not.toHaveProperty('overall_robustness');
+  });
+
+  it('RETRO-GUARD: a non-finite score is not published either', () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const out = adaptRobustnessAnalysisResponse(
+        islResponse({ score: bad, label: 'robust', fragile_edges: [], robust_edges: [] }), 10, 'available', 'available');
+      expect(out, `score=${bad}`).not.toHaveProperty('robustness_score');
+      expect(out.overall_robustness, 'a real label survives a bad score').toBe('robust');
+    }
+  });
+
+  it('POSITIVE CONTROL: genuine score/label flow through, and `level` still maps when present', () => {
+    const withLabel = adaptRobustnessAnalysisResponse(
+      islResponse({ score: 0.82, label: 'fragile', fragile_edges: [], robust_edges: [] }), 10, 'available', 'available');
+    expect(withLabel.robustness_score).toBe(0.82);
+    expect(withLabel.overall_robustness).toBe('fragile');
+
+    const withLevel = adaptRobustnessAnalysisResponse(
+      islResponse({ confidence: 0.4, level: 'low', fragile_edges: [], robust_edges: [] }), 10, 'available', 'available');
+    expect(withLevel.robustness_score, 'confidence is the declared fallback SOURCE, not a fabrication').toBe(0.4);
+    expect(withLevel.overall_robustness).toBe('fragile');
+
+    // A genuine 0 score is a measurement.
+    const zero = adaptRobustnessAnalysisResponse(
+      islResponse({ score: 0, label: 'fragile', fragile_edges: [], robust_edges: [] }), 10, 'available', 'available');
+    expect(zero).toHaveProperty('robustness_score');
+    expect(zero.robustness_score).toBe(0);
+  });
+
+  it('the ISL-unavailable fallback states no robustness verdict at all', () => {
+    const out = createFallbackRobustnessAnalysis('ISL timeout');
+    expect(out).not.toHaveProperty('robustness_score');
+    expect(out).not.toHaveProperty('overall_robustness');
+    expect(out.source, 'the refusal is carried machine-readably instead').toBe('unavailable');
+  });
+});
+
+describe('absence gate §D3 · robust edges never fabricate switch_probability', () => {
+  for (const shape of ABSENCE_SHAPES) {
+    it(`object-format switch_probability is OMITTED when ${shape.toUpperCase()}`, () => {
+      const out = normalizeRobustEdges([{ edge_id: 'x->y', ...absent('switch_probability', shape) }] as any);
+      expect(out.edges).toHaveLength(1);
+      expect(out.edges[0]).not.toHaveProperty('switch_probability');
+    });
+  }
+
+  it('string-format robust edges carry NO switch_probability (a string has no measurement)', () => {
+    const out = normalizeRobustEdges(['a->b', 'c::d']);
+    expect(out.edges).toHaveLength(2);
+    for (const e of out.edges) expect(e).not.toHaveProperty('switch_probability');
+  });
+
+  it('POSITIVE CONTROL: a measured object-format switch_probability survives verbatim', () => {
+    const out = normalizeRobustEdges([{ edge_id: 'x->y', switch_probability: 0.3 }] as any);
+    expect(out.edges[0].switch_probability).toBe(0.3);
+    expect(out.edges[0].edge_id).toBe('x->y');
   });
 });

--- a/tests/gates/numeric-safety-deep-scan.test.ts
+++ b/tests/gates/numeric-safety-deep-scan.test.ts
@@ -1053,10 +1053,40 @@ describe('absence gate §D3 · robust edges never fabricate switch_probability',
     });
   }
 
-  it('string-format robust edges carry NO switch_probability (a string has no measurement)', () => {
+  // ⚠ BLOCKED ON A CROSS-REPO CONTRACT CHANGE — NOT a doctrine question.
+  //
+  // The string arm still fabricates `switch_probability: 1`. This lane made it
+  // omit, ran the authoritative gate, and MEASURED the consequence: every
+  // /v2/run response then fails its own egress contract, because
+  // @talchain/schemas (vendored 0.22.0) declares
+  // `EnrichmentRobustnessEdgeSchema.switch_probability: z.number()` REQUIRED
+  // for robust_edges as well as fragile_edges. The producer-side guard stamps
+  // `enrichment_contract_ok: false` and a user-visible
+  // ENRICHMENT_CONTRACT_MISMATCH warning on every response (4 issue paths on
+  // the golden fixture), and CEE shadow-validates the same body against the
+  // same schema.
+  //
+  // Trading a wrong number for a standing false alarm on a fail-open guard is
+  // the broken-alarm trap, so the omission was reverted and the blocker
+  // reported instead of quietly fabricating OR quietly breaking the contract.
+  //
+  // TO UN-SKIP: relax the field in olumi-schemas to `z.number().optional()`
+  // (which is what PLoT's own NormalizedEdgeInfoV3 already publishes — the two
+  // contracts disagree TODAY, latently, for fragile_edges), release, re-pin the
+  // vendored tarball, delete the fabrication in normalizeRobustEdge, un-skip.
+  // This test failing after that change is the signal the work landed.
+  it.skip('string-format robust edges carry NO switch_probability (a string has no measurement) — BLOCKED: @talchain/schemas requires it', () => {
     const out = normalizeRobustEdges(['a->b', 'c::d']);
     expect(out.edges).toHaveLength(2);
     for (const e of out.edges) expect(e).not.toHaveProperty('switch_probability');
+  });
+
+  it('the string-arm fabrication is PINNED as a known defect, so it cannot be forgotten or mistaken for a measurement', () => {
+    // This is deliberately an assertion about a value we consider WRONG. It
+    // exists so the fabrication is visible in the suite rather than silent, and
+    // so removing it (once the schema is relaxed) is a deliberate act.
+    const out = normalizeRobustEdges(['a->b']);
+    expect(out.edges[0].switch_probability, 'still fabricated — see the blocker above').toBe(1);
   });
 
   it('POSITIVE CONTROL: a measured object-format switch_probability survives verbatim', () => {

--- a/tests/isl-adapters.test.ts
+++ b/tests/isl-adapters.test.ts
@@ -407,7 +407,15 @@ describe('Robustness Analysis Adapter', () => {
   });
 
   describe('normalizeRobustEdges', () => {
-    it('normalizes string format edges', () => {
+    // CORRECTED AT SOURCE (ROADMAP 1.240, sibling 3). The final assertion here
+    // used to read `expect(...switch_probability).toBe(1); // Robust = 100%
+    // stability`, pinning a number manufactured from a bare "from->to" string
+    // that carries no measurement — and manufacturing it on an INVERTED scale
+    // (switch_probability high = MORE likely to flip the winner, which is what
+    // classifyEdgeSeverity and the doctrine-013 `visible` gate read it as).
+    // The identifiers and parsing are still pinned; only the invented number is
+    // now asserted absent.
+    it('normalizes string format edges and emits NO switch_probability (a string carries no measurement)', () => {
       const edges = ['a->b', 'c::d'];
 
       const result = normalizeRobustEdges(edges);
@@ -416,7 +424,10 @@ describe('Robustness Analysis Adapter', () => {
       expect(result.edges[0].edge_id).toBe('a->b');
       expect(result.edges[0].from_id).toBe('a');
       expect(result.edges[0].to_id).toBe('b');
-      expect(result.edges[0].switch_probability).toBe(1); // Robust = 100% stability
+      expect(result.edges[0]).not.toHaveProperty('switch_probability');
+      expect(result.edges[1].from_id).toBe('c');
+      expect(result.edges[1].to_id).toBe('d');
+      expect(result.edges[1]).not.toHaveProperty('switch_probability');
     });
 
     it('handles object format edges (fallback)', () => {
@@ -427,12 +438,34 @@ describe('Robustness Analysis Adapter', () => {
       expect(result.edges[0].switch_probability).toBe(0.9);
     });
 
-    it('defaults switch_probability to 1 for object format', () => {
-      const edges = [{ edge_id: 'x->y' }];
+    // CORRECTED AT SOURCE (ROADMAP 1.240, sibling 3): was
+    // `defaults switch_probability to 1 for object format`, which pinned
+    // `objEdge.switch_probability ?? 1`. All three absence shapes are exercised
+    // because `??` and the old `!== undefined` guards disagree about `null`,
+    // and `null` is the shape a JSON wire actually delivers.
+    it('OMITS switch_probability for object format when absent — missing key, null, or undefined', () => {
+      const cases: Array<[string, unknown]> = [
+        ['missing key', { edge_id: 'x->y' }],
+        ['null', { edge_id: 'x->y', switch_probability: null }],
+        ['undefined', { edge_id: 'x->y', switch_probability: undefined }],
+        ['NaN', { edge_id: 'x->y', switch_probability: Number.NaN }],
+        ['Infinity', { edge_id: 'x->y', switch_probability: Number.POSITIVE_INFINITY }],
+      ];
+      for (const [label, edge] of cases) {
+        const result = normalizeRobustEdges([edge] as any);
+        expect(result.edges, label).toHaveLength(1);
+        expect(result.edges[0], `${label} must not fabricate switch_probability`)
+          .not.toHaveProperty('switch_probability');
+      }
+    });
 
-      const result = normalizeRobustEdges(edges);
-
-      expect(result.edges[0].switch_probability).toBe(1);
+    it('POSITIVE CONTROL: a measured object-format switch_probability still passes through verbatim', () => {
+      const result = normalizeRobustEdges([{ edge_id: 'x->y', switch_probability: 0.3 }] as any);
+      expect(result.edges[0].switch_probability).toBe(0.3);
+      // and a genuine 0 is a measurement, not an absence
+      const zero = normalizeRobustEdges([{ edge_id: 'x->y', switch_probability: 0 }] as any);
+      expect(zero.edges[0]).toHaveProperty('switch_probability');
+      expect(zero.edges[0].switch_probability).toBe(0);
     });
 
     it('tracks errors for unknown formats', () => {
@@ -559,13 +592,22 @@ describe('Robustness Analysis Adapter', () => {
   });
 
   describe('createFallbackRobustnessAnalysis', () => {
-    it('creates empty result with failed status', () => {
+    // CORRECTED AT SOURCE (ROADMAP 1.240). This asserted
+    // `overall_robustness === 'moderate'` and `robustness_score === 0.5` on the
+    // ISL-UNAVAILABLE path — Instance A's defect in the robustness channel. A
+    // fallback that names a robustness VERDICT is indistinguishable from a
+    // genuine ISL 'moderate', and 0.5 reads as a measured midpoint. Nothing was
+    // computed, so both are now absent; `source: 'unavailable'` carries the
+    // machine-readable refusal.
+    it('creates empty result with failed status and NO fabricated robustness verdict or score', () => {
       const result = createFallbackRobustnessAnalysis('ISL timeout');
 
       expect(result.edges).toHaveLength(0);
       expect(result.factors).toHaveLength(0);
-      expect(result.overall_robustness).toBe('moderate');
-      expect(result.robustness_score).toBe(0.5);
+      expect(result).not.toHaveProperty('overall_robustness');
+      expect(result).not.toHaveProperty('robustness_score');
+      expect(result.overall_robustness).toBeUndefined();
+      expect(result.robustness_score).toBeUndefined();
       expect(result.edge_sensitivity_status).toBe('failed');
       expect(result.factor_sensitivity_status).toBe('failed');
       expect(result.source).toBe('unavailable');

--- a/tests/isl-adapters.test.ts
+++ b/tests/isl-adapters.test.ts
@@ -407,15 +407,15 @@ describe('Robustness Analysis Adapter', () => {
   });
 
   describe('normalizeRobustEdges', () => {
-    // CORRECTED AT SOURCE (ROADMAP 1.240, sibling 3). The final assertion here
-    // used to read `expect(...switch_probability).toBe(1); // Robust = 100%
-    // stability`, pinning a number manufactured from a bare "from->to" string
-    // that carries no measurement — and manufacturing it on an INVERTED scale
-    // (switch_probability high = MORE likely to flip the winner, which is what
-    // classifyEdgeSeverity and the doctrine-013 `visible` gate read it as).
-    // The identifiers and parsing are still pinned; only the invented number is
-    // now asserted absent.
-    it('normalizes string format edges and emits NO switch_probability (a string carries no measurement)', () => {
+    // ⚠ The `switch_probability: 1` asserted here is a KNOWN FABRICATION that
+    // this lane could not remove: @talchain/schemas (vendored 0.22.0) declares
+    // the field REQUIRED on robust_edges, so omitting it makes every /v2/run
+    // response fail its own egress contract. Full reasoning and the exact
+    // one-line schema change needed are on normalizeRobustEdge in
+    // src/integrations/isl/adapters/robustness-analysis.ts, and the blocked
+    // assertion is present-and-skipped in
+    // tests/gates/numeric-safety-deep-scan.test.ts §D3.
+    it('normalizes string format edges (switch_probability is FABRICATED — see blocker)', () => {
       const edges = ['a->b', 'c::d'];
 
       const result = normalizeRobustEdges(edges);
@@ -424,10 +424,7 @@ describe('Robustness Analysis Adapter', () => {
       expect(result.edges[0].edge_id).toBe('a->b');
       expect(result.edges[0].from_id).toBe('a');
       expect(result.edges[0].to_id).toBe('b');
-      expect(result.edges[0]).not.toHaveProperty('switch_probability');
-      expect(result.edges[1].from_id).toBe('c');
-      expect(result.edges[1].to_id).toBe('d');
-      expect(result.edges[1]).not.toHaveProperty('switch_probability');
+      expect(result.edges[0].switch_probability, 'fabricated, not measured').toBe(1);
     });
 
     it('handles object format edges (fallback)', () => {

--- a/tests/robustness-analysis.test.ts
+++ b/tests/robustness-analysis.test.ts
@@ -105,8 +105,18 @@ describe('Edge Normalization in adaptRobustnessAnalysisResponse', () => {
 
     expect(result.fragile_edges).toEqual([]);
     expect(result.robust_edges).toEqual([]);
-    expect(result.overall_robustness).toBe('moderate');
-    expect(result.robustness_score).toBe(0.5);
+    // CORRECTED AT SOURCE (ROADMAP 1.240, sibling 2). This asserted
+    // `overall_robustness === 'moderate'` and `robustness_score === 0.5` for an
+    // ISL response that carried NO robustness object at all — i.e. it pinned a
+    // robustness VERDICT about the user's graph manufactured from silence, and
+    // a score indistinguishable from a measured midpoint. "Handles missing data
+    // gracefully" turned out to mean "invents an answer". Absence is now
+    // absence; the assertions are inverted rather than deleted.
+    expect(result).not.toHaveProperty('overall_robustness');
+    expect(result).not.toHaveProperty('robustness_score');
+    // The rest of the adaptation still happens — no over-suppression.
+    expect(result.edges_provenance).toBe('isl:/api/v1/robustness/analyze/v2');
+    expect(result.source).toBe('isl');
   });
 
   it('handles fragile edges with missing from_id/to_id by parsing edge_id', () => {
@@ -190,7 +200,11 @@ describe('createFallbackRobustnessAnalysis', () => {
 
     expect(result.fragile_edges).toEqual([]);
     expect(result.robust_edges).toEqual([]);
-    expect(result.overall_robustness).toBe('moderate');
+    // CORRECTED AT SOURCE (ROADMAP 1.240): the ISL-UNAVAILABLE fallback used to
+    // return `overall_robustness: 'moderate'`, indistinguishable from a genuine
+    // ISL 'moderate'. Nothing was computed, so no verdict is stated; `source`
+    // carries the refusal machine-readably.
+    expect(result).not.toHaveProperty('overall_robustness');
     expect(result.source).toBe('unavailable');
   });
 });

--- a/tests/robustness-enrichment.test.ts
+++ b/tests/robustness-enrichment.test.ts
@@ -221,7 +221,14 @@ describe('enrichFactorSensitivity', () => {
     expect(result.sensitivity).toBe(0.75);
   });
 
-  it('defaults to 0 when neither sensitivity_score nor sensitivity is present', () => {
+  // CORRECTED AT SOURCE (ROADMAP 1.240, sibling 1). This test previously read
+  // `defaults to 0 when neither sensitivity_score nor sensitivity is present`
+  // and asserted `result.sensitivity === 0`. It PINNED the fabrication: a
+  // factor ISL said nothing about was published as a factor measured to have
+  // ZERO influence on the decision. Absent is not zero, so the assertion is
+  // inverted rather than deleted — deleting it would leave the behaviour
+  // unpinned in the other direction.
+  it('OMITS sensitivity when neither sensitivity_score nor sensitivity is present (absent ≠ 0)', () => {
     const factor = {
       node_id: 'fac_price',
       direction: 'positive' as const,
@@ -229,6 +236,41 @@ describe('enrichFactorSensitivity', () => {
 
     const result = enrichFactorSensitivity(factor, TEST_GRAPH);
 
+    expect(result).not.toHaveProperty('sensitivity');
+    expect(result.sensitivity).toBeUndefined();
+    // ... and the rest of the entry is still built (no over-suppression).
+    expect(result.factor_id).toBe('fac_price');
+    expect(result.direction).toBe('positive');
+  });
+
+  it('OMITS sensitivity when ISL sends it as null (the shape a wire absence takes)', () => {
+    // JSON has no `undefined`; an absent numeric field arrives as `null` or as
+    // a missing key. Both must behave identically here.
+    const asNull = enrichFactorSensitivity(
+      { node_id: 'fac_price', sensitivity_score: null as any, sensitivity: null as any },
+      TEST_GRAPH,
+    );
+    expect(asNull).not.toHaveProperty('sensitivity');
+  });
+
+  it('OMITS sensitivity when ISL sends a non-finite value (NaN / ±Infinity)', () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const r = enrichFactorSensitivity(
+        { node_id: 'fac_price', sensitivity_score: bad },
+        TEST_GRAPH,
+      );
+      expect(r, `sensitivity_score=${bad} must not reach egress`).not.toHaveProperty('sensitivity');
+    }
+  });
+
+  it('POSITIVE CONTROL: a genuine measured ZERO is preserved, not suppressed', () => {
+    // Over-suppression is an equal failure. `0` is a real measurement meaning
+    // "this factor genuinely does not move the outcome" and must survive.
+    const result = enrichFactorSensitivity(
+      { node_id: 'fac_price', sensitivity_score: 0 },
+      TEST_GRAPH,
+    );
+    expect(result).toHaveProperty('sensitivity');
     expect(result.sensitivity).toBe(0);
   });
 


### PR DESCRIPTION
PR #277 fixed three instances of **"PLoT fabricates a value or a verdict when upstream data is absent"** and — more usefully — named **why the species kept surviving**. This slice goes after that cause. The headline deliverable is the instrument, not the instance count.

---

## Primary — the instrument

#277's diagnosis, quoted:

> `tests/gates/numeric-safety-deep-scan.test.ts` feeds `NaN`/`±Infinity` but never `null` — the estate's numeric-safety gate is blind to the exact shape ISL actually sends.

That blindness is what made the class structurally invisible: **every `?? 0`, `|| default` and `!== undefined` guard that fabricates on a null upstream field passed its own safety test.** The instrument agreed with the code about which shapes exist, so it could only ever confirm what the code already assumed.

The gate now feeds **three distinct absence shapes** — `null`, missing key, `undefined` — through the fields it already exercised with NaN/Infinity, plus the constraint margins and the validation status where the known instances lived.

**Reachability is stated per shape, not assumed** (file header):

| Shape | Reachability | Where exercised |
|---|---|---|
| `null` | **Wire-reachable and MEASURED** on the deployed service (#276's wire capture; recorded in `isl-types.ts`). The shape that actually fabricated. | every block |
| missing key | Wire-reachable (`exclude_none=True`). Reads identically to `undefined` in JS — which is exactly why the two were conflated. | every block |
| `undefined` | **NOT wire-reachable** — JSON has no `undefined`. Reachable only for in-process callers. | unit seam (§D) only, and explicitly not claimed as a wire case |

The header also states **what the gate does not reach** — the HTTP socket (§C drives the real `createFallbackValidation`, not a stubbed wire; the wire→fallback leg stays covered by `isl-validation-unavailable-no-fabricated-verdict.test.ts`), `/v1/run`'s dev-only sibling surfaces, and the three dead producers queued for deletion.

### Retro-proof — the headline evidence

The extended gate was copied onto the **pre-#277 tree (`c79c63c1`)** in a worktree **outside the repo root** (trap 9c) and run there. A gate that would not have caught the known defects cannot be trusted to catch the next one.

**24 failed | 35 passed | 1 skipped (60)** at `c79c63c1`. What turned red:

| Block | #277 defect | Result at `c79c63c1` |
|---|---|---|
| §C1/C3 | Instance A — fabricated identifiability **verdict** | **RED ×4.** `adaptValidationResponse` returned `'uncertain'` for `status` null / missing / undefined; `createFallbackValidation` returned `'uncertain'`; `/v1/run` emitted the literal `ISL_UNCERTAIN` critique, `source:'isl'`, *"ISL validation reports partial identifiability"* |
| §C2 | Instance A sibling — enrichment | **RED.** Failure prints `{"identifiable":false,…}` |
| §B | Instance B — fabricated measured-zero margin | **RED ×3, on the NULL arm only.** The MISSING and UNDEFINED arms were **green** — the exact asymmetry that let the old `undefined`-shaped control pass for months |
| §D | this lane's own siblings | **RED ×12** — D1 ×3, D2 ×6, D3 ×3 (RED-first per sibling; these are not #277 defects) |
| §A NULL | **not a #277 defect** — the fourth instance, below | **RED ×2**, and equally red on pristine `8f7938f5`, i.e. pre-existing and live |
| **positive controls** | — | **ALL GREEN at `c79c63c1`** — the gate discriminates, it does not simply fail everything |

The §B result is the single most useful line in this PR: **the same test, same code, same assertion — green on two absence shapes and red on the third.** That is the shape-blindness, measured.

### The gate immediately found a FOURTH live instance

`src/lib/intervention-normaliser.ts` · `denormaliseOptionResult`, on the **live `/v2/run` → CEE path**:

```ts
mean: denormaliseValue(opt.outcome.mean, range)             // null * rangeWidth + min === min
std:  opt.outcome.std !== undefined ? opt.outcome.std * rangeWidth : undefined   // null !== undefined → true → 0
```

- An outcome ISL never computed shipped as a **precise measured outcome sitting exactly at the bottom of the goal range** — "this option achieves the worst possible result".
- `std !== undefined` is the **identical guard #277 removed from `buildConstraintFields`**, still live here. A null std became a measured `0`: perfect certainty.
- Every fabricated stat is finite and in range, so all existing finiteness/range checks passed them, `hasAllRequiredOutcomeStats` returned `true`, and **`option_comparison_status` reported a confident `'computed'`**.

It hid for the same reason as Instance B: `undefined` and a missing key both produce `NaN` here (rejected downstream), so **only `null` — the shape the wire actually carries — coerces to a plausible number.**

Fixed the same way #277 fixed Instance B: the wire type declares `| null` so the compiler forbids computing before validating, and `finiteNum` runs **before** the arithmetic.

### Absence pins re-pointed

`tests/constraint-margin-plumbing.test.ts`'s *"missing margin is DISTINGUISHABLE from a zero margin"* pin expressed absence only by omitting the key. It now runs **twice — `null` (default, the live shape) and missing key**. There is deliberately **no `undefined` arm**: JSON cannot carry one, so no ISL response can produce it; that shape is covered at the adapter seam instead.

---

## Secondary — the three siblings #277 reported and did not fix

All three verified at the bytes. All use `??`, which handles `null` correctly — so these are the broader class, not the `!== undefined` bug.

### 1 · `robustness-enrichment.ts:181` — `?? 0` → zero factor sensitivity — **FIXED**

**#277's reachability line is corrected.** It read *"Live … the deployed CEE path, into the untyped `z.record` enrichment."* The **call** is live (`buildRobustnessDataForCee` ← `routes/v2/run.ts:6488`, unconditional). The **value has zero readers.**

Complete reader manifest for `RobustnessDataForCee`, scope `src/ lib/ tools/ scripts/ contracts/`, claim type *no read of `factor_sensitivity` exists*:

| Reference | Kind |
|---|---|
| `plot-types.ts:341` | declaration |
| `robustness-enrichment.ts:13,198,217,227` | producer + comments |
| `routes/v2/run.ts:97,103,6488` | import + producer call |
| `routes/v2/run.ts:3777, 3946, 4026` | passed to `buildCeeReviewRequest` |
| **`routes/v2/run.ts:3806`** | **the only field read: `robustnessData?.fragile_edges`** |

`buildCeeReviewRequest` builds `sensitive_parameters` from the **raw** `islResult.factor_sensitivity` with `f.sensitivity_score ?? f.sensitivity` — already honest, no `?? 0`. So the fabricated `sensitivity: 0` never reached a wire. Fixed anyway: **a value with no reader today is the value the next lane wires up believing it is measured.** Pinned at the unit seam because there is no egress to pin — stated, not implied.

`EnrichedFactorSensitivity.sensitivity` is now optional. The required-ness *was* the stated justification for the `?? 0` ("the output type requires a numeric sensitivity value for CEE consumption"), so the field moved rather than the honesty.

### 2 · `robustness-analysis.ts:407` — `?? 0.5` robustness score — **FIXED, plus its label twin**

Fixing the score alone would have left the class open on the same expression. `label: rawRobustness.label ?? mapLevelToLabel(rawRobustness.level)` — and `mapLevelToLabel`'s `default:` arm returns `'moderate'` for `undefined`. So an ISL response carrying **neither `label` nor `level`** published a **moderate-robustness verdict about the user's graph**, invented by PLoT. That is Instance A's species in the robustness channel, and it is the worse of the two: a label reads as a conclusion where a score reads as a statistic.

`createFallbackRobustnessAnalysis` — the **ISL-unavailable** path — did the same (`'moderate'` / `0.5`), indistinguishable from a genuine ISL `'moderate'`. Also fixed.

Both fields are now optional on `PLoTRobustnessAnalysisResult` (and on `PLoTSensitivityResult`, `PLoTFactorSensitivityResult`, `SensitivityAnalysisEnrichment` — the ripple the compiler forced). `/v1/run`'s only consumers were already absence-safe: `hasRobustness = isl_sensitivity?.overall_robustness !== undefined` and `=== 'fragile'`.

Reachability confirmed as #277 stated: `analyseRobustness` ← `routes/v1/run.ts:999` only.

### 3 · `robustness-analysis.ts:233` — `?? 1` switch_probability — **HALF FIXED, HALF BLOCKED. This is the consumer finding.**

**Two corrections to #277's entry, both at the bytes:**

- **It is not `/v1/run` only.** `normalizeRobustEdges` is also called from `routes/v2/run.ts:2675`, on the live V2 path.
- **The object arm is not the live one.** ISL sends `robust_edges` as bare strings, so the arm that actually fires is `normalizeRobustEdge` (`:88`), which **hardcoded `switch_probability: 1`** with the comment *"Robust edges have 100% stability"*.

That hardcoded 1 is worse than a fabricated number: it is fabricated **under the wrong name on an inverted scale**. `switch_probability` is P(flipping this edge switches the recommended option) — `normalizeFragileEdge` feeds exactly this field to `classifyEdgeSeverity` and the doctrine-013 `visible` gate, where **higher = more fragile**. "100% stability" would be ≈ 0. So an edge ISL called *robust* was published carrying the maximum of the fragility scale.

**Object arm (`?? 1`): FIXED** — omitted unless `isFiniteNumber`.

**String arm: reverted, and the reason is the finding.**

I made it omit, ran the authoritative gate, and measured the consequence:

```
@talchain/schemas (vendored 0.22.0) dist/boundary/enrichment.js:269
  EnrichmentRobustnessEdgeSchema = z.object({ …
    switch_probability: z.number(),        // REQUIRED
```

That schema covers `robust_edges` as well as `fragile_edges`; CEE persists this body verbatim and shadow-validates it against the same schema; and PLoT's own producer-side guard stamps `_meta.evidence.enrichment_contract_ok: false` **plus a user-visible `ENRICHMENT_CONTRACT_MISMATCH` warning on every response** — measured, 4 issue paths on the golden fixture, with the warning text landing on the wire.

Trading a wrong number for a **standing false alarm on a fail-open guard** is the broken-alarm trap, and relaxing a shared cross-repo contract is not a decision a PLoT-write lane can take unilaterally. So per the ruling — *report it rather than fabricating to keep the shape* — the fabrication stays, **loudly**:

- `normalizeRobustEdge` carries the full blocker, the exact schema line, and `// FABRICATED … Do not read as a measurement.` on the value itself.
- The honest assertion is **present and `it.skip`ped** in gate §D3 with the un-skip recipe, so it cannot be forgotten.
- A companion test **pins the fabrication as a known defect**, so removing it is a deliberate act rather than an accident.

**This also exposes a live contract skew (hazard 1) that pre-dates this PR:** PLoT already publishes `NormalizedEdgeInfoV3.switch_probability?: number`, documented *"OPTIONAL: omitted when the source edge carries no switch_probability"*, and `normalizeFragileEdge` already omits it on that basis. The two contracts **disagree today**, latently, for fragile edges — a fragile edge with no measured switch_probability will trip the same guard. The one-line fix belongs in olumi-schemas: `switch_probability: z.number().optional()`.

**Handover:** relax it in olumi-schemas → release → re-pin the vendored tarball here → delete the fabrication → un-skip §D3.

---

## Evidence

**RED-first at the seam, per sibling.** The pre-#277 retro run is simultaneously the per-sibling RED-first: §D1 ×3, §D2 ×5, §D3 ×4 all red against the unfixed code. Four **existing tests pinned the fabrications** and were corrected at source, not absorbed into a baseline:

| Test | Pinned |
|---|---|
| `robustness-enrichment.test.ts` "defaults to 0 when neither…" | `sensitivity === 0` |
| `isl-adapters.test.ts` "normalizes string format edges" | `switch_probability === 1` |
| `isl-adapters.test.ts` "defaults switch_probability to 1…" | `?? 1` |
| `isl-adapters.test.ts` "creates empty result with failed status" | `'moderate'` / `0.5` on the ISL-unavailable path |
| `robustness-analysis.test.ts` "handles missing robustness data gracefully" | `'moderate'` / `0.5` from an empty ISL response |
| `robustness-analysis.test.ts` "returns empty normalized edge arrays" | `'moderate'` |

*"Handles missing data gracefully"* turned out to mean *"invents an answer"*. Assertions were **inverted, not deleted** — deleting would leave the behaviour unpinned in the other direction.

**Positive controls, everywhere.** Over-suppression is an equal failure, so each fix is paired with a control proving a genuine value still flows: a measured `0.03333` margin still denormalises to ≈ £2,000; a real `partially_identifiable` still produces the real `source:'isl'` critique **and** populates the enrichment; genuine `0.42` / `0` sensitivity, `0.82` / `0` robustness score, `0.3` / `0` switch_probability all survive verbatim; every status ISL genuinely declares still maps to its real verdict. **A genuine measured `0` is a measurement and must never be suppressed** — pinned separately in each block.

The §B positive control carries an explicit failure message: *"the positive control must actually reach `constraint_margins` — otherwise every §B absence assertion above is vacuous"* (trap 13).

**Mutation-checked**, in a worktree **outside the repo root**, removed before the gate run:

| Mutant | Result |
|---|---|
| M1 · revert the outcome-denormalisation fix | **2 red** (§A NULL: fabricated stats + `'computed'` status) |
| M2 · restore `?? 0` factor sensitivity | **6 red** |
| M3 · restore `?? 0.5` score + `'moderate'` label default | **5 red** |
| M4 · restore `?? 1` / hardcoded 1 switch_probability | **6 red** |
| M5 · restore the fallback's `'moderate'` / `0.5` | **2 red** |

The mutation harness asserts its anchor exists and verifies the write landed (trap 15). It **caught its own defect**: M5's write-verifier used "the old text is gone", which is wrong for an additive mutant whose replacement *contains* the original — it reported `WRITE DID NOT LAND` rather than silently passing. Corrected to "the marker landed and the file changed", then M5 re-run.

## Gate

Repo's authoritative gate (`npm test` → `tools/run-all-tests.js`). Pristine baseline derived in the same clone at `8f7938f5` **before any edit**.

| | Test files | Tests |
|---|---|---|
| Pristine baseline `8f7938f5` | 572 passed, 4 skipped (576) | 6094 passed, 29 skipped (6134) |
| This branch | 572 passed, 4 skipped (576) | 6144 passed, 30 skipped (6185) |

Delta **+50 tests, +1 skipped, +0 files** — no test file was added or removed (the diff modifies four existing suites and the gate), which is why the file counts are identical. **Zero pre-existing tests broken**: the six that failed mid-lane all *pinned the fabrications* and were corrected at source, listed above. The `+1 skipped` is the single blocked §D3 assertion. `npm test` exit 0. `npx tsc --noEmit` clean.

*Baseline provenance: test counts read from the pristine run's own `reports/tests.json` in this clone at `8f7938f5` before any edit (`success: true`, 0 failed); they match the numbers #277 recorded for the same commit.*

## Stated limits

- **No change to the ISL request/response shape.** The `0316098b` drift pin is untouched and stays honest.
- **`staging` is unprotected** (`gh api …/branches/staging/protection` → HTTP 404 "Branch not protected"), so this PR's review plus the gate run above **is** the gate.
- **The gate does not drive the HTTP socket.** §C's stimulus is the real `createFallbackValidation`; the wire→fallback leg (404 / timeout / 5xx / breaker) stays covered by `isl-validation-unavailable-no-fabricated-verdict.test.ts`. Stated in the file header rather than implied by coverage.
- **§A does not turn red pre-#277** on the missing/undefined arms — those fields were already guarded absence-safely. §A is not retro-evidence; it closes shape-blindness going forward. Only §B and §C carry the retro-proof, and only the NULL arm of §B.
- **The `undefined` shape is not claimed as wire-reachable** anywhere. It is exercised only at the unit seam.
- **Not fixed, same species, deliberately out of scope:** `createFallbackSensitivity` (`'moderate'`) and `createFallbackFactorSensitivity` (`'moderate'` / `0.5`) sit on `analyseSensitivity` / `analyseFactorSensitivity` — the dead producers #277 proved have **zero call sites** and which A1 has rowed for deletion. Pinning them here would pin code that is scheduled to disappear. `facts/mapper.ts:197` (`robustness.score ?? 0.5`) and `createLocalHeuristicResult`'s derived `switch_probability` are also unfixed: the former is a separate fact-assembly surface, the latter is a **disclosed local heuristic** (`plot:computeSensitivityAll` / `fallback_local_heuristic`), which is a different claim from an undisclosed substitute. Both named here rather than left for a later grep.
- **The three dead-producer deletions are not in this PR** (A1's slice) — the `TRANSCRIPT.egress` contract test makes deletion expensive and that instrument is what proves those producers are broken.
