### PR TITLE
fix(v2/run): hoist the intervention ingress guard above normalizeOptions(), so #281's unreachability claim is true

### DIFF
--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -1161,6 +1161,11 @@ function resolveSeed(providedSeed: string | number | undefined, graph: EngineGra
  *
  * Normalizes to:
  * - { "factor_price": { "value": 10, "source": "user_specified" } }
+ *
+ * TOTAL OR LOUD. Every entry must carry a finite value; one that does not
+ * THROWS rather than being dropped. The route guarantees that by rejecting the
+ * same entries at the Phase 1a++ ingress guard, which runs above this
+ * function's only call site — see the in-body comment for the derivation.
  */
 function normalizeInterventions(
   interventions: Record<string, number | { value: number; source?: string }>
@@ -1179,11 +1184,45 @@ function normalizeInterventions(
     // preflight can no longer see. `{"f": null, "g": 60}` lost `f` silently
     // and passed preflight as a one-intervention option.
     //
-    // The drop is now UNREACHABLE on the route: the ingress guard 422s any
-    // entry this reader rejects, so by the time a request is analysed every
-    // entry carries a finite value and this function is total.
+    // There is no longer a drop at all — a rejected entry throws.
+    //
+    // REACHABILITY of that throw, derived rather than asserted. This function
+    // has exactly one caller (normalizeOptions), which in turn has exactly one
+    // call site: the first statement of the Phase 1 block in the POST /v2/run
+    // handler. The Phase 1a++ ingress guard sits ABOVE that statement and 422s
+    // every entry THIS SAME READER rejects, reading the raw body. So a
+    // malformed entry cannot reach this loop from the wire.
+    //   · The one shape the guard skips rather than scans is an `interventions`
+    //     value that is not a plain object; the Ajv body schema types it
+    //     `{ type: 'object' }`, and an array or string body is rejected 400
+    //     BAD_INPUT before this handler runs (measured, not assumed).
+    //
+    // An EARLIER revision of this comment claimed the *drop* was "UNREACHABLE
+    // on the route" while the guard still ran ~160 lines further down, i.e.
+    // AFTER this function. That was false: the drop executed on every malformed
+    // request (measured — replacing it with a throw produced a stack through
+    // normalizeOptions from the handler). The guard was nonetheless correct,
+    // because it reads the RAW body and the drop cannot blind it; what was
+    // wrong was the reachability claim, and the fact that "no consumer sees the
+    // edited set" depended on nobody adding a `normalizedOptions` reader into
+    // the gap. The guard was hoisted above the call site so the claim above is
+    // structural. Read that placement comment before moving either one.
+    //
+    // WHY THROW rather than skip. `OptionV3.interventions[].value` is a required
+    // number, so absence cannot be represented here: skipping silently changes
+    // WHAT WAS ANALYSED while still returning a confident answer, and any
+    // substituted number fabricates. Refusing is the only non-fabricating
+    // disposal, and it converts an undetectable edit into a logged, named
+    // failure. Same disposal, same reason, as normaliseOptions() and
+    // normaliseGoalConstraints() in lib/intervention-normaliser.ts.
     const value = readInterventionValue(intervention);
-    if (value === undefined) continue;
+    if (value === undefined) {
+      throw new Error(
+        `normalizeInterventions: non-finite intervention value for node '${nodeId}' ` +
+        `(received ${JSON.stringify(intervention) ?? 'undefined'}). ` +
+        `Intervention values must be validated at the request boundary before normalisation.`,
+      );
+    }
 
     const source = (intervention && typeof intervention === 'object')
       ? (intervention as { source?: string }).source
@@ -4471,6 +4510,91 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         }
 
         // =================================================================
+        // Phase 1a++: Intervention Ingress-Shape Guard (ROADMAP 1.278)
+        // =================================================================
+        // Same defect class as the Phase 1b++ constraint guard below, on the
+        // sibling field: the runV3 body JSON-schema types `interventions` as
+        // `{ type: 'object' }` — the container only, the VALUES entirely
+        // unvalidated — so every shape decision was made by hand downstream.
+        //
+        // Two hand-written answers existed and they disagreed:
+        //   - normalizeInterventions() DROPPED any entry that was neither a
+        //     number nor an object with a `value` key;
+        //   - preflight's INVALID_INTERVENTION_VALUE then validated the
+        //     ALREADY-NORMALISED options — the view the drop had edited.
+        // So preflight structurally could not see the entries the drop removed.
+        // MEASURED on the pristine tip: `{"f": null, "g": 60}` lost `f`
+        // silently, passed preflight as a one-intervention option, and then
+        // threw inside canonicaliseOption() on the RAW body — surfacing as
+        // HTTP 200 + analysis_status:"failed" + PLOT_INTERNAL_ERROR. A
+        // malformed request must get a malformed-request answer, not a masked
+        // internal error and not an analysis of a set the caller never sent.
+        //
+        // This guard reads the RAW body (the only view that still contains the
+        // dropped entries), rejects on the SHARED readInterventionValue()
+        // predicate that normalizeInterventions() now also uses, and names the
+        // offending option id AND factor key.
+        //
+        // WHY IT SITS HERE, ABOVE PHASE 1 (corrected in a follow-up slice).
+        // The sole call site of normalizeOptions() — and therefore of the
+        // silent drop inside normalizeInterventions() — is the first statement
+        // of the Phase 1 block immediately below. This guard originally sat
+        // ~160 lines BELOW that call, and the comment on the drop claimed the
+        // drop was "UNREACHABLE on the route". That claim was FALSE: measured
+        // on the pristine tip by replacing the drop with a throw, `{f: null,
+        // g: 60}` produced a stack `normalizeInterventions -> normalizeOptions
+        // -> <this handler>` on every malformed request. The guard was still
+        // CORRECT below (it reads the raw body, so the earlier drop cannot
+        // blind it, and the 422 was measured green) — but the safety property
+        // "no consumer ever sees the silently-edited option set" was POSITIONAL:
+        // it held only because nobody had yet added a `normalizedOptions` reader
+        // into the gap. That is a hand-maintained invariant — the exact defect
+        // class this fix exists to close. Above the call site the property is
+        // structural instead, and that is what lets normalizeInterventions()
+        // refuse LOUDLY instead of dropping silently (see its comment).
+        //
+        // It still runs before preflight, before hashRequest() and before
+        // normaliseOptionsForISL(), so no consumer downstream can see a
+        // non-finite intervention value.
+        //
+        // Preflight's own INVALID_INTERVENTION_VALUE check is deliberately
+        // LEFT IN PLACE as defence-in-depth (the same disposal ROADMAP 1.277
+        // gave #278's caller-side guard) and keeps covering direct in-process
+        // callers of runPreflightValidation().
+        if (Array.isArray(body.options)) {
+          for (const option of body.options) {
+            const interventions = (option as { interventions?: unknown })?.interventions;
+            if (!interventions || typeof interventions !== 'object' || Array.isArray(interventions)) continue;
+            for (const [factorKey, raw] of Object.entries(interventions as Record<string, unknown>)) {
+              if (readInterventionValue(raw) !== undefined) continue;
+              const optionId = String((option as { id?: unknown })?.id ?? '');
+              return reply.status(422).send(buildBlockedResponse(
+                `Invalid intervention value: options[id=${optionId}].interventions['${factorKey}'] must be a finite number`,
+                [{
+                  id: randomUUID(),
+                  code: 'INVALID_INTERVENTION_VALUE',
+                  severity: 'blocker',
+                  // Message names the offending option id AND factor key (the
+                  // CritiqueV3 shape has no field_path; the path goes in the
+                  // text, matching INVALID_CONSTRAINT_SHAPE below). The ids are
+                  // ALSO carried structurally in affected_option_ids /
+                  // affected_node_ids so a consumer need not parse prose.
+                  message: `Option '${optionId}' has an invalid intervention value for node '${factorKey}'. Value must be a finite number, either as options[].interventions['${factorKey}'] or as options[].interventions['${factorKey}'].value.`,
+                  source: 'validation',
+                  affected_option_ids: [optionId],
+                  affected_node_ids: [factorKey],
+                  blocks_analysis: true,
+                }],
+                body.graph,
+                body.options,
+                requestId,
+                requestComputedAt,
+              ));
+            }
+          }
+        }
+
+        // =================================================================
         // Phase 1: Normalization
         // =================================================================
         const normStart = performance.now();
@@ -4607,71 +4731,6 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             requestId,
             requestComputedAt,
           ));
