### PR TITLE
fix(v2/run): reject non-finite intervention values at the REQUEST BOUNDARY — and close the silent drop that hid them

### DIFF
--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -331,11 +331,52 @@ export function deriveRange(
  * - Zero-width range (min == max): return 0.5 (midpoint)
  * - Value outside range: clamp to [0, 1]
  *
- * @param value Raw value to normalise
+ * ABSENCE IN ⇒ ABSENCE OUT (ROADMAP 1.278). The parameter is `unknown` and the
+ * return is `… | undefined` **on purpose** — the ingress side of the same
+ * fabricate-on-absence class ROADMAP 1.277 closed on `denormaliseValue`, and
+ * deliberately given the SAME shape so a reader of this file does not have to
+ * remember which of the two adjacent primitives self-guards.
+ *
+ * The signature used to be `(value: number, …)`, and that `number` was a
+ * compile-time fiction: `interventions` arrives through an Ajv schema that types
+ * the CONTAINER only (`{ type: 'object' }`), so the values were never validated
+ * against it. `null` therefore reached the arithmetic and coerced to 0:
+ *
+ *     normaliseValue(null, { min: 10, max: 20 })  → { normalised: 0, clamped: true  }
+ *     normaliseValue(null, { min: 0,  max: 200 }) → { normalised: 0, clamped: false }
+ *
+ * i.e. an unspecified intervention silently became **"intervene at the range
+ * minimum"** — a different question, answered confidently — and on a min-0 range
+ * it was not even flagged as clamped. `clamped` is the only signal this struct
+ * carries about a suspect input, and the SILENT case is precisely the one where
+ * a caller could have noticed.
+ *
+ * Note the asymmetry that hid it: `undefined`, a missing key and a non-numeric
+ * string all produce `NaN` here, which downstream finiteness checks reject — so
+ * absence tests written with those shapes passed, while `null`, the shape the
+ * wire actually carries, produced a plausible finite number. `NaN` was in fact
+ * asserted as a DELIBERATELY UNGUARDED SEAM by
+ * tests/gates/numeric-safety-deep-scan.test.ts; that assertion is updated in
+ * this slice, because the seam is now closed.
+ *
+ * @param value Raw value to normalise — UNTRUSTED; may be any wire shape
  * @param range Normalisation range
- * @returns Normalised value in [0, 1]
+ * @returns `{ normalised, clamped }`, or `undefined` if `value` was not a finite
+ *          number (absent / null / NaN / ±Infinity / non-numeric)
  */
-export function normaliseValue(value: number, range: NormalisationRange): { normalised: number; clamped: boolean } {
+export function normaliseValue(
+  value: unknown,
+  range: NormalisationRange,
+): { normalised: number; clamped: boolean } | undefined {
+  // Absence in ⇒ absence out. Never arithmetic on a non-number: `null` coerces
+  // to 0 and manufactures the range minimum as a plausible intervention.
+  const v = finiteNum(value);
+  if (v === undefined) return undefined;
+
+  return normaliseFiniteValue(v, range);
+}
+
+function normaliseFiniteValue(value: number, range: NormalisationRange): { normalised: number; clamped: boolean } {
   const { min, max } = range;
   const rangeWidth = max - min;
 
@@ -650,7 +691,28 @@ export function normaliseOptions(
         ? factorContext.range
         : fallbackRanges.get(factorId) ?? { min: 0, max: 1, source: 'default' };
 
-      const { normalised, clamped } = normaliseValue(intervention.value, range);
+      // ROADMAP 1.278 — explicit absence handling. `InterventionValueV3.value`
+      // is a REQUIRED number, so there is no honest way to represent absence in
+      // the normalised output: omitting the entry would silently change WHAT WAS
+      // ANALYSED while still returning a confident answer (the worse failure),
+      // and substituting any number fabricates. The only non-fabricating
+      // disposal is to refuse.
+      //
+      // REACHABILITY: unreachable from the wire. POST /v2/run rejects a
+      // non-finite intervention value at the Phase 1a++ ingress guard
+      // (422 INVALID_INTERVENTION_VALUE) before this runs, and that guard shares
+      // its predicate with normalizeInterventions(). This throw is
+      // defence-in-depth for a FUTURE in-process caller, and it converts a
+      // silent fabrication into a loud, precisely-named failure.
+      const normalisation = normaliseValue(intervention.value, range);
+      if (normalisation === undefined) {
+        throw new Error(
+          `normaliseOptions: non-finite intervention value for option '${option.id}' factor '${factorId}' ` +
+          `(received ${JSON.stringify(intervention.value) ?? 'undefined'}). ` +
+          `Intervention values must be validated at the request boundary before normalisation.`,
+        );
+      }
+      const { normalised, clamped } = normalisation;
 
       normalisedInterventions[factorId] = {
         value: normalised,
@@ -1238,8 +1300,30 @@ export function normaliseGoalConstraints(
       producerDeclaredRange === undefined ||
       rangesEqual(interventionScale, producerDeclaredRange);
 
-    // Normalise value
-    let { normalised, clamped } = normaliseValue(value, range);
+    // Normalise value — explicit absence handling (ROADMAP 1.278).
+    //
+    // REACHABILITY of a non-finite `value` here: NONE, from any of the three
+    // producers of a GoalConstraint, each already finiteness-guarded:
+    //   1. client `body.goal_constraints`  → routes/v2/run.ts Phase 1b++
+    //      ingress-shape guard rejects a non-finite `value` with a 422
+    //      INVALID_CONSTRAINT_SHAPE naming the index and field.
+    //   2. graph-compiled constraint nodes → normalisation/constraint-compiler.ts
+    //      skips a node whose observed_state.value is not a finite number.
+    //   3. auto-synthesis from goal_threshold → routes/v2/run.ts guards
+    //      `Number.isFinite(autoThreshold)`, and goal_threshold itself is
+    //      parsed with an explicit null→undefined + isFinite branch.
+    // `NormalisedGoalConstraint.normalised_value` is a required number, so — as
+    // at the intervention call site above — refusing is the only disposal that
+    // neither fabricates nor silently drops a constraint from the analysis.
+    const constraintNormalisation = normaliseValue(value, range);
+    if (constraintNormalisation === undefined) {
+      throw new Error(
+        `normaliseGoalConstraints: non-finite value for constraint '${constraint_id}' on node '${node_id}' ` +
+        `(received ${JSON.stringify(value) ?? 'undefined'}). ` +
+        `Constraint values must be validated at the request boundary before normalisation.`,
+      );
+    }
+    let { normalised, clamped } = constraintNormalisation;
 
     // Prefer the node's CEE-stamped, already-normalised goal_threshold when it
     // corresponds to the same target under a producer-declared cap.

--- a/src/lib/intervention-value.ts
+++ b/src/lib/intervention-value.ts
@@ -1,0 +1,57 @@
+/**
+ * Intervention value reader — the SINGLE definition of "what /v2/run accepts as
+ * an intervention value", shared by the request-boundary guard and the request
+ * normaliser so the two can never disagree about which entries are valid.
+ *
+ * WHY THIS EXISTS (ROADMAP 1.278)
+ * ------------------------------------------------------------------------
+ * `/v2/run` accepts TWO intervention wire shapes:
+ *
+ *     simple   { "factor_price": 10 }
+ *     rich     { "factor_price": { "value": 10, "source": "user_specified" } }
+ *
+ * The Ajv body schema types `interventions` as `{ type: 'object' }` — the
+ * container only, the VALUES entirely unvalidated — so every shape decision was
+ * made by hand, in two places, with two different answers:
+ *
+ *   - `normalizeInterventions` (routes/v2/run.ts) DROPPED any entry that was
+ *     neither a number nor an object carrying a `value` key, under the comment
+ *     "Skip invalid entries (will be caught by validation)".
+ *   - preflight's `INVALID_INTERVENTION_VALUE` check then validated the
+ *     ALREADY-NORMALISED options — i.e. the view the drop had already edited.
+ *
+ * So the comment was false for exactly the entries the drop removed: preflight
+ * could not catch them because preflight could no longer see them. `{"f": null,
+ * "g": 60}` lost `f` silently and passed preflight with a one-intervention
+ * option the caller never asked for. (Measured; see the ingress guard in
+ * routes/v2/run.ts and tests/intervention-ingress-shape-guard.test.ts.)
+ *
+ * A hand-maintained mirror WILL drift, and the drift reads as green. This module
+ * is the derive-don't-mirror fix: one predicate, two consumers.
+ */
+
+/**
+ * Read the numeric value out of either accepted intervention wire shape.
+ *
+ * ABSENCE IN ⇒ ABSENCE OUT. The parameter is `unknown` on purpose — this reads
+ * UNVALIDATED request data, so a `number` parameter here would be the same
+ * compile-time fiction that ROADMAP 1.277 removed from `denormaliseValue`.
+ *
+ * A rich object may carry additional keys (`source`, `raw_value`, `uncertainty`,
+ * …); only `value` is read, and unknown keys are preserved by the caller.
+ *
+ * @param raw One entry of an `options[].interventions` map, exactly as received
+ * @returns The finite intervention value, or `undefined` when the entry carries
+ *          none (null / missing / non-numeric / NaN / ±Infinity / a rich object
+ *          with no finite `value`)
+ */
+export function readInterventionValue(raw: unknown): number | undefined {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) ? raw : undefined;
+  }
+  if (raw !== null && typeof raw === 'object' && !Array.isArray(raw) && 'value' in raw) {
+    const value = (raw as { value: unknown }).value;
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  }
+  return undefined;
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -170,6 +170,7 @@ import { deriveMarginPrecision } from '../../trust/margin-precision.js';
 import { deriveConfidenceTier, reconcileConfidenceTier } from '../../trust/confidence-tier.js';
 import { detectDominantFactor } from '../../trust/factor-dominance.js';
 import type { IdentifiabilityAssessment } from '../../types/engine-v3.js';
+import { readInterventionValue } from '../../lib/intervention-value.js';
 import {
   normaliseOptionsForISL,
   denormaliseISLResult,
@@ -1167,18 +1168,30 @@ function normalizeInterventions(
   const result: Record<string, { value: number; source: 'user_specified' | 'brief_extraction' | 'cee_hypothesis' }> = {};
 
   for (const [nodeId, intervention] of Object.entries(interventions ?? {})) {
-    if (typeof intervention === 'number') {
-      // Simple number → wrap in object with default source
-      result[nodeId] = { value: intervention, source: 'user_specified' };
-    } else if (intervention && typeof intervention === 'object' && 'value' in intervention) {
-      // Already rich object - normalize source
-      const source = intervention.source;
-      const validSource = (source === 'brief_extraction' || source === 'cee_hypothesis')
-        ? source
-        : 'user_specified';
-      result[nodeId] = { value: intervention.value, source: validSource };
-    }
-    // Skip invalid entries (will be caught by validation)
+    // ROADMAP 1.278: inclusion is decided by the SHARED reader, the same
+    // predicate the Phase 1a++ ingress guard rejects on — so "what survives
+    // normalisation" and "what the boundary accepts" cannot drift apart.
+    //
+    // The comment that used to sit on the else-branch here read "Skip invalid
+    // entries (will be caught by validation)". That was FALSE, and it was the
+    // defect: preflight's INVALID_INTERVENTION_VALUE check runs against the
+    // ALREADY-NORMALISED options, so an entry dropped here is an entry
+    // preflight can no longer see. `{"f": null, "g": 60}` lost `f` silently
+    // and passed preflight as a one-intervention option.
+    //
+    // The drop is now UNREACHABLE on the route: the ingress guard 422s any
+    // entry this reader rejects, so by the time a request is analysed every
+    // entry carries a finite value and this function is total.
+    const value = readInterventionValue(intervention);
+    if (value === undefined) continue;
+
+    const source = (intervention && typeof intervention === 'object')
+      ? (intervention as { source?: string }).source
+      : undefined;
+    const validSource = (source === 'brief_extraction' || source === 'cee_hypothesis')
+      ? source
+      : 'user_specified';
+    result[nodeId] = { value, source: validSource };
   }
 
   return result;
@@ -4567,6 +4580,71 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             requestId,
             requestComputedAt,
           ));
+        }
+
+        // =================================================================
+        // Phase 1a++: Intervention Ingress-Shape Guard (ROADMAP 1.278)
+        // =================================================================
+        // Same defect class as the Phase 1b++ constraint guard below, on the
+        // sibling field: the runV3 body JSON-schema types `interventions` as
+        // `{ type: 'object' }` — the container only, the VALUES entirely
+        // unvalidated — so every shape decision was made by hand downstream.
+        //
+        // Two hand-written answers existed and they disagreed:
+        //   - normalizeInterventions() DROPPED any entry that was neither a
+        //     number nor an object with a `value` key;
+        //   - preflight's INVALID_INTERVENTION_VALUE then validated the
+        //     ALREADY-NORMALISED options — the view the drop had edited.
+        // So preflight structurally could not see the entries the drop removed.
+        // MEASURED on the pristine tip: `{"f": null, "g": 60}` lost `f`
+        // silently, passed preflight as a one-intervention option, and then
+        // threw inside canonicaliseOption() on the RAW body — surfacing as
+        // HTTP 200 + analysis_status:"failed" + PLOT_INTERNAL_ERROR. A
+        // malformed request must get a malformed-request answer, not a masked
+        // internal error and not an analysis of a set the caller never sent.
+        //
+        // This guard reads the RAW body (the only view that still contains the
+        // dropped entries), rejects on the SHARED readInterventionValue()
+        // predicate that normalizeInterventions() now also uses, and names the
+        // offending option id AND factor key. It runs before preflight, before
+        // hashRequest(), and before normaliseOptionsForISL(), so no consumer
+        // downstream can see a non-finite intervention value.
+        //
+        // Preflight's own INVALID_INTERVENTION_VALUE check is deliberately
+        // LEFT IN PLACE as defence-in-depth (the same disposal ROADMAP 1.277
+        // gave #278's caller-side guard) and keeps covering direct in-process
+        // callers of runPreflightValidation().
+        if (Array.isArray(body.options)) {
+          for (const option of body.options) {
+            const interventions = (option as { interventions?: unknown })?.interventions;
+            if (!interventions || typeof interventions !== 'object' || Array.isArray(interventions)) continue;
+            for (const [factorKey, raw] of Object.entries(interventions as Record<string, unknown>)) {
+              if (readInterventionValue(raw) !== undefined) continue;
+              const optionId = String((option as { id?: unknown })?.id ?? '');
+              return reply.status(422).send(buildBlockedResponse(
+                `Invalid intervention value: options[id=${optionId}].interventions['${factorKey}'] must be a finite number`,
+                [{
+                  id: randomUUID(),
+                  code: 'INVALID_INTERVENTION_VALUE',
+                  severity: 'blocker',
+                  // Message names the offending option id AND factor key (the
+                  // CritiqueV3 shape has no field_path; the path goes in the
+                  // text, matching INVALID_CONSTRAINT_SHAPE below). The ids are
+                  // ALSO carried structurally in affected_option_ids /
+                  // affected_node_ids so a consumer need not parse prose.
+                  message: `Option '${optionId}' has an invalid intervention value for node '${factorKey}'. Value must be a finite number, either as options[].interventions['${factorKey}'] or as options[].interventions['${factorKey}'].value.`,
+                  source: 'validation',
+                  affected_option_ids: [optionId],
+                  affected_node_ids: [factorKey],
+                  blocks_analysis: true,
+                }],
+                normalizedGraph,
+                normalizedOptions,
+                requestId,
+                requestComputedAt,
+              ));
+            }
+          }
         }
 
         // =================================================================

--- a/tests/gates/numeric-safety-deep-scan.test.ts
+++ b/tests/gates/numeric-safety-deep-scan.test.ts
@@ -208,9 +208,34 @@ async function run(app: FastifyInstance) {
 // ---------------------------------------------------------------------------
 
 describe('WP5 gate · numeric seam + boundary guard (unit)', () => {
-  it('normaliseValue(NaN) propagates NaN — the seam non-finite must be caught at boundaries', () => {
-    const { normalised } = normaliseValue(N, { min: 0, max: 1, source: 'default' });
-    expect(Number.isNaN(normalised)).toBe(true); // documents the seam: arithmetic does not self-guard
+  it('normaliseValue(NaN) SELF-GUARDS to undefined (ROADMAP 1.278) — the last bare numeric seam is closed', () => {
+    // This assertion used to read `Number.isNaN(normaliseValue(N, …).normalised) === true`,
+    // documenting normaliseValue as a DELIBERATELY UNGUARDED seam whose non-finite
+    // inputs "must be caught at boundaries". ROADMAP 1.278 ends that, for the same
+    // reason ROADMAP 1.277 ended it for the sibling denormaliseValue: the seam was
+    // only ever safe against the shapes that produce NaN. It was NOT safe against
+    // `null`, which coerces to 0 and yields the RANGE MINIMUM as a plausible,
+    // finite, un-flagged intervention — a value no downstream finiteness check can
+    // distinguish from a real one. That is why asserting the NaN half kept passing
+    // while the class stayed open: this gate was testing the one absence shape the
+    // arithmetic happened to poison loudly.
+    //
+    // WHAT PROVES THE GUARD BITES (not just that it exists): the mutation run for
+    // this slice reverted the primitive hardening alone and the DEFECT-labelled
+    // cases in tests/intervention-normaliser-absence.test.ts went RED — including
+    // the SILENT one, `null` on a min-0 range, which returns
+    // `{ normalised: 0, clamped: false }` when the guard is absent.
+    //
+    // Boundary guards are still required and still asserted — see the Phase 1a++
+    // ingress guard pinned by tests/intervention-ingress-shape-guard.test.ts. The
+    // primitive is defence-in-depth, not a replacement for them.
+    expect(normaliseValue(N, { min: 0, max: 1, source: 'default' })).toBeUndefined();
+    expect(normaliseValue(null, { min: 10, max: 20, source: 'default' })).toBeUndefined();
+    // The SILENT shape specifically: a min-0 range fabricated 0 with clamped:false.
+    expect(normaliseValue(null, { min: 0, max: 200, source: 'default' })).toBeUndefined();
+    // Positive control: a real value is untouched, and 0 is a REAL value.
+    expect(normaliseValue(0.5, { min: 0, max: 1, source: 'default' })).toEqual({ normalised: 0.5, clamped: false });
+    expect(normaliseValue(0, { min: 0, max: 200, source: 'default' })).toEqual({ normalised: 0, clamped: false });
   });
 
   it('denormaliseValue(NaN) SELF-GUARDS to undefined (ROADMAP 1.277) — no longer a bare seam', () => {

--- a/tests/intervention-ingress-shape-guard.test.ts
+++ b/tests/intervention-ingress-shape-guard.test.ts
@@ -1,0 +1,282 @@
+/**
+ * ROADMAP 1.278 — Phase 1a++ Intervention Ingress-Shape Guard (POST /v2/run).
+ *
+ * ============================================================================
+ * WHAT WAS ACTUALLY BROKEN (measured on pristine 016393fa, not inferred)
+ * ============================================================================
+ * The Ajv body schema types `interventions` as `{ type: 'object' }` — the
+ * container only, the VALUES unvalidated. Two hand-written shape decisions then
+ * disagreed with each other:
+ *
+ *   - `normalizeInterventions()` DROPPED any entry that was neither a number nor
+ *     an object with a `value` key, under the comment
+ *     "Skip invalid entries (will be caught by validation)";
+ *   - preflight's `INVALID_INTERVENTION_VALUE` check then ran against the
+ *     ALREADY-NORMALISED options — the very view the drop had edited.
+ *
+ * So the comment was false for exactly the entries the drop removed: preflight
+ * structurally could not see them. Measured behaviour on the pristine tip:
+ *
+ *   REQUEST                                 PRISTINE RESULT
+ *   {"f": null}                             422 EMPTY_INTERVENTIONS
+ *                                             — "does not specify what it
+ *                                               changes", which MISDESCRIBES a
+ *                                               malformed value as an absent one
+ *   {"f": null, "g": 60}                    HTTP 200, analysis_status "failed",
+ *                                             PLOT_INTERNAL_ERROR
+ *                                             (TypeError "Cannot read properties
+ *                                             of null (reading 'value')" thrown
+ *                                             inside canonicaliseOption, which
+ *                                             reads the RAW body)
+ *   {"f": "abc" | [1,2] | {}, "g": 60}      HTTP 200, "failed",
+ *                                             PLOT_INTERNAL_ERROR (TypeError
+ *                                             "Cannot read properties of
+ *                                             undefined (reading 'toFixed')")
+ *   {"f": {"value": null}}                  422 INVALID_INTERVENTION_VALUE
+ *                                             (preflight CAN see this one — the
+ *                                             drop preserves a `value` key)
+ *
+ * A malformed request must get a malformed-request answer. A 200 carrying an
+ * internal error is neither, and it is the shape a client is least able to act
+ * on. The guard reads the RAW body — the only view that still contains the
+ * dropped entries — and rejects on the SAME `readInterventionValue()` predicate
+ * `normalizeInterventions()` now uses, so the two cannot drift apart.
+ *
+ * ============================================================================
+ * TEST LABELS — assigned by what the MUTATION RUN PROVED, not by intent
+ * ============================================================================
+ *   DEFECT:           went RED when the Phase 1a++ guard was reverted alone.
+ *   PIN:              green on pristine too — an existing guard already covered
+ *                     that path. Does NOT prove this lane's fix; it pins that
+ *                     the fix did not REGRESS behaviour that was already right.
+ *   POSITIVE CONTROL: green both ways by design. A control that went red on the
+ *                     pristine source would be a broken control.
+ *
+ * ENVELOPE NOTE: this is a 422 `buildBlockedResponse`, not a 400. The ruling
+ * asked for "the same error format the route's other 400s use" — inspected, and
+ * /v2/run has exactly ONE 400 (the preValidation unknown-TOP-LEVEL-key filter,
+ * which cannot carry per-field structure) against fifteen 422
+ * `buildBlockedResponse` rejections, including the direct precedent for this
+ * exact defect class on the sibling field (Phase 1b++, `goal_constraints`).
+ * `INVALID_INTERVENTION_VALUE` already existed as a 422 blocker code with a
+ * humaniser. Matching the house shape was the instruction; 422 IS the house
+ * shape here. See the PR body.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// --------------------------------------------------------------------------
+// Mocked ISL. `islCallCount` is the instrument for the strongest claim in this
+// file: a malformed request must never reach the compute layer at all.
+// --------------------------------------------------------------------------
+let islCallCount = 0;
+let lastIslOptions: unknown = null;
+
+function islPayload(options: Array<{ id: string }>) {
+  return {
+    options: options.map((o, i) => ({
+      option_id: o.id, win_probability: i === 0 ? 0.72 : 0.28, probability_of_goal: 0.6,
+      expected_outcome: 0.7, confidence_interval: [0.5, 0.9],
+      outcome: { mean: 0.7 - i * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1 },
+      rank: i + 1,
+    })),
+    edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2', edge_sensitivity_status: 'available',
+    factors: [], factor_sensitivity: [], value_of_information: [],
+    factors_provenance: 'unavailable', factor_sensitivity_status: 'skipped_no_factor_values',
+    overall_robustness: 'robust', robustness_score: 0.8,
+    fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl',
+  };
+}
+
+const svc = {
+  isEnabled: () => true,
+  isAvailable: async () => true,
+  validateCausal: async () => ({
+    status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [],
+    backdoor_paths: [], issues: [], explanation: { summary: 'm', reasoning: 't' }, source: 'isl',
+  }),
+  analyseSensitivity: async () => ({ overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' }),
+  analyseRobustness: async (_g: unknown, _n: string, o: Array<{ id: string }>) => {
+    islCallCount++; lastIslOptions = JSON.parse(JSON.stringify(o)); return islPayload(o);
+  },
+  analyseFactorSensitivity: async () => ({ factors: [], value_of_information: [], robustness_label: 'robust', robustness_score: 0.8, latency_ms: 0, source: 'unavailable' }),
+  computeCounterfactual: async () => { throw new Error('not used'); },
+  callAnalysisEndpoint: async (_e: string, b: { options?: Array<{ id: string }> }) => {
+    islCallCount++; lastIslOptions = JSON.parse(JSON.stringify(b.options ?? []));
+    return { data: islPayload(b.options ?? []), error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => svc, islService: svc };
+});
+
+const { createServer } = await import('../src/createServer.js');
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'G' },
+    { id: 'f', kind: 'factor', label: 'F', observed_state: { value: 100 } },
+    { id: 'g', kind: 'factor', label: 'GG', observed_state: { value: 50 } },
+  ],
+  edges: [
+    { from: 'f', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'g', to: 'goal', strength: { mean: 0.4, std: 0.1 } },
+  ],
+};
+
+let app: FastifyInstance;
+
+async function post(o1Interventions: unknown, o2Interventions: unknown = { f: 80, g: 40 }) {
+  islCallCount = 0; lastIslOptions = null;
+  const res = await app.inject({
+    method: 'POST', url: '/v2/run', headers: { 'content-type': 'application/json' },
+    payload: {
+      graph: GRAPH,
+      options: [
+        { id: 'o1', label: 'O1', interventions: o1Interventions },
+        { id: 'o2', label: 'O2', interventions: o2Interventions },
+      ],
+      goal_node_id: 'goal', seed: '42',
+    },
+  });
+  return { res, body: JSON.parse(res.body) as Record<string, unknown> };
+}
+
+function critiques(body: Record<string, unknown>) {
+  return (body.critiques ?? []) as Array<Record<string, unknown>>;
+}
+
+beforeAll(async () => {
+  process.env.RATE_LIMIT_ENABLED = '0';
+  process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+  app = await createServer();
+});
+afterAll(async () => {
+  await app?.close();
+  delete process.env.RATE_LIMIT_ENABLED;
+  delete process.env.CEE_ORCHESTRATOR_ENABLED;
+});
+
+describe('ROADMAP 1.278 · Phase 1a++ intervention ingress-shape guard', () => {
+  it('DEFECT: a bare null alongside a valid intervention is REJECTED, not silently dropped', async () => {
+    // Pristine: HTTP 200 + analysis_status "failed" + PLOT_INTERNAL_ERROR.
+    const { res, body } = await post({ f: null, g: 60 });
+    expect(res.statusCode).toBe(422);
+    expect(body.analysis_status).toBe('blocked');
+    expect(critiques(body).length).toBeGreaterThan(0);
+    expect(critiques(body).map(c => c.code)).toContain('INVALID_INTERVENTION_VALUE');
+    expect(critiques(body).map(c => c.code)).not.toContain('PLOT_INTERNAL_ERROR');
+  });
+
+  it('DEFECT: the malformed request never reaches the compute layer', async () => {
+    // The claim that actually matters: PLoT does not answer a question it was
+    // not asked. On pristine this ALSO happened to be true for `{f:null,g:60}`
+    // (it crashed first) — but only by accident of a TypeError, and it was NOT
+    // true for the request as a whole, which still returned HTTP 200.
+    const { res } = await post({ f: null, g: 60 });
+    expect(res.statusCode).toBe(422);
+    expect(islCallCount).toBe(0);
+    expect(lastIslOptions).toBeNull();
+  });
+
+  it('DEFECT: the 422 names the offending option id AND factor key, in message and structurally', async () => {
+    const { body } = await post({ f: null, g: 60 });
+    const c = critiques(body).find(x => x.code === 'INVALID_INTERVENTION_VALUE')!;
+    expect(c).toBeDefined();
+    expect(c.severity).toBe('blocker');
+    expect(c.source).toBe('validation');
+    expect(c.blocks_analysis).toBe(true);
+    // Structural — a consumer must not have to parse prose.
+    expect(c.affected_option_ids).toEqual(['o1']);
+    expect(c.affected_node_ids).toEqual(['f']);
+    // Prose — names both, and says what a valid value looks like.
+    expect(String(c.message)).toContain("Option 'o1'");
+    expect(String(c.message)).toContain("node 'f'");
+    expect(String(c.message)).toContain('finite number');
+    // The status_reason carries the precise field path.
+    expect(String(body.status_reason)).toContain("options[id=o1].interventions['f']");
+  });
+
+  it('DEFECT: every malformed BARE shape is rejected (the shapes the drop made invisible)', async () => {
+    for (const bad of ['abc', '', true, false, [1, 2], {}, { source: 'user_specified' }, { value: undefined }]) {
+      const { res, body } = await post({ f: bad, g: 60 });
+      expect(res.statusCode, `shape ${JSON.stringify(bad)}`).toBe(422);
+      expect(critiques(body).map(c => c.code), `shape ${JSON.stringify(bad)}`).toContain('INVALID_INTERVENTION_VALUE');
+      expect(islCallCount, `shape ${JSON.stringify(bad)}`).toBe(0);
+    }
+  });
+
+  it('DEFECT: a lone bare null is no longer MISDESCRIBED as "no interventions"', async () => {
+    // Pristine: EMPTY_INTERVENTIONS — "Option 'O1' does not specify what it
+    // changes." The caller DID specify `f`; the value was malformed. An honest
+    // error names the real fault.
+    const { res, body } = await post({ f: null });
+    expect(res.statusCode).toBe(422);
+    expect(critiques(body).map(c => c.code)).toContain('INVALID_INTERVENTION_VALUE');
+    expect(critiques(body).map(c => c.code)).not.toContain('EMPTY_INTERVENTIONS');
+  });
+
+  it('PIN: the RICH null shape stays rejected (preflight already caught this one)', async () => {
+    // Green on pristine too — preflight could see `{value: null}` because the
+    // drop preserves any entry carrying a `value` key. Pinned so that moving
+    // the decision to the ingress guard did not lose the rejection.
+    const { res, body } = await post({ f: { value: null, source: 'user_specified' } });
+    expect(res.statusCode).toBe(422);
+    expect(critiques(body).map(c => c.code)).toContain('INVALID_INTERVENTION_VALUE');
+    expect(islCallCount).toBe(0);
+  });
+
+  it('PIN: a rich non-finite value is rejected on both branches', async () => {
+    for (const bad of [{ value: 'abc' }, { value: true }, { value: null }, { value: [1] }]) {
+      const { res, body } = await post({ f: bad, g: 60 });
+      expect(res.statusCode, JSON.stringify(bad)).toBe(422);
+      expect(critiques(body).map(c => c.code), JSON.stringify(bad)).toContain('INVALID_INTERVENTION_VALUE');
+    }
+  });
+
+  it('POSITIVE CONTROL: a fully valid request is byte-identically unaffected', async () => {
+    const { res, body } = await post({ f: 120, g: 60 });
+    expect(res.statusCode).toBe(200);
+    expect(body.analysis_status).not.toBe('blocked');
+    expect(critiques(body).map(c => c.code)).not.toContain('INVALID_INTERVENTION_VALUE');
+    expect(islCallCount).toBeGreaterThan(0);
+    // The exact normalised interventions handed to the compute layer. If the
+    // guard or the shared reader had altered ANY valid value, this is what
+    // would move.
+    expect(JSON.stringify((lastIslOptions as Array<Record<string, unknown>>).map(o => ({ id: o.id, interventions: o.interventions }))))
+      .toBe(JSON.stringify([
+        { id: 'o1', interventions: { f: 0.8571428571428571, g: 0.8571428571428571 } },
+        { id: 'o2', interventions: { f: 0.14285714285714285, g: 0.14285714285714285 } },
+      ]));
+  });
+
+  it('POSITIVE CONTROL: valid EDGE values survive — 0, negatives, and the rich shape with extra keys', async () => {
+    // 0 is the sharpest arm: a real 0 normalises to the same place the null
+    // defect fabricated, so an over-reaching guard would eat it.
+    for (const good of [
+      { f: 0, g: 60 },
+      { f: -50, g: 60 },
+      { f: { value: 0, source: 'user_specified' }, g: 60 },
+      // Rich object with additional keys — the shape tests/categorical-migration-
+      // safety.test.ts sends (`raw_value: '£180,000'`). Unknown keys must remain
+      // forward-compatible, per the nested-object convention on this route.
+      { f: { value: 180000, raw_value: '£180,000', source: 'user_specified' }, g: 60 },
+    ]) {
+      const { res, body } = await post(good);
+      expect(res.statusCode, JSON.stringify(good)).toBe(200);
+      expect(critiques(body).map(c => c.code), JSON.stringify(good)).not.toContain('INVALID_INTERVENTION_VALUE');
+    }
+  });
+
+  it('POSITIVE CONTROL: an EMPTY interventions map still gets EMPTY_INTERVENTIONS, not the new code', async () => {
+    // Proves the guard did not over-reach into the adjacent, correct diagnosis.
+    // `{}` genuinely does not specify what the option changes.
+    const { res, body } = await post({});
+    expect(res.statusCode).toBe(422);
+    expect(critiques(body).map(c => c.code)).toContain('EMPTY_INTERVENTIONS');
+    expect(critiques(body).map(c => c.code)).not.toContain('INVALID_INTERVENTION_VALUE');
+  });
+});

--- a/tests/intervention-normaliser-absence.test.ts
+++ b/tests/intervention-normaliser-absence.test.ts
@@ -1,0 +1,204 @@
+/**
+ * ROADMAP 1.278 — `normaliseValue`: absence in ⇒ absence out (the INGRESS half
+ * of the fabricate-on-absence class ROADMAP 1.277 closed on `denormaliseValue`).
+ *
+ * ============================================================================
+ * THE MECHANISM
+ * ============================================================================
+ * `normaliseValue(value: number, range)` declared a `number` parameter. That
+ * `number` was a compile-time fiction: `options[].interventions` arrives through
+ * an Ajv body schema that types the CONTAINER only (`interventions: { type:
+ * 'object' }`), so the VALUES were never validated against it.
+ *
+ *     normaliseValue(null, { min: 10, max: 20 })
+ *       === (null - 10) / 10  →  clamp
+ *       === { normalised: 0, clamped: true }      // the RANGE MINIMUM
+ *
+ *     normaliseValue(null, { min: 0, max: 200 })
+ *       === { normalised: 0, clamped: false }     // ← and SILENT
+ *
+ * An unspecified intervention became "intervene at the range minimum" — a
+ * different question, answered confidently. On a min-0 range it was not even
+ * flagged as clamped, so `clamped` (the struct's only suspicion signal) said
+ * nothing. And a numeric STRING was silently coerced: `'15'` on [10,20] returned
+ * a confident 0.5.
+ *
+ * ============================================================================
+ * TEST LABELS — assigned by what the MUTATION RUN PROVED, not by intent
+ * ============================================================================
+ *   DEFECT:           went RED when the primitive hardening was reverted alone.
+ *                     These discriminate — they are the reason this file exists.
+ *   POSITIVE CONTROL: green both ways BY DESIGN. A control that went red on the
+ *                     pristine source would be a broken control, not evidence.
+ *
+ * The mutation arm for this file was `normaliseValue` reverted to its pristine
+ * `(value: number)` body in a throwaway clone OUTSIDE the repo root, with the
+ * Phase 1a++ ingress guard left in place — so these results are attributable to
+ * the primitive alone.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normaliseValue,
+  normaliseOptions,
+  normaliseGoalConstraints,
+  buildNormalisationContext,
+  type NormalisationRange,
+} from '../src/lib/intervention-normaliser.js';
+import type { EngineNodeV3, OptionV3 } from '../src/types/engine-v3.js';
+
+const R = (min: number, max: number): NormalisationRange => ({ min, max, source: 'default' });
+
+// Every shape that carries no finite number. `undefined` and a missing key are
+// NOT wire-reachable (JSON has neither) but ARE reachable for in-process
+// callers, so they are exercised and not claimed as wire cases.
+const ABSENT_SHAPES: Array<[string, unknown]> = [
+  ['null (the wire shape)', null],
+  ['undefined', undefined],
+  ['NaN', Number.NaN],
+  ['+Infinity', Number.POSITIVE_INFINITY],
+  ['-Infinity', Number.NEGATIVE_INFINITY],
+  ['non-numeric string', 'abc'],
+  ['NUMERIC string', '15'],
+  ['empty string', ''],
+  ['boolean true', true],
+  ['boolean false', false],
+  ['empty object', {}],
+  ['array', [1, 2]],
+];
+
+describe('ROADMAP 1.278 · normaliseValue — absence in ⇒ absence out', () => {
+  it('DEFECT: null no longer becomes the range MINIMUM', () => {
+    // Pristine: { normalised: 0, clamped: true } — i.e. "intervene at 10".
+    expect(normaliseValue(null, R(10, 20))).toBeUndefined();
+  });
+
+  it('DEFECT: the SILENT case — null on a min-0 range was not even flagged as clamped', () => {
+    // Pristine: { normalised: 0, clamped: false }. This is the sharpest arm:
+    // the ONE signal a caller could have inspected said "nothing to see here".
+    expect(normaliseValue(null, R(0, 200))).toBeUndefined();
+  });
+
+  it('DEFECT: absence beats the zero-width-range shortcut', () => {
+    // Pristine, min===max===5: `value / max` → 0/5 → { normalised: 0, clamped: true }.
+    // The zero-width branch has its own arithmetic, so it needed its own arm.
+    expect(normaliseValue(null, R(5, 5))).toBeUndefined();
+    // …and the max<=0 zero-width branch, which returns a flat 0.5 midpoint.
+    expect(normaliseValue(null, R(0, 0))).toBeUndefined();
+  });
+
+  it('DEFECT: a NUMERIC STRING is no longer silently coerced to a confident value', () => {
+    // Pristine: '15' on [10,20] → { normalised: 0.5, clamped: false }. JS string
+    // arithmetic made a wire string indistinguishable from a measured number.
+    expect(normaliseValue('15', R(10, 20))).toBeUndefined();
+  });
+
+  it('DEFECT: every absence shape maps to undefined, on every range branch', () => {
+    for (const [label, shape] of ABSENT_SHAPES) {
+      for (const range of [R(10, 20), R(0, 200), R(5, 5), R(0, 0), R(-100, 100)]) {
+        expect(normaliseValue(shape, range), `${label} @ [${range.min},${range.max}]`).toBeUndefined();
+      }
+    }
+  });
+
+  it('POSITIVE CONTROL: a real value normalises byte-identically, and 0 is a REAL value', () => {
+    // The over-suppression trap: a genuine 0 maps to the SAME normalised 0 the
+    // null defect fabricated. If the guard over-reached, this is what would break.
+    expect(normaliseValue(0, R(0, 200))).toEqual({ normalised: 0, clamped: false });
+    expect(normaliseValue(0, R(0, 0))).toEqual({ normalised: 0.5, clamped: false });
+    expect(normaliseValue(10, R(10, 20))).toEqual({ normalised: 0, clamped: false });
+    expect(normaliseValue(15, R(10, 20))).toEqual({ normalised: 0.5, clamped: false });
+    expect(normaliseValue(20, R(10, 20))).toEqual({ normalised: 1, clamped: false });
+    expect(normaliseValue(250000, R(0, 500000))).toEqual({ normalised: 0.5, clamped: false });
+    // Negative values, and the sign-preserving range
+    expect(normaliseValue(-50, R(-100, 100))).toEqual({ normalised: 0.25, clamped: false });
+    // Clamping still reports itself
+    expect(normaliseValue(-10, R(0, 100))).toEqual({ normalised: 0, clamped: true });
+    expect(normaliseValue(150, R(0, 100))).toEqual({ normalised: 1, clamped: true });
+    // Zero-width range, value on the point
+    expect(normaliseValue(5, R(5, 5))).toEqual({ normalised: 1, clamped: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The two production callers — explicit absence handling
+// ---------------------------------------------------------------------------
+
+const NODES: EngineNodeV3[] = [
+  { id: 'goal', kind: 'goal', label: 'G' } as EngineNodeV3,
+  { id: 'f', kind: 'factor', label: 'F', observed_state: { value: 100 } } as EngineNodeV3,
+];
+
+describe('ROADMAP 1.278 · callers handle absence explicitly (never fabricate, never silently drop)', () => {
+  it('DEFECT: normaliseOptions REFUSES a non-finite intervention value, naming option and factor', () => {
+    // Pristine: no throw — the option was normalised to the range minimum and
+    // the analysis proceeded on an intervention the caller never specified.
+    const options = [
+      { id: 'opt1', label: 'O1', interventions: { f: { value: null as unknown as number, source: 'user_specified' } } },
+      { id: 'opt2', label: 'O2', interventions: { f: { value: 80, source: 'user_specified' } } },
+    ] as unknown as OptionV3[];
+    const context = buildNormalisationContext(NODES, 'goal', undefined, options);
+
+    expect(() => normaliseOptions(options, context)).toThrow(/non-finite intervention value/);
+    // The message must name BOTH the option id and the factor key precisely.
+    expect(() => normaliseOptions(options, context)).toThrow(/option 'opt1'/);
+    expect(() => normaliseOptions(options, context)).toThrow(/factor 'f'/);
+  });
+
+  it('POSITIVE CONTROL: a fully valid option set normalises to exactly the same bytes', () => {
+    const options = [
+      { id: 'opt1', label: 'O1', interventions: { f: { value: 120, source: 'user_specified' } } },
+      { id: 'opt2', label: 'O2', interventions: { f: { value: 80, source: 'user_specified' } } },
+    ] as unknown as OptionV3[];
+    const context = buildNormalisationContext(NODES, 'goal', undefined, options);
+    const result = normaliseOptions(options, context);
+
+    // Byte-exact. These are the PRISTINE values (range [72,128] source
+    // 'inferred_spread', derived from observed_state 100 and the {120,80}
+    // intervention spread) — the range-derivation chain is untouched by this
+    // slice and must stay so. This control earned its keep on the first run: it
+    // caught a wrong expectation of mine (I had assumed a [80,120] range giving
+    // 1 and 0).
+    expect(JSON.stringify(result.options)).toBe(JSON.stringify([
+      { id: 'opt1', label: 'O1', interventions: { f: { value: 0.8571428571428571, source: 'user_specified' } } },
+      { id: 'opt2', label: 'O2', interventions: { f: { value: 0.14285714285714285, source: 'user_specified' } } },
+    ]));
+    expect(result.diagnostics.map(d => [d.option_id, d.factor_id, d.original_value, d.normalised_value, d.clamped, d.range.min, d.range.max, d.range.source]))
+      .toEqual([
+        ['opt1', 'f', 120, 0.8571428571428571, false, 72, 128, 'inferred_spread'],
+        ['opt2', 'f', 80, 0.14285714285714285, false, 72, 128, 'inferred_spread'],
+      ]);
+  });
+
+  it('DEFECT: normaliseGoalConstraints REFUSES a non-finite constraint value, naming constraint and node', () => {
+    // Pristine: no throw — the constraint threshold silently became the range
+    // minimum, so the margin/satisfaction verdict answered a threshold nobody set.
+    //
+    // REACHABILITY (stated, not assumed): NONE from the wire. All three
+    // GoalConstraint producers are already finiteness-guarded — the Phase 1b++
+    // ingress-shape guard (client goal_constraints), constraint-compiler.ts
+    // (graph constraint nodes), and the Number.isFinite(autoThreshold) branch
+    // (auto-synthesis from goal_threshold). This is defence-in-depth.
+    const constraints = [
+      { constraint_id: 'c1', node_id: 'goal', operator: '>=', value: null as unknown as number, label: 'L' },
+    ] as never;
+
+    expect(() => normaliseGoalConstraints(constraints, NODES)).toThrow(/non-finite value for constraint/);
+    expect(() => normaliseGoalConstraints(constraints, NODES)).toThrow(/constraint 'c1'/);
+    expect(() => normaliseGoalConstraints(constraints, NODES)).toThrow(/node 'goal'/);
+  });
+
+  it('POSITIVE CONTROL: a valid constraint normalises unchanged', () => {
+    const constraints = [
+      { constraint_id: 'c1', node_id: 'f', operator: '>=', value: 100, label: 'L' },
+    ] as never;
+    const result = normaliseGoalConstraints(constraints, NODES);
+    // Byte-exact. `NormalisedGoalConstraint` OVERWRITES `value` with the
+    // normalised number and preserves the user-unit input in `original_value`
+    // (this control caught a second wrong expectation of mine — I had asserted a
+    // `normalised_value` field, which exists only on the diagnostics).
+    expect(JSON.stringify(result.constraints)).toBe(JSON.stringify([
+      { constraint_id: 'c1', node_id: 'f', operator: '>=', value: 0.5, original_value: 100, label: 'L' },
+    ]));
+  });
+});


### PR DESCRIPTION
PR #280 closed the fabricate-on-absence class at the EGRESS primitive (`denormaliseValue`) and, in its Siblings section, reported `normaliseValue` as the INGRESS twin — deliberately unfixed, because the disposal was a doctrine call. This slice takes that ruling and lands it.

ROADMAP 1.278.

---

## ⚠ Read this first: the brief's reachability premise was WRONG, and the real defect is worse

The lane brief stated the defect was live-reachable as `{"options":[{"interventions":{"f":null}}]}` → `normaliseValue` → confident analysis of the range minimum. **I verified at the bytes and that is false at `016393fa`.** `normaliseValue` is NOT reachable with a non-finite value from `/v2/run`. What I found instead is a different, live, and by the ruling's own standard *worse* failure.

**Measured**, by booting the real server with a mocked ISL and injecting each shape (probe run, pristine tip):

| Request | Pristine result |
|---|---|
| `{"f": {"value": null}}` | **422 `INVALID_INTERVENTION_VALUE`** — already correct |
| `{"f": null}` | 422 **`EMPTY_INTERVENTIONS`** — *"Option 'O1' does not specify what it changes."* The caller **did** specify `f`. A malformed value is misdescribed as an absent one |
| `{"f": null, "g": 60}` | **HTTP 200**, `analysis_status: "failed"`, `PLOT_INTERNAL_ERROR` — `TypeError: Cannot read properties of null (reading 'value')` at `canonicalise.ts:263` |
| `{"f": "abc"\|`[1,2]`\|`{}`\|`{source:'x'}`, "g": 60}` | **HTTP 200**, `"failed"`, `PLOT_INTERNAL_ERROR` — `TypeError: … (reading 'toFixed')` at `canonicalise.ts:143` |
| `{"f": 120, "g": 60}` (control) | 200, `partial`, ISL receives `{f: 0.857…, g: 0.857…}` |

### Why `normaliseValue` was unreachable

Three facts, each derived from the source rather than assumed:

1. `normalizeInterventions` (`run.ts:1164`) **silently DROPS** any entry that is neither a number nor an object carrying a `value` key, under the comment `// Skip invalid entries (will be caught by validation)`.
2. Preflight's `INVALID_INTERVENTION_VALUE` check (`validation/preflight-v2.ts:217-230`) is **complete and correct** — but it validates the **already-normalised** options, i.e. the view the drop has already edited. **`runPreflightValidation` has exactly one caller** (`run.ts:4961`), `passed: blockers.length === 0` (`preflight-v2.ts:952`), and a hard `422` return at `run.ts:4985`.
3. `normaliseOptionsForISL` has **exactly one caller** (`run.ts:5375`), which sits *after* preflight (4961) and after `hashRequest` (5262).

So the rich-null form 422s at preflight, and the bare-malformed form throws in `canonicaliseOption` — which reads the **RAW body** — before the normaliser is ever reached.

### The comment was the defect

`"(will be caught by validation)"` is **false for exactly the entries the drop removes**: preflight structurally cannot see them. This is trap 14 in miniature — an excuse label sitting over a real gap — and trap 12, two hand-written copies of "what is a valid intervention" disagreeing with each other.

And the consequence is the failure mode this ruling condemns most strongly. From the ruling: *"Silent DROPPING is worse (changes what was analysed while still answering)."* That is precisely what `{"f": null, "g": 60}` does — `f` disappears, the option becomes a one-intervention option nobody asked for, and it passes preflight. It only fails to be analysed because it happens to hit a `TypeError` later. **The safety here was an accident of a crash, not a guard** — and the crash itself surfaces as a **200**, which is neither an answer nor an error a client can act on.

**The ruling stands and is unchanged by this.** A malformed request gets a malformed-request answer. The fix just had to be aimed at the mechanism that actually exists.

---

## ASSESS-FIRST: what can the live producers emit?

**Verdict: no live producer can emit a non-finite intervention value. This 422 is pure hardening — no user-visible failure is being introduced.** Read-only audit, static analysis only (nothing was run against a deployed service).

| Producer | Verdict | Evidence |
|---|---|---|
| **CEE** (`olumi-assistants-service` @ `b35d09de`) | **CANNOT** | Two independent nets. (1) `tools/plot-intervention-scale.ts:205-208` returns `{value: null, rule: 'dropped'}` for `!isFiniteNumber(value)`, excluded at `:374`. (2) `orchestrator/plot-client.ts:285-289` **hard-throws** a payload error — ``if (typeof val !== 'number' \|\| !Number.isFinite(val)) throwPayloadError(...)`` — called unconditionally at `:422` before the HTTP call, not flag-gated. CEE also only ever emits the **simple** shape (`build-turn-context.ts:1549` returns `Record<string, number>`). |
| **UI** (`DecisionGuideAI` @ `8b2f5945`) | **CANNOT on any live path** — but see hazard below | Both live entrypoints pre-filter on `Number.isFinite`: `adapter.ts:207-226` (`flattenInterventions`) and `labelUtils.ts:618-633` (`unwrapInterventionValue`). |
| **PLoT-internal** | **CANNOT** | `normaliseOptionsForISL` is imported by exactly one module (`run.ts:174`); the route is the only entry (`app.inject` appears in `src/` only in three comment lines in `logging/decision-tokens.ts`). `/v1/simulate-batch` and `/v1/intervene` use different shapes and pipelines. `grep '"value": *null'` over `fixtures/ tools/ scripts/ examples/ contracts/` → 0 hits. |

### 🚨 Filed immediately — UI latent hazard (not a blocker for this PR)

The UI has two **unguarded** hops that are joined, one wiring change away from live:

- `src/adapters/plot/v2/adapter.ts:144-146` — `extractOptionsFromNodes` accepts `{value: null}` on a bare `'value' in rawValue` test and even flips the option to `status: 'ready'`.
- `src/adapters/plot/v2/adapter.ts:554-558` — `uiOptionToV2Option` does `typeof iv === 'number' ? iv : iv.value` with no finiteness check, which would put a bare `null` on the wire.

Reachable only via the `options.length === 0` fallback (`adapter.ts:1086-1087`) or `executeV2Run` (`:1654`, no production caller today). The store permits the value: `InterventionSchema.value: z.number()` (`canvas/domain/nodes.ts:110`) but `validateNodeData` is explicitly warning-only and never throws (`nodes.ts:350-383`), and `applyDraftResult.ts:484` writes CEE-supplied interventions in unvalidated. **A UI-side fix is filed as its own task.**

Also worth recording: CEE pins `@talchain/schemas` **0.25.0**, the UI pins **0.22.0**, and **neither validates the outbound `/v2/run` request against the shared contract**. The package contains no RunRequest schema for this route at all; the only typed intervention shape in it (`OptionForAnalysisSchema`, `z.record(z.string(), z.number())`) has **zero importers in CEE**. The wire contract on this seam is enforced only by hand-rolled checks at each end — which is exactly how this defect got in.

---

## The fix

### 1. Boundary — Phase 1a++ Intervention Ingress-Shape Guard (primary, altitude-correct)

`src/routes/v2/run.ts`, placed with the other ingress-shape guards, **before** preflight, `hashRequest`, and `normaliseOptionsForISL`. It reads the **RAW body** — the only view that still contains the dropped entries — and rejects with `422 INVALID_INTERVENTION_VALUE`, naming the offending option id and factor key both in prose and structurally (`affected_option_ids` / `affected_node_ids`).

**⚠ Deviation from the ruling's letter, and why — envelope is 422, not 400.** The ruling said *"in the same error format the route's other 400s use — inspect and match, don't invent a new shape."* I inspected. `/v2/run` has **exactly one 400**: the `preValidation` unknown-**top-level**-key filter (`run.ts:4189`), which fires before the handler, uses the `error.v1` envelope, and has no place to carry per-field structure. Against that sit **fifteen** `422 buildBlockedResponse` rejections — including **the direct precedent for this exact defect class on the sibling field**: "Phase 1b++: Constraint Ingress-Shape Guard", written because *"The runV3 body JSON-schema types goal_constraints only as an array of objects — the inner fields are UNVALIDATED."* Same problem, same route, same file. And `INVALID_INTERVENTION_VALUE` **already exists** as a 422 blocker code, in the `CritiqueV3` union (`types/engine-v3.ts:672`), with a humaniser (`critique-humaniser.ts:134`). Matching the house shape *was* the instruction; **422 is the house shape here**, and 400 would have been the invented one.

**⚠ Second deviation — the ruling's Ajv snippet is wrong for this codebase.** `interventions: { type: 'object', additionalProperties: { type: 'number' } }` would **reject the rich object form**, which is a live, supported, and *contract-documented* shape: `contracts/openapi.yaml` declares `interventions.additionalProperties: $ref interventionValueV3`, an object with required `value: number`. Tightening Ajv to `number` would break every rich-shape caller (`tests/categorical-migration-safety.test.ts` sends `{value: 180000, raw_value: '£180,000', source: 'user_specified'}`). Ajv also cannot satisfy the ruling's own envelope requirement: its errors carry the **array index** (`body/options/0/…`), never the **option id**. A hand-rolled guard is the only mechanism that can name what the ruling asked to be named.

### 2. Derive-don't-mirror — one predicate, two consumers

New `src/lib/intervention-value.ts` exports `readInterventionValue(raw: unknown): number \| undefined` — the single definition of the two accepted wire shapes. **Both** the ingress guard and `normalizeInterventions` now use it, so "what the boundary accepts" and "what survives normalisation" cannot drift apart. The false comment is replaced with the measured truth, and the drop is now unreachable on the route.

Preflight's own check is **deliberately left in place** as defence-in-depth — the same disposal #280 gave #278's caller-side guard — and still covers direct in-process callers of `runPreflightValidation`.

### 3. Primitive hardening — `normaliseValue` takes `unknown`

```
BEFORE                                          AFTER
normaliseValue(null, {min:10,max:20})           → undefined
  → { normalised: 0, clamped: true }
normaliseValue(null, {min:0, max:200})          → undefined
  → { normalised: 0, clamped: false }  ← SILENT
normaliseValue('15', {min:10,max:20})           → undefined
  → { normalised: 0.5, clamped: false } ← COERCED
```

The `min:0` case is the sharpest: `clamped` is the only suspicion signal the struct carries, and on a min-0 range it said **nothing**. And JS string arithmetic made a wire *string* `'15'` indistinguishable from a measured number.

**Shape decision (the struct question).** I took the ruling's stated preference — return `undefined`, absence-in-absence-out — over a discriminated union, primarily for a reason the ruling names: `denormaliseValue` sits **directly adjacent in the same file** and already has this shape. A reader must not have to remember that one of two neighbouring primitives self-guards by returning `undefined` and the other by some other convention. The cost is real but bounded: `normaliseValue` has only two production callers.

**Caller disposal — both REFUSE, and why that is not a cop-out.** `InterventionValueV3.value` and `NormalisedGoalConstraint`'s value are **required numbers**. There is no honest way to represent absence in either output: omitting the entry silently changes *what was analysed* while still returning a confident answer (the ruling's worse failure), and substituting any number fabricates. So each caller throws with a message naming the precise option+factor / constraint+node. This is defence-in-depth in the strict sense — it converts a silent fabrication into a loud, precisely-named failure on a path that, after the boundary fix, cannot be reached from the wire.

### 4. `:1242` disposition — reachability is ZERO, and it was ALREADY ZERO

The brief asked me to assess whether a null can reach the goal-constraint path. **It cannot, and it could not before this PR either.** `normaliseGoalConstraints` has exactly one caller (`run.ts:5487`). Complete manifest of the three producers of a `GoalConstraint`, each already finiteness-guarded:

| # | Producer | Existing guard |
|---|---|---|
| 1 | client `body.goal_constraints` | `run.ts:4615-4655` Phase 1b++ — `typeof c.value !== 'number' \|\| !Number.isFinite(c.value)` → **422 `INVALID_CONSTRAINT_SHAPE`** naming index + field |
| 2 | graph constraint nodes | `normalisation/constraint-compiler.ts:192` — non-finite `observed_state.value` ⇒ node **skipped** with a repair record |
| 3 | auto-synthesis from `goal_threshold` | `run.ts:4746` `Number.isFinite(autoThreshold)`; and `goal_threshold` itself parsed at `run.ts:4238-4247` with an explicit `null → undefined` branch |

So `:1242` gets **defence-in-depth only** (explicit `undefined` handling), no boundary work, and the reachability manifest is recorded inline in the source so the next reader does not have to re-derive it.

---

## RED-first + mutation evidence

Two throwaway clones per arm, **outside the repo root** (trap 9c), removed before any gate run.

### RED-first — new tests against the PRISTINE source at `016393fa`

**13 failed | 7 passed** across the three files. The 7 passes are 2 `PIN` + 5 `POSITIVE CONTROL` — green on pristine **by design**.

Ingress guard (`tests/intervention-ingress-shape-guard.test.ts`) — 5 RED:
```
× DEFECT: a bare null alongside a valid intervention is REJECTED, not silently dropped
    → expected 200 to be 422
× DEFECT: the malformed request never reaches the compute layer
× DEFECT: the 422 names the offending option id AND factor key, in message and structurally
× DEFECT: every malformed BARE shape is rejected (the shapes the drop made invisible)
× DEFECT: a lone bare null is no longer MISDESCRIBED as "no interventions"
✓ PIN: the RICH null shape stays rejected (preflight already caught this one)
✓ PIN / ✓ 3× POSITIVE CONTROL
```

Primitive (`tests/intervention-normaliser-absence.test.ts`) — 7 RED:
```
× DEFECT: null no longer becomes the range MINIMUM          → expected {normalised:0,clamped:true}  to be undefined
× DEFECT: the SILENT case — null on a min-0 range …         → expected {normalised:0,clamped:false} to be undefined
× DEFECT: absence beats the zero-width-range shortcut
× DEFECT: a NUMERIC STRING is no longer silently coerced    → expected {normalised:0.5,…} to be undefined
× DEFECT: every absence shape maps to undefined, on every range branch
× DEFECT: normaliseOptions REFUSES a non-finite intervention value, naming option and factor
× DEFECT: normaliseGoalConstraints REFUSES a non-finite constraint value, naming constraint and node
```

Plus the updated `numeric-safety-deep-scan` assertion — 1 RED.

### Mutation arms — each new test bites its OWN mutation, and only its own

| Arm | Reverted | Ingress tests | Primitive tests | numeric-safety gate |
|---|---|---|---|---|
| **A** | Boundary fix alone (`run.ts`: guard + shared-reader normalisation) | **5 RED** | 10 ✓ | ✓ |
| **B** | Primitive hardening alone (`intervention-normaliser.ts`) | 10 ✓ | **7 RED** | **1 RED** |

Clean separability: neither arm's tests fire on the other arm's mutation. Labels are assigned by **what the mutation run proved**, not by intent — the legend is in each file header.

### Positive controls (one per changed path)

| Path | Control |
|---|---|
| ingress guard | a fully valid request → 200, and the **exact serialised bytes** of the interventions handed to the compute layer (`{f: 0.8571428571428571, g: 0.8571428571428571}` / `{f: 0.14285714285714285, …}`) |
| ingress guard | valid **edge** values survive: `0`, negatives, and the rich shape **with extra keys** (`raw_value: '£180,000'`) |
| ingress guard | an **empty** `interventions` map still gets `EMPTY_INTERVENTIONS`, **not** the new code — proves the guard did not over-reach into the adjacent, correct diagnosis |
| primitive | `0` is a **REAL value** and is preserved — the sharpest over-suppression trap, since a genuine 0 maps to the same normalised 0 the null defect fabricated |
| primitive | clamping still reports itself; zero-width ranges unchanged; `normaliseOptions` and `normaliseGoalConstraints` byte-exact |

**The byte-exact controls earned their keep**: they caught **two** wrong expectations of mine on the first run — I had assumed a `[80,120]` range (it is `[72,128]`, `inferred_spread`) and asserted a `normalised_value` field on `NormalisedGoalConstraint` (that field exists only on the diagnostics; the constraint overwrites `value` and preserves `original_value`).

---

## The one existing test changed

`tests/gates/numeric-safety-deep-scan.test.ts` asserted `Number.isNaN(normaliseValue(NaN, …).normalised) === true` — documenting `normaliseValue` as a **deliberately unguarded seam** whose non-finite inputs "must be caught at boundaries". #280 split this assertion in two and moved only the `denormaliseValue` half; this slice moves the other half, so the split closes.

The reason is recorded inline rather than the assertion silently flipped: **the seam was only ever safe against the shapes that produce NaN.** It was not safe against `null`, which coerces to 0 and yields a finite, plausible, un-flagged range minimum. That is why asserting the NaN half kept passing while the class stayed open — *this gate was testing the one absence shape the arithmetic happened to poison loudly.* What proves the new guard bites is stated in the test: mutation arm B reds the DEFECT cases including the silent `min:0` one.

---

## Gates

Baseline derived **before any change**, in this clone at pristine `016393fa`.

| | Baseline (pristine `016393fa`) | After |
|---|---|---|
| `npx tsc -p tsconfig.json --noEmit` | exit 0 | exit 0 |
| Test Files | 573 passed \| 4 skipped (577) | 575 passed \| 4 skipped (579) |
| Tests | 6165 passed \| 30 skipped (6206) | 6185 passed \| 30 skipped (6226) |

Net **+20 tests** = 10 (ingress file) + 10 (primitive file). The gate assertion was modified, not added, so it does not change the count. **Skip count unchanged at 30** — nothing was skipped or quarantined to get green. Full `scripts/pre-push-validate.sh`: **6/6 PASS**.

**Two disclosures, because neither is visible in the numbers above:**

1. **`tsconfig.json` includes `src/**/*.ts` ONLY — the typecheck gate is BLIND to tests** (and `tsconfig.strict.json` merely extends it). So raising `normaliseValue`'s return type did **not** produce the compiler-forced enumeration of test call sites that #280 relied on; the ~25 existing `normaliseValue(...).normalised` call sites in `tests/` are unchecked by any gate and pass only because they all supply finite values. I verified them by running them, not by typechecking them. This is trap 2's refinement — *ask what the config EXCLUDES* — and it applies to this repo, not just CEE.
2. **The first `git push` was REJECTED by the pre-push hook and the second passed with no code change in between.** I truncated the first run's output to five lines and therefore **cannot attribute the failure** — that was my error. Two subsequent full runs of `scripts/pre-push-validate.sh` are green with identical test counts (6185/30). Recording it rather than quietly keeping the green: an unexplained red is not the same as a green.

**CI on this PR: 11/11 GREEN** at `295b640` — `audit`, `gates (ubuntu-latest)`, `gates (macos-latest)`, **`gates (windows-latest)`**, `guard`, `safety` ×2, `smoke`, `test`, `update_release_draft`, `verify`. No red to tolerate, explain, or inherit.

**CI reds:** derived, not assumed. Branch protection on `staging` re-derived this session — `gh api repos/Talchain/plot-lite-service/branches/staging/protection` → **404 "Branch not protected"**. CI lint runs `eslint src tests --ext .ts --max-warnings 97`; this tree reports **86 warnings, 0 errors**, and **none are attributable to the files this PR touches** (the two in `run.ts` are pre-existing unused type imports at lines 82 and 103). Note `npm run lint` uses `--max-warnings 0` and therefore fails on this repo regardless of this PR — it is stricter than the gate CI actually enforces.

---

## What would refute this

Stated so the reviewer can attack it cheaply:

- If any caller of `runPreflightValidation` or `normaliseOptionsForISL` exists that I did not find, the unreachability claims weaken. I derived both manifests by grep over all of `src/` and both returned exactly one caller; the greps are quoted above.
- The producer verdicts are **static analysis only** — no live service was probed. If CEE or the UI can reach a path my reviewer knows about that bypasses `validateRunPayload` / `flattenInterventions`, the "pure hardening" claim becomes "user-visible failure", and the ruling still stands but a producer fix becomes urgent rather than merely filed.
- The UI hazard's unreachability rests on `generateScenarios`' node predicate being strictly narrower than its caller's filter. That argument is sound at the source but was not proven against all runtime store states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
