### PR TITLE
fix(v2/run,facts): stop publishing TWO quantities under the name sensitivity_score (family-4 slice 0)

### DIFF
--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -35,8 +35,15 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     //
     // `FactorSensitivityResultV3` has no `importance_score` member at all, so
     // this is dropped on BOTH paths — graph-primary AND the ISL-only fallback.
-    // It has never been on the wire. (`src/facts/mapper.ts` SYNTHESISES one from
-    // the already-substituted PLoT row; that is not a passthrough.)
+    // It has never been on the wire.
+    //
+    // ⭐ UPDATED — family-4 slice 0, 2026-07-27. This entry used to end
+    // "(`src/facts/mapper.ts` SYNTHESISES one from the already-substituted PLoT
+    // row; that is not a passthrough.)" — an accurate confession of a live
+    // defect: the drop was declared here while a same-named field WAS in fact
+    // emitted, one level down, inside `fact_objects[].data`. That synthesis has
+    // been REMOVED (`mapFactorSensitivity`), so the drop is now true of the
+    // whole /v2/run body rather than of `factor_sensitivity[]` alone.
     'factor_sensitivity[].importance_score',
     // ISL's own MC uncertainty-importance ordering. On the graph-primary path
     // the published `factor_sensitivity[].importance_rank` is PLoT's own

--- a/src/facts/mapper.ts
+++ b/src/facts/mapper.ts
@@ -40,12 +40,19 @@ export interface OptionResultInput {
   };
 }
 