-        }
-
-        // =================================================================
-        // Phase 1a++: Intervention Ingress-Shape Guard (ROADMAP 1.278)
-        // =================================================================
-        // Same defect class as the Phase 1b++ constraint guard below, on the
-        // sibling field: the runV3 body JSON-schema types `interventions` as
-        // `{ type: 'object' }` — the container only, the VALUES entirely
-        // unvalidated — so every shape decision was made by hand downstream.
-        //
-        // Two hand-written answers existed and they disagreed:
-        //   - normalizeInterventions() DROPPED any entry that was neither a
-        //     number nor an object with a `value` key;
-        //   - preflight's INVALID_INTERVENTION_VALUE then validated the
-        //     ALREADY-NORMALISED options — the view the drop had edited.
-        // So preflight structurally could not see the entries the drop removed.
-        // MEASURED on the pristine tip: `{"f": null, "g": 60}` lost `f`
-        // silently, passed preflight as a one-intervention option, and then
-        // threw inside canonicaliseOption() on the RAW body — surfacing as
-        // HTTP 200 + analysis_status:"failed" + PLOT_INTERNAL_ERROR. A
-        // malformed request must get a malformed-request answer, not a masked
-        // internal error and not an analysis of a set the caller never sent.
-        //
-        // This guard reads the RAW body (the only view that still contains the
-        // dropped entries), rejects on the SHARED readInterventionValue()
-        // predicate that normalizeInterventions() now also uses, and names the
-        // offending option id AND factor key. It runs before preflight, before
-        // hashRequest(), and before normaliseOptionsForISL(), so no consumer
-        // downstream can see a non-finite intervention value.
-        //
-        // Preflight's own INVALID_INTERVENTION_VALUE check is deliberately
-        // LEFT IN PLACE as defence-in-depth (the same disposal ROADMAP 1.277
-        // gave #278's caller-side guard) and keeps covering direct in-process
-        // callers of runPreflightValidation().
-        if (Array.isArray(body.options)) {
-          for (const option of body.options) {
-            const interventions = (option as { interventions?: unknown })?.interventions;
-            if (!interventions || typeof interventions !== 'object' || Array.isArray(interventions)) continue;
-            for (const [factorKey, raw] of Object.entries(interventions as Record<string, unknown>)) {
-              if (readInterventionValue(raw) !== undefined) continue;
-              const optionId = String((option as { id?: unknown })?.id ?? '');
-              return reply.status(422).send(buildBlockedResponse(
-                `Invalid intervention value: options[id=${optionId}].interventions['${factorKey}'] must be a finite number`,
-                [{
-                  id: randomUUID(),
-                  code: 'INVALID_INTERVENTION_VALUE',
-                  severity: 'blocker',
-                  // Message names the offending option id AND factor key (the
-                  // CritiqueV3 shape has no field_path; the path goes in the
-                  // text, matching INVALID_CONSTRAINT_SHAPE below). The ids are
-                  // ALSO carried structurally in affected_option_ids /
-                  // affected_node_ids so a consumer need not parse prose.
-                  message: `Option '${optionId}' has an invalid intervention value for node '${factorKey}'. Value must be a finite number, either as options[].interventions['${factorKey}'] or as options[].interventions['${factorKey}'].value.`,
-                  source: 'validation',
-                  affected_option_ids: [optionId],
-                  affected_node_ids: [factorKey],
-                  blocks_analysis: true,
-                }],
-                normalizedGraph,
-                normalizedOptions,
-                requestId,
-                requestComputedAt,
-              ));
-            }
-          }
         }
 
         // =================================================================

