### PR TITLE
fix(tests): migrate undeclared-keys gate onto the published egress harness (it was blind to its own third producer)

### DIFF
--- a/src/integrations/isl/adapters/robustness-analysis.ts
+++ b/src/integrations/isl/adapters/robustness-analysis.ts
@@ -69,8 +69,17 @@ function normalizeFragileEdge(edge: ISLFragileEdgeInfo): NormalizedEdgeInfo {
     ...(isFiniteNumber(edge.switch_probability)
       ? { switch_probability: edge.switch_probability }
       : {}),
-    // Passthrough marginal_switch_probability from ISL (optional field)
-    ...(edge.marginal_switch_probability !== undefined
+    // marginal_switch_probability: same rule as switch_probability above.
+    // `!== undefined` admits a null straight through to egress, where
+    // @talchain/schemas 0.22.0 types this `z.number().optional()` and a null
+    // FAILS validation. Not reachable on the pinned V2 path — ISL's V2 handler
+    // serialises with `model_dump(by_alias=True, exclude_none=True)`, which is
+    // recursive, so a null is OMITTED rather than sent, and PLoT pins that path
+    // on every call (client.ts:98 `?response_version=2`, :180
+    // `X-ISL-Response-Version: 2`). It arms the day that pin changes, which is
+    // exactly the asymmetry #278 documented: a guard that costs nothing now and
+    // closes a class later.
+    ...(isFiniteNumber(edge.marginal_switch_probability)
       ? { marginal_switch_probability: edge.marginal_switch_probability }
       : {}),
     // Preserve alternative_winner_id from ISL for label resolution downstream

--- a/src/integrations/isl/types/isl-types.ts
+++ b/src/integrations/isl/types/isl-types.ts
@@ -554,14 +554,25 @@ export interface ISLConstraintResult {
    * Contract step-2 slice 6b: ISL echoes back, verbatim, the constraint_id PLoT
    * sent on the matching `goal_constraints[]` entry (ISL @0316098b onwards).
    *
-   * Optional AND nullable, both deliberate and both MEASURED against the
-   * deployed service rather than assumed:
-   *  - `undefined` — a pre-6b ISL that dropped the field at parse.
-   *  - `null` — the deployed ISL when the caller supplied no id. The route
-   *    serialises with `exclude_none=True`, but that does not reach inside this
-   *    object: `failure_margin_median` and `near_miss_fraction` come back null
-   *    on the same wire too. Do NOT narrow this to `string | undefined`, and do
-   *    not write a reader that tests for key-absence.
+   * Optional AND nullable, both deliberate — but ⚠ the SCOPE of the measurement
+   * behind the `null` arm was wrong and is corrected here:
+   *  - `undefined` — a pre-6b ISL that dropped the field at parse, AND the
+   *    PINNED V2 PATH PLoT ACTUALLY USES. `client.ts:98` appends
+   *    `?response_version=2` and `:180` sends `X-ISL-Response-Version: 2` on
+   *    every call; ISL's V2 handler serialises fully-typed models with
+   *    `model_dump(by_alias=True, exclude_none=True)`, and pydantic-v2's
+   *    `exclude_none` IS recursive across nested models. So on PLoT's path the
+   *    field is OMITTED when unsupplied.
+   *  - `null` — the LEGACY v1 format, i.e. a request without the version pin.
+   *    The capture that produced the earlier note here ("the deployed ISL sends
+   *    null"; "exclude_none does not reach inside this object") was a hand-curl
+   *    WITHOUT the pin, so it measured v1 and was generalised to a path PLoT
+   *    never takes. A capture proves what it was pointed at.
+   *
+   * KEEP BOTH ARMS ANYWAY. Do NOT narrow to `string | undefined`, and do not
+   * write a reader that tests for key-absence: the union costs nothing, it is
+   * correct for a pre-6b ISL and for any un-pinned or re-versioned path, and it
+   * is what forces the validate-before-compute discipline below.
    *
    * Read it via resolveConstraintIds (routes/v2/constraint-identity.ts), never
    * directly — the positional fallback beneath it is still load-bearing during
@@ -576,14 +587,22 @@ export interface ISLConstraintResult {
   /**
    * Median failure margin, NORMALISED, as ISL sends it.
    *
-   * `| null` is MEASURED, not defensive — the deployed service sends the key
-   * with a null value for an absent margin (same wire as `constraint_id` above;
-   * `exclude_none=True` does not reach inside this object). Declaring it
-   * `number | undefined` was a compile-time fiction that cost us a real defect:
-   * both denormalisation sites guarded with `!== undefined`, so `null` passed,
-   * `null * rangeWidth` evaluated to 0, and a FABRICATED MEASURED ZERO breach
-   * margin shipped to egress — while the comment above that code claimed the
-   * zero-fabrication had already been killed.
+   * `| null` is DEFENCE-IN-DEPTH, not a measurement of PLoT's path — ⚠ scope
+   * corrected, same error as `constraint_id` above. The null was captured on
+   * the LEGACY v1 format (a hand-curl without the version pin); on the pinned
+   * V2 path PLoT actually uses, `exclude_none=True` is recursive and this key
+   * is OMITTED, not null.
+   *
+   * The defect it documents was real as a TYPE defect, and the fix stands:
+   * declaring it `number | undefined` was a compile-time fiction, both
+   * denormalisation sites guarded with `!== undefined`, so a `null` would pass,
+   * `null * rangeWidth` would evaluate to 0, and a FABRICATED MEASURED ZERO
+   * breach margin would ship to egress — while the comment above that code
+   * claimed the zero-fabrication had already been killed. What is NOT
+   * established is that arm's live REACHABILITY at the current ISL pin: the
+   * retro-proof went red on the null arm only, so #277's Instance-B
+   * live-reachability premise inherits the same mis-scoping and should not be
+   * cited as evidence of a shipping defect at this pin.
    *
    * Keep the `| null`. It is what makes `fmm * rangeWidth` a type error, so the
    * only way to compute with this value is to validate it first (nonNeg()).

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -13,7 +13,7 @@
  * @see Schema v2.6 §B.8 - Range derivation priority chain
  */
 
-import type { EngineNodeV3, OptionV3, InterventionValueV3, OutcomeStatsV3, RepairRecord } from '../types/engine-v3.js';
+import type { EngineNodeV3, OptionV3, InterventionValueV3, RepairRecord } from '../types/engine-v3.js';
 import { finiteNum } from '../util/numeric.js';
 
 // -----------------------------------------------------------------------------
@@ -666,74 +666,6 @@ export function normaliseOptions(
   }));
 
   return { options: normalisedOptions, diagnostics, transforms, repairs };
-}
-
-// -----------------------------------------------------------------------------
-// Outcome Denormalisation
-// -----------------------------------------------------------------------------
-
-/**
- * Denormalise outcome statistics from ISL response.
- *
- * ISL returns outcomes in normalised [0,1] space. This function
- * transforms them back to the goal node's original units.
- *
- * @param outcome Normalised outcome stats from ISL
- * @param goalContext Goal node normalisation context
- * @returns Denormalised outcome stats
- */
-/** @internal Not used in runtime — denormaliseISLResult handles this via denormaliseOptionResult. */
-function denormaliseOutcome(
-  outcome: OutcomeStatsV3,
-  goalContext: FactorNormalisationContext
-): OutcomeStatsV3 {
-  const range = goalContext.range;
-
-  return {
-    mean: denormaliseValue(outcome.mean, range),
-    std: outcome.std !== undefined
-      ? outcome.std * (range.max - range.min) // Scale std by range width
-      : undefined,
-    p10: denormaliseValue(outcome.p10, range),
-    p50: denormaliseValue(outcome.p50, range),
-    p90: denormaliseValue(outcome.p90, range),
-    n_samples: outcome.n_samples,
-    n_valid_samples: outcome.n_valid_samples,
-    validity_ratio: outcome.validity_ratio,
-  };
-}
-
-/**
- * Denormalise a single expected outcome value.
- *
- * @param expectedOutcome Normalised expected outcome
- * @param goalContext Goal node normalisation context
- * @returns Denormalised expected outcome
- */
-/** @internal Not used in runtime — denormaliseISLResult handles this via denormaliseOptionResult. */
-function denormaliseExpectedOutcome(
-  expectedOutcome: number,
-  goalContext: FactorNormalisationContext
-): number {
-  return denormaliseValue(expectedOutcome, goalContext.range);
-}
-
-/**
- * Denormalise a confidence interval.
- *
- * @param interval Normalised confidence interval [p10, p90]
- * @param goalContext Goal node normalisation context
- * @returns Denormalised confidence interval
- */
-/** @internal Not used in runtime — denormaliseISLResult handles this via denormaliseOptionResult. */
-function denormaliseConfidenceInterval(
-  interval: [number, number],
-  goalContext: FactorNormalisationContext
-): [number, number] {
-  return [
-    denormaliseValue(interval[0], goalContext.range),
-    denormaliseValue(interval[1], goalContext.range),
-  ];
 }
 
 // -----------------------------------------------------------------------------

--- a/src/routes/v1/explain-policy.ts
+++ b/src/routes/v1/explain-policy.ts
@@ -11,6 +11,8 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { replyWithAppError } from '../../errors.js';
 import { isFlagOn } from '../../cee/codes.js';
 import { validateSequentialGraph, isSequentialGraph } from '../../util/sequential-validation.js';
+import { validatePolicyTreeShape } from '../../util/policy-tree-validation.js';
+import { isFiniteNumber } from '../../util/numeric.js';
 import type {
   ExplainPolicyRequest,
   ExplainPolicyResponse,
@@ -107,99 +109,6 @@ async function callCeeExplainPolicy(
 }
 
 /**
- * Validate the untrusted `policy_tree` down to the fields this handler reads.
- *
- * ## Why this exists
- *
- * The route casts `req.body as ExplainPolicyRequest` and previously validated
- * only that `policy_tree`, `policy_tree.nodes` and `policy_tree.root_id` were
- * *truthy*. Everything below that was read as if the TypeScript types were
- * enforced at the wire, and they are not: a node without `children` reached
- * `n.children.length` and the resulting TypeError surfaced to callers as an
- * opaque 500 "Something went wrong". Reproduced live on staging build
- * `220739b` with `{"policy_tree":{"root_id":"r","depth":2,"nodes":[{"id":"r"}]}}`.
- *
- * This is the same defect class PR #265 fixed for `sequential_metadata`.
- * That fix made `validateSequentialGraph` total; `policy_tree` was left
- * unhardened, and this route also re-reads `sequential_metadata.stages`
- * directly (see `readStageLabels`), on a path the validator does not cover.
- *
- * ## The rule for anyone editing this file
- *
- * Every field of `policy_tree` or `graph` that the handler reads must either
- * be validated here (typed 400) or be read totally (no throw, no fabricated
- * output) at the point of use. Malformed input must produce an honest
- * envelope, never a 500.
- *
- * Load-bearing fields are validated because the analysis is genuinely
- * uncomputable without them:
- * - `nodes[].stage`          — the grouping key, and a required response field
- * - `nodes[].expected_value` — arithmetic input; also `.toFixed()` in the output
- * - `nodes[].children`       — the sole terminal-node discriminator
- * Cosmetic fields (`type`, `label`, `action`, `policy_summary`) are read
- * totally instead, so a request that succeeds today keeps succeeding.
- */
-function validatePolicyTreeShape(
-  policyTree: IslPolicyTreeResponse
-): { code: string; field: string; message: string } | null {
-  if (!Array.isArray(policyTree.nodes)) {
-    return {
-      code: 'INVALID_POLICY_TREE',
-      field: 'policy_tree.nodes',
-      message: `policy_tree.nodes must be an array of policy tree nodes, received ${policyTree.nodes === null ? 'null' : typeof policyTree.nodes}.`,
-    };
-  }
-
-  for (let i = 0; i < policyTree.nodes.length; i++) {
-    const node = policyTree.nodes[i] as unknown;
-
-    if (node === null || typeof node !== 'object' || Array.isArray(node)) {
-      return {
-        code: 'INVALID_POLICY_TREE_NODE',
-        field: `policy_tree.nodes[${i}]`,
-        message: `policy_tree.nodes[${i}] is not a policy tree node — expected an object, received ${node === null ? 'null' : Array.isArray(node) ? 'array' : typeof node}.`,
-      };
-    }
-
-    const n = node as Record<string, unknown>;
-
-    if (typeof n.id !== 'string' || n.id.length === 0) {
-      return {
-        code: 'INVALID_POLICY_TREE_NODE',
-        field: `policy_tree.nodes[${i}].id`,
-        message: `policy_tree.nodes[${i}] is missing a non-empty string "id".`,
-      };
-    }
-
-    if (typeof n.stage !== 'number' || !Number.isFinite(n.stage)) {
-      return {
-        code: 'INVALID_POLICY_TREE_NODE',
-        field: `policy_tree.nodes[${i}].stage`,
-        message: `policy_tree.nodes[${i}] ("${n.id}") has "stage" of type ${n.stage === null ? 'null' : typeof n.stage}, expected a finite number. Stage explanations are grouped by this value.`,
-      };
-    }
-
-    if (typeof n.expected_value !== 'number' || !Number.isFinite(n.expected_value)) {
-      return {
-        code: 'INVALID_POLICY_TREE_NODE',
-        field: `policy_tree.nodes[${i}].expected_value`,
-        message: `policy_tree.nodes[${i}] ("${n.id}") has "expected_value" of type ${n.expected_value === null ? 'null' : typeof n.expected_value}, expected a finite number. Risk and rationale figures are computed from it.`,
-      };
-    }
-
-    if (!Array.isArray(n.children)) {
-      return {
-        code: 'INVALID_POLICY_TREE_NODE',
-        field: `policy_tree.nodes[${i}].children`,
-        message: `policy_tree.nodes[${i}] ("${n.id}") has "children" of type ${n.children === null ? 'null' : typeof n.children}, expected an array of child node IDs. Terminal nodes are identified by an empty "children" array.`,
-      };
-    }
-  }
-
-  return null;
-}
-
-/**
  * Read stage labels from `graph.sequential_metadata.stages` without trusting
  * its shape.
  *
@@ -220,7 +129,7 @@ function readStageLabels(graph: ExplainPolicyRequest['graph']): Map<number, stri
   for (const stage of rawStages) {
     if (stage === null || typeof stage !== 'object') continue;
     const { index, label } = stage as { index?: unknown; label?: unknown };
-    if (typeof index !== 'number' || !Number.isFinite(index)) continue;
+    if (!isFiniteNumber(index)) continue;
     if (typeof label !== 'string' || label.length === 0) continue;
     stageLabels.set(index, label);
   }
@@ -347,7 +256,13 @@ export async function registerExplainPolicyRoute(app: FastifyInstance) {
     '/v1/explain/policy',
     async (req: FastifyRequest, reply: FastifyReply) => {
       const start = Date.now();
-      const body = req.body as ExplainPolicyRequest;
+      // `?? {}` because a POST whose body is the valid JSON literal `null`
+      // gives `req.body === null`, and `body.policy_tree` then threw a
+      // TypeError that surfaced as the same opaque 500 this route's
+      // validators exist to eliminate. Every other primitive body is safe:
+      // reading a missing property off a string/number/boolean yields
+      // undefined, which the presence checks below refuse honestly.
+      const body = (req.body ?? {}) as ExplainPolicyRequest;
       const requestId = String(req.id);
 
       // Validate policy_tree

--- a/src/routes/v2/constraint-identity.ts
+++ b/src/routes/v2/constraint-identity.ts
@@ -20,16 +20,38 @@
  * the slice: it is the only identity that survives reordering and the only one
  * that can tell two constraints on the SAME node with the SAME operator apart.
  *
- * ⚠ MEASURED, NOT ASSUMED — and the spec this slice was handed was WRONG here.
- * The brief stated the field is "omitted, not null, when unsupplied
- * (exclude_none=True)". Against the deployed service it is PRESENT AND NULL:
+ * ⚠ SCOPE CORRECTED — the earlier note here was MEASURED ON THE WRONG PATH.
+ *
+ * This block previously said the original spec ("omitted, not null, when
+ * unsupplied (exclude_none=True)") was WRONG, on the strength of a capture
+ * showing
  *   {"constraint_id": null, "node_id": "con_cost_cap", ..., "binding": false}
- * `exclude_none=True` IS applied at the route (src/api/robustness.py:1389) but
- * demonstrably does not reach inside this object — `failure_margin_median` and
- * `near_miss_fraction` come back null on the same wire, and always have. So the
- * null is the long-standing behaviour of this path, not a 6b regression.
- * Consequence for readers: test BOTH shapes and never assert key-absence. The
- * `typeof === 'string'` gate below is what makes the tier robust to either.
+ * and concluded that `exclude_none=True` "demonstrably does not reach inside
+ * this object". **That conclusion does not hold, because that capture was taken
+ * without the response-version pin — it is the LEGACY v1 format.**
+ *
+ * PLoT pins V2 on EVERY call: `client.ts:98` appends `?response_version=2` and
+ * `:180` sends `X-ISL-Response-Version: 2`, and all five ISL service methods go
+ * through `ISLClient.request` (integrations/isl/index.ts:246,286,323,407,549).
+ * ISL's V2 handler serialises fully-typed models with
+ * `model_dump(by_alias=True, exclude_none=True)` and no plain-dict escape at any
+ * hop; pydantic-v2's `exclude_none` is RECURSIVE (verified empirically on
+ * 2.12.5: a nested `None` inside `List[Model]` is dropped). **So on the path
+ * PLoT actually uses, these fields are OMITTED, never null — the original spec
+ * was right for the pinned path, and the "correction" of it was wrong in
+ * scope.** The same error propagated to `failure_margin_median` and
+ * `near_miss_fraction`, and downstream to #277's live-reachability premise: the
+ * fabricated-zero-margin defect's reachability AT THIS ISL PIN is NOT
+ * established.
+ *
+ * A capture proves what it was pointed at. This one was pointed at v1.
+ *
+ * NOTHING BELOW CHANGES. Reading both shapes stays, as defence-in-depth: it
+ * costs nothing, it is what keeps the resolver correct against a pre-6b ISL and
+ * against any future un-pinned or re-versioned path, and the fixture test
+ * exercises both arms. The `typeof === 'string'` gate is what makes the tier
+ * robust to either. What changed is the CLAIM — so the next lane does not build
+ * a reachability argument on a measurement of a path PLoT never takes.
  *
  * ── Tier 2/3: the pre-6b reconstruction, DELIBERATELY KEPT ───────────────────
  * Positional, then a (node_id, operator) scan. Retained for the overlap window:

--- a/src/util/policy-tree-validation.ts
+++ b/src/util/policy-tree-validation.ts
@@ -1,0 +1,148 @@
+/**
+ * Total validation of an untrusted `policy_tree`, down to the fields a reader
+ * actually consumes.
+ *
+ * ## Why this exists
+ *
+ * `/v1/explain/policy` casts `req.body as ExplainPolicyRequest` and previously
+ * validated only that `policy_tree`, `policy_tree.nodes` and
+ * `policy_tree.root_id` were *truthy*. Everything below that was read as if the
+ * TypeScript types were enforced at the wire, and they are not: a node without
+ * `children` reached `n.children.length` and the resulting TypeError surfaced to
+ * callers as an opaque 500 "Something went wrong". Reproduced live on staging
+ * build `220739b` with
+ * `{"policy_tree":{"root_id":"r","depth":2,"nodes":[{"id":"r"}]}}`.
+ *
+ * This is the same defect class PR #265 fixed for `sequential_metadata`. That
+ * fix made `validateSequentialGraph` total and gave it a home in
+ * `src/util/sequential-validation.ts`; this is its sibling, and it lives beside
+ * it for the same reason — `/v1/analysis/policy-tree` is registered and live, so
+ * a second consumer of a policy tree is foreseeable, and it must not have to
+ * re-validate by hand or re-derive the `{code, field, message}` envelope.
+ *
+ * ## Layering
+ *
+ * The parameter is typed STRUCTURALLY (`{ nodes?: unknown }`), not as the route's
+ * `IslPolicyTreeResponse`. Two reasons, and the first is the point of the whole
+ * module: the declared type is exactly what is NOT enforced at the wire, so
+ * accepting it here would re-assert the guarantee this function exists to
+ * doubt. Second, `src/util` is a leaf — importing a `src/routes/v1` type would
+ * invert the layering, the inversion `src/util/numeric.ts` documents avoiding.
+ *
+ * ## The rule for anyone editing a consumer
+ *
+ * Every field of `policy_tree` that a handler reads must either be validated
+ * here (typed 400) or be read totally (no throw, no fabricated output) at the
+ * point of use. Malformed input must produce an honest envelope, never a 500.
+ *
+ * Load-bearing fields are validated because the analysis is genuinely
+ * uncomputable without them:
+ * - `nodes[].stage`          — the grouping key, and a required response field
+ * - `nodes[].expected_value` — arithmetic input; also `.toFixed()` in the output
+ * - `nodes[].children`       — the sole terminal-node discriminator
+ * Cosmetic fields (`type`, `label`, `action`, `policy_summary`) are read totally
+ * instead, so a request that succeeds today keeps succeeding.
+ *
+ * ## ⚠ Ordering, for callers
+ *
+ * At `/v1/explain/policy` this runs as the LAST validator, deliberately: a body
+ * malformed in both its graph and its policy_tree keeps reporting the graph code
+ * it reported before the check existed (e.g. `INVALID_STAGE_DEFINITION`, pinned
+ * by #265's live evidence and by the PRESERVATION CONTROL in
+ * `tests/explain-policy-malformed-tree.regression.test.ts`). Ordered last, it
+ * never renames a 400 that callers already receive. A new consumer that runs it
+ * FIRST does not inherit that property and must establish its own.
+ *
+ * ## ⚠ CORRECTED SCOPE — it is NOT only 500→400
+ *
+ * #273 stated the invariant as *"this change only ever converts a 500 into a
+ * 400"*. That is **not exactly true**, and the imprecision is recorded here
+ * rather than quietly kept: the disclosure named three flips, but its own
+ * "load-bearing" definition excluded `id`, and there is a fourth.
+ *
+ * A tree that is well-formed in `stage`, `expected_value` and `children` but
+ * carries a missing / non-string / empty `id` returned **200 before, 400 now**.
+ * A present-but-wrongly-typed `stage` (e.g. the string `"2"`) is the same shape
+ * of flip: it grouped and rendered before, and is refused now.
+ *
+ * The `id` check is nevertheless KEPT, not relaxed to absence-only, because
+ * `id` IS read on the success path: `decisionText`'s last resort returns
+ * `node.id` straight into user-facing prose (`"the optimal action is …"`) and
+ * into `key_decision`. A non-string `id` therefore renders as `"[object
+ * Object]"` or `"undefined"` — the same fabrication-into-prose class the
+ * `policy_summary` fix in that route eliminated. Refusing honestly is correct;
+ * the overclaiming sentence was the defect, so the sentence is what changed.
+ */
+
+import { isFiniteNumber } from './numeric.js';
+
+/** The typed refusal a caller turns into its own 400 envelope. */
+export interface PolicyTreeShapeIssue {
+  code: string;
+  field: string;
+  message: string;
+}
+
+/**
+ * Returns the first shape violation found, or `null` when the tree is safe to
+ * read. Total: never throws, whatever the input contains.
+ */
+export function validatePolicyTreeShape(policyTree: {
+  nodes?: unknown;
+}): PolicyTreeShapeIssue | null {
+  if (!Array.isArray(policyTree.nodes)) {
+    return {
+      code: 'INVALID_POLICY_TREE',
+      field: 'policy_tree.nodes',
+      message: `policy_tree.nodes must be an array of policy tree nodes, received ${policyTree.nodes === null ? 'null' : typeof policyTree.nodes}.`,
+    };
+  }
+
+  for (let i = 0; i < policyTree.nodes.length; i++) {
+    const node = policyTree.nodes[i] as unknown;
+
+    if (node === null || typeof node !== 'object' || Array.isArray(node)) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}]`,
+        message: `policy_tree.nodes[${i}] is not a policy tree node — expected an object, received ${node === null ? 'null' : Array.isArray(node) ? 'array' : typeof node}.`,
+      };
+    }
+
+    const n = node as Record<string, unknown>;
+
+    if (typeof n.id !== 'string' || n.id.length === 0) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}].id`,
+        message: `policy_tree.nodes[${i}] is missing a non-empty string "id".`,
+      };
+    }
+
+    if (!isFiniteNumber(n.stage)) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}].stage`,
+        message: `policy_tree.nodes[${i}] ("${n.id}") has "stage" of type ${n.stage === null ? 'null' : typeof n.stage}, expected a finite number. Stage explanations are grouped by this value.`,
+      };
+    }
+
+    if (!isFiniteNumber(n.expected_value)) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}].expected_value`,
+        message: `policy_tree.nodes[${i}] ("${n.id}") has "expected_value" of type ${n.expected_value === null ? 'null' : typeof n.expected_value}, expected a finite number. Risk and rationale figures are computed from it.`,
+      };
+    }
+
+    if (!Array.isArray(n.children)) {
+      return {
+        code: 'INVALID_POLICY_TREE_NODE',
+        field: `policy_tree.nodes[${i}].children`,
+        message: `policy_tree.nodes[${i}] ("${n.id}") has "children" of type ${n.children === null ? 'null' : typeof n.children}, expected an array of child node IDs. Terminal nodes are identified by an empty "children" array.`,
+      };
+    }
+  }
+
+  return null;
+}