-/** Minimal factor sensitivity shape. */
+/**
+ * Minimal factor sensitivity shape.
+ *
+ * FAMILY-4 SLICE 0 (2026-07-27): `importance_score` was removed. It was never
+ * an input any caller supplied — `FactorSensitivityResultV3` has no
+ * `importance_score` member and "it has never been on the wire"
+ * (src/contracts/isl-to-ui.contract.ts:36-40) — so the `?? f.sensitivity_score`
+ * fallback below it unconditionally SYNTHESISED an alias of another quantity.
+ */
 export interface FactorSensitivityInput {
   node_id: string;
   label?: string;
   sensitivity_score?: number;
-  importance_score?: number;
   importance_rank: number;
   elasticity?: number;
   direction?: 'positive' | 'negative' | 'mixed';
@@ -146,14 +153,26 @@ function mapFactorSensitivity(
   lineage: FactLineage,
 ): FactObjectV1[] {
   return factors.map((f, idx) => {
+    // ── FAMILY-4 SLICE 0 (2026-07-27) ──────────────────────────────────────
+    // `sensitivity_score` and `elasticity` are DIFFERENT quantities. They are
+    // now forwarded verbatim, each omitted when the producer did not measure
+    // it. Removed here, deliberately:
+    //   - `importance_score: f.importance_score ?? f.sensitivity_score ?? 0`
+    //     — `f.importance_score` is always undefined (no member exists on
+    //     `FactorSensitivityResultV3`), so this emitted a same-named ALIAS of
+    //     `sensitivity_score`. A third name for a number that already had two.
+    //   - `elasticity: f.elasticity ?? f.sensitivity_score ?? 0` — a
+    //     CROSS-QUANTITY fallback: absent elasticity silently became the
+    //     sensitivity score under the elasticity name.
+    //   - the `?? 0` coalescers — absent means "unavailable", NOT zero; a
+    //     fabricated 0 reads to every downstream ranker as "least important".
     const data: FactorSensitivityFactData = {
       type: 'factor_sensitivity',
       node_id: f.node_id,
       label: f.label ?? f.node_id,
-      sensitivity_score: f.sensitivity_score ?? 0,
-      importance_score: f.importance_score ?? f.sensitivity_score ?? 0,
+      ...(f.sensitivity_score !== undefined && { sensitivity_score: f.sensitivity_score }),
       importance_rank: f.importance_rank ?? idx + 1,
-      elasticity: f.elasticity ?? f.sensitivity_score ?? 0,
+      ...(f.elasticity !== undefined && { elasticity: f.elasticity }),
       direction: f.direction === 'mixed' ? 'positive' : (f.direction ?? 'positive'),
       confidence: f.confidence ?? 0.5,
       attribution_stability: f.attribution_stability ?? 'moderate',

--- a/src/facts/types.ts
+++ b/src/facts/types.ts
@@ -81,10 +81,28 @@ export interface FactorSensitivityFactData {
   type: 'factor_sensitivity';
   node_id: string;
   label: string;
-  sensitivity_score: number;      // 0-1
-  importance_score: number;       // 0-1
+  /**
+   * The producer's `sensitivity_score`, forwarded VERBATIM from the same
+   * response's `factor_sensitivity[]` entry — on the live graph-primary path
+   * that is the graph raw total causal effect, SIGNED and unbounded (see the
+   * `substitutions` block in src/contracts/isl-to-ui.contract.ts). It is NOT
+   * 0-1, and it is NOT the same quantity as `elasticity`.
+   *
+   * FAMILY-4 SLICE 0 (2026-07-27): optional, and OMITTED when the producer did
+   * not measure it. Absent means "unavailable", NOT zero — a coalesced 0 turns
+   * "we did not measure this" into "this is the least important driver", which
+   * is a fabricated ranking.
+   */
+  sensitivity_score?: number;
   importance_rank: number;
-  elasticity: number;
+  /**
+   * The producer's `elasticity`, forwarded verbatim. A DIFFERENT quantity from
+   * `sensitivity_score` (graph normalised influence, unsigned [0,1] on the
+   * graph-primary path) — the two may legitimately differ in magnitude and in
+   * sign. Never cross-fall-back one onto the other. Optional for the same
+   * absent-is-not-zero reason as above.
+   */
+  elasticity?: number;
   direction: 'positive' | 'negative';
   confidence: number;             // 0-1
   attribution_stability: 'high' | 'moderate' | 'low' | 'negligible';

--- a/src/review-pass/post-analysis.ts
+++ b/src/review-pass/post-analysis.ts
@@ -149,7 +149,14 @@ function buildTopDriverCard(
     card_type: 'challenge',
     review_phase: 'post_analysis',
     what: `Factor "${data.label}" is a top driver (rank ${data.importance_rank})`,
-    why: `High-importance driver with sensitivity score ${data.sensitivity_score}`,
+    // FAMILY-4 SLICE 0 (2026-07-27): `sensitivity_score` is now optional and is
+    // OMITTED when the producer did not measure it, so this prose must have an
+    // absence branch — printing "sensitivity score undefined" (or a fabricated
+    // 0) is exactly the failure the slice exists to remove.
+    why:
+      data.sensitivity_score !== undefined
+        ? `High-importance driver with sensitivity score ${data.sensitivity_score}`
+        : 'High-importance driver; no sensitivity score was measured for this factor',
     supporting_refs: [ref],
     affected_node_ids: [data.node_id],
     priority: 2,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -3230,7 +3230,23 @@ function buildResponse(
       factor_sensitivity: factorSensitivity?.map((fs, idx) => ({
         node_id: fs.factor_id,
         label: fs.factor_label ?? undefined,
-        sensitivity_score: fs.elasticity ?? 0,
+        // ── FAMILY-4 SLICE 0 (2026-07-27) ────────────────────────────────────
+        // This line used to read `fs.elasticity ?? 0`, i.e. it fed the
+        // ELASTICITY quantity into a field NAMED `sensitivity_score`. Because
+        // `factor_sensitivity[]` publishes the real `sensitivity_score` (graph
+        // raw total causal effect, SIGNED — see the `substitutions` block in
+        // src/contracts/isl-to-ui.contract.ts) in the SAME response body, one
+        // /v2/run payload carried two different quantities under one name.
+        // Measured in the committed golden
+        // tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json:
+        // `fac_hiring_cost` was -0.175 in `factor_sensitivity[]` and
+        // +0.4971042471042471 in `fact_objects[].data` — opposite signs,
+        // 2.84x apart, same field name, same response.
+        //
+        // Feed the actual quantity, and do NOT coalesce an absent one to 0:
+        // absent means "unavailable", NOT "least important"
+        // (@talchain/schemas src/boundary/enrichment.ts:239-241).
+        sensitivity_score: fs.sensitivity_score,
         importance_rank: idx + 1,
         elasticity: fs.elasticity,
         direction: fs.direction === 'unknown' ? undefined : fs.direction,

--- a/tests/facts-sensitivity-score-identity.fixture.test.ts
+++ b/tests/facts-sensitivity-score-identity.fixture.test.ts
@@ -1,0 +1,370 @@
+/**
+ * FAMILY-4 SLICE 0 — one payload, one field name, ONE quantity.
+ *
+ * DEFECT (measured, not argued). `src/routes/v2/run.ts` fed `fs.elasticity ?? 0`
+ * into the FactObject field named `sensitivity_score`, while the same /v2/run
+ * body published the real `sensitivity_score` on `factor_sensitivity[]`. On the
+ * committed golden for this fixture, `fac_hiring_cost` therefore carried:
+ *
+ *     factor_sensitivity[0].sensitivity_score  =  -0.175
+ *     fact_objects[].data.sensitivity_score    =  +0.4971042471042471
+ *
+ * Opposite sign, 2.84x apart, same field name, same response. A consumer
+ * sorting `fact_objects` by `sensitivity_score` got an ordering that
+ * contradicted `factor_sensitivity[]`, and a consumer reading the sign got the
+ * opposite direction — including from the `direction: 'negative'` sitting in
+ * the very same object.
+ *
+ * This test drives the real route and asserts the two surfaces agree.
+ *
+ * ── Why the fixture, and why pinned by HASH (CLAUDE.md trap 12b) ────────────
+ * The input is the HISTORICAL 2026-07-07 staging capture, pinned by SHA-256
+ * below. A control whose reference is "whatever staging returns now" is a
+ * control with an expiry date nobody wrote down; this one cannot silently
+ * become a tautology when the deployed producer changes. The hash assertions
+ * run FIRST and fail loudly on drift rather than assuming good.
+ *
+ * ── Why the positive controls come first (CLAUDE.md trap 13) ────────────────
+ * An equality assertion between two fields passes trivially if the fields are
+ * both absent, or if the payload happens to make them equal anyway. The first
+ * `describe` block proves the assertion can SEE a presence: facts exist, they
+ * cover the factors, and at least one factor has `sensitivity_score` genuinely
+ * DIFFERENT from `elasticity` — so the identity assertion is discriminating on
+ * this input, not vacuous.
+ *
+ * ── Gate note ───────────────────────────────────────────────────────────────
+ * `ENABLE_FACTS_ASSEMBLY` defaults ON only for test/staging
+ * (src/config/flags.ts). It is set EXPLICITLY here rather than inherited from
+ * NODE_ENV, so the test cannot silently stop exercising the surface.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'isl-v2-live-20260707',
+);
+const CAPTURE_PATH = join(FIXTURE_DIR, 'isl-staging-capture.json');
+const REQUEST_PATH = join(FIXTURE_DIR, 'isl-v2-request.json');
+
+/**
+ * Anti-tautology pin. These are the bytes of the 2026-07-07 capture (ISL build
+ * 9a22a1a) this control was written against. If a lane re-captures against a
+ * newer producer, it must create a NEW fixture directory — never re-point this
+ * control at live, and never update these hashes to make a red go away.
+ */
+const PINNED_CAPTURE_SHA256 =
+  '07ae686e6ab984eb0068ff5cd74d770e8279bdf20ec41de7383babb3b1b1efc3';
+const PINNED_REQUEST_SHA256 =
+  '83d34e71a86382168b21d00a9c8277b82e945db42e7465aec145b85e05b090fb';
+
+const capturePlain = JSON.parse(readFileSync(CAPTURE_PATH, 'utf8'));
+const requestA = JSON.parse(readFileSync(REQUEST_PATH, 'utf8'));
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(): Promise<{ data: T | null; error: string | null }> {
+    return { data: JSON.parse(JSON.stringify(capturePlain)) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+import { assembleFactObjects } from '../src/facts/index.js';
+
+function buildPlotBody() {
+  return {
+    graph: {
+      nodes: requestA.graph.nodes.map((n: any) => ({
+        id: n.id,
+        kind: n.kind,
+        label: n.label,
+        ...(n.observed_state?.value !== undefined && n.observed_state?.value !== null
+          ? { observed_state: { value: n.observed_state.value } }
+          : {}),
+      })),
+      edges: requestA.graph.edges.map((e: any) => ({
+        from: e.from,
+        to: e.to,
+        exists_probability: e.exists_probability,
+        strength: { mean: e.strength.mean, std: e.strength.std },
+      })),
+    },
+    options: requestA.options.map((o: any) => ({
+      id: o.id,
+      label: o.label,
+      interventions: Object.fromEntries(
+        Object.entries(o.interventions).map(([nodeId, value]) => [
+          nodeId,
+          { value, source: 'user_specified' },
+        ]),
+      ),
+    })),
+    goal_node_id: requestA.goal_node_id,
+    seed: String(requestA.seed),
+  };
+}
+
+type FactorRow = Record<string, any>;
+
+describe('family-4 slice 0: fact_objects vs factor_sensitivity — one name, one quantity', () => {
+  let app: FastifyInstance;
+  let body: any;
+  /** `factor_sensitivity[]` rows keyed by factor_id. */
+  let published: Map<string, FactorRow>;
+  /** `fact_objects[].data` rows of type factor_sensitivity, keyed by node_id. */
+  let facts: Map<string, FactorRow>;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    // Explicit, per the gate note above — never inherited from NODE_ENV.
+    process.env.ENABLE_FACTS_ASSEMBLY = '1';
+
+    app = await createServer();
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: buildPlotBody(),
+    });
+    expect(res.statusCode).toBe(200);
+    body = JSON.parse(res.body);
+
+    published = new Map(
+      (body.factor_sensitivity as FactorRow[]).map((f) => [f.factor_id as string, f]),
+    );
+    facts = new Map(
+      (body.fact_objects as any[])
+        .filter((o) => o?.data?.type === 'factor_sensitivity')
+        .map((o) => [o.data.node_id as string, o.data as FactorRow]),
+    );
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // POSITIVE CONTROLS — run first. If any of these fails, every assertion in
+  // the next block is vacuous and its green means nothing.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe('positive controls (trap 13 / trap 12b)', () => {
+    it('the input fixture is the pinned HISTORICAL capture, byte-for-byte', () => {
+      const sha = (p: string) =>
+        createHash('sha256').update(readFileSync(p)).digest('hex');
+      expect(sha(CAPTURE_PATH), 'isl-staging-capture.json').toBe(PINNED_CAPTURE_SHA256);
+      expect(sha(REQUEST_PATH), 'isl-v2-request.json').toBe(PINNED_REQUEST_SHA256);
+    });
+
+    it('the surface under test is POPULATED — facts exist and cover the published factors', () => {
+      expect(published.size).toBeGreaterThan(0);
+      expect(facts.size).toBeGreaterThan(0);
+      // Every fact must correspond to a published row (facts are a top-5 slice
+      // of the published array, so the containment is one-way).
+      for (const nodeId of facts.keys()) {
+        expect(published.has(nodeId), `no factor_sensitivity row for ${nodeId}`).toBe(true);
+      }
+      // And the factor this defect was measured on is present.
+      expect(facts.has('fac_hiring_cost')).toBe(true);
+    });
+
+    it('the identity assertion DISCRIMINATES: at least one factor has sensitivity_score !== elasticity', () => {
+      // If the two quantities coincided on every row, the next block would pass
+      // whichever one the mapper fed — i.e. it would test nothing. On this
+      // fixture fac_hiring_cost separates them (-0.175 vs +0.4971...).
+      const separating = [...published.values()].filter(
+        (f) =>
+          typeof f.sensitivity_score === 'number' &&
+          typeof f.elasticity === 'number' &&
+          f.sensitivity_score !== f.elasticity,
+      );
+      expect(separating.length).toBeGreaterThan(0);
+      const hiring = published.get('fac_hiring_cost')!;
+      expect(hiring.sensitivity_score).toBe(-0.175);
+      expect(hiring.elasticity).toBe(0.4971042471042471);
+      // Opposite signs — the sharpest available separator.
+      expect(Math.sign(hiring.sensitivity_score)).not.toBe(Math.sign(hiring.elasticity));
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // THE FIX
+  // ───────────────────────────────────────────────────────────────────────────
+  describe('sensitivity_score means the same thing everywhere in the payload', () => {
+    it('fact_objects[].data.sensitivity_score EQUALS factor_sensitivity[].sensitivity_score for the same factor', () => {
+      for (const [nodeId, data] of facts) {
+        const row = published.get(nodeId)!;
+        expect(
+          data.sensitivity_score,
+          `fact_objects[${nodeId}].data.sensitivity_score (${data.sensitivity_score}) ` +
+            `diverges from factor_sensitivity[${nodeId}].sensitivity_score (${row.sensitivity_score}) ` +
+            '— two values, one name, one payload',
+        ).toBe(row.sensitivity_score);
+      }
+    });
+
+    it('the measured divergence is closed by VALUE and by SIGN (fac_hiring_cost: -0.175 vs +0.4971042471042471)', () => {
+      const factData = facts.get('fac_hiring_cost')!;
+      expect(factData.sensitivity_score).toBe(-0.175);
+      expect(factData.sensitivity_score).not.toBe(0.4971042471042471);
+      expect(Math.sign(factData.sensitivity_score)).toBe(
+        Math.sign(published.get('fac_hiring_cost')!.sensitivity_score),
+      );
+    });
+
+    it('within a single fact, the sign of sensitivity_score agrees with its own co-located direction', () => {
+      for (const [nodeId, data] of facts) {
+        if (typeof data.sensitivity_score !== 'number' || data.sensitivity_score === 0) continue;
+        expect(
+          data.sensitivity_score < 0 ? 'negative' : 'positive',
+          `fact_objects[${nodeId}].data: sensitivity_score ${data.sensitivity_score} ` +
+            `contradicts its own direction '${data.direction}'`,
+        ).toBe(data.direction);
+      }
+    });
+
+    it('no `importance_score` is emitted anywhere in the /v2/run body', () => {
+      // It was synthesised as a third name for the same number. It has never
+      // been on `factor_sensitivity[]` and must not reappear one level down.
+      expect(JSON.stringify(body)).not.toContain('"importance_score"');
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // BYTE-IDENTITY / NON-OVER-REACH CONTROLS — the fix must change exactly one
+  // thing. Quantities that LEGITIMATELY differ must still differ.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe('controls: the fix does not collapse distinct quantities, and moves nothing else', () => {
+    it('elasticity is still forwarded verbatim and still DIFFERS from sensitivity_score where the producer says it does', () => {
+      for (const [nodeId, data] of facts) {
+        expect(data.elasticity, `elasticity for ${nodeId}`).toBe(
+          published.get(nodeId)!.elasticity,
+        );
+      }
+      const hiring = facts.get('fac_hiring_cost')!;
+      expect(hiring.elasticity).toBe(0.4971042471042471);
+      // Different magnitude AND different sign — and that is CORRECT: they are
+      // different quantities (raw total causal effect vs normalised influence).
+      expect(hiring.elasticity).not.toBe(hiring.sensitivity_score);
+    });
+
+    it('factor_sensitivity[] itself is untouched — the source array keeps its pinned values', () => {
+      expect(
+        (body.factor_sensitivity as FactorRow[]).map((f) => [
+          f.factor_id,
+          f.sensitivity_score,
+          f.elasticity,
+          f.importance_rank,
+          f.direction,
+        ]),
+      ).toEqual([
+        ['fac_hiring_cost', -0.175, 0.4971042471042471, 1, 'negative'],
+        ['fac_team_maturity', 0.13745631067961164, 0.39045780474351904, 2, 'positive'],
+        ['fac_tech_lead', 0, 0, 3, 'positive'],
+        ['fac_dev_headcount', 0, 0, 4, 'positive'],
+      ]);
+    });
+
+    it('the non-quantity members of each fact are unchanged (label, rank, direction, confidence, stability)', () => {
+      expect(
+        [...facts.entries()]
+          .map(([nodeId, d]) => [nodeId, d.label, d.importance_rank, d.direction, d.confidence, d.attribution_stability])
+          .sort((a, b) => String(a[0]).localeCompare(String(b[0]))),
+      ).toEqual([
+        ['fac_dev_headcount', 'Developer Headcount Added', 4, 'positive', 0.3, 'negligible'],
+        ['fac_hiring_cost', 'Hiring and Salary Cost', 1, 'negative', 0.44075, 'low'],
+        ['fac_team_maturity', 'Team Technical Maturity', 2, 'positive', 0.44455, 'low'],
+        ['fac_tech_lead', 'Tech Lead in Place', 3, 'positive', 0.3, 'negligible'],
+      ]);
+    });
+  });
+});
+
+/**
+ * Unit-level pin for the ABSENCE branches. The 2026-07-07 capture happens to
+ * carry both quantities on every factor, so a route-level test alone cannot
+ * see the `?? 0` coalescers or the cross-quantity fallback that used to sit in
+ * `mapFactorSensitivity`. Reverting either of those hunks must turn something
+ * red (CLAUDE.md trap 11), so they are pinned directly on the mapper.
+ */
+describe('family-4 slice 0: mapFactorSensitivity absence branches', () => {
+  const LINEAGE = {
+    graph_hash: '0123456789abcdef',
+    seed: 42,
+    config_version: '1',
+    isl_request_id: 'req-test',
+  };
+
+  function factorData(input: Record<string, unknown>) {
+    const env = assembleFactObjects(
+      { analysis_status: 'computed', factor_sensitivity: [input as any] },
+      LINEAGE,
+    );
+    const fact = env.facts.find((f) => f.fact_type === 'factor_sensitivity');
+    expect(fact, 'no factor_sensitivity fact assembled').toBeDefined();
+    return fact!.data as Record<string, unknown>;
+  }
+
+  it('an absent sensitivity_score is OMITTED, never coalesced to 0', () => {
+    const data = factorData({ node_id: 'f1', importance_rank: 1, elasticity: 0.9 });
+    expect(data).not.toHaveProperty('sensitivity_score');
+    expect(data.elasticity).toBe(0.9);
+  });
+
+  it('an absent elasticity is OMITTED, and never falls back to sensitivity_score', () => {
+    const data = factorData({ node_id: 'f1', importance_rank: 1, sensitivity_score: -0.42 });
+    expect(data).not.toHaveProperty('elasticity');
+    // The pre-slice code emitted `elasticity: f.elasticity ?? f.sensitivity_score ?? 0`,
+    // i.e. -0.42 under the elasticity name — a different quantity, silently.
+    expect(data.sensitivity_score).toBe(-0.42);
+  });
+
+  it('both absent ⇒ both omitted; no fabricated zeros anywhere in the fact', () => {
+    const data = factorData({ node_id: 'f1', importance_rank: 1 });
+    expect(data).not.toHaveProperty('sensitivity_score');
+    expect(data).not.toHaveProperty('elasticity');
+    expect(data).not.toHaveProperty('importance_score');
+  });
+
+  it('present values are forwarded verbatim and independently — no aliasing', () => {
+    const data = factorData({
+      node_id: 'f1',
+      importance_rank: 1,
+      sensitivity_score: -0.175,
+      elasticity: 0.4971042471042471,
+    });
+    expect(data.sensitivity_score).toBe(-0.175);
+    expect(data.elasticity).toBe(0.4971042471042471);
+    expect(data).not.toHaveProperty('importance_score');
+  });
+});

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -1429,7 +1429,6 @@
         "node_id": "fac_dev_headcount",
         "label": "Developer Headcount Added",
         "sensitivity_score": 0,
-        "importance_score": 0,
         "importance_rank": 4,
         "elasticity": 0,
         "direction": "positive",
@@ -1443,7 +1442,7 @@
         "isl_request_id": "__VOLATILE__",
         "n_samples": 10000
       },
-      "content_hash": "38fd5d2b2f426534"
+      "content_hash": "ca00892ac3008435"
     },
     {
       "fact_id": "__VOLATILE__",
@@ -1457,8 +1456,7 @@
         "type": "factor_sensitivity",
         "node_id": "fac_hiring_cost",
         "label": "Hiring and Salary Cost",
-        "sensitivity_score": 0.4971042471042471,
-        "importance_score": 0.4971042471042471,
+        "sensitivity_score": -0.175,
         "importance_rank": 1,
         "elasticity": 0.4971042471042471,
         "direction": "negative",
@@ -1472,7 +1470,7 @@
         "isl_request_id": "__VOLATILE__",
         "n_samples": 10000
       },
-      "content_hash": "bfe2baa993203588"
+      "content_hash": "8bf27aa493fa8147"
     },
     {
       "fact_id": "__VOLATILE__",
@@ -1486,8 +1484,7 @@
         "type": "factor_sensitivity",
         "node_id": "fac_team_maturity",
         "label": "Team Technical Maturity",
-        "sensitivity_score": 0.39045780474351904,
-        "importance_score": 0.39045780474351904,
+        "sensitivity_score": 0.13745631067961164,
         "importance_rank": 2,
         "elasticity": 0.39045780474351904,
         "direction": "positive",
@@ -1501,7 +1498,7 @@
         "isl_request_id": "__VOLATILE__",
         "n_samples": 10000
       },
-      "content_hash": "1c5920bad28446f5"
+      "content_hash": "bb8f27b786aa4293"
     },
     {
       "fact_id": "__VOLATILE__",
@@ -1516,7 +1513,6 @@
         "node_id": "fac_tech_lead",
         "label": "Tech Lead in Place",
         "sensitivity_score": 0,
-        "importance_score": 0,
         "importance_rank": 3,
         "elasticity": 0,
         "direction": "positive",
@@ -1530,7 +1526,7 @@
         "isl_request_id": "__VOLATILE__",
         "n_samples": 10000
       },
-      "content_hash": "d7e7a5dca2cbc1df"
+      "content_hash": "1189262c579365ff"
     },
     {
       "fact_id": "__VOLATILE__",

--- a/tests/isl-v2-golden-response.pin.test.ts
+++ b/tests/isl-v2-golden-response.pin.test.ts
@@ -33,6 +33,25 @@
  * follows. Nothing else moved. Against LIVE ISL (which emits no `factor_evpi`)
  * this is unchanged behaviour — the stale fixture merely stopped exercising the
  * dead branch. The exact diff is pinned by the assertion below.
+ *
+ * REGENERATED again for FAMILY-4 SLICE 0 (2026-07-27). `routes/v2/run.ts` fed
+ * `fs.elasticity ?? 0` into the FactObject field named `sensitivity_score`, and
+ * `facts/mapper.ts` synthesised a third name (`importance_score`) for the same
+ * number — so this golden itself carried TWO values under one name:
+ * `fac_hiring_cost` at -0.175 in `factor_sensitivity[]` and +0.4971042471042471
+ * in `fact_objects[].data`. The regeneration changes EXACTLY 10 lines, all
+ * inside `fact_objects[].data` of the four factor_sensitivity facts:
+ *   - `sensitivity_score` now carries the real quantity (fac_hiring_cost
+ *     0.4971042471042471 → -0.175; fac_team_maturity 0.39045780474351904 →
+ *     0.13745631067961164; the two levers were 0 either way)
+ *   - `importance_score` is GONE (4 lines) — never on `factor_sensitivity[]`,
+ *     never in `FactorSensitivityResultV3`, synthesised here alone
+ *   - the 4 derived `content_hash` values follow
+ * `factor_sensitivity[]`, `elasticity`, `_meta.response_hash` and
+ * `response_content_hash` are UNCHANGED (`fact_objects` is excluded from
+ * `response_hash`). The behavioural pin lives in
+ * tests/facts-sensitivity-score-identity.fixture.test.ts; the assertion below
+ * makes this regeneration non-silent.
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
@@ -257,5 +276,41 @@ describe('/v2/run golden byte-identity pin (well-formed V2 envelope, build 9a22a
     expect(
       (rawBody.factor_sensitivity as any[]).some((f) => f.evpi_method === 'counterfactual'),
     ).toBe(false);
+  });
+
+  // FAMILY-4 SLICE 0 (2026-07-27): explicit pin of the ONLY response-content
+  // change vs the pre-slice golden, so this deliberate regeneration is not
+  // silent either. Same discipline as the F3 pin above.
+  it('slice-0 surface change: fact_objects carry the REAL sensitivity_score, no synthesised importance_score, and nothing else moved', () => {
+    const factData = (rawBody.fact_objects as any[])
+      .filter((o) => o?.data?.type === 'factor_sensitivity')
+      .map((o) => o.data);
+    expect(factData).toHaveLength(4);
+
+    for (const d of factData) {
+      // The synthesised third name is gone from the whole body.
+      expect(d, d.node_id).not.toHaveProperty('importance_score');
+      // sensitivity_score is the producer's own value, forwarded verbatim.
+      const row = (rawBody.factor_sensitivity as any[]).find((f) => f.factor_id === d.node_id);
+      expect(d.sensitivity_score, d.node_id).toBe(row.sensitivity_score);
+      // elasticity is a DIFFERENT quantity and is likewise forwarded verbatim.
+      expect(d.elasticity, d.node_id).toBe(row.elasticity);
+    }
+    expect(JSON.stringify(rawBody)).not.toContain('"importance_score"');
+
+    // The two factors whose numbers actually moved, pinned by value.
+    const byId = Object.fromEntries(factData.map((d) => [d.node_id, d]));
+    expect(byId.fac_hiring_cost.sensitivity_score).toBe(-0.175);
+    expect(byId.fac_hiring_cost.elasticity).toBe(0.4971042471042471);
+    expect(byId.fac_team_maturity.sensitivity_score).toBe(0.13745631067961164);
+    expect(byId.fac_team_maturity.elasticity).toBe(0.39045780474351904);
+
+    // Unmoved: fact_objects is excluded from response_hash, so the derived
+    // response hashes are byte-identical to the pre-slice golden. Pinned by
+    // value here so a future change that quietly pulls fact_objects INTO the
+    // hash cannot pass as "just a regeneration".
+    expect(rawBody.response_hash).toBe('60e3ac213554be4f');
+    expect(rawBody._meta.response_hash).toBe('60e3ac213554be4f');
+    expect(rawBody._meta.response_content_hash).toBe('rch_v2:4708fefe17cfbc43');
   });
 });

--- a/tests/review-pass.golden.test.ts
+++ b/tests/review-pass.golden.test.ts
@@ -112,7 +112,7 @@ describe('post-analysis golden fixture', () => {
         node_id: ft.node_id,
         label: ft.node_id.replace(/_/g, ' '),
         sensitivity_score: 0.85,
-        importance_score: 0.85,
+        // `importance_score` removed — family-4 slice 0 (2026-07-27).
         importance_rank: ft.importance_rank,
         elasticity: 0.72,
         direction: 'positive',

--- a/tests/review-pass.post-analysis.test.ts
+++ b/tests/review-pass.post-analysis.test.ts
@@ -66,7 +66,9 @@ function makeSensitivityFact(overrides: Partial<{
       node_id: nodeId,
       label: overrides.label ?? nodeId,
       sensitivity_score: overrides.sensitivity_score ?? 0.85,
-      importance_score: overrides.sensitivity_score ?? 0.85,
+      // `importance_score` removed — family-4 slice 0 (2026-07-27). It was a
+      // synthesised alias of `sensitivity_score` and is no longer a member of
+      // FactorSensitivityFactData.
       importance_rank: overrides.importance_rank ?? 1,
       elasticity: 0.72,
       direction: 'positive',


### PR DESCRIPTION
## Family-4 (driver rankings) — slice 0. One payload, one field name, ONE quantity.

Implements slice 0 of `docs-designs/MEANING-LAYER-FAMILY4-DRIVERS-DESIGN-2026-07-27.md` (§2.5, §4.3 F-D2, §5). No contract change, no owner object, no verdict object. Producer-side only.

**Design's one-line characterisation VERIFIED AT THE BYTES, unrefuted.** `src/routes/v2/run.ts:3233` did read `sensitivity_score: fs.elasticity ?? 0`, and the committed golden does carry the two values the design names. Two small refinements to the design's scope are recorded in "What the design under-scoped" below.

---

## 1. The defect trace

```
src/routes/v2/run.ts:3230-3239        (ISLResponseInput assembly, behind ENABLE_FACTS_ASSEMBLY)
  factor_sensitivity: factorSensitivity?.map((fs, idx) => ({
    node_id:           fs.factor_id,
    sensitivity_score: fs.elasticity ?? 0,   ← ELASTICITY, under the name sensitivity_score
    elasticity:        fs.elasticity,
    ...
  }))
        │
        ▼
src/facts/mapper.ts:153-156           (mapFactorSensitivity → fact_objects[].data)
    sensitivity_score: f.sensitivity_score ?? 0,                        → fs.elasticity
    importance_score:  f.importance_score ?? f.sensitivity_score ?? 0,  → fs.elasticity
    elasticity:        f.elasticity ?? f.sensitivity_score ?? 0,        → fs.elasticity
```

`f.importance_score` is **always** `undefined` — `FactorSensitivityResultV3` has no `importance_score` member and *"it has never been on the wire"* (`src/contracts/isl-to-ui.contract.ts:36-40`). So `:154` reduced unconditionally to an alias. **Three differently-named fields carried one number.**

And the *same response body* publishes `factor_sensitivity[].sensitivity_score` as the graph **raw total causal effect — SIGNED** (`src/lib/factor-influence.ts:793`, declared in this repo's own `substitutions` register at `isl-to-ui.contract.ts:167-174`). So `sensitivity_score` carried **two different quantities in one `/v2/run` payload**.

**Measured, not argued** — `tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json`, factor `fac_hiring_cost`:

| path | value |
|---|---|
| `factor_sensitivity[0].sensitivity_score` | **−0.175** |
| `fact_objects[].data.sensitivity_score` | **+0.4971042471042471** |

Opposite sign, 2.84× apart, same field name, same response. The `fact_objects` entry additionally contradicted **its own co-located `direction: "negative"`**.

Liveness: `ENABLE_FACTS_ASSEMBLY` (`src/config/flags.ts:81-87`) is ON in `test` and on any Render service whose name contains `staging`, OFF in production. **Staging is the product for the PoC ⇒ this was live.**

---

## 2. The fix — exact

**`src/routes/v2/run.ts:3233`**
```diff
-        sensitivity_score: fs.elasticity ?? 0,
+        sensitivity_score: fs.sensitivity_score,
```

**`src/facts/mapper.ts` — `mapFactorSensitivity`**
```diff
-      sensitivity_score: f.sensitivity_score ?? 0,
-      importance_score:  f.importance_score ?? f.sensitivity_score ?? 0,
+      ...(f.sensitivity_score !== undefined && { sensitivity_score: f.sensitivity_score }),
       importance_rank:   f.importance_rank ?? idx + 1,
-      elasticity:        f.elasticity ?? f.sensitivity_score ?? 0,
+      ...(f.elasticity !== undefined && { elasticity: f.elasticity }),
```
plus `importance_score?: number` removed from `FactorSensitivityInput` (it was never supplied by any caller).

**`src/facts/types.ts`** — `FactorSensitivityFactData.sensitivity_score` and `.elasticity` become optional and are documented as *different quantities*; `importance_score` removed. Rationale carried in the type: *absent means "unavailable", NOT zero* — a fabricated `0` reads to every downstream ranker as "least important driver".

**`src/review-pass/post-analysis.ts:152`** — `buildTopDriverCard`'s prose gains an absence branch, because `sensitivity_score` can now legitimately be absent. It must not print `sensitivity score undefined`, and must not print a fabricated `0`.

**`src/contracts/isl-to-ui.contract.ts:36-40`** — the drop register's own confession (*"`src/facts/mapper.ts` SYNTHESISES one from the already-substituted PLoT row; that is not a passthrough"*) is replaced with a record that the synthesis is gone. The declared drop is now true of the whole `/v2/run` body, not of `factor_sensitivity[]` alone.

### What the design under-scoped (two refinements, both inside the slice)

1. **The design's fix, applied alone, would have CREATED a new cross-quantity fallback.** Before this change, `mapper.ts:156` `elasticity: f.elasticity ?? f.sensitivity_score ?? 0` was harmlessly tautological — both operands resolved to `fs.elasticity`. Feeding the real `sensitivity_score` into the first slot makes `?? f.sensitivity_score` a **genuine** cross-quantity fallback that did not previously exist. It is closed here. This is the slice's own blast radius, not scope creep.
2. **The `?? 0` coalescers survive in the mapper unless the field is made optional.** Dropping `?? 0` at `run.ts:3233` alone still leaves `mapper.ts:153` fabricating a zero. Both are removed; the fields are omitted instead.

---

## 3. Consumer enumeration — every reader of the changed fields

Fields changed: `fact_objects[].data.sensitivity_score` (value), `.importance_score` (removed), `.elasticity` (behaviour on absence only). **`factor_sensitivity[]` is NOT touched.**

### 3a. PLoT-internal (complete non-test manifest, `grep -rn 'fact_objects\|assembleFactObjects\|FactObjectV1' src/` at `53dbff98`)

| Site | Reads | Changed? | Why that is correct |
|---|---|---|---|
| `src/facts/mapper.ts` `mapFactorSensitivity` | the input row | **YES — this is the fix** | — |
| `src/routes/v2/run.ts:3256,3531` | assembles + emits `fact_objects` | **YES — values on the wire** | `sensitivity_score` now means what it says; `importance_score` gone |
| `src/routes/v1/run-bundle.ts:762,813` | `assembleFactsFromBundleResults` | **NO** | that builder emits **probability facts only** (`mapper.ts:307-350`) — it never constructs a `factor_sensitivity` fact |
| `src/review-pass/post-analysis.ts:65,152` `buildTopDriverCard` | `data.sensitivity_score`, `data.importance_rank` | **NO CHANGE IN PRACTICE** (prose gains an absence branch) | `generatePostAnalysisReview` has exactly **one** non-test caller — `run-bundle.ts:792` — and it is fed `assembleFactsFromBundleResults`, which emits no factor_sensitivity facts. **The reader is real in code and unreachable on every live route.** Fixed anyway because the type change makes the absence expressible |
| `src/review-pass/sort.ts:35` `factSortKey` | `fact.fact_key` only | **NO** | never touches `data` |
| `src/review-pass/evidence-priority.ts:225` | comment only | **NO** | ⚠ see stale-label finding below |
| `src/util/response-content-hash.ts:66` | `fact_objects` is in the **EXCLUDE** list | **NO** | `response_hash` / `response_content_hash` verified byte-identical to the pre-fix golden and pinned by value in the test |
| `src/util/structural-keys.generated.ts:164` | key **names** for PII redaction | **NO** | generated from `types/engine-v3.ts` + `isl-types.ts`, not from `facts/types.ts`; `importance_score` was never in the set. `node tools/gen-structural-keys.mjs --check` unaffected |
| `contracts/openapi.yaml:6350-6358` | `fact_objects[].data` typed as bare `type: object` | **NO** | no member declared, so no spec change. Note `openapi.yaml:6168` already documents `factor_sensitivity[].importance_score` as *"⚠ NOT EMITTED by any build"* — that claim was true of `factor_sensitivity[]` and false one level down. **This PR makes it uniformly true.** |

### 3b. The CEE seam (complete non-test manifest, CEE `staging` `636edd4e`)

`grep -rn 'fact_objects' src/` in `olumi-assistants-service`, non-test:

| Site | What it is | Reads a member of `data`? |
|---|---|---|
| `orchestrator-v5/compose.ts:617` | a comment | no |
| `orchestrator-v5/context/enrichment-manifest.ts:139` | manifest entry (tripwire suppression) | no |
| `orchestrator-v5/context/enrichment-manifest.ts:249` | reason-code map `['fact_objects', R_UI_ARTEFACT]` | no |
| `orchestrator/types.ts:398` | `fact_objects?: unknown[]` — **typed `unknown[]`** | no; a member read is not expressible without a cast, and there is none |
| `orchestrator/types/guidance-item.ts:121` | a doc comment on `fact_ids?: string[]` | no |

⇒ **CEE stores `fact_objects` verbatim and reads no member of it. Behaviour change at the CEE seam: NONE.**

**CEE→UI: `fact_objects` is STRIPPED.** `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP` (`compose.ts:491-540`) is exactly `option_comparison · factor_sensitivity · results · robustness · decision_review · option_comparison_status · conditional_probabilities · edge_e_values · inference_warnings · confidence_tier · flip_thresholds · decision_brief` — **no `fact_objects`**, and the keep-list is applied debug-independently.

### 3c. UI (`DecisionGuideAI` `staging` `fff04eb5`)

`grep -rn 'fact_objects|factObjects' src --include='*.ts' --include='*.tsx'` excluding tests/fixtures ⇒ **zero production references.** The only hits are `__fixtures__/*.placeholder.json` and `components/debug/__tests__/fixtures/staging-bundles/*.json` (captured May 2026, pre-keep-list).

⇒ **UI behaviour change: NONE.** The UI's frozen `elasticity` debt family (17 files / 72 raw reads, `tools/ci-guards/claim-drift-baseline.tsv`) reads `factor_sensitivity[].elasticity`, which **this PR does not touch**. The `elasticity === influence_score` aliasing at the PLoT→CEE seam is likewise untouched.

**One caveat, stated rather than omitted:** a `CEE_TURN_DEBUG_ENABLED` bundle export is a raw-JSON artefact; if `fact_objects` ever appears in one, its values will now be the corrected ones. That is a display of raw data, not a claim, and it changes in the honest direction.

---

## 4. Unmasking warnings

**None found — and this was checked rather than assumed.** The concern raised in the dispatch was that PLoT currently aliases `elasticity === influence_score` byte-identically at the CEE seam, so several CEE divergences are accidentally masked, and that a change to `sensitivity_score` could unmask one.

That risk does **not** materialise here, for a structural reason: **the aliasing lives on `factor_sensitivity[]`, and this PR changes only `fact_objects[].data`.** Every CEE ranker named in the family-4 CEE census (R5 `decision-review/decompose.ts:188`, R13 `decision-review/invoke.ts:354`, R1/R3/R4 via `driver-influence.ts`, R9 `assist.v1.review.ts:449`) reads `factor_sensitivity[]` / `top_drivers`. **None of them reads `fact_objects`.** The `elasticity === influence_score` aliasing is byte-for-byte unchanged by this PR, so no CEE ranker that was accidentally consistent becomes inconsistent.

**What this PR therefore does NOT fix, so nobody reads it as fixed:** the `factor_sensitivity[]`-side identity defects — `elasticity` aliasing `influence_score` while ISL means something else by that name, `driver_label`/`dominant_factor`/`m1_coaching.key_drivers` crowning option-pinned levers, and the `top_drivers` vs `factor_sensitivity` **direction** contradiction (design §1.4 divergence 1). Those are slices 0b and 1.

---

## 5. RED-first + mutation evidence

All mutation work ran in a **throwaway blobless clone at `53dbff98`, outside this repo root** (CLAUDE.md traps 9 / 9c), deleted afterwards.

### RED-first — the new test on the PRISTINE tip

`tests/facts-sensitivity-score-identity.fixture.test.ts` copied onto unmodified `53dbff98`:

```
Tests  5 failed | 5 passed (10)

× fact_objects[].data.sensitivity_score EQUALS factor_sensitivity[].sensitivity_score
  → fact_objects[fac_hiring_cost].data.sensitivity_score (0.4971042471042471) diverges from
    factor_sensitivity[fac_hiring_cost].sensitivity_score (-0.175) — two values, one name, one payload
× the measured divergence is closed by VALUE and by SIGN (fac_hiring_cost: -0.175 vs +0.4971042471042471)
× within a single fact, the sign of sensitivity_score agrees with its own co-located direction
  → sensitivity_score 0.4971042471042471 contradicts its own direction 'negative'
× no `importance_score` is emitted anywhere in the /v2/run body
× elasticity is still forwarded verbatim and still DIFFERS from sensitivity_score
```

**The failure message names the divergent values**, as required.

### Positive controls FIRST (CLAUDE.md trap 13) — all 3 PASS on the pristine tip

An equality assertion between two fields is vacuous if both are absent or coincidentally equal. Proven otherwise, before the fix:

1. the input fixture is the **pinned historical capture**, SHA-256 asserted (see trap-12b note below);
2. the surface is **populated** — 4 factor_sensitivity facts, each mapping to a published row, `fac_hiring_cost` present;
3. the assertion **discriminates** — `sensitivity_score (−0.175) !== elasticity (+0.4971…)` on this input, opposite signs. If the two quantities coincided everywhere the identity test would pass whichever one the mapper fed, i.e. test nothing.

### Byte-identity / non-over-reach controls — PASS both BEFORE and AFTER

These are the "legitimately differ in magnitude but not meaning, still passes" leg:

- `fact_objects[].data.elasticity` is still `factor_sensitivity[].elasticity` verbatim, and for `fac_hiring_cost` still **differs from `sensitivity_score` in magnitude and in sign** — correct, they are different quantities. The fix must not collapse them.
- `factor_sensitivity[]` keeps its pinned values, entry for entry.
- the non-quantity members of every fact (label, `importance_rank`, `direction`, `confidence`, `attribution_stability`) are pinned by value and unmoved.

### Mutation-check — every hunk, individually reverted (CLAUDE.md trap 11)

Fix applied in the throwaway clone (14/14 green), then one hunk reverted at a time:

| Mutant | Reverted to | Result |
|---|---|---|
| **A** | `run.ts`: `sensitivity_score: fs.elasticity ?? 0` | **RED — 4 failed / 10 passed** |
| **B** | `mapper.ts`: re-add `importance_score: f.sensitivity_score ?? 0` | **RED — 3 failed / 11 passed** |
| **C** | `mapper.ts`: `elasticity: f.elasticity ?? f.sensitivity_score ?? 0` | **RED — 2 failed / 12 passed** |
| **D** | `mapper.ts`: `sensitivity_score: f.sensitivity_score ?? 0` | **RED — 2 failed / 12 passed** |
| restored | — | **14 passed** |

C and D are unreachable from the 2026-07-07 capture (it carries both quantities on every factor), so the test file carries a **unit-level `describe` calling `assembleFactObjects` directly** with absent quantities. Without it those two hunks would have been unmutated — a fix nothing could see reverting.

### Anti-tautology pin (CLAUDE.md trap 12b)

The control is driven by the **historical 2026-07-07 capture, pinned by SHA-256 in the test**:

```
isl-staging-capture.json  07ae686e6ab984eb0068ff5cd74d770e8279bdf20ec41de7383babb3b1b1efc3
isl-v2-request.json       83d34e71a86382168b21d00a9c8277b82e945db42e7465aec145b85e05b090fb
```

The invariant is computed from the **live route response**, not from the regenerated golden — so regenerating the golden cannot hollow it out. A re-capture must create a new fixture directory; these hashes are not to be updated to clear a red.

`ENABLE_FACTS_ASSEMBLY=1` is set **explicitly** in the test (design's gate note), never inherited from `NODE_ENV`.

### Golden regeneration — deliberate, and pinned so it is not silent

`UPDATE_GOLDEN=1` on `tests/isl-v2-golden-response.pin.test.ts`. **Exactly 10 lines moved, 6 in / 10 out, all inside `fact_objects[].data`:**

- `sensitivity_score`: `fac_hiring_cost` `0.4971042471042471 → −0.175`; `fac_team_maturity` `0.39045780474351904 → 0.13745631067961164`; the two option-pinned levers were `0` either way
- `importance_score`: **4 lines deleted**
- the 4 derived `content_hash` values follow

**Unchanged:** `factor_sensitivity[]`, every `elasticity`, `response_hash` (`60e3ac213554be4f`), `_meta.response_hash`, `_meta.response_content_hash` (`rch_v2:4708fefe17cfbc43`) — `fact_objects` is in the response-content-hash exclude list. All three are now **pinned by value** in the pin test, so a future change that quietly pulls `fact_objects` into the hash cannot pass as "just a regeneration". A new assertion in that file pins the slice-0 surface change, mirroring the existing F3 precedent.

---

## 6. Suite numbers

`npm test` = `node tools/run-all-tests.js` (build + vitest + fixtures + loadcheck). Measured twice on pristine `53dbff98` in a separate clone — identical both times.

| | Test Files | Tests | `tsc -p tsconfig.json --noEmit` |
|---|---|---|---|
| **Before** (pristine `53dbff98`, run twice) | 575 passed, 4 skipped (579) | 6185 passed, 30 skipped (6226) | clean, exit 0 |
| **After** | 576 passed, 4 skipped (580) | 6199 passed, 30 skipped (6241) | clean, exit 0 |

`+1` file, `+14` tests — the new fixture test. **Nothing deleted, nothing quarantined, no baseline bumped, no `--update-baseline` accepted.**

### ⚠ THE LOCAL PRE-PUSH GATE IS RED, AND SO IS THE PRISTINE TIP — read this before reading the reds

`scripts/pre-push-validate.sh` was run **four times** on this branch. Checks 1, 2, 4, 5 and 6 passed every time (branch guard · `tsc --noEmit` · no stale `.js` · `file:` dependency policy · spectral lint). **Check 3 (`npm test`) failed three of four times — and a different set of files failed each time.** The push therefore used `--no-verify`, with the gate run manually and reported here rather than bypassed silently.

**It is the machine, not the branch. The control settles it:** a fresh blobless clone of pristine `53dbff98`, `npm ci`, same host — passed the gate once, then on a later `npm test` **failed with 2 tests**, including the only genuine assertion failure observed anywhere in this investigation:

```
PRISTINE 53dbff98:  FAIL tests/perf-gate.test.ts  AssertionError: expected 680.6401249999999 to be less than 600
                    FAIL tests/auth.minimal.test.ts  (timing)
```

Full record:

| Run | Tree | Result |
|---|---|---|
| 1 | pristine `53dbff98` | 575 files / 6185 tests — **clean** |
| 2 | pristine (2nd clone) | 575 / 6185 — **clean** |
| 3 | pristine (gate) | **PASSED all 7 checks** |
| 4 | pristine (`npm test`) | **2 failed** — `perf-gate` (680ms > 600ms threshold), `auth.minimal` (timing) |
| 5 | this branch (`npm test`) | 1 file — `flip-thresholds` (wall-clock race) |
| 6 | this branch (gate) | 9 files — **all `Hook timed out in 10000ms`**, duration 271s, run concurrently with another lane's vitest fleet |
| 7 | this branch (gate) | 3 files — all hook timeouts (`validate-patch-disabled`, `stream.release`, `plot-remediation.base-call-budget`) |
| 8 | this branch (`npm test`) | 1 file — `security.headers` (`Error: timeout`) |

Why this is environmental and not a defect:

- **Zero failed assertions on this branch, in any run.** Every failure is `Hook timed out in 10000ms` or `Error: timeout` in a `beforeAll` server boot / stream wait. `Tests` counts read `6199 passed | 0 failed` while `Test Files` reads `1 failed` — a suite that never got to assert.
- **A different file fails each time.** A real defect fails the same test every time.
- **Every failing file passes in isolation on this branch** — verified for all of them: `flip-thresholds` 3/3, `sensitivity-sign-pin` 4/4, `validate-patch-disabled` + `stream.release` + `plot-remediation.base-call-budget` 7/7, `security.headers`.
- **None of them can reach this change.** `grep -c 'fact_object\|importance_score\|facts/\|sensitivity_score'` returns **0** for each failing file, and none imports any of the five changed source modules.
- `tests/gates/sensitivity-sign-pin.test.ts` — the one whose *name* implicates this surface — failed at `beforeAll` (`:101`, server boot), never reached an assertion, and passes **4/4** in isolation.

⇒ **CI is the authoritative gate for this PR.** PR checks on this repo are green-by-default (see §8); treat any red there as real.

✅ **CI SETTLED IT: all 11 PR checks GREEN on `8db916c`** — `test` (the full suite, 9m31s) · `gates` ×3 (ubuntu/macos/windows) · `audit` · `guard` · `safety` ×2 · `smoke` · `verify` · `update_release_draft`. The local reds were the host; the suite is clean on CI hardware.

### ⚠ One flake seen and chased down, reported rather than smoothed over

The first post-fix full run showed `tests/analysis/flip-thresholds.test.ts > … > does NOT surface the partial-search midpoint as flip_value on a genuine timeout` failing with `expected undefined to be defined` at `:369` (`r.margin_sensitivity`). It is **not** caused by this change, and the evidence is causal rather than statistical:

- **Not in the import closure of anything this PR touches.** The spec imports only `src/analysis/flip-thresholds.ts` and `src/cee/validation/m1-review-types.js`; `flip-thresholds.ts` imports only `m1-review-types`, `./margin-sensitivity.js` and `../config/env-int.js`. None of the five changed source files is reachable. Zero occurrences of `fact_object`, `importance_score` or `facts/` in either file.
- **It is a real wall-clock race by construction**: the test sets a 20 ms deadline against a mock whose Step-0 probe sleeps ~100 ms, and its own comment says the failing assertion is what distinguishes the binary-search-timeout branch from *"the pre-probe branch (which carries no `margin_sensitivity`)"*. Under a loaded runner the deadline can fire before the probes complete — which is exactly the observed symptom (CLAUDE.md trap 6).
- **Green 3/3 in isolation on this branch**, and green in both pristine full runs.

Reported as a flake, **not** quarantined, skipped or retried-until-green. The numbers in the table above are from the clean run.

---

## 7. Findings recorded in passing (NOT fixed here)

1. ⚠ **A stale label on the exact surface this PR touches (CLAUDE.md trap 14).** `src/review-pass/evidence-priority.ts:225-227` asserts *"V2 /run does not assemble FactObjects — facts only exist in V1 /run_bundle."* **False at this tip:** `routes/v2/run.ts:3256` assembles them and `:3531` emits them, behind `ENABLE_FACTS_ASSEMBLY`, which defaults **ON** in test/staging. Anyone reasoning about fact citations from that comment reaches the wrong conclusion. Left for a separate change so this slice stays surgical.
2. ⚠ **`generatePostAnalysisReview`'s factor_sensitivity card branches are dead on every live route.** Its one caller is `/v1/run_bundle`, which assembles probability facts only. Two card builders (`buildLowStabilityCard`, `buildTopDriverCard`) and their tests exercise a shape the route never produces. Not a defect this slice creates; worth a decision (wire it, or say so in the module).

## 8. Push / gate context (re-derived, not cited)

- `gh api repos/Talchain/plot-lite-service/branches/staging/protection` ⇒ **HTTP 404 "Branch not protected"**. `staging` is unprotected; the push is the gate. This PR is **not** merged — orchestrator merge-review.
- **PR checks are green-by-default on this repo** (`gh pr checks 281`: audit · gates ×3 · guard · safety ×2 · smoke · test · verify · update_release_draft, all pass). Treat any red on this PR as real.
- ⚠ **But `push`-to-`staging` workflows do carry standing reds**, read at the job output rather than inherited from a registry (trap 7b): `Staging Smoke Test` fails with `FAIL: SMOKE_API_KEY is required` (`SMOKE_PLOT_URL`/`SMOKE_CEE_URL`/`SMOKE_API_KEY` all empty in the job env) on every staging push, and `release.yml` / `warp-apply-from-issue.yml` / `warp-apply-manual.yml` fail at startup in 0s with a workflow-file issue. These are content-independent and fired identically on `#280` and `#281`. **A red everyone learns to ignore is a broken alarm** — flagged, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
