### PR TITLE
fix(numeric): close fabricate-on-absence at the PRIMITIVE — denormaliseValue takes `unknown`

### DIFF
--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -11,6 +11,7 @@
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
 import type { NormalisationContext, NormalisationRange } from './intervention-normaliser.js';
 import { denormaliseValue } from './intervention-normaliser.js';
+import { isFiniteNumber } from '../util/numeric.js';
 import type { MarginSensitivity } from '../analysis/margin-sensitivity.js';
 
 // =============================================================================
@@ -82,8 +83,15 @@ export function denormaliseFlipThresholds(
       return enrichWithLabels(flip, options);
     }
 
-    // Denormalise current_value and flip_value using the factor's range
+    // Denormalise current_value and flip_value using the factor's range.
+    // ROADMAP 1.277: denormaliseValue is absence-in ⇒ absence-out, so both of
+    // these are `number | undefined` and the finite checks below narrow them.
     const denormCurrent = denormaliseValue(flip.current_value, factorContext.range);
+    // `flip_value === null` means "no flip achievable" — a genuine, already-modelled
+    // absence, NOT a failed denormalisation. The primitive would now reject null on
+    // its own, but the explicit branch stays: it is what keeps that absence out of
+    // the `nonFiniteDenorm` disclosure below, which must fire only for a real
+    // mapping failure.
     const denormFlip = flip.flip_value !== null
       ? denormaliseValue(flip.flip_value, factorContext.range)
       : null;
