### PR TITLE
fix(v2/run,_meta): always emit constraint_sources when constraints exist (family-2 slice 0b)

### DIFF
--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -3595,6 +3595,19 @@ function buildResponse(
       // Uses the _internal namespace (set during Phase 1c+ synthesis) rather than
       // matching on constraint_id, so user-supplied constraints with the same ID
       // are never misclassified as auto-generated.
+      //
+      // The map is emitted WHENEVER constraints exist, INCLUDING when it is empty.
+      // The two absence states are different claims and only this producer can tell
+      // them apart:
+      //   present + EMPTY  → the constraint machinery ran and none of the constraints
+      //                      is auto-derived (they came from the request or the graph)
+      //   ABSENT           → there were no constraints at all
+      // Guarding the assignment on `Object.keys(sources).length > 0` collapsed those
+      // two into one byte-identical silence, leaving a consumer to either fabricate a
+      // provenance from that silence or fail closed on every legitimate user-constraint
+      // run. Per-ENTRY absence remains the "not auto-generated" signal, and is now a
+      // positive statement made inside a map that exists. Tests T11/T12,
+      // tests/auto-constraint-fallback.test.ts.
       if (goalConstraints?.length) {
         const sources: Record<string, string> = {};
         for (const c of goalConstraints) {
@@ -3603,9 +3616,7 @@ function buildResponse(
             sources[c.constraint_id] = internal.source;
           }
         }
-        if (Object.keys(sources).length > 0) {
-          (baseMeta as any).constraint_sources = sources;
-        }
+        (baseMeta as any).constraint_sources = sources;
       }
 
       // Surface filtered constraints (non-evaluable temporal constraints dropped before ISL)

--- a/tests/auto-constraint-fallback.test.ts
+++ b/tests/auto-constraint-fallback.test.ts
@@ -501,9 +501,14 @@ describe('T6: Auto-constraint fallback via /v2/run', () => {
     );
     expect(autoRepair).toBeUndefined();
 
-    // No constraint_sources in _meta (no auto-constraint)
-    const constraintSources = (data?._meta as any)?.constraint_sources;
-    expect(constraintSources).toBeUndefined();
+    // constraint_sources is PRESENT but EMPTY: the constraint machinery ran and
+    // had nothing to attest (no auto-synthesis). The original intent of this
+    // assertion — no false provenance is claimed for a user-supplied constraint —
+    // is preserved and strengthened: the entry is absent from a map that exists,
+    // which is a positive statement, not silence. See T11/T12 below.
+    const meta = (data?._meta ?? {}) as Record<string, unknown>;
+    expect(Object.keys(meta)).toContain('constraint_sources');
+    expect(meta.constraint_sources).toEqual({});
   });
 
   it('does NOT synthesise when goal_threshold is absent (qualitative brief)', async () => {
@@ -646,10 +651,16 @@ describe('T6: Auto-constraint fallback via /v2/run', () => {
     );
     expect(autoRepair).toBeUndefined();
 
-    // Critical: constraint_sources should NOT be present because the user-supplied
-    // constraint has no `_internal` namespace — only auto-generated constraints carry it.
-    const constraintSources = (data?._meta as any)?.constraint_sources;
-    expect(constraintSources).toBeUndefined();
+    // Critical: the map is PRESENT but carries NO ENTRY for this constraint_id,
+    // because the user-supplied constraint has no `_internal` namespace — only
+    // auto-generated constraints carry it. Per-entry absence inside a present map
+    // is the unambiguous "not auto-generated" signal; whole-map absence is not
+    // (T11/T12). Asserting the entry is absent AND the map is empty is strictly
+    // stronger than the previous `toBeUndefined()` on the whole map.
+    const meta = (data?._meta ?? {}) as Record<string, unknown>;
+    expect(Object.keys(meta)).toContain('constraint_sources');
+    expect((meta.constraint_sources as Record<string, string>).auto_goal_threshold).toBeUndefined();
+    expect(meta.constraint_sources).toEqual({});
   });
 
   // T10: User-supplied _internal is stripped at ingress — client cannot spoof provenance.
@@ -683,6 +694,83 @@ describe('T6: Auto-constraint fallback via /v2/run', () => {
     // the spoofed provenance — only server-synthesised constraints carry _internal.
     const constraintSources = (data?._meta as any)?.constraint_sources;
     expect(constraintSources?.spoofed_constraint).toBeUndefined();
+  });
+
+  // ===========================================================================
+  // T11/T12: the attestation's MAP-LEVEL absence semantics.
+  //
+  // Per-ENTRY absence has always been unambiguous ("this constraint is not
+  // auto-derived"). Whole-MAP absence was not: the emission used to be guarded
+  // by `Object.keys(sources).length > 0`, so a run whose constraint set produced
+  // no entries emitted no key at all — byte-identical to a run with no
+  // constraints, and to a future bug that drops the attestation entirely. A
+  // consumer then had to either fabricate an origin from silence or fail closed
+  // on legitimate runs. Only the producer can tell those states apart, so the
+  // producer now states it:
+  //
+  //   map PRESENT and EMPTY  = the constraint machinery ran, nothing to attest
+  //   map ABSENT             = there were no constraints at all
+  //
+  // T11 and T12 are a matched pair: T11 pins the empty map, T12 pins that the
+  // absent case did NOT collapse into it. Neither is sufficient alone — T11 with
+  // an unconditional emission would pass while destroying the distinction it
+  // exists to create.
+  // ===========================================================================
+
+  it('T11: an all-user-constraint run emits constraint_sources: {} — NOT an omitted key', async () => {
+    vi.resetModules();
+    server = await spawnServer({ env: ENV });
+
+    const { status, data } = await requestJSON(`${server.baseUrl}/v2/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        graph: VALID_GRAPH,
+        options: VALID_OPTIONS,
+        goal_node_id: 'goal',
+        goal_threshold: 0.7,
+        // Explicit user constraint: auto-synthesis cannot fire (it only fires
+        // when the compiled constraint set is EMPTY), so no constraint carries
+        // `_internal.source` and the sources map is legitimately empty.
+        goal_constraints: [
+          { constraint_id: 'mrr_target', node_id: 'mrr_factor', operator: '>=', value: 20000 },
+        ],
+      }),
+    });
+
+    expect(status).toBe(200);
+
+    const meta = (data?._meta ?? {}) as Record<string, unknown>;
+    // The KEY must exist. `?.constraint_sources` would read `undefined` for both
+    // "absent" and "present but undefined", so assert on the key itself.
+    expect(Object.keys(meta)).toContain('constraint_sources');
+    expect(meta.constraint_sources).toEqual({});
+    // And it must serialise as an empty object on the wire, not vanish.
+    expect(JSON.stringify(meta.constraint_sources)).toBe('{}');
+  });
+
+  it('T12: a run with NO constraints omits constraint_sources entirely (absent ≠ empty)', async () => {
+    vi.resetModules();
+    server = await spawnServer({ env: ENV });
+
+    const { status, data } = await requestJSON(`${server.baseUrl}/v2/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        graph: VALID_GRAPH,
+        options: VALID_OPTIONS,
+        goal_node_id: 'goal',
+        // No goal_constraints, no goal_threshold, no constraint nodes in the
+        // graph → auto-synthesis does not fire and activeGoalConstraints stays
+        // undefined. The constraint machinery never ran; there is nothing to
+        // attest about, so the producer says nothing.
+      }),
+    });
+
+    expect(status).toBe(200);
+
+    const meta = (data?._meta ?? {}) as Record<string, unknown>;
+    expect(Object.keys(meta)).not.toContain('constraint_sources');
   });
 });
 