--- a/tests/explain-policy-malformed-tree.regression.test.ts
+++ b/tests/explain-policy-malformed-tree.regression.test.ts
@@ -372,4 +372,42 @@ describe('POST /v1/explain/policy — positive controls', () => {
         .statusCode
     ).toBe(400);
   });
+
+  /**
+   * The last residual 500 in this route. `const body = req.body as
+   * ExplainPolicyRequest` then `body.policy_tree` threw a TypeError when the
+   * request body was the VALID JSON literal `null` — `req.body === null`, and
+   * the opaque 500 was exactly what every other check here exists to prevent.
+   *
+   * Injected as a raw body rather than via `post()` so the literal `null`
+   * survives serialisation; `post()` would have to stringify it back anyway.
+   * Every other primitive body is already safe — reading a missing property off
+   * a string / number / boolean yields undefined, which the presence checks
+   * refuse honestly — so those are asserted alongside as the discriminating
+   * control: they were NOT broken before, and must not change.
+   */
+  it('a literal null JSON body is a typed 400, not an opaque 500', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/explain/policy',
+      headers: { 'content-type': 'application/json' },
+      body: 'null',
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).not.toBe(500);
+    expect(JSON.parse(res.payload).message).toBeTruthy();
+  });
+
+  it('CONTROL: the other primitive bodies were already 400 and still are', async () => {
+    for (const raw of ['123', '"a string"', 'true', '[]']) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/explain/policy',
+        headers: { 'content-type': 'application/json' },
+        body: raw,
+      });
+      expect(res.statusCode, `body ${raw}`).toBe(400);
+    }
+  });
 });