@@ -94,8 +102,11 @@ export function denormaliseFlipThresholds(
     // JSON.stringify emits as a fabricated `null`. Finite-check every public
     // numeric after the map: emit the finite value, else null the flip_value AND
     // DISCLOSE via flip_reason so the null is attributable, never silent.
-    const currentFinite = Number.isFinite(denormCurrent);
-    const flipFinite = denormFlip !== null && Number.isFinite(denormFlip);
+    // `isFiniteNumber` is the type-guard flavour of the same predicate: it both
+    // rejects the non-finite value AND narrows `number | undefined` to `number`,
+    // so the emitted field is the checked value by construction.
+    const currentFinite = isFiniteNumber(denormCurrent);
+    const flipFinite = isFiniteNumber(denormFlip);
     const nonFiniteDenorm = !currentFinite || (denormFlip !== null && !flipFinite);
 
     return {
@@ -162,12 +173,14 @@ function denormaliseMarginSensitivity(
   margin: MarginSensitivity,
   range: NormalisationRange,
 ): MarginSensitivity {
-  const probeIsFinite =
-    margin.strongest_probe_value !== null && Number.isFinite(margin.strongest_probe_value);
-  const denormProbe = probeIsFinite
-    ? denormaliseValue(margin.strongest_probe_value as number, range)
-    : null;
-  const denormProbeFinite = denormProbe !== null && Number.isFinite(denormProbe);
+  // ROADMAP 1.277: the `as number` cast that used to sit on this call is GONE.
+  // It existed only to launder `number | null` past a `number` parameter — i.e. to
+  // silence the compiler about exactly the null this lane is closing. The primitive
+  // now takes `unknown` and rejects a non-number itself, so the hand-written
+  // `probeIsFinite` pre-check is redundant and has been removed with it: one guard,
+  // in the primitive, instead of a cast plus a caller-side mirror of the same test.
+  const denormProbe = denormaliseValue(margin.strongest_probe_value, range);
+  const denormProbeFinite = isFiniteNumber(denormProbe);
   return {
     ...margin,
     strongest_probe_value: denormProbeFinite ? denormProbe : null,

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -365,11 +365,50 @@ export function normaliseValue(value: number, range: NormalisationRange): { norm
  *
  * Formula: original = normalised × (max - min) + min
  *
- * @param normalised Normalised value in [0, 1]
+ * ABSENCE IN ⇒ ABSENCE OUT (ROADMAP 1.277). The parameter is `unknown` and the
+ * return is `number | undefined` **on purpose**. This is the fabricate-on-absence
+ * class closed at the PRIMITIVE rather than at ~15 call sites' vigilance.
+ *
+ * The signature used to be `(normalised: number, …): number`, and that `number`
+ * was a compile-time fiction over `as`-cast wire data: PLoT parses every ISL
+ * response with `JSON.parse(text) as T` (src/integrations/isl/client.ts:245) —
+ * no runtime validation — and ISL measurably emits `null` for absent nested
+ * numerics (`exclude_none=True` does not reach inside nested objects; same wire
+ * fact recorded on ISLOptionResult below). So `null` reached the arithmetic:
+ *
+ *     denormaliseValue(null, { min: 10, max: 20 })
+ *       === null * 10 + 10
+ *       === 10                     // the RANGE FLOOR
+ *
+ * and `Number.isFinite(10)` is **true**. An outcome ISL never computed was
+ * therefore published as a precise, confident measurement sitting exactly at the
+ * bottom of the goal range — "this option achieves the worst possible result" —
+ * and it was INVISIBLE to every post-hoc finiteness check, because a post-hoc
+ * check cannot distinguish a fabricated finite number from a measured one.
+ * This exact mechanism shipped a live defect once already (#278 /
+ * denormaliseOptionResult, documented below); ROADMAP 1.277 closes it at the
+ * source so it cannot recur through a new caller.
+ *
+ * Note the asymmetry that hid it, and why a `number` parameter was worse than
+ * useless: `undefined` and a missing key both produce `NaN` here, which every
+ * egress guard already rejects — so absence tests written with those two shapes
+ * passed while the shape the wire actually carries (`null`) sailed through.
+ *
+ * `finiteNum` rejects null/undefined/NaN/±Infinity, so only a real measurement
+ * reaches the arithmetic and an absent one stays absent. A valid value passes
+ * through byte-identically (`finiteNum` neither clamps nor coerces).
+ *
+ * @param normalised Normalised value in [0, 1] — UNTRUSTED; may be any wire shape
  * @param range Original normalisation range
- * @returns Denormalised value in original units
+ * @returns Denormalised value in original units, or `undefined` if `normalised`
+ *          was not a finite number (absent / null / NaN / ±Infinity)
  */
-export function denormaliseValue(normalised: number, range: NormalisationRange): number {
+export function denormaliseValue(normalised: unknown, range: NormalisationRange): number | undefined {
+  // Absence in ⇒ absence out. Never arithmetic on a non-number: `null` coerces
+  // to 0 and manufactures the range floor as a plausible measurement.
+  const n = finiteNum(normalised);
+  if (n === undefined) return undefined;
+
   const { min, max } = range;
   const rangeWidth = max - min;
 
@@ -379,7 +418,7 @@ export function denormaliseValue(normalised: number, range: NormalisationRange):
     return max;
   }
 
-  return normalised * rangeWidth + min;
+  return n * rangeWidth + min;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -525,8 +525,12 @@ export function transformEdgeEValues(
 
     // current_mean and flip_mean are edge effects in outcome space — denormalise
     // using goal node range when normalisation was active.
-    let currentMean = e.current_mean;
-    let flipMean = e.flip_mean;
+    // ROADMAP 1.277: `number | undefined` because denormaliseValue is now
+    // absence-in ⇒ absence-out. An absent/non-finite mean is carried as
+    // `undefined` to the numeric-egress guard below, which DROPS the whole entry
+    // and attributes the drop — it is never emitted as a fabricated number.
+    let currentMean: number | undefined = e.current_mean;
+    let flipMean: number | undefined = e.flip_mean;
     let stability = e.stability;
     let eValueNormalised: boolean | undefined;
     if (normContext && goalRange) {
@@ -617,12 +621,16 @@ export function transformEdgeEValues(
   const kept: EnrichedEdgeEValue[] = [];
   for (let i = 0; i < mapped.length; i++) {
     const out = mapped[i];
-    const keep =
-      finiteNum(out.e_value) !== undefined &&
-      finiteNum(out.current_mean) !== undefined &&
-      finiteNum(out.flip_mean) !== undefined;
-    if (keep) {
-      kept.push(out);
+    // ROADMAP 1.277: bind the CHECKED values and re-emit them, so the field that
+    // rides the wire is by construction the one the guard validated. (Previously
+    // the guard was a boolean and `out` was pushed unnarrowed — correct, but it
+    // relied on a `number` declaration that was a fiction over `as`-cast wire data.)
+    const eValue = finiteNum(out.e_value);
+    const currentMeanChecked = finiteNum(out.current_mean);
+    const flipMeanChecked = finiteNum(out.flip_mean);
+    if (eValue !== undefined && currentMeanChecked !== undefined && flipMeanChecked !== undefined) {
+      // Spread-then-override preserves key ORDER and every additive field.
+      kept.push({ ...out, e_value: eValue, current_mean: currentMeanChecked, flip_mean: flipMeanChecked });
       continue;
     }
     if (dropSink) {
@@ -648,6 +656,16 @@ export function transformEdgeEValues(
  * rather than "not computed".
  * Enriches option IDs in buckets with human-readable labels.
  */
+/**
+ * ROADMAP 1.277: the in-flight shape, before the numeric-egress filter runs.
+ * `split_value` is REQUIRED (`number`) on the outbound `ConditionalWinner`, so an
+ * absent one cannot simply be omitted — the honest disposal is to DROP the whole
+ * entry, which the type-predicate filter at the end of the map does. This draft
+ * type is what makes that drop compiler-enforced rather than remembered: the
+ * unfiltered value is not assignable to `ConditionalWinner`.
+ */
+type ConditionalWinnerDraft = Omit<ConditionalWinner, 'split_value'> & { split_value: number | undefined };
+
 /** @internal Exported for numeric-egress-guard unit tests. */
 export function transformConditionalWinners(
   islConditionalWinners: ISLConditionalWinner[] | undefined,
@@ -663,7 +681,9 @@ export function transformConditionalWinners(
 
   return islConditionalWinners.map(cw => {
     // split_value is in the factor's units — denormalise using factor range
-    let splitValue = cw.split_value;
+    // ROADMAP 1.277: `number | undefined` — an absent/non-finite split_value is
+    // carried as `undefined` to the drop filter below, never emitted.
+    let splitValue: number | undefined = cw.split_value;
     let cwNormalised: boolean | undefined;
     if (normContext && typeof splitValue === 'number') {
       const factorRange = normContext.factors.get(cw.factor_id)?.range;
@@ -677,12 +697,45 @@ export function transformConditionalWinners(
 
     // mean_outcome is in goal node units — denormalise using goal range
     if (normContext && !goalRange) cwNormalised = true; // goal range missing → can't denorm outcomes
-    const denormMeanOutcome = (val: number | undefined): number | undefined => {
-      if (val === undefined || !goalRange) return val;
+    /**
+     * ROADMAP 1.277 — THIS WAS THE LIVE FABRICATION SITE.
+     *
+     * `val` was typed `number | undefined` and the guard tested `=== undefined`
+     * ONLY. But `ISLConditionalBucket.mean_outcome` is declared `number | undefined`
+     * over an `as`-cast wire payload (`JSON.parse(text) as T`,
+     * src/integrations/isl/client.ts:245 — no runtime validation), and ISL emits
+     * `null` for an absent nested numeric. `null === undefined` is **false**, so
+     * null reached the arithmetic and `null * width + min` produced the GOAL-RANGE
+     * FLOOR — published as a confident measured mean_outcome meaning "in this
+     * bucket the winner achieves the worst possible result".
+     *
+     * The `finiteNum(...)` spread guards below were structurally blind to it: the
+     * fabricated value IS finite, so no post-hoc finiteness check could ever
+     * distinguish it from a real measurement. Fixing it required moving the guard
+     * BEFORE the arithmetic, which is what the primitive now does.
+     *
+     * `unknown` in, `number | undefined` out ⇒ an absent mean_outcome now OMITS the
+     * field. That is contract-legal without any change: `mean_outcome?: number` is
+     * optional on both ISLConditionalBucket and the outbound ConditionalBucket.
+     */
+    const denormMeanOutcome = (val: unknown): number | undefined => {
+      // No goal range ⇒ cannot map; keep the value in normalised space (the entry
+      // is flagged `_normalised: true` above). Still finite-checked, so an absent
+      // value stays absent on this path too.
+      if (!goalRange) return finiteNum(val);
       return denormaliseValue(val, goalRange);
     };
 
-    const result: ConditionalWinner = {
+    // Compute each bucket's mapped outcome ONCE, so the value that is CHECKED is
+    // by construction the value that is EMITTED. (These lines each used to call
+    // denormMeanOutcome twice — once inside the guard, once in the payload.)
+    // `finiteNum` still wraps the result: it now guards the OUTPUT (an
+    // overflow-width range can map a valid input to ±Infinity), whereas the
+    // primitive guards the INPUT. Both are needed; neither replaces the other.
+    const lowMeanOutcome = finiteNum(denormMeanOutcome(cw.low_bucket.mean_outcome));
+    const highMeanOutcome = finiteNum(denormMeanOutcome(cw.high_bucket.mean_outcome));
+
+    const result: ConditionalWinnerDraft = {
       factor_id: cw.factor_id,
       factor_label: cw.factor_label ?? resolveNodeLabel(cw.factor_id),
       split_value: splitValue,
@@ -695,7 +748,7 @@ export function transformConditionalWinners(
           runner_up_label: resolveOptionLabel(cw.low_bucket.runner_up_id!),
         }),
         win_probability: cw.low_bucket.win_probability,
-        ...(finiteNum(denormMeanOutcome(cw.low_bucket.mean_outcome)) !== undefined && { mean_outcome: denormMeanOutcome(cw.low_bucket.mean_outcome) }),
+        ...(lowMeanOutcome !== undefined && { mean_outcome: lowMeanOutcome }),
       },
       high_bucket: {
         winner_id: cw.high_bucket.winner_id,
@@ -705,7 +758,7 @@ export function transformConditionalWinners(
           runner_up_label: resolveOptionLabel(cw.high_bucket.runner_up_id!),
         }),
         win_probability: cw.high_bucket.win_probability,
-        ...(finiteNum(denormMeanOutcome(cw.high_bucket.mean_outcome)) !== undefined && { mean_outcome: denormMeanOutcome(cw.high_bucket.mean_outcome) }),
+        ...(highMeanOutcome !== undefined && { mean_outcome: highMeanOutcome }),
       },
       winner_flips: cw.winner_flips,
     };
@@ -715,7 +768,7 @@ export function transformConditionalWinners(
     // bucket win_probability is a required [0,1] probability; drop the whole
     // conditional-winner entry when any is non-finite / out-of-range rather than emit
     // a fabricated null or an impossible probability.
-  }).filter((cw) =>
+  }).filter((cw): cw is ConditionalWinner =>
     finiteNum(cw.split_value) !== undefined &&
     prob01(cw.low_bucket.win_probability) !== undefined &&
     prob01(cw.high_bucket.win_probability) !== undefined

--- a/tests/denormalise-value-absence-in-absence-out.test.ts
+++ b/tests/denormalise-value-absence-in-absence-out.test.ts
@@ -1,0 +1,342 @@
+/**
+ * ROADMAP 1.277 — close the fabricate-on-absence class at the PRIMITIVE.
+ *
+ * `denormaliseValue(normalised, range)` used to declare `normalised: number` and
+ * return `number`. That `number` was a compile-time fiction over `as`-cast wire
+ * data: PLoT parses every ISL response with `JSON.parse(text) as T`
+ * (src/integrations/isl/client.ts:245 — no runtime validation), and ISL emits
+ * `null` for an absent nested numeric. So `null` reached the arithmetic:
+ *
+ *     denormaliseValue(null, { min: 10, max: 20 }) === null * 10 + 10 === 10
+ *
+ * — the RANGE FLOOR, and `Number.isFinite(10)` is **true**. An outcome ISL never
+ * computed was published as a precise, confident measurement pinned to the worst
+ * possible result, and no post-hoc finiteness check could see it: a fabricated
+ * finite number is indistinguishable from a measured one AFTER the fact. The only
+ * place the distinction still exists is BEFORE the multiply.
+ *
+ * ── MUTATION VERDICT (measured, not asserted) ────────────────────────────────
+ * This whole file was run against the PRISTINE pre-fix source at f8e4df10 in a
+ * throwaway clone. Result: **6 failed | 10 passed**. Every failure reported the
+ * fabrication verbatim — `expected 10 to be undefined`, `expected 5 to be
+ * undefined`, `expected { winner_id: 'opt1' } to not have property
+ * "mean_outcome"`.
+ *
+ * The tests are labelled by what that run actually proved, NOT by what they were
+ * intended to prove:
+ *
+ *   `DEFECT:`    — RED on pristine. These discriminate; they are the real pins.
+ *   `PIN:`       — GREEN on pristine too. An existing caller-side guard already
+ *                  covered that path, so the test does NOT prove this lane's fix.
+ *                  It is a regression pin protecting behaviour that must survive
+ *                  the primitive change (several of these cover guards this lane
+ *                  DELETED as now-redundant, which is exactly where equivalence
+ *                  needs pinning). Calling them DEFECT tests would be the
+ *                  "passes before the fix" theatre this programme hunts.
+ *   `POSITIVE CONTROL:` — GREEN both ways BY DESIGN. Proves the fix does not
+ *                  over-suppress or drift real values. A control that went red on
+ *                  pristine would be a broken control.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildNormalisationContext,
+  denormaliseValue,
+  type NormalisationContext,
+  type NormalisationRange,
+} from '../src/lib/intervention-normaliser.js';
+import { denormaliseFlipThresholds } from '../src/lib/flip-threshold-denormaliser.js';
+import { transformConditionalWinners, transformEdgeEValues, type EdgeEValueDropSink } from '../src/routes/v2/run.js';
+import type { EngineNodeV3 } from '../src/types/engine-v3.js';
+import type { MarginSensitivity } from '../src/analysis/margin-sensitivity.js';
+
+/**
+ * Goal range [10, 20], factor range [0, 200]. Deliberately chosen so the
+ * fabricated value is UNMISTAKABLE: the goal floor is 10, which is nowhere near
+ * any legitimate denormalised outcome in these fixtures, and is not 0 (a 0 would
+ * be ambiguous with a genuine zero measurement).
+ */
+const GOAL_RANGE: NormalisationRange = { min: 10, max: 20, source: 'explicit' };
+const NODES: EngineNodeV3[] = [
+  { id: 'goal', kind: 'goal', label: 'Revenue', state_space: { range: { min: 10, max: 20 } } },
+  { id: 'f', kind: 'factor', label: 'Spend', state_space: { range: { min: 0, max: 200 } }, observed_state: { value: 0.6 } },
+];
+function ctx(): NormalisationContext {
+  return buildNormalisationContext(NODES, 'goal');
+}
+
+// ---------------------------------------------------------------------------
+// 1. The primitive
+// ---------------------------------------------------------------------------
+
+describe('ROADMAP 1.277 · denormaliseValue — absence in ⇒ absence out', () => {
+  it('DEFECT: null no longer becomes the range FLOOR disguised as a measurement', () => {
+    const out = denormaliseValue(null, GOAL_RANGE);
+    // Pre-fix this was 10 — the range floor — and Number.isFinite(10) passed it
+    // through every downstream guard as a confident measured outcome.
+    expect(out).toBeUndefined();
+    expect(out).not.toBe(GOAL_RANGE.min);
+  });
+
+  it('DEFECT: the fabricated floor was FINITE — which is why post-hoc checks were blind', () => {
+    // This is the whole reason the fix had to move BEFORE the arithmetic. Pin the
+    // pre-fix arithmetic explicitly so the reason survives in the record.
+    const preFixArithmetic = (null as unknown as number) * (GOAL_RANGE.max - GOAL_RANGE.min) + GOAL_RANGE.min;
+    expect(preFixArithmetic).toBe(10);
+    expect(Number.isFinite(preFixArithmetic)).toBe(true); // a finiteness check CANNOT catch this
+    expect(denormaliseValue(null, GOAL_RANGE)).toBeUndefined(); // the primitive can
+  });
+
+  it('DEFECT: every absence shape maps to undefined — not just the two that used to yield NaN', () => {
+    for (const v of [null, undefined, NaN, Infinity, -Infinity, '0.5', {}, [], true]) {
+      expect(denormaliseValue(v, GOAL_RANGE)).toBeUndefined();
+    }
+  });
+
+  it('DEFECT: absence beats the zero-width shortcut (a degenerate range must not manufacture max)', () => {
+    const zeroWidth: NormalisationRange = { min: 5, max: 5, source: 'explicit' };
+    expect(denormaliseValue(null, zeroWidth)).toBeUndefined(); // pre-fix: 5
+    expect(denormaliseValue(0.5, zeroWidth)).toBe(5); // positive control: still the single point
+  });
+
+  it('POSITIVE CONTROL: every genuine measurement maps exactly as before', () => {
+    expect(denormaliseValue(0, GOAL_RANGE)).toBe(10);
+    expect(denormaliseValue(0.5, GOAL_RANGE)).toBe(15);
+    expect(denormaliseValue(1, GOAL_RANGE)).toBe(20);
+    expect(denormaliseValue(0.5, { min: 10, max: 60, source: 'explicit' })).toBe(35);
+    expect(denormaliseValue(0.25, { min: 0, max: 500000, source: 'explicit' })).toBe(125000);
+    // Negative and out-of-[0,1] inputs are still mapped verbatim (no clamping).
+    expect(denormaliseValue(-1, GOAL_RANGE)).toBe(0);
+    expect(denormaliseValue(2, GOAL_RANGE)).toBe(30);
+    // Exact zero is a MEASUREMENT, never an absence.
+    expect(denormaliseValue(0, { min: 0, max: 1, source: 'default' })).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. conditional_winners — the LIVE fabrication site (run.ts denormMeanOutcome)
+// ---------------------------------------------------------------------------
+
+const WINNER_BASE = {
+  factor_id: 'f',
+  factor_label: 'Spend',
+  split_value: 0.6,
+  winner_flips: true,
+};
+
+function makeWinner(lowMean: unknown, highMean: unknown) {
+  return {
+    ...WINNER_BASE,
+    low_bucket: { winner_id: 'opt1', win_probability: 0.7, mean_outcome: lowMean },
+    high_bucket: { winner_id: 'opt2', win_probability: 0.8, mean_outcome: highMean },
+  };
+}
+
+describe('ROADMAP 1.277 · transformConditionalWinners — mean_outcome absence', () => {
+  it('DEFECT: a null mean_outcome is OMITTED, not published as the goal-range floor', () => {
+    const out = transformConditionalWinners([makeWinner(null, null)] as never, undefined, undefined, ctx());
+    expect(out).toHaveLength(1);
+
+    // Pre-fix: `null === undefined` is false, so null reached the arithmetic and
+    // both buckets carried mean_outcome: 10 — a confident "worst possible result".
+    expect(out[0].low_bucket).not.toHaveProperty('mean_outcome');
+    expect(out[0].high_bucket).not.toHaveProperty('mean_outcome');
+
+    // Assert on the SERIALISED BYTES too: the floor must not appear at all, and
+    // the omission must be an absent key, never a fabricated null.
+    const json = JSON.stringify(out);
+    expect(json).not.toContain('"mean_outcome":10');
+    expect(json).not.toContain('"mean_outcome":null');
+    expect(json).not.toContain('mean_outcome');
+  });
+
+  it('DEFECT: one null bucket is omitted while the sibling MEASURED bucket survives', () => {
+    // Guards against a fix that over-suppresses: absence is per-field, not per-entry.
+    const out = transformConditionalWinners([makeWinner(null, 0.75)] as never, undefined, undefined, ctx());
+    expect(out[0].low_bucket).not.toHaveProperty('mean_outcome');
+    expect(out[0].high_bucket.mean_outcome).toBe(17.5); // 0.75 × 10 + 10
+  });
+
+  it('PIN: a null mean_outcome does NOT drop the whole entry (the rest is still measured)', () => {
+    const out = transformConditionalWinners([makeWinner(null, null)] as never, undefined, undefined, ctx());
+    expect(out[0].split_value).toBe(120); // 0.6 × 200 + 0 — factor range, still mapped
+    expect(out[0].low_bucket.win_probability).toBe(0.7);
+    expect(out[0].winner_flips).toBe(true);
+  });
+
+  it('POSITIVE CONTROL: a fully-present entry serialises to the exact same bytes', () => {
+    const out = transformConditionalWinners([makeWinner(0.25, 0.75)] as never, undefined, undefined, ctx());
+    expect(JSON.stringify(out)).toBe(JSON.stringify([{
+      factor_id: 'f',
+      factor_label: 'Spend',     // from the ISL entry, not the node-label map
+      split_value: 120,          // 0.6 × 200 + 0
+      low_bucket: {
+        winner_id: 'opt1',
+        winner_label: 'opt1',
+        win_probability: 0.7,
+        mean_outcome: 12.5,      // 0.25 × 10 + 10
+      },
+      high_bucket: {
+        winner_id: 'opt2',
+        winner_label: 'opt2',
+        win_probability: 0.8,
+        mean_outcome: 17.5,      // 0.75 × 10 + 10
+      },
+      winner_flips: true,
+    }]));
+  });
+
+  it('POSITIVE CONTROL: mean_outcome 0 (a real zero) is PRESERVED, never mistaken for absence', () => {
+    // The sharpest over-suppression trap: 0 is falsy, and 0 normalised maps to the
+    // same goal floor (10) the null defect fabricated. It must still be emitted.
+    const out = transformConditionalWinners([makeWinner(0, 0)] as never, undefined, undefined, ctx());
+    expect(out[0].low_bucket.mean_outcome).toBe(10);
+    expect(out[0].high_bucket.mean_outcome).toBe(10);
+  });
+
+  it('PIN: no goal range — values stay normalised and are flagged, absence still omitted', () => {
+    const noGoal = buildNormalisationContext(
+      [{ id: 'f', kind: 'factor', label: 'Spend', state_space: { range: { min: 0, max: 200 } } }] as EngineNodeV3[],
+      'missing-goal',
+    );
+    const out = transformConditionalWinners([makeWinner(null, 0.75)] as never, undefined, undefined, noGoal);
+    expect(out[0]._normalised).toBe(true);
+    expect(out[0].low_bucket).not.toHaveProperty('mean_outcome');
+    expect(out[0].high_bucket.mean_outcome).toBe(0.75); // verbatim, unmapped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. edge_e_values — absence must DROP the entry, never fabricate a mean
+// ---------------------------------------------------------------------------
+
+/**
+ * NOTE — these are PINs, not defect tests, and the mutation run is why.
+ *
+ * Every denormaliseValue call in transformEdgeEValues was ALREADY preceded by a
+ * `typeof x === 'number'` guard, and `typeof null === 'object'`, so null could
+ * never reach the arithmetic on this route. The brief for this lane predicted
+ * these sites (run.ts:549/551/553/576) were the blind ones; the mutation run
+ * refuted that — all three assertions below pass on the pristine source.
+ *
+ * They stay because the primitive change widened `currentMean`/`flipMean` to
+ * `number | undefined` and rewrote the egress guard to bind-and-re-emit the
+ * checked values. That rewrite is exactly the kind of "equivalent refactor" that
+ * ships regressions under green CI, so the behaviour it must preserve is pinned.
+ */
+describe('ROADMAP 1.277 · transformEdgeEValues — null means drop, never fabricate', () => {
+  it('PIN: a null current_mean drops the entry instead of publishing the goal floor', () => {
+    const sink: EdgeEValueDropSink = { inputNull: 0, overflow: 0 };
+    const isl = [{ edge_id: 'f->goal', e_value: 0.4, current_mean: null, flip_mean: 0.5, flip_direction: 'increase' }];
+    const out = transformEdgeEValues(isl as never, undefined, ctx(), sink);
+    expect(out).toHaveLength(0);
+    expect(JSON.stringify(out)).not.toContain('10');
+    // Attributed to the INPUT, not to a transform overflow.
+    expect(sink).toEqual({ inputNull: 1, overflow: 0 });
+  });
+
+  it('PIN: a null band endpoint is omitted and cannot manufacture a band_width', () => {
+    const isl = [{
+      edge_id: 'f->goal', e_value: 0.4, current_mean: 0.5, flip_mean: 0.6, flip_direction: 'increase',
+      stability: { band_min: null, band_max: null, band_median: null, n_seeds: 8, n_seeds_flipped: 0 },
+    }];
+    const out = transformEdgeEValues(isl as never, undefined, ctx());
+    expect(out).toHaveLength(1);
+    const stability = out[0].stability as Record<string, unknown>;
+    expect(stability.band_min).toBeNull();     // preserved as the ISL-sent null, never 10
+    expect(stability).not.toHaveProperty('band_width');
+    expect(JSON.stringify(out)).not.toContain('"band_min":10');
+  });
+
+  it('POSITIVE CONTROL: a fully-present edge maps exactly and is retained', () => {
+    const out = transformEdgeEValues(
+      [{ edge_id: 'f->goal', e_value: 0.4, current_mean: 0.5, flip_mean: 0.6, flip_direction: 'increase' }] as never,
+      new Map([['f', 'Spend'], ['goal', 'Revenue']]),
+      ctx(),
+    );
+    expect(JSON.stringify(out)).toBe(JSON.stringify([{
+      edge_id: 'f::goal',
+      from_id: 'f',
+      to_id: 'goal',
+      from_label: 'Spend',
+      to_label: 'Revenue',
+      e_value: 0.4,
+      flip_direction: 'increase',
+      current_mean: 15,  // 0.5 × 10 + 10
+      flip_mean: 16,     // 0.6 × 10 + 10
+    }]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. flip thresholds — margin_sensitivity probe value
+// ---------------------------------------------------------------------------
+
+const MARGIN_BASE: MarginSensitivity = {
+  movement: 'weakens',
+  threshold: 0.05,
+  baseline_leading_option_id: 'opt1',
+  baseline_runner_up_option_id: 'opt2',
+  baseline_margin: 0.2,
+  min_probe_margin: 0.1,
+  max_probe_margin: 0.3,
+  min_probe_delta: -0.1,
+  max_probe_delta: 0.1,
+  strongest_direction: 'min',
+  strongest_probe_value: 0.25,
+  value_scale: 'normalised',
+  strongest_delta: -0.1,
+  strongest_delta_abs: 0.1,
+} as MarginSensitivity;
+
+function flipInput(probe: number | null) {
+  return [{
+    factor_id: 'f',
+    factor_label: 'Spend',
+    current_value: 0.6,
+    flip_value: 0.8,
+    direction: 'increase' as const,
+    flip_reason: 'found' as const,
+    margin_sensitivity: { ...MARGIN_BASE, strongest_probe_value: probe },
+  }];
+}
+
+/**
+ * EQUIVALENCE PINS for a guard this lane DELETED.
+ *
+ * `denormaliseMarginSensitivity` used to read:
+ *
+ *     const probeIsFinite = margin.strongest_probe_value !== null &&
+ *                           Number.isFinite(margin.strongest_probe_value);
+ *     const denormProbe = probeIsFinite
+ *       ? denormaliseValue(margin.strongest_probe_value as number, range) : null;
+ *
+ * — a hand-written pre-check plus an `as number` cast to launder the type past a
+ * `number` parameter. The primitive now performs that check itself, so both were
+ * removed. Both assertions below pass on the PRISTINE source as well; they are
+ * not evidence of a fix, they are the proof that REMOVING the guard changed
+ * nothing observable. That is the claim that actually needed a test here.
+ */
+describe('ROADMAP 1.277 · denormaliseFlipThresholds — probe value absence', () => {
+  it('PIN: a null strongest_probe_value stays null and is DISCLOSED as unavailable', () => {
+    const out = denormaliseFlipThresholds(flipInput(null) as never, ctx(), []);
+    const margin = out[0].margin_sensitivity!;
+    expect(margin.strongest_probe_value).toBeNull();
+    expect(margin.display_value_available).toBe(false);
+    expect(margin.value_scale).toBe('display');
+    expect(JSON.stringify(out)).not.toContain('"strongest_probe_value":0');
+  });
+
+  it('POSITIVE CONTROL: a present probe value denormalises exactly and is flagged available', () => {
+    const out = denormaliseFlipThresholds(flipInput(0.25) as never, ctx(), []);
+    const margin = out[0].margin_sensitivity!;
+    expect(margin.strongest_probe_value).toBe(50); // 0.25 × 200 + 0 — factor range
+    expect(margin.display_value_available).toBe(true);
+    expect(margin.value_scale).toBe('display');
+    // The surrounding entry is untouched by this lane.
+    expect(out[0].current_value).toBe(120); // 0.6 × 200
+    expect(out[0].flip_value).toBe(160);    // 0.8 × 200
+    expect(out[0].flip_reason).toBe('found');
+  });
+});

--- a/tests/gates/numeric-safety-deep-scan.test.ts
+++ b/tests/gates/numeric-safety-deep-scan.test.ts
@@ -211,7 +211,23 @@ describe('WP5 gate · numeric seam + boundary guard (unit)', () => {
   it('normaliseValue(NaN) propagates NaN — the seam non-finite must be caught at boundaries', () => {
     const { normalised } = normaliseValue(N, { min: 0, max: 1, source: 'default' });
     expect(Number.isNaN(normalised)).toBe(true); // documents the seam: arithmetic does not self-guard
-    expect(Number.isNaN(denormaliseValue(N, { min: 0, max: 1, source: 'default' }))).toBe(true);
+  });
+
+  it('denormaliseValue(NaN) SELF-GUARDS to undefined (ROADMAP 1.277) — no longer a bare seam', () => {
+    // This assertion used to read `Number.isNaN(denormaliseValue(N, …)) === true`,
+    // asserting that denormaliseValue was an unguarded seam like its sibling above.
+    // ROADMAP 1.277 deliberately ENDED that: the primitive now finite-checks its
+    // input, because the sibling `normaliseValue` shape was letting `null` — which
+    // coerces to 0, NOT to NaN — fabricate the range floor as a plausible
+    // measurement that no downstream finiteness check could detect.
+    //
+    // The half that still matters is unchanged and is asserted above:
+    // `normaliseValue` remains an unguarded seam, so boundary guards are still
+    // required there. Only denormaliseValue moved.
+    expect(denormaliseValue(N, { min: 0, max: 1, source: 'default' })).toBeUndefined();
+    expect(denormaliseValue(null, { min: 10, max: 20, source: 'default' })).toBeUndefined();
+    // Positive control: a real measurement is untouched.
+    expect(denormaliseValue(0.5, { min: 0, max: 1, source: 'default' })).toBe(0.5);
   });
 
   it('sanitiseIslVoi rejects every non-finite value (NaN/±Infinity → undefined)', () => {


### PR DESCRIPTION
PR #278 fixed `denormaliseOptionResult` — one caller that fed a wire `null` into `denormaliseValue` and published the goal-range floor as a confident measurement. It fixed the **instance**. This slice closes the **class**, at the primitive, so the next caller cannot reintroduce it.

ROADMAP 1.277.

---

## The mechanism, measured

`denormaliseValue(normalised: number, range): number` declared a `number` parameter. That `number` was a compile-time fiction: PLoT parses every ISL response with `JSON.parse(responseText) as T` (`src/integrations/isl/client.ts:245`) — **no runtime validation anywhere on that path** — and ISL emits `null` for absent nested numerics.

```
denormaliseValue(null, { min: 10, max: 20 })
  === null * 10 + 10
  === 10                      // the RANGE FLOOR
Number.isFinite(10)  === true // ← and this is the whole problem
```

An outcome ISL never computed became a **precise, confident measurement pinned to the worst possible result**, and it was structurally invisible to every post-hoc check. That is the part worth stating plainly: **no finiteness check placed after the multiply can ever catch this**, because after the multiply a fabricated finite number and a measured one are the same bytes. The only place the distinction still exists is *before* the arithmetic — which is where the guard now lives.

The asymmetry that hid it, and why a `number` parameter was worse than useless: `undefined` and a missing key both yield `NaN` here, which every egress guard already rejects. So absence tests written with those two shapes passed, while `null` — the shape the wire actually carries — sailed through.

**Change:** `denormaliseValue(normalised: unknown, range): number | undefined`. `finiteNum` runs before the arithmetic; absence in ⇒ absence out. A valid value passes through byte-identically (`finiteNum` neither clamps nor coerces).

---

## Call-site table

Raising the signature made `tsc` enumerate the sites — that compiler-forced enumeration was the point. **It found 5. It could not find the 6th, which was the live one.** Recording that honestly, because it is the reusable lesson: a type error finds assignment mismatches, not semantic ones. The live site already declared `number | undefined`, so it type-checked perfectly while fabricating.

| # | Site | Pre-existing guard | Null-blind? | Decision |
|---|---|---|---|---|
| 1 | `intervention-normaliser.ts:869` `dn()` in `denormaliseOptionResult` | `finiteNum(v)` **before** | No — this is #278's fix | **Unchanged.** Kept as defence-in-depth; now redundant with the primitive, deliberately left |
| 2 | `flip-threshold-denormaliser.ts:86` `current_value` | none, but `getFactorCurrentValue` skips null upstream (`flip-thresholds.ts:144`) | No (unreachable) | Narrowed via `isFiniteNumber`; existing disclosed fallback + `flip_reason` preserved |
| 3 | `flip-threshold-denormaliser.ts:88` `flip_value` | `!== null` | No | Explicit null branch **kept** — `null` here means "no flip achievable", a modelled absence that must stay out of the `non_finite_denormalisation` disclosure |
| 4 | `flip-threshold-denormaliser.ts:168` `strongest_probe_value` | `!== null && Number.isFinite(...)` + **`as number` cast** | No | **Guard and cast both deleted.** The cast existed only to launder `number \| null` past the `number` parameter — i.e. to silence the compiler about exactly this null. One guard in the primitive replaces a cast plus a caller-side mirror |
| 5–6 | `run.ts:534/537` `current_mean` / `flip_mean` | `typeof === 'number'` | No | Widened to `number \| undefined`; absent ⇒ the existing numeric-egress guard **drops the entry and attributes the drop**, never emits a number |
| 7–9 | `run.ts:549/551/553` band endpoints | `typeof === 'number'` + `finiteNum` after | No | Unchanged |
| 10 | `run.ts:576` `seed_flip_means[]` | `typeof v === 'number'` | No | Unchanged |
| 11 | `run.ts:671` `split_value` | `typeof === 'number'` | No | Widened; drop filter made a **type predicate** so the drop is compiler-enforced rather than remembered |
| **12–13** | **`run.ts:682` `denormMeanOutcome`, consumed at 698 & 708** | **`val === undefined` ONLY** | **YES — LIVE** | **THE FIX.** `unknown` in; absent `mean_outcome` is now **omitted**. Contract-legal with no contract change: `mean_outcome?: number` is optional on both `ISLConditionalBucket` and the outbound `ConditionalBucket` |

### Correction to the lane brief

The brief predicted the blind sites were `run.ts:549/551/553/576`. **That was wrong, and the mutation run proved it wrong.** Those four are preceded by `typeof x === 'number'`, and `typeof null === 'object'` — null could never reach the arithmetic there. The genuinely blind site was `denormMeanOutcome` (line 682), whose guard tested `=== undefined` and therefore let `null` straight through on the live `/v2/run` → CEE path. Recording this because the tests I wrote for the predicted sites are green on pristine, and shipping them labelled "DEFECT" would have been exactly the theatre this programme hunts.

---

## RED-first evidence + mutation proof

`tests/denormalise-value-absence-in-absence-out.test.ts` (16 tests) was run against the **pristine pre-fix source at `f8e4df10`**, in a throwaway clone **outside the repo root** (trap 9c), removed before any gate run.

**Verdict: 6 failed | 10 passed.** Every failure named the fabrication verbatim:

```
DEFECT: null no longer becomes the range FLOOR …            → expected 10 to be undefined
DEFECT: the fabricated floor was FINITE …                   → expected 10 to be undefined
DEFECT: every absence shape maps to undefined …             → expected 10 to be undefined
DEFECT: absence beats the zero-width shortcut …             → expected  5 to be undefined
DEFECT: a null mean_outcome is OMITTED …    → expected { winner_id: 'opt1' } to not have property "mean_outcome"
DEFECT: one null bucket is omitted, sibling survives …      → same
```

Tests are labelled by **what that run actually proved**, not by intent — the legend is in the file header:

- **`DEFECT:` (6)** — RED on pristine. These discriminate.
- **`PIN:` (5)** — green on pristine too. An existing caller-side guard already covered that path, so they do **not** prove this lane's fix. They are regression pins, and three of them cover guards this lane **deleted** as redundant (`probeIsFinite`, the `as number` cast, the unnarrowed egress push) — proving the removal changed nothing observable is the claim that actually needed a test.
- **`POSITIVE CONTROL:` (5)** — green both ways *by design*. A control that went red on pristine would be a broken control.

### Positive controls (one per changed route)

| Route | Control |
|---|---|
| primitive | `0→10`, `0.5→15`, `1→20`, `0.5/[10,60]→35`, `0.25/[0,500000]→125000`, no clamping (`-1→0`, `2→30`), zero-width range → single point |
| `transformConditionalWinners` | full entry asserted as **exact serialised bytes** |
| `transformConditionalWinners` | **`mean_outcome: 0` is PRESERVED** — the sharpest over-suppression trap, since a real zero maps to the same floor (10) the null defect fabricated |
| `transformEdgeEValues` | full edge asserted as **exact serialised bytes** (`current_mean: 15`, `flip_mean: 16`) |
| `denormaliseFlipThresholds` | probe `0.25 → 50`, `display_value_available: true`, surrounding entry unchanged |

The byte-exact control earned its keep: it caught a wrong expectation of mine (`factor_label` resolution) on the first run.

---

## Contract collisions

**None.** No shared contract was relaxed, and nothing needed the #278 skipped-assertion treatment.

- `mean_outcome?: number` — already optional on `ISLConditionalBucket` (`isl-types.ts:499`) and `ConditionalBucket` (`engine-v3.ts:1773`). Omission is contract-legal as-is.
- `split_value: number` and `current_mean: number` are **required** on the outbound types, so absence there cannot be omitted. Honest disposal is to **drop the whole entry**, which the pre-existing numeric-egress guards already do — and which is now compiler-enforced via a `ConditionalWinnerDraft` type plus a type-predicate filter, instead of relying on a `number` declaration that was a fiction.

---

## Siblings

**Swept `src/lib/` for numeric primitives doing arithmetic on a typed-`number` parameter reachable by null through an `as`-cast wire boundary.** Complete list of exported numeric primitives in `src/lib/`: `isFiniteRange`, `normaliseValue`, `denormaliseValue`, `sanitiseIslVoi`, `getFixtureCacheSize`, `countEvidence`, `countPriors`. One genuine sibling.

### ⚠ REPORTED, NOT FIXED — `normaliseValue` (`src/lib/intervention-normaliser.ts:338`)

Same class, **ingress** side, and **live-reachable**: the Ajv schema for `/v2/run` declares `interventions: { type: 'object' }` (`run.ts` ~1233) — the *values inside are entirely unvalidated*, so a null intervention passes request validation and reaches `normaliseValue` at `intervention-normaliser.ts:653`.

Measured:

```
normaliseValue(null, {min:10, max:20})  → { normalised: 0, clamped: true  }
normaliseValue(null, {min:0,  max:200}) → { normalised: 0, clamped: false }   ← SILENT
```

A null intervention becomes **"intervene at the range minimum"**, and on a min-0 range it is not even flagged as clamped.

**Not fixed here, deliberately.** The disposal is a doctrine call, not a mechanical one: reject the request `400` vs drop the intervention vs default it. Silently dropping an intervention changes *what was analysed* while still returning a confident answer — a worse failure than the one being fixed. It also returns a struct (`{normalised, clamped}`), so "absence out" needs a shape decision. Queued for its own slice with a doctrine ruling.

Not siblings, checked and cleared:
- `sanitiseIslVoi(value: unknown): number | undefined` (`evpi-emission.ts:39`) — already the correct shape; used as the exemplar.
- `normaliseValue(value: number)` in `validation/identical-options.ts:35` — local rounding helper; its only caller explicitly maps invalid input to `NaN` so it cannot match a valid canonical key. Safe by construction.

---

## One existing test changed

`tests/gates/numeric-safety-deep-scan.test.ts` asserted `Number.isNaN(denormaliseValue(NaN, …)) === true` — i.e. that `denormaliseValue` *was* an unguarded seam. This lane deliberately ends that, so the assertion was split: the `normaliseValue` half (still an unguarded seam, boundary guards still required) is unchanged and still asserted; the `denormaliseValue` half now asserts `toBeUndefined()`, with the reason recorded inline rather than the assertion silently flipped.

---

## Gates

Baseline derived **before** any change, in a **separate pristine clone** at `f8e4df10` (the first baseline run was discarded — an edit landed mid-run, so it could not be trusted).

| | Baseline (pristine `f8e4df10`) | After |
|---|---|---|
| `tsc --noEmit` | exit 0 | exit 0 |
| Test Files | 572 passed \| 4 skipped (576) | 573 passed \| 4 skipped (577) |
| Tests | 6148 passed \| 30 skipped (6189) | 6165 passed \| 30 skipped (6206) |

Zero failures, no baseline bump, nothing quarantined or skipped. Net **+17 tests** = 16 (new file) + 1 (the gate assertion split in two). Skip count unchanged at 30 — nothing was skipped to get green.

**CI reds:** derived, not assumed. The immediately preceding merged PR (#279) was **11/11 green — including `gates (windows-latest)` and `audit`**. There is no standing red to tolerate on this repo right now; any red on this PR is mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