### PR DESCRIPTION
Family-2 **slice 0b** — a surgical producer fix. One line of behaviour change in `src/routes/v2/run.ts`.

Found by the family-2 amendment lane's self-review (`MEANING-LAYER-FAMILY2-AMENDMENT-2026-07-27.md` §1(d), §6.2).

---

## 1. The emptiness condition, verified at the bytes

The amendment predicted *"an all-user-constraint run emits `constraint_sources: {}`"* — actually, no map at all. **Confirmed, and it is broader than "all-user-constraint".**

`_meta.constraint_sources` is built from `_internal.source` on each active constraint. The complete writer manifest for `_internal` at `02386d9c`, over the whole `src/` tree:

| Site | Role |
|---|---|
| `src/routes/v2/run.ts:4851` | **sole writer.** Phase 1c+ auto-synthesis sets `_internal: { source: 'auto_from_goal_threshold' }` |
| `src/routes/v2/run.ts:4775` | **deleter.** Strips client-supplied `_internal` at ingress (anti-spoofing) |
| `src/normalisation/constraint-filter.ts:200` | pass-through only — preserves an existing `_internal`, never creates one |
| `src/normalisation/constraint-compiler.ts:230-240` | builds compiled constraints from an explicit **field allowlist** with no `_internal` member |

Auto-synthesis fires only when `constraintCompilation.constraints.length === 0` (`run.ts:4837`), so when it fires the auto constraint is the **only** constraint. There is no mixed auto+user run.

One path reassigns the constraint set *after* synthesis and had to be checked: `run.ts:4953` replaces it wholesale with the temporal-filter output (`constraintCompilation.constraints = temporalFilterResult.passed`). That filter is the same `constraint-filter.ts` that **preserves `_internal`** (`:200`), so provenance survives filtering; and if it drops the lone auto constraint the set becomes empty, `activeGoalConstraints` stays `undefined` (`:5011-5013`), and the map is correctly ABSENT. `activeGoalConstraints` is assigned exactly once and never mutated afterwards. The conclusion is unaffected:

- `sources` **non-empty** ⟺ `goalConstraints === [auto_goal_threshold]`
- `sources` **empty** ⟺ *any* request- or graph-supplied constraint is present — not merely the "all-user" case, but **every run that carries a user or graph constraint at all**
- `goalConstraints` falsy ⟺ no constraints whatsoever (`activeGoalConstraints` stays `undefined`, `run.ts:4996-5001`)