--- a/tests/isl-egress-undeclared-keys.contract.test.ts
+++ b/tests/isl-egress-undeclared-keys.contract.test.ts
@@ -22,6 +22,35 @@
  *      then forwarded the whole object VERBATIM, so a PLoT-internal key
  *      transited to ISL.
  *
+ * ⚠ MIGRATED ONTO THE PUBLISHED HARNESS — AND THE MIGRATION WAS NOT COSMETIC
+ * --------------------------------------------------------------------------
+ * This file previously carried PRIVATE copies of the capture shim and the
+ * fixture graph. The private graph was the PRE-slice-2 fixture, and it is
+ * BLIND to one of the three `mean` producers this file names.
+ *
+ * Its constraint targeted `fac_cost` — a `kind: 'factor'` node with an
+ * `observed_state.value`. `buildParameterUncertaintiesV3` (translator-v3.ts)
+ * already emits a PU for exactly that shape, so `classifyConstraintPu`
+ * (constraint-pu-injection.ts:67) returned `existing` and the injector
+ * `continue`d at :154 — its wire-entry push at :182 was UNREACHABLE. The old
+ * comment labelling `fac_cost` "Producer 3: a constrained node with no PU of
+ * its own → constraint injection" was therefore false, and the old positive
+ * control ("all three `mean` producers fired") was satisfied by the TRANSLATOR
+ * alone: two observed_state PUs plus one prior PU, and nothing from the
+ * injector.
+ *
+ * `tests/helpers/isl-egress-producers.ts` fixed this by adding a
+ * `kind: 'constraint'` node (`con_cost_cap`) and pointing the constraint at
+ * it — a node the translator does not emit a PU for, so the injector actually
+ * runs. That graph was found to be necessary BY MUTATION, not by reading:
+ * re-introducing the slice-6 `mean` key into the injector left the old fixture
+ * completely green.
+ *
+ * The positive control below now asserts the injected entry is PRESENT and
+ * carries `CONSTRAINT_PINNED_STD` — something ONLY the injector branch can
+ * produce (TESTING-DISCIPLINE rule 1: name the branch the fixture must reach,
+ * and assert something only that branch can produce).
+ *
  * RULE 3 (TESTING-DISCIPLINE.md): these assertions are made on the SERIALIZED
  * bytes handed to `fetch` — `ISLClient.request()` builds `requestBodyText =
  * JSON.stringify(body)` (client.ts:140) and passes that exact string as the