--- a/tests/gates/numeric-safety-deep-scan.test.ts
+++ b/tests/gates/numeric-safety-deep-scan.test.ts
@@ -208,50 +208,50 @@ async function run(app: FastifyInstance) {
 // ---------------------------------------------------------------------------
 
 describe('WP5 gate · numeric seam + boundary guard (unit)', () => {
-  it('normaliseValue(NaN) SELF-GUARDS to undefined (ROADMAP 1.278) — the last bare numeric seam is closed', () => {
-    // This assertion used to read `Number.isNaN(normaliseValue(N, …).normalised) === true`,
-    // documenting normaliseValue as a DELIBERATELY UNGUARDED seam whose non-finite
-    // inputs "must be caught at boundaries". ROADMAP 1.278 ends that, for the same
-    // reason ROADMAP 1.277 ended it for the sibling denormaliseValue: the seam was
-    // only ever safe against the shapes that produce NaN. It was NOT safe against
-    // `null`, which coerces to 0 and yields the RANGE MINIMUM as a plausible,
-    // finite, un-flagged intervention — a value no downstream finiteness check can
-    // distinguish from a real one. That is why asserting the NaN half kept passing
-    // while the class stayed open: this gate was testing the one absence shape the
-    // arithmetic happened to poison loudly.
+  it('BOTH normalisation primitives SELF-GUARD to undefined — no bare numeric seam remains', () => {
+    // These two assertions used to be two it-blocks, and the second one carried a
+    // paragraph reading: "The half that still matters is unchanged and is asserted
+    // above: `normaliseValue` remains an unguarded seam, so boundary guards are
+    // still required there. Only denormaliseValue moved."
     //
-    // WHAT PROVES THE GUARD BITES (not just that it exists): the mutation run for
-    // this slice reverted the primitive hardening alone and the DEFECT-labelled
+    // That was true when ROADMAP 1.277 hardened denormaliseValue alone, and it went
+    // STALE the moment ROADMAP 1.278 hardened normaliseValue too — in the SAME
+    // describe block, sixteen lines above the sentence denying it. The cost of the
+    // stale half is specific and not cosmetic: a reader deciding whether a NEW
+    // caller of normaliseValue needs its own finiteness check read "remains an
+    // unguarded seam" and added a caller-side mirror of a guard the primitive
+    // already performs — one more hand-maintained duplicate of a live invariant.
+    // The two are therefore collapsed into ONE claim, so the pair can only ever be
+    // described together and cannot drift apart again.
+    //
+    // WHY THE PAIR SELF-GUARDS. Both were "unguarded seams whose non-finite inputs
+    // must be caught at boundaries", and both were only ever safe against the
+    // shapes that produce NaN. Neither was safe against `null`, which coerces to 0
+    // and yields the RANGE MINIMUM as a plausible, finite, UN-FLAGGED value that no
+    // downstream finiteness check can distinguish from a real one. That is why
+    // asserting the NaN half kept passing while the class stayed open: this gate
+    // was testing the one absence shape the arithmetic happened to poison loudly.
+    //
+    // WHAT PROVES THE GUARDS BITE (not just that they exist): the mutation run for
+    // ROADMAP 1.278 reverted the primitive hardening alone and the DEFECT-labelled
     // cases in tests/intervention-normaliser-absence.test.ts went RED — including
     // the SILENT one, `null` on a min-0 range, which returns
     // `{ normalised: 0, clamped: false }` when the guard is absent.
     //
     // Boundary guards are still required and still asserted — see the Phase 1a++
     // ingress guard pinned by tests/intervention-ingress-shape-guard.test.ts. The
-    // primitive is defence-in-depth, not a replacement for them.
+    // primitives are defence-in-depth, not a replacement for them.
     expect(normaliseValue(N, { min: 0, max: 1, source: 'default' })).toBeUndefined();
     expect(normaliseValue(null, { min: 10, max: 20, source: 'default' })).toBeUndefined();
     // The SILENT shape specifically: a min-0 range fabricated 0 with clamped:false.
     expect(normaliseValue(null, { min: 0, max: 200, source: 'default' })).toBeUndefined();
-    // Positive control: a real value is untouched, and 0 is a REAL value.
-    expect(normaliseValue(0.5, { min: 0, max: 1, source: 'default' })).toEqual({ normalised: 0.5, clamped: false });
-    expect(normaliseValue(0, { min: 0, max: 200, source: 'default' })).toEqual({ normalised: 0, clamped: false });
-  });
 
-  it('denormaliseValue(NaN) SELF-GUARDS to undefined (ROADMAP 1.277) — no longer a bare seam', () => {
-    // This assertion used to read `Number.isNaN(denormaliseValue(N, …)) === true`,
-    // asserting that denormaliseValue was an unguarded seam like its sibling above.
-    // ROADMAP 1.277 deliberately ENDED that: the primitive now finite-checks its
-    // input, because the sibling `normaliseValue` shape was letting `null` — which
-    // coerces to 0, NOT to NaN — fabricate the range floor as a plausible
-    // measurement that no downstream finiteness check could detect.
-    //
-    // The half that still matters is unchanged and is asserted above:
-    // `normaliseValue` remains an unguarded seam, so boundary guards are still
-    // required there. Only denormaliseValue moved.
     expect(denormaliseValue(N, { min: 0, max: 1, source: 'default' })).toBeUndefined();
     expect(denormaliseValue(null, { min: 10, max: 20, source: 'default' })).toBeUndefined();
-    // Positive control: a real measurement is untouched.
+
+    // Positive controls: a real value is untouched, and 0 is a REAL value.
+    expect(normaliseValue(0.5, { min: 0, max: 1, source: 'default' })).toEqual({ normalised: 0.5, clamped: false });
+    expect(normaliseValue(0, { min: 0, max: 200, source: 'default' })).toEqual({ normalised: 0, clamped: false });
     expect(denormaliseValue(0.5, { min: 0, max: 1, source: 'default' })).toBe(0.5);
   });
 

--- a/tests/intervention-ingress-shape-guard.test.ts
+++ b/tests/intervention-ingress-shape-guard.test.ts
@@ -280,3 +280,107 @@ describe('ROADMAP 1.278 · Phase 1a++ intervention ingress-shape guard', () => {
     expect(critiques(body).map(c => c.code)).not.toContain('INVALID_INTERVENTION_VALUE');
   });
 });
+
+// ===========================================================================
+// GUARD PLACEMENT — the guard must run ABOVE normalizeOptions(), not below it
+// ===========================================================================
+/**
+ * WHAT WAS WRONG, AND WHAT WAS NOT (both measured on 84f549ce, the tip before
+ * this slice — the split matters, because half the review finding was right and
+ * half was not):
+ *
+ *   REFUTED — there was NO live silent-drop → 200. The guard reads the RAW
+ *   `body.options`, so the earlier drop cannot blind it. Every DEFECT case in
+ *   the describe above was already GREEN on that tip.
+ *
+ *   CONFIRMED — the guard nonetheless sat ~160 lines BELOW the sole call site
+ *   of normalizeOptions(), so the drop RAN on every malformed request, and the
+ *   comment on it claimed it was "UNREACHABLE on the route". Proven by
+ *   replacing the drop with a throw in a throwaway worktree: `{f: null, g: 60}`
+ *   produced
+ *       normalizeInterventions (run.ts:1186) → normalizeOptions (run.ts:1206)
+ *       → <POST /v2/run handler> (run.ts:4485)
+ *   and the route answered HTTP 200 + PLOT_INTERNAL_ERROR — the exact masked
+ *   shape ROADMAP 1.278 exists to close.
+ *
+ * So the property "no consumer ever sees the silently-edited option set" was
+ * POSITIONAL, not structural: it held only because nobody had yet added a
+ * `normalizedOptions` reader into the gap. Hoisting the guard above the call
+ * site makes it structural, which is what allows normalizeInterventions() to
+ * throw instead of dropping.
+ *
+ * INSTRUMENT. Placement has no direct route-visible signature, so it is
+ * measured by PRECEDENCE against a blocker raised by code that used to run
+ * first. These cases went RED on 84f549ce (they returned the goal-node code)
+ * and are the mutation target: revert the hoist and they RED again — as do the
+ * DEFECT cases above, which turn into 200 + PLOT_INTERNAL_ERROR once the drop
+ * is a throw.
+ *
+ * NOTE — this is a deliberate, disclosed behaviour change: when a request is
+ * malformed in BOTH its interventions and its goal node, the reported blocker
+ * is now the intervention one. Both were always blockers; only which is
+ * reported first moves.
+ */
+describe('ROADMAP 1.278 · Phase 1a++ guard PLACEMENT (above normalizeOptions)', () => {
+  async function postWith(overrides: Record<string, unknown>, interventions: unknown) {
+    islCallCount = 0; lastIslOptions = null;
+    const res = await app.inject({
+      method: 'POST', url: '/v2/run', headers: { 'content-type': 'application/json' },
+      payload: {
+        graph: GRAPH,
+        options: [
+          { id: 'o1', label: 'Option One', interventions },
+          { id: 'o2', label: 'O2', interventions: { f: 80, g: 40 } },
+        ],
+        goal_node_id: 'goal', seed: '42',
+        ...overrides,
+      },
+    });
+    return { res, body: JSON.parse(res.body) as Record<string, unknown> };
+  }
+
+  it('DEFECT: the guard runs before goal validation — a malformed value outranks GOAL_NODE_NOT_IN_GRAPH', async () => {
+    // On 84f549ce this returned 422 GOAL_NODE_NOT_IN_GRAPH, because goal
+    // validation sits between normalizeOptions() and where the guard used to be.
+    const { res, body } = await postWith({ goal_node_id: 'nope' }, { f: null, g: 60 });
+    expect(res.statusCode).toBe(422);
+    expect(critiques(body).map(c => c.code)).toContain('INVALID_INTERVENTION_VALUE');
+    expect(critiques(body).map(c => c.code)).not.toContain('GOAL_NODE_NOT_IN_GRAPH');
+    expect(islCallCount).toBe(0);
+  });
+
+  it('DEFECT: the guard runs before goal-kind validation — it outranks GOAL_NODE_NOT_CAUSAL too', async () => {
+    // Second arm, so the pin is not resting on one goal-validation branch.
+    const graphWithOptionNode = {
+      nodes: [...GRAPH.nodes, { id: 'optnode', kind: 'option', label: 'An Option Node' }],
+      edges: GRAPH.edges,
+    };
+    const { res, body } = await postWith(
+      { graph: graphWithOptionNode, goal_node_id: 'optnode' },
+      { f: null, g: 60 },
+    );
+    expect(res.statusCode).toBe(422);
+    expect(critiques(body).map(c => c.code)).toContain('INVALID_INTERVENTION_VALUE');
+    expect(critiques(body).map(c => c.code)).not.toContain('GOAL_NODE_NOT_CAUSAL');
+  });
+
+  it('PIN: the user_message still resolves the option LABEL from the raw body', async () => {
+    // The hoist moved the humaniser's label sources from `normalizedGraph` /
+    // `normalizedOptions` (which do not exist yet above Phase 1) to `body.graph`
+    // / `body.options`. normalizeOptions() copies `id` and `label` verbatim, so
+    // the rendered message must be unchanged — this is what proves that.
+    const { body } = await postWith({}, { f: null, g: 60 });
+    const c = critiques(body).find(x => x.code === 'INVALID_INTERVENTION_VALUE')!;
+    expect(c).toBeDefined();
+    expect(String(c.user_message)).toBe('Option One has an invalid effect value. Each intervention must be a valid number.');
+  });
+
+  it('POSITIVE CONTROL: with VALID interventions the goal-node blocker is unchanged', async () => {
+    // The guard must not have swallowed the adjacent diagnosis — only reordered
+    // it for requests that are malformed in BOTH places.
+    const { res, body } = await postWith({ goal_node_id: 'nope' }, { f: 120, g: 60 });
+    expect(res.statusCode).toBe(422);
+    expect(critiques(body).map(c => c.code)).toContain('GOAL_NODE_NOT_IN_GRAPH');
+    expect(critiques(body).map(c => c.code)).not.toContain('INVALID_INTERVENTION_VALUE');
+  });
+});


### PR DESCRIPTION
## What this fixes

#281 shipped the Phase 1a++ intervention ingress-shape guard on `POST /v2/run`, and left this comment on the drop branch inside `normalizeInterventions()`:

> The drop is now **UNREACHABLE** on the route: the ingress guard 422s any entry this reader rejects, so by the time a request is analysed every entry carries a finite value and this function is total.

**That sentence was false, and this PR makes it true rather than rewording it.**

## The verdict, split — because half the review finding was right and half was not

Two reviewers converged on this line. Their shared conclusion was that the silent-drop→200 defect #281 claimed to close was *still live on the route*. It is not. But the reachability half of the finding is exactly right, and it mattered.

**REFUTED — there is no live silent-drop → 200.** The guard iterates **`body.options`, the RAW body**, not `normalizedOptions`. The earlier `normalizeOptions()` call therefore cannot blind it. Measured on pristine `84f549ce`: all 10 cases in `tests/intervention-ingress-shape-guard.test.ts` green, including `{"f": null, "g": 60}` → **422 `INVALID_INTERVENTION_VALUE`**, `islCallCount === 0`. No request was being analysed with an intervention silently removed.

**CONFIRMED — the drop was being reached, and the comment denied it.** `normalizeOptions()` ran at `run.ts:4485`, **159 lines above** the guard at `:4644`. Proven, not inferred: in a throwaway worktree outside the repo root, the `continue` at `:1186` was replaced with a `throw` on pristine staging, and `{"f": null, "g": 60}` produced

```
Error: PROBE_DROP_REACHED:f
    at normalizeInterventions (run.ts:1186:36)
    at run.ts:1209:20 -> Array.map -> normalizeOptions (run.ts:1206:18)
    at <POST /v2/run handler> (run.ts:4485:33)
```

So the drop executed on **every** malformed request. What kept that harmless was **position**, not structure: the property "no consumer ever sees the silently-edited option set" held only because nobody had yet put a `normalizedOptions` reader into the ~160-line gap. That is a hand-maintained invariant guarding a silent edit — the same defect class #281 exists to close, reintroduced one level up. And the comment told the next reader the gap could not exist, which is precisely the reader who would have closed it.

## The change

1. **Hoist the guard above the sole `normalizeOptions()` call site** — it now sits immediately above the Phase 1 block. Pure move; the guard body is byte-identical except its two label-source arguments (`normalizedGraph`/`normalizedOptions` → `body.graph`/`body.options`), which do not exist yet at the new position. `normalizeOptions()` copies `id` and `label` verbatim, and the humaniser reads only those, so the rendered `user_message` is unchanged — pinned by a test.

2. **The drop becomes a throw.** With the guard structurally above, `normalizeInterventions()` is total-or-loud: an entry carrying no finite value throws with the node id rather than vanishing. `OptionV3.interventions[].value` is a required number, so absence cannot be represented; skipping silently changes *what was analysed* while still returning a confident answer, and any substituted number fabricates. Refusing is the only non-fabricating disposal — the same one #281 already gave `normaliseOptions()` and `normaliseGoalConstraints()` in `lib/intervention-normaliser.ts`.

3. **The comment now states a derived claim.** Complete manifest: neither function is exported; `normalizeInterventions` has exactly one caller (`normalizeOptions`, `:1248`), which has exactly one call site (`:4609`). The one shape the guard skips rather than scans is a non-plain-object `interventions`; the Ajv body schema types it `{ type: 'object' }` and an array or string body is rejected **400 `BAD_INPUT`** before the handler runs — measured, not assumed.

## Disclosed behaviour change

When a request is malformed in **both** its interventions and its goal node, the reported blocker is now the intervention one (previously `GOAL_NODE_NOT_IN_GRAPH` / `GOAL_NODE_NOT_CAUSAL`). Both were always blockers; only which is reported first moves. A request with *valid* interventions gets the goal-node blocker exactly as before — pinned by a positive control.

## Evidence

**RED-first, at the route.** The 3 new PLACEMENT `DEFECT` cases were RED on `84f549ce` (they returned the goal-node code). Placement has no direct route-visible signature, so it is instrumented by precedence against a blocker raised by code that used to run first.

**Mutation, in a throwaway worktree outside the repo root, removed before every gate run:**

| Mutant | Result |
|---|---|
| **M1** — revert the hoist alone, keep the throw | **10 RED / 4 green.** All 5 original `DEFECT` cases + both `PIN`s go red — they become **HTTP 200 + `PLOT_INTERNAL_ERROR`**, the exact masked shape #281 closed — plus the 3 new PLACEMENT cases. All 4 positive controls stay green, as controls must. |
| **M2** — revert the throw alone, keep the hoist | **14/14 green.** |

**M2 is disclosed as a negative result, not buried:** the throw is *not* test-bitten in isolation, because after the hoist it is unreachable by construction. Its value is demonstrated only jointly with M1, which shows the branch *was* executing and that making it loud converts an undetectable edit into a named failure. This is the same disposal — and the same honest limitation — as the sibling throws #281 shipped in `intervention-normaliser.ts`.

## Rider — a trap-14 stale claim inside the seam-documentation gate

`tests/gates/numeric-safety-deep-scan.test.ts` asserted at `:232` that `normaliseValue` self-guards, and then stated sixteen lines later at `:249–251`:

> The half that still matters is unchanged and is asserted above: `normaliseValue` **remains an unguarded seam**, so boundary guards are still required there. Only denormaliseValue moved.

True under ROADMAP 1.277 (which hardened `denormaliseValue` alone); stale the moment 1.278 hardened `normaliseValue` too — in the same `describe`, contradicting an assertion above it. The cost is concrete: a reader deciding whether a new caller needs its own finiteness check reads "remains an unguarded seam" and adds a caller-side mirror of a guard the primitive already performs.

The two `it`-blocks are collapsed into one — *"BOTH normalisation primitives SELF-GUARD to undefined"* — so the pair can only ever be described together and cannot drift apart again. Every assertion is preserved; the stale paragraph is deleted.

## On the duplicate traversal (efficiency review)

Not addressed, deliberately. After the hoist the guard and the normaliser each traverse the interventions once, sharing `readInterventionValue` — the single predicate #281 created. Two traversals at µs scale do not justify result-sharing plumbing across a boundary whose whole point is that the two views are different (raw vs normalised). Correctness and truthful comments outrank the microseconds.

## Gates

`check-no-stale-js` · `eslint --max-warnings 97` (86, unchanged) · `validate:contracts` · `build` · `RATE_LIMIT_ENABLED=0 npm test` — the sequence `.github/workflows/ci.yml` runs.

`npm run gates` and `npm run lint` (`--max-warnings 0`) fail **identically on pristine `84f549ce`** in a control worktree — 1 pass / 6 fail either way, 86 warnings either way. Pre-existing and not attributable to this change; CI's lint cap is 97, not 0.

ROADMAP 1.278.
