### PR TITLE
docs(review-pass): correct the fact/citation seam comment in evidence-priority (trap 14)

### DIFF
--- a/src/review-pass/evidence-priority.ts
+++ b/src/review-pass/evidence-priority.ts
@@ -221,15 +221,24 @@ export function buildEvidencePriorityCard(
     review_phase: 'post_analysis',
     what: `Gathering better evidence on ${topFactorLabels} could change the recommendation.`,
     why: `These factors have high sensitivity but low confidence — better data would most improve decision quality.`,
-    // NOTE (known asymmetry): These IDs are constructed placeholders
-    // (`sensitivity_{factor_id}`), not real fact_id values from assembleFactObjects().
-    // V2 /run does not assemble FactObjects — facts only exist in V1 /run_bundle.
-    // When the orchestrator's explain_results tool produces CommentaryBlocks with
-    // [fact_id] citations, those resolve against facts assembled by CEE from the
-    // V2 response, not against facts in the V2 response itself. This is an
-    // architectural boundary: PLoT V2 → CEE → FactObjects → citations.
-    // Do not spend time debugging "citation doesn't resolve" in A.8 integration
-    // testing — this is expected until V2 adopts fact assembly.
+    // NOTE (namespace asymmetry): these ref IDs are constructed placeholders
+    // (`sensitivity_{factor_id}`), not fact_id values from assembleFactObjects().
+    // /v2/run DOES assemble and emit `fact_objects` when ENABLE_FACTS_ASSEMBLY is
+    // on — default ON under NODE_ENV=test and on any Render service whose name
+    // contains 'staging', OFF in production unless set explicitly. Read the rule
+    // at src/config/flags.ts rather than trusting this line.
+    // The two ID spaces cannot collide: a real fact_id is a 16-char SHA-256 hex
+    // digest (generateFactId, src/facts/hash.ts) and `sensitivity_` is not hex,
+    // so these placeholders stay disjoint from the assembled namespace rather
+    // than shadowing it.
+    // Citation consequence: a [fact_id] citation in an explain_results
+    // CommentaryBlock resolves against neither these refs NOR our emitted
+    // fact_objects — CEE assembles no FactObjects of its own and skip-lists
+    // `fact_objects` in its analysis→LLM projection, so no fact_id from this
+    // response reaches the model that writes the commentary (verify in
+    // olumi-assistants-service: src/orchestrator-v5/context/enrichment-manifest.ts).
+    // Treat these refs as provenance breadcrumbs for `items`, not as resolvable
+    // citations.
     supporting_refs: topItems.map(i => ({
       kind: 'fact' as const,
       id: `sensitivity_${i.factor_id}`,


### PR DESCRIPTION
Comment-only. A NOTE in `src/review-pass/evidence-priority.ts` asserted three things about
the fact/citation seam. Two of them are false at this tip, and the false version was the one
telling readers not to investigate ("Do not spend time debugging..."). Trap 14: an honest label
that decayed into an excuse for not looking.

**Base drift, disclosed.** Work was done at `53dbff98`; while CI ran, the sibling family-4
slice-0 PR (#282) merged and moved `staging` to `02386d9c`, touching `src/facts/mapper.ts`,
`src/facts/types.ts` and `src/routes/v2/run.ts` — three files this PR *cites*. Every claim below
was **re-derived at `02386d9c`** afterwards. Two line numbers moved (`run.ts` assembly
`3256→3272`, emission `3531→3547`) and are corrected here; the load-bearing bytes —
`flags.ts:81-87`, `generateFactId` in `hash.ts:47-56`, `engine-v3.ts:1477` — are **unchanged**,
so no verdict flipped. `src/review-pass/evidence-priority.ts` was not touched by #282
(`git diff 53dbff98..02386d9c -- <file>` empty), so the gate numbers below still describe this
diff and GitHub reports the branch MERGEABLE.

The comment itself deliberately cites **file paths only, never line numbers**, precisely so it
cannot rot the way the version it replaces did.

## What the comment claimed vs what is true (re-derived at `02386d9c`)

**Claim A — "V2 /run does not assemble FactObjects — facts only exist in V1 /run_bundle." FALSE.**

- `src/routes/v2/run.ts:3206` — `if (FLAGS.ENABLE_FACTS_ASSEMBLY) {`
- `src/routes/v2/run.ts:3272` — `const envelope = assembleFactObjects(islInput, lineage);`
- `src/routes/v2/run.ts:3547` — `fact_objects: assembledFactObjects ?? [],`
- `src/types/engine-v3.ts:1477` — `fact_objects` is a REQUIRED field on `RunResponseV3`.
- Already pinned by an existing test with both controls: `tests/v2-fact-objects.test.ts`
  asserts populated when the flag is on (`:171-173`) and `[]` when off (`:396-398`).

Flag posture, verbatim from `src/config/flags.ts:81-87`:

```ts
get ENABLE_FACTS_ASSEMBLY() {
  const raw = process.env.ENABLE_FACTS_ASSEMBLY;
  if (raw === '0' || raw === 'false') return false;
  // Default on for test/staging, off for production unless explicitly enabled
  if (raw === '1' || raw === 'true') return true;
  return process.env.NODE_ENV === 'test' || process.env.RENDER_SERVICE_NAME?.includes('staging') === true;
},
```

So: **ON** under `NODE_ENV=test` and on any Render service whose name contains `staging`;
**OFF** in production unless set explicitly. Staging is the product for this PoC, so the
comment was describing an absent feature on the very environment where it is live.

**Claim B — the `sensitivity_{factor_id}` placeholders. TRUE, and now stated with its reason.**

They are still placeholders, and they are **disjoint from the real fact_id namespace by
construction, not by luck**: `generateFactId` (`src/facts/hash.ts:47-57`) returns
`sha256(...).slice(0, 16)` — 16 lowercase hex chars. The literal prefix `sensitivity_`
contains non-hex characters, so no placeholder can ever equal a real `fact_id`.
**No collision, therefore no code defect, therefore no code change in this PR.**

**Claim C — "[fact_id] citations resolve against facts assembled by CEE from the V2 response." FALSE on both halves.**

Traced at the bytes in a fresh read-only clone of `olumi-assistants-service` @ `cf10c553`:

1. **CEE assembles no FactObjects.** Complete scope — `assembleFactObjects|FactObjectV1`
   over CEE `src/**/*.ts` returns exactly **one** hit, and it is a type comment, not an
   implementation: `src/orchestrator/types.ts:397-398`
   (`/** FactObjectV1[] — CEE reads fact_type, fact_id */ fact_objects?: unknown[];`).
   Zero implementations, zero call sites.
2. **CEE does not read PLoT's `fact_objects` into the coach context either.** It is an
   explicit member of `ENRICHMENT_ANALYSIS_LLM_SKIP` —
   `src/orchestrator-v5/context/enrichment-manifest.ts:249` `['fact_objects', R_UI_ARTEFACT]`
   — whose own doc comment (`:188-194`) reads "Manifest fields the analysis→LLM projection
   deliberately does NOT read". Corroborated by zero `fact_objects` references in any
   projection file (`projection-summaries.ts`, `canonical-analysis-state.ts`,
   `context-pack-assembler.ts`, `analysis-fallback.ts` — 0 hits each).
3. **There is no citation resolver anywhere in CEE.** `explain-results.ts` (244 lines) contains
   no fact/citation resolution; its `fact` tokens are turn-level `ExplainResultsHandlerFact`
   records, a different concept from `FactObjectV1`.

**Verdict: no `fact_id` from a V2 response reaches the model that writes CommentaryBlocks.**
The old comment pointed readers at a CEE-side assembly step that does not exist.

## Finding: `fact_objects` is emitted on the staging wire and read by nobody

Worth a decision, not fixed here (trap-10 shape — an emitted field with zero readers).

PLoT assembles `fact_objects` on every staging `/v2/run`, and it terminates at CEE:

- Not read by the analysis→LLM projection (skip-listed, above).
- **Not forwarded to the UI either.** Complete reviewed membership of
  `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP` (`src/orchestrator-v5/compose.ts:491-538`, closing
  `] as const;` at `:538`) — 12 entries: `option_comparison`, `factor_sensitivity`, `results`,
  `robustness`, `decision_review`, `option_comparison_status`, `conditional_probabilities`,
  `edge_e_values`, `inference_warnings`, `confidence_tier`, `flip_thresholds`, `decision_brief`.
  `fact_objects` is **absent**. Single call site `compose.ts:674` → block at `:721`.

Two consequences worth an orchestrator ruling:

1. PLoT pays assembly + payload cost on every staging run for a field with no consumer.
2. **A second trap-14, this time in CEE:** the rationale string `R_UI_ARTEFACT`
   (`enrichment-manifest.ts:180-181`) justifies the skip as "keep-listed to the UI transport"
   — but `fact_objects` is not in that keep-list. The rationale is accurate for
   `decision_brief` (which *is* keep-listed) and false for `fact_objects`. `compose.ts:545`
   separately lists `review_cards` among deliberately-dropped fields. Not touched here; CEE is
   another lane's repo.

Also note the served orchestrator prompts instruct the model to "cite fact_ids when available"
and "Never invent a fact_id" (e.g. `src/prompts/orchestrator-cf-v28.ts:1030-1036`) while no
`fact_id` is ever placed in its context — so "available" is never satisfied. Flagging only.

## Gates

Comment-only, so the change must be a provable no-op.

| | `tsc --noEmit` | Test Files | Tests |
|---|---|---|---|
| Pristine `53dbff98` | exit 0 | 575 passed, 4 skipped (579) | 6185 passed, 30 skipped (6226) |
| With this change | exit 0 | 575 passed, 4 skipped (579) | 6185 passed, 30 skipped (6226) |

Counts identical in every column, both runs in the same fresh blobless clone outside the
repo root. Runtime corroboration from the suite's own boot log: `feature_flags_boot` emits
`"ENABLE_FACTS_ASSEMBLY":true` under `NODE_ENV=test`, which is the posture the new comment
states.
- `npx tsc --noEmit` is byte-identical to the repo's own `npm run typecheck`
  (`tsc -p tsconfig.json --noEmit`), and `npm test` is step 3 of the authoritative
  `scripts/pre-push-validate.sh`.
- Diff proof: one file, comment lines only — no statement, identifier, or emitted value
  changed. `git diff -w --stat` and a comment-stripped comparison are recorded below.

## Zero file overlap

A sibling PLoT lane is in flight on `src/routes/v2/run.ts` + fixtures. This PR touches
**only** `src/review-pass/evidence-priority.ts`.

Scope of the overlap check: **all 33 open PLoT PRs** (`gh pr list --state open --limit 100`,
count asserted at 33, then filtered on `.files[].path == "src/review-pass/evidence-priority.ts"`)
— **zero matches**. Disjoint from the in-flight `run.ts` lane; merges can serialise in any order.

Do not merge — for orchestrator merge-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