@@ -43,51 +72,44 @@
  * caller-supplied and latent; it is recorded in the PR body, not changed.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
-import { ISLClient } from '../src/integrations/isl/client.js';
+import { CONSTRAINT_PINNED_STD } from '../src/integrations/isl/constraint-pu-injection.js';
 import {
-  toISLRobustnessRequest,
-  type ISLRobustnessRequestV3,
-} from '../src/integrations/isl/translator-v3.js';
-import { injectConstraintParameterUncertainties } from '../src/integrations/isl/constraint-pu-injection.js';
-import { createISLInferenceFn } from '../src/analysis/flip-thresholds.js';
-import { createISLService } from '../src/integrations/isl/index.js';
-import type { EngineGraphV3, EngineNodeV3, OptionV3, GoalConstraint } from '../src/types/engine-v3.js';
+  PRODUCERS,
+  installEgressCapture,
+  uninstallEgressCapture,
+  type EgressCapture,
+  type ProducerSpec,
+} from './helpers/isl-egress-producers.js';
 
 // -----------------------------------------------------------------------------
-// Egress capture — the exact string given to fetch as the request body.
+// Producer lookup — FAILS LOUD on drift (trap 12: derive, don't mirror).
+// A renamed or removed producer must break this file, never silently skip it.
 // -----------------------------------------------------------------------------
 