Measured against the built server, pre-fix:

| Run | `constraint_sources` |
|---|---|
| `goal_threshold`, no constraints (auto fires) | `{"auto_goal_threshold":"auto_from_goal_threshold"}` |
| user-supplied `goal_constraints` | **key ABSENT** |
| no constraints, no threshold | **key ABSENT** |

The last two rows are the defect: **indistinguishable**. A consumer had two options, both wrong — fabricate an origin from silence, or fail closed on every legitimate user-constraint run.

**Refinement to the amendment:** it framed this as the all-user-constraint case. It is every constrained run that is not the auto case. The remediation is unchanged; the blast radius of the ambiguity was understated.

## 2. The fix

`src/routes/v2/run.ts` — the inner `if (Object.keys(sources).length > 0)` guard is removed. The outer `if (goalConstraints?.length)` guard is **retained deliberately**:

```
present + EMPTY  = the constraint machinery ran, nothing to attest
ABSENT           = there were no constraints at all
```

The absent state is genuinely reachable, so this is **not** an unconditional emission — an unconditional emission would destroy the distinction the change exists to create. T12 pins exactly that.

Per-**entry** absence is unchanged, and is now a positive statement made inside a map that exists rather than silence.

## 3. RED-first and mutation

Pristine `02386d9c`, tests added before the fix:

| Check | Result |
|---|---|
| **RED-first** — T11 + the two existing map-level absence assertions, updated to the new contract | **3 RED** on pristine: `expected [ 'source_path', …(13) ] to include 'constraint_sources'` |
| T12 (no-constraint run omits the key) on pristine | **GREEN** — as it must be; absent is already correct there |
| **Mutation 1** — restore the emptiness guard, tests untouched | **3 RED**, naming the missing key |
| **Mutation 2** — drop the outer guard, emit unconditionally | **T12 RED**: `expected [ 'source_path', …(14) ] to not include 'constraint_sources'` |

Both mutants bite, in **opposite directions**. T11 alone would pass under an unconditional emission; T12 alone would pass under the defect. They are a matched pair and neither is vacuous.

Mutation ran in a throwaway clone at a **sibling path outside this repo root**, removed before any gate run (trap 9c).

## 4. Byte-identity control

Built server, three fixed request bodies, volatile fields neutralised.

**Noise floor first** — two captures of the *same* build differ by **0 lines** on all three cases, so any residual diff is signal, not nondeterminism. (The first scrubber pass was insufficient: uuids, `content_hash`, `fact_id`, `isl_request_id`, `processing_time_ms` and non-deterministic array ORDER all had to be neutralised. Without that control I would have attributed ~40 lines of noise to this change.)

Pristine vs fixed:

| Case | Diff |
|---|---|
| auto-synthesis run (**non-empty map** — positive control) | **BYTE-IDENTICAL** |
| no-constraint run (**absent map** — negative control) | **BYTE-IDENTICAL** |
| user-constraint run | exactly **one** added line: `"constraint_sources": {},` |

## 5. Consumers — zero affected today

- **CEE staging `cf10c553`:** `grep -rn "constraint_sources"` over **all 3,389 tracked files** → **0 hits**. Complete scope, fresh shallow clone, not the local tree. It stores `_meta` byte-for-byte with no readers.
- **UI staging `ContractIntegrityTab.tsx`:** already coalesces `(meta?.constraint_sources ?? {})` at `:569` and renders only when `Object.keys(...).length > 0` at `:1113` — absent and empty are **already identical** to it. Its own spec fixture is `constraint_sources: {}`. This change makes the wire match what the UI test already assumed.
- **PLoT internal:** the only other references are the type (`engine-v3.ts:2774`, unchanged — already optional) and `structural-keys.generated.ts:92`, which is generated from the types and so does not drift.

**Noted, not fixed (out of scope):** the UI's `?? {}` is itself the "fabricate from silence" coalescing this change removes at the producer — the UI cannot distinguish the two states either. Per the amendment §6.3 the derivation belongs to CEE, and `_meta` stays stripped at the transport boundary, so this is not a UI fix to make here.

## 6. Suite

| | Test files | Tests |
|---|---|---|
| Pristine `02386d9c` | 576 passed, 4 skipped (580) | **6,200** passed, 30 skipped (6,241) |
| This branch | 576 passed, 4 skipped (580) | **6,202** passed, 30 skipped (6,243) |

Delta is **exactly the two added tests**. Nothing deleted, quarantined, skipped, or baselined. Both runs from fresh blobless clones at lane-unique paths; `npm test` exit 0 on each.

Local pre-push gate: **6/6 PASS, 0 failures** — no perf-gate flake on this run.

## 7. Lane disjointness

Another PLoT lane is in flight on `src/review-pass/evidence-priority.ts` (comment-only). **Zero overlap** — this PR's complete changed-file set is:

```
src/routes/v2/run.ts
tests/auto-constraint-fallback.test.ts
```

`git status` on `src/review-pass/evidence-priority.ts` in this working tree is empty; it is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