-interface Capture {
-  url: string;
-  bodyText: string;
-  body: any;
+function producer(name: string): ProducerSpec {
+  const spec = PRODUCERS.find((p) => p.name === name);
+  if (spec === undefined) {
+    throw new Error(
+      `No producer named "${name}" in PRODUCERS. This gate names its producers ` +
+        `explicitly so a rename cannot silently drop coverage. Known: ` +
+        `${PRODUCERS.map((p) => p.name).join(', ')}`,
+    );
+  }
+  return spec;
 }
 
-let captured: Capture[] = [];
-
-function installFetchCapture(responseBody: unknown = {}): void {
-  captured = [];
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async (url: any, init: any) => {
-      const bodyText = String(init?.body ?? '');
-      captured.push({ url: String(url), bodyText, body: JSON.parse(bodyText) });
-      return {
-        ok: true,
-        status: 200,
-        headers: { get: () => null },
-        text: async () => JSON.stringify(responseBody),
-        json: async () => responseBody,
-      } as any;
-    }),
-  );
+/** Drive one producer and return the single body it put on the wire. */
+async function runOne(name: string): Promise<EgressCapture> {
+  const captures = await producer(name).run();
+  expect(captures).toHaveLength(1);
+  return captures[0]!;
 }
 
 /** Every JSON path in the captured bytes matching `container[*].key`. */
 function undeclaredKeyPaths(
-  capture: Capture,
+  capture: EgressCapture,
   collect: (body: any) => Array<{ path: string; obj: any }>,
   key: string,
 ): string[] {
@@ -111,185 +133,51 @@ const collectObservedStates = (body: any) =>
     .filter(({ obj }) => obj !== null && obj !== undefined);
 
 // -----------------------------------------------------------------------------
-// Fixtures — a PLoT-internal graph that exercises every `mean` producer.
-// -----------------------------------------------------------------------------
-
-/**
- * `metadata` is what PLoT's own normaliser attaches to a constraint node's
- * observed_state (graph-normaliser.ts:274-276) so the constraint compiler can
- * read `.operator`. It is PLoT-internal and must not reach ISL. It is not on
- * `EngineNodeV3.observed_state`, hence the cast — which is precisely why the
- * verbatim forward was invisible to the typechecker.
- */
-function nodeWithInternalMetadata(): EngineNodeV3 {
-  return {
-    id: 'fac_headcount',
-    kind: 'factor',
-    label: 'Headcount',
-    observed_state: {
-      value: 0.4,
-      std: 0.08,
-      baseline: 0.3,
-      unit: 'people',
-      raw_value: 40,
-      cap: 100,
-      factor_type: 'quantitative',
-      uncertainty_drivers: ['hiring_pipeline'],
-      // PLoT-internal: read by constraint-compiler.ts, never by ISL.
-      metadata: { operator: '<=', source: 'cee_constraint_node' },
-    } as EngineNodeV3['observed_state'],
-  } as EngineNodeV3;
-}
-
-function buildGraph(): EngineGraphV3 {
-  const nodes: EngineNodeV3[] = [
-    nodeWithInternalMetadata(),
-    // Producer 2: external factor with a uniform prior → PU synthesised from range.
-    {
-      id: 'fac_market',
-      kind: 'factor',
-      label: 'Market growth',
-      category: 'external',
-      prior: { distribution: 'uniform', range_min: 0.2, range_max: 0.6 },
-    } as EngineNodeV3,
-    // Producer 3: a constrained node with no PU of its own → constraint injection.
-    {
-      id: 'fac_cost',
-      kind: 'factor',
-      label: 'Cost',
-      observed_state: { value: 0.55 },
-    } as EngineNodeV3,
-    // In the graph but with no observed_state, so the translator emits no PU
-    // for it — the realistic "insert" branch of the flip probe.
-    { id: 'fac_no_obs', kind: 'factor', label: 'Unmeasured' } as EngineNodeV3,
-    { id: 'goal_margin', kind: 'outcome', label: 'Margin' } as EngineNodeV3,
-  ];
-
-  return {
-    nodes,
-    edges: [
-      {
-        from: 'fac_headcount',
-        to: 'goal_margin',
-        exists_probability: 0.9,
-        strength: { mean: 0.5, std: 0.1 },
-      },
-      {
-        from: 'fac_market',
-        to: 'goal_margin',
-        exists_probability: 0.8,
-        strength: { mean: 0.3, std: 0.12 },
-      },
-      {
-        from: 'fac_cost',
-        to: 'goal_margin',
-        exists_probability: 0.85,
-        strength: { mean: -0.4, std: 0.09 },
-      },
-    ],
-  } as EngineGraphV3;
-}
-
-/**
- * The `/v1/run` leg reaches ISL through `analyseRobustness`, which consumes the
- * trust-layer `Graph` (edges carry `weight` / `belief_exists` / `strength_std`,
- * not a `strength` object). `weight` is PLoT's own coefficient: ISL's `EdgeV2`
- * declares no such field, and `analyseRobustness` was forwarding it alongside
- * the `strength` distribution it derives from it.
- */
-function buildV1Graph(): any {
-  return {
-    nodes: [
-      nodeWithInternalMetadata(),
-      { id: 'fac_cost', kind: 'factor', label: 'Cost', observed_state: { value: 0.55, std: 0.05 } },
-      { id: 'goal_margin', kind: 'outcome', label: 'Margin' },
-    ],
-    edges: [
-      {
-        from: 'fac_headcount',
-        to: 'goal_margin',
-        weight: 0.5,
-        belief_exists: 0.9,
-        strength_std: 0.1,
-      },
-      { from: 'fac_cost', to: 'goal_margin', weight: -0.4, belief_exists: 0.85, strength_std: 0.09 },
-    ],
-  };
-}
-
-const OPTIONS: OptionV3[] = [
-  { id: 'opt_a', label: 'Hire', interventions: { fac_headcount: { value: 0.8 } } },
-  { id: 'opt_b', label: 'Hold', interventions: { fac_headcount: { value: 0.2 } } },
-] as unknown as OptionV3[];
-
-const CONSTRAINTS: GoalConstraint[] = [
-  { constraint_id: 'c1', node_id: 'fac_cost', operator: '<=', value: 0.7, label: 'Cost cap' },
-] as unknown as GoalConstraint[];
-
-function buildV2Request(): ISLRobustnessRequestV3 {
-  const graph = buildGraph();
-  const request = toISLRobustnessRequest(
-    graph,
-    OPTIONS,
-    'goal_margin',
-    'req_slice6',
-    2000,
-    undefined,
-    CONSTRAINTS,
-    'seed-slice6',
-  );
-  // The /v2/run route runs this immediately after building the request
-  // (run.ts:5659-5663); it MUTATES request.parameter_uncertainties, so a
-  // translator-only assertion would miss the key it re-adds.
-  injectConstraintParameterUncertainties(request, CONSTRAINTS, graph.nodes, 'goal_margin');
-  return request;
-}
-
-function newClient(): ISLClient {
-  return new ISLClient({
-    baseUrl: 'https://isl.test',
-    apiKey: 'test-key',
-    timeoutMs: 5_000,
-    maxRetries: 1,
-  });
-}
-
-// -----------------------------------------------------------------------------
 
 describe('PLoT → ISL egress carries no undeclared request key (slice 6)', () => {
   const savedEnv = { ...process.env };
 
   beforeEach(() => {
-    installFetchCapture({ status: 'ok' });
+    installEgressCapture({ status: 'ok' });
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    uninstallEgressCapture();
     process.env = { ...savedEnv };
   });
 
   describe('/api/v1/robustness/analyze/v2 — the /v2/run analysis body', () => {
-    async function captureV2Body(): Promise<Capture> {
-      await newClient().request({
-        endpoint: '/api/v1/robustness/analyze/v2',
-        body: buildV2Request(),
-        requestId: 'req_slice6',
-      });
-      expect(captured).toHaveLength(1);
-      return captured[0]!;
-    }
+    const captureV2Body = () => runOne('v2-run-base');
 
-    it('POSITIVE CONTROL: the instrument sees the bytes and their declared keys', async () => {
+    it('POSITIVE CONTROL: the instrument sees the bytes, and ALL THREE `mean` producers fired', async () => {
       const c = await captureV2Body();
+      const body = c.body as any;
 
       // The capture is real bytes, not an empty object (trap 13).
       expect(c.bodyText.length).toBeGreaterThan(200);
       expect(c.url).toContain('/api/v1/robustness/analyze/v2');
 
-      // All three `mean` producers fired, so the absence assertions below are
-      // being made over a body that HAS parameter_uncertainties to inspect.
-      const pu = c.body.parameter_uncertainties as any[];
-      expect(pu.map((p) => p.node_id).sort()).toEqual(['fac_cost', 'fac_headcount', 'fac_market']);
+      const pu = body.parameter_uncertainties as any[];
+
+      // Producer 1 (observed_state) and producer 2 (uniform prior), from the
+      // translator; plus producer 3 (constraint injection), from the injector.
+      expect(pu.map((p) => p.node_id).sort()).toEqual([
+        'con_cost_cap',
+        'fac_cost',
+        'fac_headcount',
+        'fac_market',
+      ]);
+
+      // ⚠ THE ASSERTION THE OLD PRIVATE FIXTURE COULD NOT MAKE.
+      // `con_cost_cap` is `kind: 'constraint'`, so the translator emits no PU
+      // for it — the ONLY way this entry can exist is
+      // `injectConstraintParameterUncertainties`, and CONSTRAINT_PINNED_STD is
+      // a value only that branch writes. Without this, the `mean` absence
+      // assertions below would be made over a body the injector never touched.
+      const injected = pu.find((p) => p.node_id === 'con_cost_cap');
+      expect(injected).toBeDefined();
+      expect(injected.std).toBe(CONSTRAINT_PINNED_STD);
+
       for (const p of pu) {
         expect(typeof p.node_id).toBe('string');
         expect(p.distribution).toBe('normal');
@@ -298,13 +186,13 @@ describe('PLoT → ISL egress carries no undeclared request key (slice 6)', () =
 
       // Edge `strength.mean` IS declared by ISL — proof that the assertions
       // below target the specific undeclared keys and not the string "mean".
-      for (const e of c.body.graph.edges as any[]) {
+      for (const e of body.graph.edges as any[]) {
         expect(typeof e.strength.mean).toBe('number');
         expect(typeof e.strength.std).toBe('number');
       }
 
       // The observed_state allowlist must keep every ISL-DECLARED field.
-      const os = (c.body.graph.nodes as any[]).find((n) => n.id === 'fac_headcount')!.observed_state;
+      const os = (body.graph.nodes as any[]).find((n) => n.id === 'fac_headcount')!.observed_state;
       expect(os).toMatchObject({
         value: 0.4,
         std: 0.08,
@@ -319,7 +207,7 @@ describe('PLoT → ISL egress carries no undeclared request key (slice 6)', () =
       // constraint_id is undeclared on ISL today but is being ADOPTED, not
       // dropped (Codex OQ-5). Pinned present so a later lane cannot delete it
       // by mistaking it for slice-6 cleanup.
-      expect((c.body.goal_constraints as any[])[0].constraint_id).toBe('c1');
+      expect((body.goal_constraints as any[])[0].constraint_id).toBe('c1');
     });
 
     it('no parameter_uncertainties[].mean — from the observed_state, prior, or constraint-injection producer', async () => {
@@ -341,77 +229,61 @@ describe('PLoT → ISL egress carries no undeclared request key (slice 6)', () =
   });
 
   describe('flip probe — the cloned body sent per probe point', () => {
-    async function captureProbeBody(): Promise<Capture[]> {
-      const original = buildV2Request();
-      const client = newClient();
-      const inferenceFn = createISLInferenceFn(
-        async (endpoint, body, requestId, signal) => {
-          const res = await client.request<any>({ endpoint, body, requestId, signal });
-          return { data: res.data };
-        },
-        original as any,
-        'req_slice6',
-      );
-      // A probe on a factor already in the PU list (clone path) and one on a
-      // factor that is not (insert path) — the two branches at
-      // flip-thresholds.ts:840-859.
-      await inferenceFn('fac_headcount', 0.75);
-      await inferenceFn('fac_no_obs', 0.25);
-      expect(captured).toHaveLength(2);
-      return captured;
-    }
+    // A probe on a factor already in the PU list (clone path) and one on a
+    // factor that is not (insert path) — the two branches at
+    // flip-thresholds.ts:840-859.
+    const captureProbeBodies = async (): Promise<EgressCapture[]> => [
+      await runOne('flip-probe-clone'),
+      await runOne('flip-probe-insert'),
+    ];
 
     it('POSITIVE CONTROL: both probe branches produced real bytes with PU entries', async () => {
-      const [clonePath, insertPath] = await captureProbeBody();
-      expect(clonePath!.body.parameter_uncertainties.length).toBe(3);
-      expect(insertPath!.body.parameter_uncertainties.length).toBe(4);
-      for (const c of [clonePath!, insertPath!]) {
-        for (const p of c.body.parameter_uncertainties as any[]) {
+      const [clonePath, insertPath] = await captureProbeBodies();
+      const cloneBody = clonePath!.body as any;
+      const insertBody = insertPath!.body as any;
+
+      // The base body already carries the injected constraint PU, so the clone
+      // path is 4 and the insert path adds a fifth.
+      expect(cloneBody.parameter_uncertainties.length).toBe(4);
+      expect(insertBody.parameter_uncertainties.length).toBe(5);
+      expect(insertBody.parameter_uncertainties.map((p: any) => p.node_id)).toContain('fac_no_obs');
+
+      // The injected constraint PU survives the clone — the probe operates
+      // downstream of the injector, which is why this file captures at fetch.
+      for (const b of [cloneBody, insertBody]) {
+        expect(b.parameter_uncertainties.map((p: any) => p.node_id)).toContain('con_cost_cap');
+        for (const p of b.parameter_uncertainties as any[]) {
           expect(typeof p.std).toBe('number');
         }
       }
+
       // The probe moves observed_state.value — the field ISL actually reads.
-      const moved = (clonePath!.body.graph.nodes as any[]).find((n) => n.id === 'fac_headcount');
+      const moved = (cloneBody.graph.nodes as any[]).find((n) => n.id === 'fac_headcount');
       expect(moved.observed_state.value).toBe(0.75);
     });
 
     it('no parameter_uncertainties[].mean on either probe branch', async () => {
-      for (const c of await captureProbeBody()) {
+      for (const c of await captureProbeBodies()) {
         expect(undeclaredKeyPaths(c, collectParameterUncertainties, 'mean')).toEqual([]);
       }
     });
 
     it('no observed_state.metadata survives the probe clone', async () => {
-      for (const c of await captureProbeBody()) {
+      for (const c of await captureProbeBodies()) {
         expect(undeclaredKeyPaths(c, collectObservedStates, 'metadata')).toEqual([]);
       }
     });
   });
 
   describe('/v1/run → analyseRobustness — the second live ISL producer', () => {
-    async function captureV1Body(): Promise<Capture> {
-      process.env.ISL_ENABLE = '1';
-      process.env.ISL_BASE_URL = 'https://isl.test';
-      process.env.ISL_API_KEY = 'test-key';
-
-      const service = createISLService();
-      await service.analyseRobustness(
-        buildV1Graph(),
-        'goal_margin',
-        [
-          { id: 'opt_a', label: 'Hire', interventions: { fac_headcount: 0.8 } },
-          { id: 'opt_b', label: 'Hold', interventions: { fac_headcount: 0.2 } },
-        ],
-        'req_slice6_v1',
-      );
-      expect(captured).toHaveLength(1);
-      return captured[0]!;
-    }
+    const captureV1Body = () => runOne('v1-run-analyse-robustness');
 
     it('POSITIVE CONTROL: the /v1 body was captured and carries its declared edge fields', async () => {
       const c = await captureV1Body();
-      expect(c.body.graph.edges.length).toBe(2);
-      for (const e of c.body.graph.edges as any[]) {
+      const body = c.body as any;
+
+      expect(body.graph.edges.length).toBe(2);
+      for (const e of body.graph.edges as any[]) {
         expect(typeof e.from).toBe('string');
         expect(typeof e.to).toBe('string');
         expect(typeof e.exists_probability).toBe('number');
@@ -420,8 +292,8 @@ describe('PLoT → ISL egress carries no undeclared request key (slice 6)', () =
         expect(typeof e.strength.mean).toBe('number');
         expect(typeof e.strength.std).toBe('number');
       }
-      expect((c.body.graph.edges as any[]).map((e) => e.strength.mean)).toEqual([0.5, -0.4]);
-      expect((c.body.parameter_uncertainties as any[]).length).toBeGreaterThan(0);
+      expect((body.graph.edges as any[]).map((e) => e.strength.mean)).toEqual([0.5, -0.4]);
+      expect((body.parameter_uncertainties as any[]).length).toBeGreaterThan(0);
     });
 
     it('no graph.edges[].weight', async () => {
@@ -438,6 +310,72 @@ describe('PLoT → ISL egress carries no undeclared request key (slice 6)', () =
       const c = await captureV1Body();
       expect(undeclaredKeyPaths(c, collectObservedStates, 'metadata')).toEqual([]);
       expect(c.bodyText).not.toContain('cee_constraint_node');
+    });
+  });
+
+  /**
+   * The three groups above name the producers that were leaking at slice 6. A
+   * producer added LATER would not be covered by any of them — the same
+   * "the gate never reached that path" defect this file was migrated to fix,
+   * one level up. This sweep closes that by deriving its subjects from
+   * PRODUCERS rather than naming them.
+   *
+   * NOT VACUOUS (rule 2): the `causal-*` producers send no graph and no
+   * parameter_uncertainties at all, so an unguarded sweep would pass over them
+   * by inspecting nothing. The control below asserts the sweep actually
+   * inspected containers of all three kinds, and reports which producers were
+   * inspectable — so an instrument that went blind reports zero, not green.
+   */
+  describe('EVERY producer in the manifest, derived — no undeclared key anywhere', () => {
+    interface Inspected {
+      name: string;
+      pu: number;
+      edges: number;
+      observedStates: number;
+    }
+
+    async function sweep(): Promise<Inspected[]> {
+      const rows: Inspected[] = [];
+      for (const spec of PRODUCERS) {
+        for (const c of await spec.run()) {
+          // The RESPONSE-VERSION PIN, asserted on the wire rather than read off
+          // client.ts. ISL's V2 handler serialises with
+          // `model_dump(by_alias=True, exclude_none=True)`, which is recursive,
+          // so on THIS path a null field is OMITTED, never sent. Any capture of
+          // a `null`-bearing ISL body is therefore the LEGACY v1 format — a
+          // hand-curl without the pin — and says nothing about what PLoT
+          // receives. Pinned here so that scope cannot be mislaid again.
+          expect(c.url).toContain('response_version=2');
+          expect(undeclaredKeyPaths(c, collectParameterUncertainties, 'mean')).toEqual([]);
+          expect(undeclaredKeyPaths(c, collectEdges, 'weight')).toEqual([]);
+          expect(undeclaredKeyPaths(c, collectObservedStates, 'metadata')).toEqual([]);
+          expect(c.bodyText).not.toContain('cee_constraint_node');
+          rows.push({
+            name: spec.name,
+            pu: collectParameterUncertainties(c.body).length,
+            edges: collectEdges(c.body).length,
+            observedStates: collectObservedStates(c.body).length,
+          });
+        }
+      }
+      return rows;
+    }
+
+    it('no undeclared key on any producer, and the sweep inspected real containers', async () => {
+      const rows = await sweep();
+
+      // Every producer was driven and put at least one body on the wire.
+      expect(rows.length).toBeGreaterThanOrEqual(PRODUCERS.length);
+      expect(new Set(rows.map((r) => r.name))).toEqual(new Set(PRODUCERS.map((p) => p.name)));
+
+      // The sweep inspected containers of all three kinds — otherwise every
+      // absence assertion above passed by looking at nothing.
+      expect(rows.reduce((n, r) => n + r.pu, 0)).toBeGreaterThan(0);
+      expect(rows.reduce((n, r) => n + r.edges, 0)).toBeGreaterThan(0);
+      expect(rows.reduce((n, r) => n + r.observedStates, 0)).toBeGreaterThan(0);
+
+      // And the constraint-injection branch was reached inside the sweep too.
+      expect(rows.filter((r) => r.pu >= 4).length).toBeGreaterThan(0);
     });
   });
 });

--- a/tests/robustness-analysis.test.ts
+++ b/tests/robustness-analysis.test.ts
@@ -144,6 +144,44 @@ describe('Edge Normalization in adaptRobustnessAnalysisResponse', () => {
     expect(result.fragile_edges[0].switch_probability).toBeUndefined();
   });
 
+  it('a NULL marginal_switch_probability is omitted, not forwarded to egress', () => {
+    // `normalizeFragileEdge` used to spread this field on `!== undefined`, so a
+    // null passed straight through to egress, where @talchain/schemas types it
+    // `z.number().optional()` and a null FAILS validation. Its immediate
+    // neighbour switch_probability already guarded with `isFiniteNumber`; this
+    // pins the asymmetry closed.
+    //
+    // Not reachable on the pinned V2 path (ISL's V2 handler serialises with a
+    // recursive `exclude_none=True`, and PLoT pins `?response_version=2` on
+    // every call — client.ts:98/:180), so this is defence-in-depth against the
+    // day that pin changes. A null is what the LEGACY v1 format sends.
+    const response = {
+      robustness: {
+        fragile_edges: [
+          {
+            edge_id: 'nodeA->nodeB',
+            switch_probability: 0.3,
+            marginal_switch_probability: null,
+          },
+        ],
+      },
+    } as unknown as ISLRobustnessAnalyzeV2Response;
+
+    const result = adaptRobustnessAnalysisResponse(
+      response,
+      100,
+      'available',
+      'available',
+      'test-request-msp-null'
+    );
+
+    expect(result.fragile_edges).toHaveLength(1);
+    // The finite neighbour still survives — this is an omission, not a wipe.
+    expect(result.fragile_edges[0].switch_probability).toBe(0.3);
+    expect(result.fragile_edges[0].marginal_switch_probability).toBeUndefined();
+    expect('marginal_switch_probability' in result.fragile_edges[0]).toBe(false);
+  });
+
   it('tracks normalization errors for malformed edges', () => {
     const response: ISLRobustnessAnalyzeV2Response = {
       robustness: {


### PR DESCRIPTION
## Summary

Three findings from the reuse review, plus five folded in from the altitude and cross-repo reviews. The headline is a **test-integrity defect**: a standing gate was asserting over a fixture that could not reach one of the three producers it names.

---

## FINDING 1 — the undeclared-keys gate was blind to its own third producer

`tests/isl-egress-undeclared-keys.contract.test.ts` (PR #274) carried **private copies** of the capture shim and fixture graph that PR #275 later published as `tests/helpers/isl-egress-producers.ts`.

**Verified at the bytes — the premise holds.** The private graph's constraint targeted `fac_cost`, a `kind: 'factor'` node with an `observed_state.value`. `buildParameterUncertaintiesV3` already emits a PU for exactly that shape, so `classifyConstraintPu` (`constraint-pu-injection.ts:67`) returned `existing`, the injector `continue`d at `:154`, and its wire-entry push at `:182` was **unreachable**. The comment labelling `fac_cost` *"Producer 3: a constrained node with no PU of its own → constraint injection"* was false, and the positive control *"all three `mean` producers fired"* was satisfied by the **translator alone** (two observed_state PUs + one prior PU).

Confirmed independently against the committed fixture: the helper's graph yields **4** PUs including `con_cost_cap` at `std: 0.001` (`CONSTRAINT_PINNED_STD`, a value only the injector writes); the private graph yielded **3**, none injected.

### The mutation proof (the deliverable)

Re-introduced the slice-6 `mean` key into the injector's wire entry, in a throwaway clone **outside the repo root**, removed before the gate run.

| Arm | Fixture | Result |
|---|---|---|
| **Control** | old test, **no** mutation | 11/11 **green** — the harness sees |
| **A** | **old** test + mutation | **11/11 GREEN — blind** |
| **B** | **migrated** test + mutation | **3 FAILED**, naming `parameter_uncertainties[3].mean` (index 3 = the injected `con_cost_cap`) |
| Revert | migrated test, mutation reverted | green (66/66 with the drift-pairing sibling) |

### Honest scoping — the estate was **not** blind overall

Run against the same mutation, the sibling gate `tests/isl-request-drift-pairing.contract.test.ts` (#275) **fails with 8 errors**, including *"LIVE PAIRING: the body derived RIGHT NOW carries no unexplained undeclared key"*. There was defence-in-depth. What was blind was specifically #274's **named** gate — the one whose test titles claim to cover the constraint-injection producer. This is a lying-coverage defect, not an unguarded live defect.

### What changed

Migrated onto the published harness (`PRODUCERS` / `installEgressCapture` / `uninstallEgressCapture`), deleting every private copy. Producer lookup **fails loud** on a rename rather than silently skipping (trap 12). Added:
- a positive control asserting the injected `con_cost_cap` entry is **present** with `CONSTRAINT_PINNED_STD` — something only the injector branch can produce (rule 1);
- an **all-producer sweep** derived from `PRODUCERS`, so a producer added later cannot outflank the gate, with a non-vacuous control (the `causal-*` producers send no graph at all, so the sweep asserts it inspected containers of all three kinds).

No producer input changed, so the pinned egress fixtures and the replay hash chain are untouched.

---

## FINDING 2 — inline finite-number guards

`explain-policy.ts` wrote the `typeof === 'number' && Number.isFinite` predicate inline three times; `src/util/numeric.ts` declares itself the single source of truth and exports `isFiniteNumber`. Now used.

**Correction to the brief:** the three sites guard `n.stage`, `n.expected_value` and `index` — the same predicate *family* over three different values, not `n.stage` three times.

---

## FINDING 3 — `validatePolicyTreeShape` extracted (decision: **yes, move it**)

Moved to `src/util/policy-tree-validation.ts`, beside its sibling `sequential-validation.ts`.

**#273's ordering property survives, untouched by construction:** it is a *call-site* property — the validator runs LAST, after `validateSequentialGraph`. Extracting the *declaration* does not move the *call*. The preservation control (`explain-policy-malformed-tree.regression.test.ts:349`, pinning `INVALID_STAGE_DEFINITION`) still guards it and would go red on a reorder.

**Layering:** the parameter is typed **structurally** (`{ nodes?: unknown }`), not as the route's `IslPolicyTreeResponse`. The declared type is exactly what is *not* enforced at the wire, so accepting it would re-assert the guarantee the function exists to doubt — and it keeps `src/util` a leaf, avoiding the inversion `numeric.ts` documents.

---

## Folded in from the altitude review

**Deleted three dead twins** — `denormaliseOutcome`, `denormaliseExpectedOutcome`, `denormaliseConfidenceInterval` (`intervention-normaliser.ts`). Zero-reference claim **re-derived independently**: a whole-repo sweep (excluding `node_modules`/`dist`/`.git`/`coverage`) returns exactly 3 hits, all their own declarations; all three unexported, so no barrel can reach them. Each still performed the unguarded `denormaliseValue(outcome.mean, …)` that #278 fixed — twins differing in *safety*. Also removed the now-unused `OutcomeStatsV3` import.

---

## Folded in from the cross-repo review

**F1 — scope correction, CONFIRMED at the bytes.** `client.ts:98` appends `?response_version=2` and `:180` sends `X-ISL-Response-Version: 2`; all five ISL service methods route through `ISLClient.request` (`index.ts:246,286,323,407,549`). So the `{"constraint_id": null, …}` capture is the **legacy v1 format** and says nothing about PLoT's path. Corrected the mis-scoped comments in `constraint-identity.ts` and `isl-types.ts`; **no behaviour changed** — both shapes are still read, as defence-in-depth. Also pinned the version-pin **on the wire** in the egress test, so the scope cannot be mislaid again.

**F5** — `marginal_switch_probability` now guarded with `isFiniteNumber`, matching its immediate neighbour. Pinned by a new test.

**F3 — decision: correct the disclosure, keep the `id` check.** `id` *is* read on the success path: `decisionText`'s last resort returns `node.id` into user-facing prose and `key_decision`, so a non-string `id` renders as `"[object Object]"`/`"undefined"` — the fabrication class this route's `policy_summary` fix eliminated. Refusing is correct; the overclaiming sentence was the defect. The docstring now records the fourth flip (missing/empty `id`: 200 before, 400 now) and the string-`stage` case.

**F4** — `req.body ?? {}`. Pinned by a new test, with a control proving the other primitive bodies were already 400.

---

## Verification

- **Pristine baseline** re-derived independently at `dd144f77` in a separate clone: **572 files passed / 4 skipped; 6144 tests passed / 30 skipped**, exit 0.
- **Mutation-checked every behavioural fix** (rule 11). F4 and F5 each turn their new test **red** when reverted, while the other 33 tests in those files stay green — discriminating, not blanket-failing.
- No baseline bumps, no quarantines, nothing excluded.
- Mutation work in a throwaway clone **outside the repo root**, removed before the gate run (rules 7 / 9c).

**Disclosure:** the F4/F5 mutation checks were done by in-place revert in this lane's own private clone rather than a separate worktree, then restored and re-verified green; no other agent reads this clone. The finding-1 mutation used a fully separate throwaway clone.
