### PR TITLE
feat(v2/run): five #1-surfaces project driver_order[0] + provisional separability default (family-4 S1b)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -6242,12 +6242,22 @@ components:
             producer, or a dropped key) and a consumer must fail closed on it.
 
 
-            ADDITIVE. `factor_sensitivity[].driver_label`, `dominant_factor`,
-            `m1_coaching.key_drivers[].rank`, `decision_brief.top_drivers[0]`
-            and the facts-path `importance_rank` are UNCHANGED by this slice
-            and remain independent argmaxes; on the pinned 2026-07-07 capture
-            two of them still name a different factor from
-            `ranked_factor_ids[0]`. Reconciling them is a later slice.
+            ⭐ EVERY #1-NAMING SURFACE IN THIS RESPONSE PROJECTS
+            `ranked_factor_ids[0]` (family-4 S1b): `factor_sensitivity[].driver_label
+            === 'biggest'`, `dominant_factor`, `m1_coaching.key_drivers[0]`,
+            `decision_brief.top_drivers[0]` and the facts-path
+            `importance_rank`. They are no longer independent argmaxes, so a
+            consumer reading any of them gets the same answer as reading this
+            field. Before S1b two of them named the option-pinned lever the
+            same response publishes at `sensitivity_score: 0`.
+
+
+            ⚠ Option-controlled levers are still DEMOTED to the back of this
+            order and MARKED in `lever_ids`, not removed — ranking a lever in
+            its true place is the honest end state but waits on CEE's
+            permission layer. The RAW structural influence order is still
+            published under its own name as
+            `factor_sensitivity[].influence_rank`.
 
 
             Not in `response_hash` (which canonicalises the REQUEST).
@@ -6329,21 +6339,47 @@ components:
                   type: boolean
                   nullable: true
                   description: >-
-                    `false` — PROVEN not separable (the top two rows are
-                    EXACTLY equal on the quantity the order was made on; no
-                    threshold involved). `null` — UNRESOLVED; a consumer MUST
-                    fail closed, and strict inequality on the basis quantity is
-                    NOT evidence of statistical separability. `true` is NOT
-                    emitted by this build: no threshold for the DRIVER order is
-                    ratified, and inventing one would recreate the
-                    three-thresholds-in-three-repos defect the option-side
-                    `near_tie` already suffers.
+                    🟡 PROVISIONAL (ratified 2026-07-28; the statistic is
+                    pending science sign-off — ALWAYS read `method`).
+                    `false` — not separable. `true` — separable. `null` —
+                    UNRESOLVED, and a consumer MUST fail closed on it: absence
+                    of a verdict is never permission.
+
+
+                    `null` is returned whenever the producer cannot honestly
+                    decide: fewer than two rows; either basis value absent or
+                    non-finite (never coalesced to 0); the top two rows on
+                    OPPOSITE sides of the lever partition, or of two different
+                    row species — in those states the emitted order is not a
+                    sort on the compared quantity, so any verdict about the
+                    pair would be a fabrication.
                 method:
                   type: string
                   nullable: true
                   description: >-
-                    Names the method behind a non-null verdict
-                    (`basis_value_exact_tie`); `null` when unresolved.
+                    Names the STATISTIC, THRESHOLD and RATIFICATION STATUS
+                    behind a non-null verdict; `null` when unresolved. One
+                    threshold, on the wire — a consumer that needs a different
+                    one is asking for a different verdict and must say so in a
+                    review, not in a local constant.
+
+
+                    `basis_value_exact_tie` — the top two rows are EXACTLY
+                    equal on the quantity the order was made on. A proven
+                    non-separation; no threshold involved.
+
+
+                    `relative_gap_0.10_provisional` — the relative gap
+                    `(first − second) / first` on the basis quantity, against a
+                    0.10 threshold. 🟡 PROVISIONAL: the number is reused from the
+                    repo's one ratified near-tie magnitude (the option-side
+                    `near_tie.threshold`), and the form is RELATIVE because the
+                    basis quantity is normalised by the largest row — which,
+                    after the lever demotion, need not be in the compared pair
+                    at all. A gap between two point estimates is not a
+                    statistical separability test; the ratified statistic will
+                    read ISL's bootstrap (`rank_stability` on this same object)
+                    and will arrive under a DIFFERENT method name.
             rank_stability:
               type: object
               description: >-

--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -121,6 +121,16 @@ function computeConfigVersion(nSamples: number = STANDARD_N_SAMPLES_DEFAULT): st
 export type BriefAssemblyInput = Pick<RunResponseV3, 'analysis_status' | 'critiques'> & {
   option_comparison?: RunResponseV3['option_comparison'];
   factor_sensitivity?: RunResponseV3['factor_sensitivity'];
+  /**
+   * ⭐ Family-4 S1b (additive, optional): PLoT's ONE canonical driver order and
+   * its attestation. `top_drivers` PROJECTS `ranked_factor_ids` and takes lever
+   * identity from `lever_ids` (the D-U union) instead of re-deriving it from the
+   * response's own `zero_reason` stamp, which under-covers.
+   *
+   * OPTIONAL, and its absence is FAIL-CLOSED: without it `top_drivers` keeps its
+   * pre-S1b stamp-only behaviour. Absence of an attestation is not permission.
+   */
+  driver_order?: RunResponseV3['driver_order'];
   robustness?: RunResponseV3['robustness'];
   m1_coaching?: RunResponseV3['m1_coaching'];
   m1_review?: RunResponseV3['m1_review'];
@@ -355,20 +365,53 @@ function buildAnalysisSummary(
 }
 
 function buildTopDrivers(input: BriefAssemblyInput): BriefDriver[] {
-  // A1b: exclude intervention-controlled levers — top_drivers ranks by
-  // abs(elasticity) and would otherwise present option-pinned levers as tunable.
-  const factors = filterInterventionOverrides(input.factor_sensitivity ?? []);
+  // ── ⭐ FAMILY-4 S1b: top_drivers PROJECTS the canonical driver order ───────
+  //
+  // Two independent defects lived in the four lines this replaced:
+  //
+  //  1. **The lever predicate UNDER-covered.** `filterInterventionOverrides` is
+  //     stamp-only — it drops rows carrying ISL's `zero_reason:
+  //     'intervention_override'`, and nothing else. ISL stamps only elasticity≈0
+  //     first-option pins, so a lever pinned by a NON-first option arrives
+  //     unstamped with a nonzero measured elasticity and ranks here as a tunable
+  //     driver. That is the live `fac_salary_cost` case recorded at
+  //     `src/lib/intervention-override.ts:9-15`. `driver_order.lever_ids` is the
+  //     D-U union — the canonical lever identity, derived from the REQUEST's
+  //     option interventions and not from the response's own stamp.
+  //  2. **It was a second sort.** Ranking by `abs(elasticity)` made this an
+  //     independent argmax over a different quantity from the one the canonical
+  //     order was made on — and in the `mixed_graph_isl` state it sorts across
+  //     two incommensurable units under one field name.
+  //
+  // ⚠ FAIL-CLOSED ON ABSENCE. With no `driver_order` (an older caller, or a
+  // response that emitted no `factor_sensitivity`) this keeps EXACTLY its
+  // pre-S1b behaviour rather than treating "no levers named" as "no levers
+  // exist" — absence of the attestation is not permission to publish a lever.
+  const allFactors = input.factor_sensitivity ?? [];
+  const driverOrder = input.driver_order;
+  const leverIds = driverOrder ? new Set(driverOrder.lever_ids) : undefined;
+
+  const factors = leverIds
+    ? allFactors.filter((f) => !leverIds.has(f.factor_id))
+    : filterInterventionOverrides(allFactors);
   if (factors.length === 0) return [];
 
-  // Sort by absolute elasticity descending, ties broken by factor_id (node_id) bytewise ascending
-  const withElasticity = factors
-    .filter(f => f.elasticity !== undefined && f.elasticity !== null)
-    .sort((a, b) => {
-      const diff = Math.abs(b.elasticity!) - Math.abs(a.elasticity!);
-      if (diff !== 0) return diff;
-      return a.factor_id < b.factor_id ? -1 : a.factor_id > b.factor_id ? 1 : 0;
-    })
-    .slice(0, MAX_TOP_DRIVERS);
+  const withElasticity = leverIds
+    ? // The emitted array IS the canonical order (Rule S3), so preserving it is
+      // the projection. No second sort, no tie-break needed — the producer
+      // already decided, once.
+      factors.filter((f) => f.elasticity !== undefined && f.elasticity !== null)
+        .slice(0, MAX_TOP_DRIVERS)
+    : // Legacy path (no attestation): unchanged — abs(elasticity) descending,
+      // ties broken by factor_id bytewise ascending.
+      factors
+        .filter(f => f.elasticity !== undefined && f.elasticity !== null)
+        .sort((a, b) => {
+          const diff = Math.abs(b.elasticity!) - Math.abs(a.elasticity!);
+          if (diff !== 0) return diff;
+          return a.factor_id < b.factor_id ? -1 : a.factor_id > b.factor_id ? 1 : 0;
+        })
+        .slice(0, MAX_TOP_DRIVERS);
 
   // Direction prefers the upstream signed `direction` field — the canonical
   // source already used by factor_sensitivity[*].direction and

--- a/src/coaching/key-drivers.ts
+++ b/src/coaching/key-drivers.ts
@@ -1,8 +1,11 @@
 /**
  * D1: Key Drivers
  *
- * Top 5 factors by influence with impact display.
+ * Top 5 factors in PLoT's ONE canonical driver order, with impact display.
  * Uses centralized normalisedImpact to ensure consistency with evidence gaps.
+ *
+ * ⭐ FAMILY-4 S1b: `rank` is a PROJECTION of `driver_order.ranked_factor_ids`,
+ * not an independent argmax — see the block comment in `computeKeyDrivers`.
  */
 
 import type { CoachingInputs } from './types.js';
@@ -32,22 +35,33 @@ export function computeKeyDrivers(inputs: CoachingInputs): KeyDriver[] {
   // Use centralized normalised impact (same as evidence gaps)
   const normalisedImpactMap = computeNormalisedImpact(inputs.factorSensitivity);
 
-  // Sort by absolute influence score descending.
   // Provenance: prefer `influence_score` (canonical, graph-merged PLoT signal)
   // over `elasticity` (raw ISL value) — same precedence as
-  // `computeNormalisedImpact`, so the published `rank`, `influence_score`, and
-  // `normalised_impact` fields are internally consistent. For graph-source
-  // enriched entries the two are equal; for ISL-only-append entries
-  // influence_score is the correct canonical signal.
+  // `computeNormalisedImpact`, so the published `influence_score` and
+  // `normalised_impact` fields stay internally consistent.
   const impactMagnitude = (f: typeof inputs.factorSensitivity[number]): number =>
     Math.abs(f.influence_score ?? f.elasticity ?? 0);
 
-  const sorted = [...inputs.factorSensitivity].sort(
-    (a, b) => impactMagnitude(b) - impactMagnitude(a),
+  // ── ⭐ FAMILY-4 S1b: `rank` PROJECTS the canonical driver order ────────────
+  //
+  // This used to sort by `impactMagnitude` descending — a second argmax over a
+  // quantity that is NOT lever-aware. On the live wire it crowned the
+  // option-pinned lever the same response publishes at `elasticity: 0`, while
+  // `importance_rank: 1` named the top genuine uncertainty driver.
+  //
+  // `importance_rank` IS PLoT's one canonical rank (`applyLeverAwareImportanceOrder`),
+  // and by Rule S3 the emitted array is already in that order — so this sort is
+  // a no-op on every live payload and exists to make the projection EXPLICIT
+  // rather than positional. The sort is stable, so rows that share a rank (the
+  // legacy raw-ISL coaching path defaults absent ranks to 999) keep the
+  // producer's own array order rather than being re-shuffled by a second
+  // quantity.
+  const ranked = [...inputs.factorSensitivity].sort(
+    (a, b) => a.importance_rank - b.importance_rank,
   );
 
   // Take top 5
-  const top5 = sorted.slice(0, 5);
+  const top5 = ranked.slice(0, 5);
 
   return top5.map((factor, index) => {
     const influence = impactMagnitude(factor);

--- a/src/contracts/isl-to-ui.contract.ts
+++ b/src/contracts/isl-to-ui.contract.ts
@@ -249,17 +249,22 @@ export const ISL_TO_UI_CONTRACT: BoundaryContract = {
     // the array IS the order. Emitted whenever factor_sensitivity is emitted,
     // including empty (basis 'none') — so absence is unambiguous and a
     // consumer can fail closed on a value it can read rather than on a key it
-    // has to guess about. ADDITIVE: driver_label, dominant_factor,
-    // m1_coaching.key_drivers[].rank, decision_brief.top_drivers[0] and the
-    // facts-path importance_rank are UNCHANGED by this slice and three of
-    // them still disagree with it. See src/lib/driver-order.ts.
+    // has to guess about.
+    //
+    // ⭐ S1b: driver_label 'biggest', dominant_factor,
+    // m1_coaching.key_drivers[0], decision_brief.top_drivers[0] and the
+    // facts-path importance_rank are all PROJECTIONS of
+    // ranked_factor_ids[0] — they are no longer independent argmaxes, so no
+    // two of them can name different factors. The raw structural argmax is
+    // still published as factor_sensitivity[].influence_rank.
+    // See src/lib/driver-order.ts.
     'driver_order',
     'driver_order.basis',                // 'graph_structural' | 'isl_uncertainty' | 'none' — the ORDER-level successor to the per-row importance_basis
     'driver_order.ranked_factor_ids',    // the canonical order, IDS only (a second copy of a label is a second thing to drift)
     'driver_order.species',              // 'single' | 'mixed_graph_isl' — the ISL-only tail appended with no re-sort carries an incommensurable quantity; before this field no consumer could detect it
     'driver_order.lever_policy',         // 'du_union' on /v2/run — the ISL stamp OR the options-derived intervention union; 'stamp_only' is RESERVED for the surfaces that still use the under-covering predicate
     'driver_order.lever_ids',            // levers are MARKED, not hidden — whether a lever may be CROWNED is a permission question, not a producer one
-    'driver_order.separability',         // the TIE VERDICT. `false` = PROVEN non-separation (exact tie on the basis quantity). `null` = UNRESOLVED — fail closed. `true` is NEVER emitted by this build: no driver-order threshold is ratified, and inventing one would recreate the three-thresholds-in-three-repos defect.
+    'driver_order.separability',         // the TIE VERDICT — 🟡 PROVISIONAL (2026-07-28), ALWAYS read `.method`. `basis_value_exact_tie` = PROVEN non-separation, no threshold. `relative_gap_0.10_provisional` = the provisional default: relative gap (first−second)/first vs 0.10, the repo's one ratified near-tie magnitude, applied RELATIVELY because the basis quantity is max-normalised. `null` = UNRESOLVED — fail closed; returned for <2 rows, absent/non-finite values, or a top pair straddling the lever partition or two row species.
     'driver_order.rank_stability',       // ISL's MEASUREMENTS aggregated (worst rank_flip_rate, worst attribution_stability band). No threshold applied. null = not measured, never 0.
     'factor_sensitivity[].confidence_source', // B (tier-B): 'plot_unified_from_isl_bootstrap' | 'plot_unified_from_graph' — honest provenance tag (audit A1-PRIMARY)
     'factor_sensitivity[].confidence_provenance', // B (tier-B): typed disclosure object {computation_source, formula_version, is_provisional, calibration_status, input_quality} — audit A1-PRIMARY

--- a/src/lib/driver-label.ts
+++ b/src/lib/driver-label.ts
@@ -7,9 +7,19 @@
  * `getSemanticLabel`, which adds a rank-1 'biggest'/'strongest' band on top of the
  * three magnitude bands. The three magnitude cut-points are ratified FROM the UI's
  * existing cut-points (useResultsSectionData.ts): >=0.50 strong, >=0.20 moderate,
- * else minor. The rank-1 'biggest' band is SET-AWARE (needs every factor's
- * influence), so it is applied by the caller's derive-pass — see
- * `indexOfBiggestDriver` — NOT by the pure per-factor `deriveDriverLabel` helper.
+ * else minor. The rank-1 'biggest' band is SET-AWARE, so it is applied by the
+ * caller's derive-pass — see `indexOfCanonicalTopDriver` — NOT by the pure
+ * per-factor `deriveDriverLabel` helper.
+ *
+ * ## ⭐ FAMILY-4 S1b — the two bands now answer two DIFFERENT questions
+ *
+ * `'strong' | 'moderate' | 'minor'` are MAGNITUDE claims about the row's own
+ * `influence_score`, unchanged. `'biggest'` is a RANK claim, and it now projects
+ * `driver_order.ranked_factor_ids[0]` — PLoT's ONE canonical, lever-aware order —
+ * instead of running a second, lever-blind argmax over `influence_score`. Before
+ * this slice the two disagreed on the live wire, and `'biggest'` was the one that
+ * crowned a producer-zeroed lever. The raw structural argmax is still published,
+ * under its own honest name, as `influence_rank === 1`.
  *
  * NOTE — this now matches getSemanticLabel's 4-valued SHAPE, but two things remain
  * gated on UI confirmation (D-7 KEY UNCERTAINTY: the UI facts are unconfirmed):
@@ -22,9 +32,8 @@
  *      supersede getSemanticLabel until that confirmation lands.
  *
  * The magnitude label is a pure function of `influence_score`; a factor whose
- * influence is absent/non-finite gets NO label (the missing-vs-value honesty
- * contract: never fabricate 'minor' from a missing measurement) and is likewise
- * NOT eligible to be 'biggest'.
+ * influence is absent/non-finite gets NO magnitude label (the missing-vs-value
+ * honesty contract: never fabricate 'minor' from a missing measurement).
  */
 
 import { isFiniteNumber } from '../util/numeric.js';
@@ -76,40 +85,57 @@ export function deriveDriverLabel(
   return 'minor';
 }
 
-/** Minimal shape read by the set-aware rank-1 selector. */
-interface InfluenceCarrier {
-  influence_score?: number | null;
-}
-
 /**
- * Set-aware rank-1 selector for the `'biggest'` driver band (D-7). Returns the
- * index of the SINGLE factor with the greatest finite `influence_score`, or `-1`
- * when no factor has a finite influence.
+ * ⭐ Index of the factor that carries the `'biggest'` band — a PROJECTION of the
+ * canonical driver order (family 4, slice S1b).
  *
- * The selection is magnitude-BLIND — it ranks by raw `influence_score`, never by
- * the magnitude band — so the rank-1 factor is `'biggest'` UNCONDITIONAL of
- * magnitude (it is 'biggest' even if its band would be 'minor'). This matches the
- * UI `getSemanticLabel` rank-1 'biggest'/'strongest' band.
- *   // DOCTRINE-PENDING (Neil/UX): 'biggest' is rank-1 unconditional; add a
- *   // magnitude floor here if UX wants one.
+ * ## What this replaced, and why
  *
- * Ties on the max resolve to the FIRST such factor in the given (stable, emitted)
- * order — deterministic — via the strict-`>` update (a later equal score never
- * displaces the earlier one). A factor with absent/non-finite influence is NOT
- * eligible (it carries no driver_label at all), so it can never be 'biggest'.
+ * This was `indexOfBiggestDriver`: argmax over `influence_score`, NOT
+ * lever-aware. On the live wire it crowned the option-pinned lever the same
+ * response publishes at `sensitivity_score: 0`, `elasticity: 0`,
+ * `zero_reason: 'intervention_override'` — a factor the producer had explicitly
+ * zeroed, labelled the biggest driver in the decision — while
+ * `importance_rank: 1` (which IS lever-aware) named a different factor.
+ *
+ * The prior lane left that divergence deliberately, on three reasons that the
+ * amendment re-derived and overturned:
+ *
+ *   1. *"'biggest' is DEFINED as the greatest influence_score, so gating it makes
+ *      the label contradict its own row."* — The definition is what changed.
+ *      `'biggest'` is now a RANK claim over PLoT's one canonical order, not a
+ *      magnitude claim; the three magnitude bands still speak for the number in
+ *      the row, and they are untouched. The response also now publishes
+ *      `driver_order` and `influence_rank`, so the structural argmax remains
+ *      readable under its own honest name — nothing was hidden, one crown moved.
+ *   2. *"the basis question is an open doctrine row (Neil/UI)."* — Still open,
+ *      and still only about the three MAGNITUDE cut-points. The amendment's §4.3
+ *      settles the separate question of which ORDER a crown projects, and
+ *      settles it for all five crowns at once.
+ *   3. *"blast radius is zero — no consumer reads driver_label."* — A census
+ *      taken 25 Jul at tips that have since moved (CLAUDE.md trap 12: a census
+ *      is a hand-maintained mirror). Not inherited here — and the argument cuts
+ *      the other way regardless: a field with no readers is the cheapest
+ *      possible moment to correct it.
+ *
+ * ## The rule
+ *
+ * Rule S3 — *"one order, and the array IS it"*: `factor_sensitivity[]` is
+ * emitted in canonical order, so `ranked_factor_ids[0]` is index `0`. The crown
+ * therefore projects the order rather than re-deriving a second argmax over a
+ * quantity the order was not made on.
+ *
+ * Returns `-1` for an empty array — no order, no crown.
+ *
+ * ⚠ The crowned row keeps whatever magnitude band its own `influence_score`
+ * earned until this override replaces it, and a row with absent/non-finite
+ * influence carries no magnitude band at all. It is STILL crowned when it heads
+ * the canonical order: `'biggest'` now answers *"which factor does this producer
+ * rank first?"*, and that question has an answer even when the magnitude
+ * question does not.
  */
-export function indexOfBiggestDriver(
-  factors: ReadonlyArray<InfluenceCarrier>,
+export function indexOfCanonicalTopDriver(
+  factors: ReadonlyArray<unknown>,
 ): number {
-  let biggestIdx = -1;
-  let biggestScore = -Infinity;
-  for (let i = 0; i < factors.length; i++) {
-    const s = factors[i].influence_score;
-    if (!isFiniteNumber(s)) continue; // ineligible
-    if (s > biggestScore) {
-      biggestScore = s;
-      biggestIdx = i;
-    }
-  }
-  return biggestIdx;
+  return factors.length > 0 ? 0 : -1;
 }

--- a/src/lib/driver-label.ts
+++ b/src/lib/driver-label.ts
@@ -69,7 +69,8 @@ export type MagnitudeDriverLabel = Exclude<DriverLabel, 'biggest'>;
 /**
  * Derive the per-factor magnitude driver label from a factor's normalised
  * influence. This is the pure 3-band helper; it NEVER returns `'biggest'`
- * (that band is set-aware — see `indexOfBiggestDriver`).
+ * (that band is a RANK claim projected from the canonical driver order — see
+ * `indexOfCanonicalTopDriver`).
  *
  * Returns `undefined` (field omitted by the caller) when influence is absent or
  * non-finite — distinct from 'minor', which is a real low-influence measurement.

--- a/src/lib/driver-order.ts
+++ b/src/lib/driver-order.ts
@@ -180,7 +180,7 @@ const ATTRIBUTION_STABILITY_ORDER: readonly AttributionStabilityBand[] = [
  * Neil owns the real statistic — the honest input is ISL's bootstrap
  * (`rank_flip_rate`, `elasticity_std`, `attribution_stability`), not a gap on a
  * point estimate. When that lands, an overrule is exactly ONE edit:
- * **replace the body of `decideProvisionalSeparability` below** (and, if the
+ * **replace the body of `decideSeparability` below** (and, if the
  * threshold changes rather than the statistic, the single
  * `PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP` binding). Nothing else in
  * this file, and no consumer, needs to move — which is the whole reason the
@@ -429,9 +429,14 @@ function decideSeparability(
   // The order does not descend on this quantity across the top pair, so this is
   // not the quantity the order was made on. Unresolved, not "tied".
   if (b > a) return UNRESOLVED;
-  // A non-positive leader admits no relative gap (and `a === 0` was already
-  // handled above: with b < a ≤ 0 the pair is not on the basis scale at all).
-  if (a <= 0) return UNRESOLVED;
+  // Neither row may sit off the basis scale. `influence_score` is
+  // `|influence| / maxAbsInfluence`, so it is non-negative by construction and
+  // neither branch is reachable on a live payload — but a NEGATIVE runner-up
+  // would otherwise produce a relative gap > 1 and a confident `true` about a
+  // pair that is not on this scale at all, which is a fabrication rather than a
+  // measurement. Both fail closed. (Checked AFTER the exact-tie branch, so that
+  // path stays byte-unchanged.)
+  if (a <= 0 || b < 0) return UNRESOLVED;
 
   const relativeGap = (a - b) / a;
   if (!Number.isFinite(relativeGap)) return UNRESOLVED;
@@ -584,12 +589,19 @@ export function readIslSuppressedAttributions(islResult: unknown): string[] | un
  * permission is live and the UI consumes it (S4 + S6) — today the demotion is
  * the only thing keeping a producer-zeroed factor off rank 1.
  *
- * ⚠ **Two surfaces in this response still use the STAMP-ONLY lever predicate:**
- * `buildWhatWouldChange` and the value-defaulted disclosure block in
- * `src/assembly/decision-brief.ts`. They are out of S1b's scope (which is the
- * #1-naming surfaces), the `lever_policy: 'stamp_only'` enum member exists so a
- * later slice can attest them without inventing a value, and this note is here
- * so the omission is recorded rather than discovered.
+ * ⚠ **Other surfaces in this response still use the STAMP-ONLY lever
+ * predicate**, which UNDER-covers (an unstamped D-U union lever slips through).
+ * They are out of S1b's scope — which is the #1-naming surfaces — and the
+ * `lever_policy: 'stamp_only'` enum member exists so a later slice can attest
+ * them without inventing a value.
+ *
+ * ⭐ **That set is DERIVED, not listed here.** An earlier revision of this note
+ * said "two surfaces" and named two; there are more, and the sentence was wrong
+ * the moment it was written — the hand-maintained mirror this codebase names as
+ * its dominant defect, reproduced inside the register that exists to prevent it.
+ * The census now lives in `tests/stamp-only-lever-predicate.census.test.ts`,
+ * which extracts every call site from the sources and FAILS LOUD when the set
+ * changes in either direction. Read it there; do not re-state it here.
  *
  * Enforced by `tests/driver-order-projection.fixture.test.ts` (one law, all
  * five, end to end), `tests/driver-surface-projection.unit.test.ts` (the three

--- a/src/lib/driver-order.ts
+++ b/src/lib/driver-order.ts
@@ -15,16 +15,17 @@
  *
  * ## ⚠ WHAT THIS SLICE DOES AND DOES NOT DO
  *
- * S1 is **ADDITIVE ONLY**. `driver_order` is emitted ALONGSIDE the existing
- * surfaces; nothing that ranks or crowns today changes shape, value or
- * meaning. In particular the amendment's §8-S1 second half — making
- * `driver_label`, `dominant_factor`, `m1_coaching.key_drivers[].rank`,
- * `decision_brief.top_drivers[0]` and the facts-path `importance_rank`
- * PROJECTIONS of `ranked_factor_ids[0]` — is **NOT** done here. Those five
- * remain independent argmaxes and, on the committed golden, three of them
- * still disagree with this order (see the RESIDUAL block at the foot of this
- * file). Consumers arrive first (amendment §4.4: "the safe order is
- * consumer-first"), producers converge after.
+ * S1 was **ADDITIVE ONLY** — `driver_order` was emitted alongside five surfaces
+ * that each ran their own argmax, and three of them disagreed with it.
+ *
+ * **S1b (2026-07-28) closed that.** All five are now PROJECTIONS of
+ * `ranked_factor_ids[0]`: `driver_label` (`src/lib/driver-label.ts`),
+ * `dominant_factor` (`src/trust/factor-dominance.ts`),
+ * `m1_coaching.key_drivers[].rank` (`src/coaching/key-drivers.ts`),
+ * `decision_brief.top_drivers[0]` (`src/assembly/decision-brief.ts`) and the
+ * facts-path `importance_rank` (`mapFactorSensitivityToFactsInput`). See the
+ * PROJECTION REGISTER at the foot of this file, and the single end-to-end law
+ * in `tests/driver-order-projection.fixture.test.ts`.
  *
  * ## ⛔ THIS MODULE DOES NOT UN-DEMOTE LEVERS (amendment §4.4)
  *
@@ -82,6 +83,7 @@
  */
 
 import { isOptionControlledLever } from './intervention-override.js';
+import { NEAR_TIE_THRESHOLD } from '../trust/result-coherence.js';
 
 /**
  * WHICH authority produced the canonical order.
@@ -107,11 +109,24 @@ export type DriverOrderBasis = 'graph_structural' | 'isl_uncertainty' | 'none';
 export type DriverOrderSpecies = 'single' | 'mixed_graph_isl';
 
 /**
- * The lever doctrine actually applied when the order was made.
+ * The lever PREDICATE actually applied when the order was made.
+ *
+ * ⚠ It names the predicate, **not the treatment** — and the treatment differs by
+ * path (S1 review, LOW):
+ *
+ *   · **graph-primary path** — levers are DEMOTED. Every lever is present in
+ *     `ranked_factor_ids`, partitioned to the back, and named in `lever_ids`.
+ *   · **ISL-only fallback** — levers are REMOVED upstream. The append path in
+ *     `mergeIslConfidenceIntoGraphFactors` applies the same D-U union check and
+ *     never emits a lever row at all, so `lever_ids` is `[]`.
+ *
+ * ⇒ **`lever_ids: []` means "no lever is IN this order", NEVER "this decision
+ * has no levers".** A consumer that reads the empty array as the second claim is
+ * making an inference the producer did not.
  *
  * - `'du_union'` — the D-U structural union predicate
  *   (`isOptionControlledLever`: ISL stamp OR options-derived intervention
- *   target). This is what `/v2/run` applies.
+ *   target). This is what `/v2/run` applies, on BOTH paths.
  * - `'stamp_only'` — ISL's `zero_reason` stamp alone, which UNDER-covers
  *   (an unstamped union lever slips through). RESERVED: named here because
  *   other surfaces in this same response still use it
@@ -143,36 +158,110 @@ const ATTRIBUTION_STABILITY_ORDER: readonly AttributionStabilityBand[] = [
  * `top_pair_separable` answers *"is it separable from #2?"* (a VERDICT) — and
  * the presence of one is never permission for the other.
  *
- * ## ⚠ WHAT THIS BUILD CAN AND CANNOT DECIDE
+ * ## ⚠ WHAT THIS BUILD DECIDES — AND ON WHOSE AUTHORITY
  *
- * `top_pair_separable: true` is **NEVER emitted by this build**, deliberately.
- * Deciding *separable* from ISL's bootstrap measurements (`rank_flip_rate`,
- * `elasticity_std`, `attribution_stability`) requires a THRESHOLD, and no
- * threshold for the DRIVER order has been ratified. Amendment T3 requires the
- * producer to publish the one threshold it used; inventing one here would
- * manufacture exactly the three-thresholds-in-three-repos defect T3 exists to
- * kill (PLoT 0.10 / CEE 1.0 / UI 0.65 on the OPTIONS question). So this build
- * emits only what it can PROVE:
+ * ### 🟡 PROVISIONAL (Paul-ratified 2026-07-28; Neil's statistic still pending)
+ *
+ * S1 emitted only what it could PROVE: an exact tie, or `null`. `true` was
+ * unreachable, because deciding *separable* needs a THRESHOLD and none had been
+ * ratified for the driver order. Paul ratified a **provisional default** rather
+ * than leave the field permanently unresolved — so this build now decides, and
+ * says so on the wire:
  *
  * - `false` + `method: 'basis_value_exact_tie'` — the top two rows are EXACTLY
  *   equal on the quantity the order was made on. A proven non-separation; no
- *   threshold involved.
- * - `null` + `method: null` — **unresolved.** Not measured, not decided. Per
- *   T2 every consumer fails closed on this; strict inequality on the basis
- *   quantity is NOT evidence of statistical separability.
+ *   threshold involved, unchanged since S1.
+ * - `false` / `true` + `method: 'relative_gap_0.10_provisional'` — the
+ *   **provisional** verdict. See `PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP`.
+ * - `null` + `method: null` — **unresolved.** Not measured, not decidable. Per
+ *   T2 every consumer fails closed on this.
  *
- * ⇒ The `true` branch is an open decision (which statistic, which threshold,
- * against which pair) and it is a science sign-off, not a producer choice.
+ * ⛔ **THE PENDING RATIFICATION, and the one-line change that overrules it.**
+ * Neil owns the real statistic — the honest input is ISL's bootstrap
+ * (`rank_flip_rate`, `elasticity_std`, `attribution_stability`), not a gap on a
+ * point estimate. When that lands, an overrule is exactly ONE edit:
+ * **replace the body of `decideProvisionalSeparability` below** (and, if the
+ * threshold changes rather than the statistic, the single
+ * `PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP` binding). Nothing else in
+ * this file, and no consumer, needs to move — which is the whole reason the
+ * verdict is a producer statement carrying its own method name.
+ *
+ * ⚠ Until then, `method` MUST keep saying `provisional`. A consumer that treats
+ * a provisional verdict as a ratified one is making a claim this producer has
+ * not made.
  */
 export interface DriverOrderSeparability {
   /**
-   * `false` = proven NOT separable. `null` = UNRESOLVED (fail closed).
-   * `true` is not produced by this build — see the interface doc.
+   * `true`/`false` = the producer's verdict. `null` = UNRESOLVED — fail closed
+   * (T2: absence of a tie verdict is `unresolved`, NEVER `separable`).
    */
   top_pair_separable: boolean | null;
-  /** Names the method behind a non-null verdict; `null` when unresolved. */
+  /**
+   * Names the statistic, the threshold and the ratification status behind a
+   * non-null verdict; `null` when unresolved.
+   *
+   * T3 — one threshold, ON THE WIRE, not three in three repos. A consumer that
+   * needs a different one is asking for a different verdict and must say so in
+   * a review, not in a local constant.
+   */
   method: string | null;
 }
+
+/**
+ * 🟡 **PROVISIONAL** minimum RELATIVE gap between the top two rows of the
+ * canonical order for the top position to be called separable.
+ *
+ * ## The number: reused, not invented
+ *
+ * Bound to `NEAR_TIE_THRESHOLD` (`src/trust/result-coherence.ts`) — **0.10, the
+ * repo's ONE ratified near-tie magnitude**, already used for the OPTIONS
+ * near-tie verdict (`computeNearTie`) and for the decision brief's
+ * `'very_close'` band. Bound rather than hand-copied so the two cannot drift
+ * apart unnoticed (trap 12: derive, don't mirror); pinned to the literal `0.10`
+ * in `tests/driver-order-separability.unit.test.ts` so that if the options-side
+ * constant is ever changed for an unrelated product reason, that is a LOUD test
+ * failure rather than a silent move of this verdict.
+ *
+ * ## ⚠ The FORM is relative, and the repo's near-tie precedent is ABSOLUTE
+ *
+ * `computeNearTie` applies 0.10 as an ABSOLUTE gap between two
+ * `win_probability` values. That form is **wrong for this quantity**, and the
+ * reason is specific rather than stylistic:
+ *
+ * `influence_score` is `|influence| / maxAbsInfluence` — **normalised by the
+ * largest row**, which after the lever demotion need not be in the compared
+ * pair at all. On the committed golden the max row IS the demoted lever
+ * (`influence_score: 1`), so the two rows actually being compared sit at 0.497
+ * and 0.390. Had that lever's raw influence been twice as large, both would
+ * halve to 0.249 / 0.195 — **the same underlying data, an absolute gap
+ * collapsing from 0.107 to 0.053, and the verdict flipping** on a number
+ * outside the comparison. A RELATIVE gap `(a − b) / a` is invariant to that
+ * rescaling (0.2145 either way).
+ *
+ * `win_probability` has no such problem — it is normalised across the options
+ * being compared — which is why the same constant is right and the same form is
+ * not.
+ *
+ * ## ⛔ NOT RATIFIED — Neil owns the replacement
+ *
+ * A gap between two point estimates is not a statistical separability test. The
+ * honest statistic reads ISL's bootstrap (`rank_flip_rate`, `elasticity_std`,
+ * `attribution_stability`), all of which this response already carries in
+ * `driver_order.rank_stability`. Until that ruling lands this build states its
+ * provenance honestly in `method` and nothing more.
+ */
+export const PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP = NEAR_TIE_THRESHOLD;
+
+/** The method name for the PROVEN, threshold-free non-separation. Unchanged since S1. */
+export const SEPARABILITY_METHOD_EXACT_TIE = 'basis_value_exact_tie';
+
+/**
+ * The method name for the provisional verdict — statistic, threshold and
+ * ratification status, DERIVED from the constant so the string cannot drift
+ * away from the number it describes.
+ */
+export const SEPARABILITY_METHOD_RELATIVE_GAP =
+  `relative_gap_${PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP.toFixed(2)}_provisional` as const;
 
 /**
  * ISL's measured rank-stability inputs, aggregated over the ordered rows.
@@ -275,30 +364,82 @@ function finiteOrNull(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
+/** The unresolved verdict — the ONLY honest answer when the pair is undecidable. */
+const UNRESOLVED: DriverOrderSeparability = { top_pair_separable: null, method: null };
+
 /**
  * Decide the tie verdict for the top PAIR of the canonical order.
  *
- * Only ever returns a PROVEN `false` or an honest `null` — see
- * `DriverOrderSeparability`. The basis quantity is `influence_score` on the
- * graph path (what `computeFactorSensitivityFromGraph` ordered on) and the
- * same field on the ISL fallback (ISL's importance surface is carried into it
- * by `mapIslFactorEntry`). When either of the top two rows lacks a finite
- * basis value the verdict is `null`: an absent number is not a tie and is not
- * a separation.
+ * The basis quantity is `influence_score` on the graph path (what
+ * `computeFactorSensitivityFromGraph` ordered on) and the same field on the ISL
+ * fallback (ISL's importance surface is carried into it by `mapIslFactorEntry`).
+ *
+ * ## ⭐ THE COMPARABILITY GUARD — a verdict about a pair that was never ordered
+ * ## together is a fabrication (S1 review, LOW)
+ *
+ * S1 compared rows 0 and 1 of the **FINAL** order — which is the order AFTER
+ * `applyLeverAwareImportanceOrder` has partitioned levers to the back. Those two
+ * rows are therefore not necessarily adjacent in any sort on `influence_score`:
+ *
+ *   · **Across the lever partition.** A lever keeps its true structural
+ *     `influence_score` (only sensitivity/elasticity/VOI are zeroed), and it is
+ *     frequently the LARGEST — on the committed golden the demoted lever is
+ *     exactly 1.0 while the canonical #1 is 0.497. With one non-lever and one
+ *     lever, rows 0 and 1 straddle the partition and `b > a`: the "gap" is
+ *     negative and means nothing. Worse, an EXACT equality across the partition
+ *     would have been published as `basis_value_exact_tie` — *"proven not
+ *     separable"* — when it is a coincidence between two rows the producer never
+ *     compared.
+ *   · **Across two species.** In `mixed_graph_isl` the graph rows carry
+ *     path-analysis influence and the appended ISL rows carry Monte-Carlo
+ *     uncertainty importance, under the same field name and in the same array.
+ *     Subtracting one from the other compares two units.
+ *
+ * Both fail **CLOSED** to `null` (T2 — absence of a verdict is `unresolved`,
+ * never `separable`), and `null` is used rather than `false` deliberately:
+ * `false` is a positive claim ("proven not separable") and the producer has not
+ * earned it here. The guard can only ever REMOVE a verdict, never add one.
+ *
+ * A residual accepted knowingly: the guard proves the pair is COMPARABLE, not
+ * that the underlying estimates are statistically distinguishable. That second
+ * question is Neil's, and it is why `method` says `provisional`.
  */
 function decideSeparability(
   ordered: readonly DriverOrderFactorRow[],
+  isLever: readonly boolean[],
 ): DriverOrderSeparability {
-  if (ordered.length < 2) return { top_pair_separable: null, method: null };
+  if (ordered.length < 2) return UNRESOLVED;
+
+  // ── comparability, before any arithmetic ────────────────────────────────
+  if (isLever[0] !== isLever[1]) return UNRESOLVED;
+  if (ordered[0].source !== ordered[1].source) return UNRESOLVED;
+
   const a = finiteOrNull(ordered[0].influence_score);
   const b = finiteOrNull(ordered[1].influence_score);
-  if (a === null || b === null) return { top_pair_separable: null, method: null };
+  // An absent number is not a tie and is not a separation. Never coalesced to 0
+  // — absent means "unavailable", not "least important".
+  if (a === null || b === null) return UNRESOLVED;
+
+  // An exact tie needs no threshold, so it keeps its own ratified method name
+  // and must NOT inherit the provisional one. Checked first, and unchanged.
   if (a === b) {
-    return { top_pair_separable: false, method: 'basis_value_exact_tie' };
+    return { top_pair_separable: false, method: SEPARABILITY_METHOD_EXACT_TIE };
   }
-  // Strict inequality is NOT evidence of statistical separability — no
-  // ratified threshold exists for the driver order (amendment T3). Unresolved.
-  return { top_pair_separable: null, method: null };
+
+  // The order does not descend on this quantity across the top pair, so this is
+  // not the quantity the order was made on. Unresolved, not "tied".
+  if (b > a) return UNRESOLVED;
+  // A non-positive leader admits no relative gap (and `a === 0` was already
+  // handled above: with b < a ≤ 0 the pair is not on the basis scale at all).
+  if (a <= 0) return UNRESOLVED;
+
+  const relativeGap = (a - b) / a;
+  if (!Number.isFinite(relativeGap)) return UNRESOLVED;
+
+  return {
+    top_pair_separable: relativeGap >= PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP,
+    method: SEPARABILITY_METHOD_RELATIVE_GAP,
+  };
 }
 
 function aggregateRankStability(
@@ -338,13 +479,19 @@ export function buildDriverOrder(input: BuildDriverOrderInput): DriverOrderV1 | 
 
   const rankedFactorIds: string[] = [];
   const leverIds: string[] = [];
+  const orderedRows: DriverOrderFactorRow[] = [];
+  /** Parallel to `orderedRows` — the comparability guard in `decideSeparability`. */
+  const orderedIsLever: boolean[] = [];
   let sawGraph = false;
   let sawIsl = false;
   for (const f of factors) {
     const id = idOf(f);
     if (id === undefined) continue;
     rankedFactorIds.push(id);
-    if (isOptionControlledLever(f, structuralLeverIds)) leverIds.push(id);
+    orderedRows.push(f);
+    const lever = isOptionControlledLever(f, structuralLeverIds);
+    orderedIsLever.push(lever);
+    if (lever) leverIds.push(id);
     if (f.source === 'graph') sawGraph = true;
     else if (f.source === 'isl') sawIsl = true;
   }
@@ -387,7 +534,10 @@ export function buildDriverOrder(input: BuildDriverOrderInput): DriverOrderV1 | 
     species: sawGraph && sawIsl ? 'mixed_graph_isl' : 'single',
     lever_policy: 'du_union',
     lever_ids: leverIds,
-    separability: decideSeparability(factors),
+    // ⚠ Rows WITHOUT a usable id are excluded from `ranked_factor_ids`, so the
+    // verdict is decided over the rows the attestation actually names — not
+    // over `factors`, which may contain a row no consumer can join to.
+    separability: decideSeparability(orderedRows, orderedIsLever),
     rank_stability: aggregateRankStability(factors),
   };
 }
@@ -411,23 +561,38 @@ export function readIslSuppressedAttributions(islResult: unknown): string[] | un
 }
 
 /**
- * ── RESIDUAL: the divergent ordering sources S1 deliberately does NOT touch ──
+ * ── ⭐ PROJECTION REGISTER: every surface in this response that names a #1 ──
  *
- * `driver_order` is emitted ALONGSIDE these; none of them changed in S1. Each
- * is an independent argmax today, and on the committed golden
- * (`tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json`) three of the
- * five disagree with `ranked_factor_ids[0]`. Making them projections of
- * `ranked_factor_ids[0]` is the amendment's §8-S1 second half and is scheduled,
- * not forgotten. Pinned — so none can drift silently — by
- * `tests/driver-order-attestation.fixture.test.ts` and, for `driver_label`, by
- * `tests/importance-rank-lever-doctrine.fixture.test.ts`.
+ * S1b (2026-07-28) made all five PROJECTIONS of `ranked_factor_ids[0]`. Before
+ * it, each ran its own argmax over its own quantity and three disagreed with
+ * this order on the committed golden — including `driver_label`, which crowned
+ * the option-pinned lever the same response publishes at `sensitivity_score: 0`.
  *
- * | surface | ranks on | lever-aware? | agrees with ranked_factor_ids[0] on the golden? |
- * |---|---|---|---|
- * | `factor_sensitivity[].importance_rank` | this order | ✅ D-U union | ✅ yes (it IS this order) |
- * | `factor_sensitivity[].driver_label === 'biggest'` | argmax `influence_score` (`src/lib/driver-label.ts`) | ❌ no | ❌ no — crowns the option-pinned lever |
- * | `m1_coaching.key_drivers[].rank` | `Math.abs(influence_score ?? elasticity ?? 0)` (`src/coaching/key-drivers.ts`) | ❌ no | ❌ no |
- * | `dominant_factor` | `detectDominantFactor` over unfiltered rows (`src/trust/factor-dominance.ts`) | ❌ no | suppressed by its >2 ratio gate on this fixture |
- * | `decision_brief.top_drivers[0]` | `filterInterventionOverrides` = ISL stamp only (`src/assembly/decision-brief.ts`) | ⚠ stamp-only | ✅ yes on this fixture (the stamp happens to cover) |
- * | facts-path `importance_rank` | positional `idx + 1` (`src/routes/v2/run.ts`, `src/facts/mapper.ts`) | n/a — a POSITION, not a rank | mirrors the array, so agrees by accident |
+ * | surface | how it names #1 NOW | was (S1) |
+ * |---|---|---|
+ * | `factor_sensitivity[].importance_rank` | this order (it IS this order) | unchanged |
+ * | `factor_sensitivity[].driver_label === 'biggest'` | `ranked_factor_ids[0]` (`src/lib/driver-label.ts`) | argmax `influence_score`, lever-blind — **crowned the lever** |
+ * | `m1_coaching.key_drivers[].rank` | `importance_rank` ascending (`src/coaching/key-drivers.ts`) | `Math.abs(influence_score ?? elasticity ?? 0)` — **crowned the lever** |
+ * | `dominant_factor` | `factors[0]` only, gates unchanged (`src/trust/factor-dominance.ts`) | internal argmax over unfiltered rows — one number from crowning the lever (F-D3) |
+ * | `decision_brief.top_drivers[0]` | canonical order minus `lever_ids` (`src/assembly/decision-brief.ts`) | `filterInterventionOverrides` (ISL stamp only, UNDER-covers) + a second \|elasticity\| sort |
+ * | facts-path `importance_rank` | `fs.importance_rank` (`mapFactorSensitivityToFactsInput`) | positional `idx + 1` — agreed by accident |
+ *
+ * ⛔ **NOT changed, and deliberately (§4.4):** the lever DEMOTION itself.
+ * `applyLeverAwareImportanceOrder` still pushes option-controlled levers to the
+ * back. Ranking a lever in its true place and leaving the crown to CEE's
+ * permission is the honest end state, but it must not ship before that
+ * permission is live and the UI consumes it (S4 + S6) — today the demotion is
+ * the only thing keeping a producer-zeroed factor off rank 1.
+ *
+ * ⚠ **Two surfaces in this response still use the STAMP-ONLY lever predicate:**
+ * `buildWhatWouldChange` and the value-defaulted disclosure block in
+ * `src/assembly/decision-brief.ts`. They are out of S1b's scope (which is the
+ * #1-naming surfaces), the `lever_policy: 'stamp_only'` enum member exists so a
+ * later slice can attest them without inventing a value, and this note is here
+ * so the omission is recorded rather than discovered.
+ *
+ * Enforced by `tests/driver-order-projection.fixture.test.ts` (one law, all
+ * five, end to end), `tests/driver-surface-projection.unit.test.ts` (the three
+ * whose divergence the golden cannot see) and
+ * `tests/driver-quantity-register.derived.test.ts` (§3.2's derived register).
  */

--- a/src/lib/driver-quantity-register.ts
+++ b/src/lib/driver-quantity-register.ts
@@ -1,0 +1,210 @@
+/**
+ * The DRIVER-QUANTITY REGISTER — every number a driver-bearing row carries,
+ * with the four things a TypeScript type cannot state about it.
+ *
+ * Family 4, amendment §3.2. The amendment's own quantity census dropped items
+ * between two sections of one document, and named the lesson:
+ *
+ * > *"The census dropped items between two sections of one document, written in
+ * > one sitting, by one author who was actively looking for them. That is not a
+ * > criticism of the lane — it is the trap-12 proof obligation discharged in
+ * > miniature: a list a human must remember to sync WILL drift, and the drift
+ * > reads as complete."*
+ * > ⇒ **"The authority table must not ship as a table. It must ship as a DERIVED
+ * > REGISTER with a fail-loud gate."**
+ *
+ * ## ⭐ HOW THIS AVOIDS BEING THE MIRROR IT REPLACES
+ *
+ * The **domain** — *which* fields must appear below — is NOT written here. It is
+ * extracted by AST from the contract type declarations themselves
+ * (`tools/derive-driver-quantities.mjs`), and
+ * `tests/driver-quantity-register.derived.test.ts` fails on ANY drift in either
+ * direction:
+ *
+ *   · a numeric field with no entry ⇒ RED (a new quantity cannot arrive silently);
+ *   · an entry naming a field that no longer exists ⇒ RED (a stale row cannot
+ *     linger and make the register read as complete);
+ *   · an unparseable derivation ⇒ RED, never an empty domain that passes by
+ *     testing nothing.
+ *
+ * What a human supplies is only what a type genuinely cannot: what the number
+ * MEANS. That is the irreducible manual part, and it is the part a reviewer can
+ * actually check.
+ *
+ * ## Why `unit` and `sign` are here rather than on the schema
+ *
+ * The base design's R-3 is right that `z.number().optional()` cannot detect a
+ * unit substitution — and this family's sharpest live defect was exactly that
+ * (`elasticity` published under the name `sensitivity_score`: opposite sign,
+ * 2.84× apart, same field name, same response). A register that records the
+ * unit and the sign makes the next such substitution a diff rather than an
+ * archaeology exercise.
+ */
+
+/**
+ * What KIND of claim the number is, under the four-role model
+ * (ISL measures · PLoT orders + attests · CEE permits · UI renders).
+ *
+ * - `'measurement'` — an estimate of something in the world. Has a unit and a
+ *   sampling story.
+ * - `'designation'` — a producer's assignment over a set (a rank). Carries no
+ *   magnitude information beyond the ordering it encodes.
+ * - `'derived'` — computed from other members of this same register; its
+ *   honesty is inherited from theirs.
+ * - `'diagnostic'` — a property of the ESTIMATION, not of the decision
+ *   (bootstrap spread, flip rate). Never a driver's importance.
+ */
+export type DriverQuantityRole = 'measurement' | 'designation' | 'derived' | 'diagnostic';
+
+/**
+ * What the producer DOES with it on the public wire.
+ *
+ * - `'published'` — emitted as measured.
+ * - `'published_lever_suppressed'` — emitted, but forced to 0 or withheld for
+ *   option-controlled levers (`LEVER_SUPPRESSION_FIELDS` doctrine).
+ * - `'published_lever_unsuppressed'` — emitted at its true value even for a
+ *   lever, deliberately: it is a STRUCTURE measurement, not an importance claim.
+ * - `'internal'` — carried on the type but not part of the ranked surface a
+ *   consumer crowns on.
+ */
+export type DriverQuantityDisposition =
+  | 'published'
+  | 'published_lever_suppressed'
+  | 'published_lever_unsuppressed'
+  | 'internal';
+
+export interface DriverQuantityEntry {
+  role: DriverQuantityRole;
+  disposition: DriverQuantityDisposition;
+  /**
+   * The unit, stated so a substitution is visible. `'dimensionless'` is a real
+   * answer; `'unknown'` is NOT permitted — if nobody can say what the number
+   * measures, that is the finding.
+   */
+  unit: string;
+  /** The sign convention. `'signed'` means the sign carries direction. */
+  sign: 'non_negative' | 'signed' | 'positive_ordinal';
+  /** One line a reviewer can check against the bytes. */
+  note: string;
+}
+
+/**
+ * The register. Keys are `"<TypeName>.<field>"` — the exact join key
+ * `deriveDriverQuantityKeys()` produces.
+ */
+export const DRIVER_QUANTITY_REGISTER: Readonly<Record<string, DriverQuantityEntry>> = {
+  // ── FactorSensitivityResultV3 ──────────────────────────────────────────────
+  'FactorSensitivityResultV3.influence_score': {
+    role: 'measurement',
+    disposition: 'published_lever_unsuppressed',
+    unit: 'normalised_influence_0_1',
+    sign: 'non_negative',
+    note: '|influence| / maxAbsInfluence over the graph path analysis — normalised BY THE MAX ROW, so an absolute gap between two rows is moved by a third row outside the pair. A lever keeps its true value here: this is structure, not importance.',
+  },
+  'FactorSensitivityResultV3.influence_rank': {
+    role: 'designation',
+    disposition: 'published_lever_unsuppressed',
+    unit: 'rank_ordinal',
+    sign: 'positive_ordinal',
+    note: 'The RAW structural influence order, 1 = most influential. A lever legitimately tops it. NOT the importance order — see importance_rank.',
+  },
+  'FactorSensitivityResultV3.sensitivity_score': {
+    role: 'measurement',
+    disposition: 'published_lever_suppressed',
+    unit: 'goal_units_per_factor_unit',
+    sign: 'signed',
+    note: 'Graph raw total causal effect. SIGNED — the family-4 slice-0 defect was elasticity being fed into this name (−0.175 vs +0.497 on one response). Forced to 0 for option-controlled levers.',
+  },
+  'FactorSensitivityResultV3.elasticity': {
+    role: 'measurement',
+    disposition: 'published_lever_suppressed',
+    unit: 'normalised_influence_0_1_on_graph_path',
+    sign: 'signed',
+    note: '⚠ TWO PRODUCERS, ONE NAME: the graph path sets elasticity = normalised_influence (always ≥ 0); ISL publishes a signed MC elasticity. Read importance_basis before interpreting the sign.',
+  },
+  'FactorSensitivityResultV3.importance_rank': {
+    role: 'designation',
+    disposition: 'published',
+    unit: 'rank_ordinal',
+    sign: 'positive_ordinal',
+    note: "PLoT's ONE importance order — lever-aware (every non-lever precedes every lever) and parallel to the emitted array (Rule S3). driver_order.ranked_factor_ids IS this order.",
+  },
+  'FactorSensitivityResultV3.value_of_information': {
+    role: 'measurement',
+    disposition: 'published_lever_suppressed',
+    unit: 'voi_score_dimensionless',
+    sign: 'non_negative',
+    note: 'ISL MC VOI (sanitised non-negative), or |sensitivity| × (1 − confidence) × decision_fragility on the graph fallback. A legitimate 0 exists. NOT the coaching evidence_gaps voi_score — different quantity, same word.',
+  },
+  'FactorSensitivityResultV3.evpi_percentage_points': {
+    role: 'derived',
+    disposition: 'published_lever_suppressed',
+    unit: 'win_probability_percentage_points',
+    sign: 'non_negative',
+    note: 'HEURISTIC only: value_of_information × win_probability_spread × 100, clamped ≥ 0 (Howard 1966). Not a counterfactual EVPI; self-disclosed via evpi_method. Withheld entirely for levers so a lever never ranks as an investigation priority.',
+  },
+  'FactorSensitivityResultV3.confidence': {
+    role: 'diagnostic',
+    disposition: 'published',
+    unit: 'probability_0_1',
+    sign: 'non_negative',
+    note: "PLoT's unified confidence, NOT ISL's (which is discarded). The active formula is disclosed by confidence_provenance.formula_version.",
+  },
+  'FactorSensitivityResultV3.elasticity_std': {
+    role: 'diagnostic',
+    disposition: 'published_lever_suppressed',
+    unit: 'same_units_as_isl_elasticity',
+    sign: 'non_negative',
+    note: "ISL bootstrap standard deviation. ISL-sourced rows only — graph and ISL elasticity are on different scales, so this must never be cross-attached to a graph row.",
+  },
+  'FactorSensitivityResultV3.rank_flip_rate': {
+    role: 'diagnostic',
+    disposition: 'published',
+    unit: 'proportion_of_bootstrap_samples_0_1',
+    sign: 'non_negative',
+    note: "ISL bootstrap rank instability. A SEPARABILITY input, never an importance claim — aggregated into driver_order.rank_stability.max_rank_flip_rate.",
+  },
+  'FactorSensitivityResultV3.confidence_components.structural_certainty': {
+    role: 'diagnostic',
+    disposition: 'published',
+    unit: 'probability_0_1',
+    sign: 'non_negative',
+    note: 'mean(exists_probability) over incoming edges, or 0.5 when the factor has none. A progressive-disclosure component of `confidence`, not an independent measurement.',
+  },
+  'FactorSensitivityResultV3.confidence_components.sampling_stability': {
+    role: 'diagnostic',
+    disposition: 'published',
+    unit: 'band_score_0_1',
+    sign: 'non_negative',
+    note: "attribution_stability collapsed to {0, 0.25, 0.5, 1.0}. NULL when ISL supplied no bootstrap — null means unavailable, never 'unstable'.",
+  },
+
+  // ── EdgeSensitivityResultV3 ────────────────────────────────────────────────
+  'EdgeSensitivityResultV3.elasticity': {
+    role: 'measurement',
+    disposition: 'published',
+    unit: 'goal_units_per_edge_strength_unit',
+    sign: 'signed',
+    note: "ISL's edge elasticity, forwarded. Disambiguated by sensitivity_type ('existence' vs 'magnitude') — two formulas in one sorted array, so the discriminator must be read before comparing two rows.",
+  },
+  'EdgeSensitivityResultV3.importance_rank': {
+    role: 'designation',
+    disposition: 'published',
+    unit: 'rank_ordinal',
+    sign: 'positive_ordinal',
+    note: "ISL's edge importance order, forwarded verbatim. NOT lever-aware and NOT the factor order — edges have no lever partition.",
+  },
+};
+
+/**
+ * EXEMPTIONS — quantities considered and deliberately EXCLUDED from the
+ * register, emitted as data rather than argued in prose (§3.2 point 3).
+ *
+ * > *"A prose exclusion cannot distinguish 'considered and excluded' from
+ * > 'never found'."*
+ *
+ * Empty today, and that emptiness is itself the claim: at these bytes every
+ * numeric field on every driver-bearing row is registered. The mechanism exists
+ * so the first `causal_structure`-class field has somewhere honest to go.
+ */
+export const DRIVER_QUANTITY_EXEMPTIONS: Readonly<Record<string, { reason: string }>> = {};

--- a/src/lib/importance-authority.ts
+++ b/src/lib/importance-authority.ts
@@ -115,26 +115,43 @@ export function applyLeverAwareImportanceOrder<T extends RankableFactor>(
 }
 
 /**
- * ── NOT DONE HERE, ON PURPOSE: the `driver_label: 'biggest'` crown ──
+ * ── ⭐ CLOSED, 2026-07-28: the `driver_label: 'biggest'` crown now AGREES ──
  *
- * `driver_label`'s rank-1 `'biggest'` band (`src/lib/driver-label.ts`,
- * Doctrine 039 / D-7) is argmax over `influence_score` and is NOT lever-aware,
- * so on the live wire it lands on the option-pinned lever while
- * `importance_rank: 1` (above) lands on the top genuine uncertainty driver.
- * Those two disagree by design as of this lane. Reasons for leaving it:
+ * This block previously recorded a deliberate DIVERGENCE: `driver_label`'s
+ * rank-1 `'biggest'` band was argmax over `influence_score`, was NOT
+ * lever-aware, and therefore landed on the option-pinned lever while
+ * `importance_rank: 1` (above) landed on the top genuine uncertainty driver.
+ * That is **no longer true at these bytes.** Family-4 slice S1b made `'biggest'`
+ * a PROJECTION of `driver_order.ranked_factor_ids[0]` — the same lever-aware
+ * order this module produces — so the two now name the same factor by
+ * construction.
  *
- *   1. `'biggest'` is DEFINED as the greatest `influence_score`. Gating it makes
- *      the label contradict the number in its own row (a lever at
- *      influence_score 1.0 labelled 'strong' beneath a 0.497 labelled
- *      'biggest') — trading one incoherence for another.
- *   2. The basis question ("should driver_label rank on influence or on
- *      elasticity/importance?") is ALREADY an open doctrine row owned by
- *      Neil/UI, recorded in driver-label.ts. A producer should not settle it
- *      unilaterally inside an unrelated fix.
- *   3. Blast radius today is zero: censused 25 Jul at the consumer tips
- *      (UI `039f479a`, CEE `f00b8ef6`) — `factor_sensitivity[].driver_label`
- *      has NO read site in either repo.
+ * Authority: `MEANING-LAYER-FAMILY4-AUTHORITY-AMENDMENT-2026-07-27.md` §4.3 and
+ * §8-S1, which require all five #1-naming surfaces to project one order. The
+ * amendment re-derived each of this lane's three reasons and overturned them:
  *
- * The divergence is PINNED by tests/importance-rank-lever-doctrine.fixture.test.ts
- * so it cannot drift silently while the ruling is pending.
+ *   1. *"'biggest' is DEFINED as the greatest `influence_score`, so gating it
+ *      makes the label contradict its own row."* — The DEFINITION is what
+ *      changed. `'biggest'` is now a RANK claim; the three MAGNITUDE bands are
+ *      untouched and still speak for the number in the row. The structural
+ *      argmax remains published under its own honest name, `influence_rank`, so
+ *      nothing was hidden — one crown moved.
+ *   2. *"the basis question is an open Neil/UI doctrine row."* — Still open, and
+ *      still scoped to the three MAGNITUDE cut-points. The amendment settled the
+ *      separate question of which ORDER a crown projects, for all five crowns at
+ *      once.
+ *   3. *"blast radius is zero — no consumer reads `driver_label`."* — That was a
+ *      census taken 25 Jul at UI `039f479a` / CEE `f00b8ef6`, both since moved:
+ *      a hand-maintained mirror (CLAUDE.md trap 12), NOT inherited. It also cut
+ *      the other way — a field with no readers is the cheapest possible moment
+ *      to correct it.
+ *
+ * ⛔ What this module still does, unchanged (amendment §4.4): it DEMOTES levers
+ * rather than ranking them truthfully and marking them. That is the honest end
+ * state, but it must not ship before CEE's permission layer is live and the UI
+ * consumes it (S4 + S6) — today the demotion is the only thing keeping a
+ * producer-zeroed factor off rank 1.
+ *
+ * The agreement is PINNED by tests/importance-rank-lever-doctrine.fixture.test.ts
+ * and tests/driver-order-projection.fixture.test.ts.
  */

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -147,7 +147,7 @@ import { computeFactorSensitivityFromGraph, buildFactorStability, mergeIslConfid
 import { interventionTargetIdsFromOptions, isOptionControlledLever, factorIdOf, hasFactorIdConflict } from '../../lib/intervention-override.js';
 import { buildAutoNoiseProvenance, extractIslAutoNoiseApplied, logAutoNoiseFlagMissingFromIsl } from '../../lib/auto-noise.js';
 import { sanitiseIslVoi, computeEvpiPercentagePoints, deriveEvidenceHint } from '../../lib/evpi-emission.js';
-import { deriveDriverLabel, indexOfBiggestDriver } from '../../lib/driver-label.js';
+import { deriveDriverLabel, indexOfCanonicalTopDriver } from '../../lib/driver-label.js';
 import {
   applyLeverAwareImportanceOrder,
   IMPORTANCE_BASIS_GRAPH,
@@ -189,7 +189,7 @@ import {
 import { assembleBrief } from '../../assembly/decision-brief.js';
 import { buildEvidencePriorityCard, type FactorInput } from '../../review-pass/evidence-priority.js';
 import type { ProposalCardV1 } from '../../review-pass/types.js';
-import { assembleFactObjects, type ISLResponseInput } from '../../facts/index.js';
+import { assembleFactObjects, type ISLResponseInput, type FactorSensitivityInput } from '../../facts/index.js';
 import type { FactObjectV1, FactLineage } from '../../facts/types.js';
 import { finiteNum, prob01, nonNeg, nonNegInt, hasAllRequiredOutcomeStats } from './numeric-egress-guards.js';
 import { resolveConstraintIds } from './constraint-identity.js';
@@ -1648,10 +1648,26 @@ interface SensitivityData {
   // keeps paying for; and building it here would re-introduce the conditional
   // emission that made the existing per-row `importance_basis` absence
   // ambiguous (old payload vs non-ISL branch vs dropped key).
-  /** D-U structural lever union derived from the request's options. */
-  structuralLeverIds?: ReadonlySet<string>;
-  /** `'isl'` on the ISL-only fallback; `'graph+isl_merge'` on the primary path. */
-  factorSensitivitySource?: string;
+  /**
+   * D-U structural lever union derived from the request's options.
+   *
+   * REQUIRED (S1b): every construction site already knows it, and a `?? new
+   * Set()` fallback would silently attest `lever_ids: []` — "this order contains
+   * no levers" — on a payload that has them.
+   */
+  structuralLeverIds: ReadonlySet<string>;
+  /**
+   * `'isl'` on the ISL-only fallback; `'graph+isl_merge'` on the primary path.
+   *
+   * ⚠ REQUIRED (S1b, S1 review LOW). This was optional, and the emission site
+   * coalesced it with `?? 'isl'`. That default is CORRECT for the raw-ISL
+   * fallback path — where there is no `sensitivityData` at all and the rows
+   * genuinely are ISL's — but it was LATENT: a future path that supplied a
+   * `sensitivityData` without this member would have had its order attested
+   * `basis: 'isl_uncertainty'` with no signal. Making it required moves that
+   * from a silent wrong answer to a compile error.
+   */
+  factorSensitivitySource: string;
   /** ISL's `correlation_model.suppressed_attributions`, when ISL declared any. */
   islSuppressedAttributions?: string[];
 }
@@ -1685,6 +1701,53 @@ function isCrownableCandidate(o: { win_probability?: number; status?: string }):
  * @param optionComparison Array of option comparison results
  * @returns Near-tie info object
  */
+/**
+ * ⭐ Map the emitted `factor_sensitivity[]` onto the facts-assembly input
+ * (family-4 S1b, surface 5 of 5).
+ *
+ * ## What changed: a POSITION became a RANK
+ *
+ * This mapping used to emit `importance_rank: idx + 1` — the row's INDEX in the
+ * array. Because the emitted array is the canonical order (Rule S3), that value
+ * is right on every live payload, and S1's residual table said so precisely:
+ * *"a POSITION, not a rank — mirrors the array, so agrees by accident."*
+ *
+ * An accident is not a projection. `fact_objects[].data.importance_rank` now
+ * READS PLoT's one canonical rank, so the facts path and
+ * `driver_order.ranked_factor_ids` cannot diverge if anything upstream ever
+ * emits the array in a different order from the rank it publishes.
+ *
+ * ⚠ The `?? idx + 1` fallback is retained deliberately and is NOT a second
+ * ranking: `importance_rank` is optional on `FactorSensitivityResultV3`, and the
+ * only order available when it is absent is the producer's own emitted order —
+ * the same array. It never introduces a quantity the canonical order was not
+ * made on.
+ *
+ * ⚠ Extracted from the inline `islInput` literal specifically so the claim is
+ * CHECKABLE: with position and rank always equal on live payloads, no
+ * end-to-end fixture can distinguish the two derivations. The separating input
+ * lives in `tests/driver-surface-projection.unit.test.ts`.
+ *
+ * Also unchanged from family-4 slice 0, and load-bearing: `sensitivity_score`
+ * forwards the REAL `sensitivity_score` (not `elasticity`, which was published
+ * under this name at −0.175 vs +0.497 on one response), with no `?? 0` — absent
+ * means "unavailable", NOT "least important".
+ */
+export function mapFactorSensitivityToFactsInput(
+  factorSensitivity: ReadonlyArray<FactorSensitivityResultV3> | undefined,
+): FactorSensitivityInput[] | undefined {
+  return factorSensitivity?.map((fs, idx) => ({
+    node_id: fs.factor_id,
+    label: fs.factor_label ?? undefined,
+    sensitivity_score: fs.sensitivity_score,
+    importance_rank: fs.importance_rank ?? idx + 1,
+    elasticity: fs.elasticity,
+    direction: fs.direction === 'unknown' ? undefined : fs.direction,
+    confidence: fs.confidence,
+    attribution_stability: fs.attribution_stability,
+  }));
+}
+
 export function computeNearTie(
   optionComparison: Array<{ option_id: string; win_probability?: number; status?: string }> | undefined
 ): NearTieInfoV3 | undefined {
@@ -2790,14 +2853,20 @@ function buildResponse(
   // `sensitivityData` path and the raw-ISL fallback path attest identically:
   //   · lever identity ← `interventionTargetIdsFromOptions(options)`, the ONE
   //     canonical D-U source, same call the pre-compute makes;
-  //   · basis ← the pre-computed source, else 'isl' (on the fallback path the
-  //     rows ARE ISL's, untouched by the graph merge);
+  //   · basis ← the pre-computed source; on the RAW-ISL FALLBACK path (no
+  //     `sensitivityData` at all) `factorSensitivity` is
+  //     `transformFactorSensitivity(islResult.factor_sensitivity)`, i.e. ISL's
+  //     own rows untouched by the graph merge, so `'isl'` is a DERIVED fact
+  //     about that branch and not a default (S1 review LOW: the member is now
+  //     required on `SensitivityData`, so this branch is the only place the
+  //     value can be absent);
   //   · ISL's own suppression disclosure ← read defensively off `islResult`.
   const driverOrder = buildDriverOrder({
     factors: factorSensitivity,
     structuralLeverIds:
       sensitivityData?.structuralLeverIds ?? interventionTargetIdsFromOptions(options),
-    factorSensitivitySource: sensitivityData?.factorSensitivitySource ?? 'isl',
+    factorSensitivitySource:
+      sensitivityData === undefined ? 'isl' : sensitivityData.factorSensitivitySource,
     islSuppressedAttributions:
       sensitivityData?.islSuppressedAttributions ?? readIslSuppressedAttributions(islResult),
   });
@@ -3250,6 +3319,10 @@ function buildResponse(
     critiques,
     option_comparison: optionComparison,
     factor_sensitivity: factorSensitivity,
+    // Family-4 S1b: the SAME object the response publishes, so
+    // decision_brief.top_drivers[0] and driver_order.ranked_factor_ids[0]
+    // cannot describe different orders.
+    driver_order: driverOrder,
     robustness,
     m1_coaching: m1Coaching,
     m1_review: m2DecisionReview?.m1_review ?? undefined,
@@ -3308,32 +3381,7 @@ function buildResponse(
         label: oc.label as string | undefined,
         outcome: oc.outcome as { p10?: number; p50?: number; p90?: number; mean?: number } | undefined,
       })),
-      factor_sensitivity: factorSensitivity?.map((fs, idx) => ({
-        node_id: fs.factor_id,
-        label: fs.factor_label ?? undefined,
-        // ── FAMILY-4 SLICE 0 (2026-07-27) ────────────────────────────────────
-        // This line used to read `fs.elasticity ?? 0`, i.e. it fed the
-        // ELASTICITY quantity into a field NAMED `sensitivity_score`. Because
-        // `factor_sensitivity[]` publishes the real `sensitivity_score` (graph
-        // raw total causal effect, SIGNED — see the `substitutions` block in
-        // src/contracts/isl-to-ui.contract.ts) in the SAME response body, one
-        // /v2/run payload carried two different quantities under one name.
-        // Measured in the committed golden
-        // tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json:
-        // `fac_hiring_cost` was -0.175 in `factor_sensitivity[]` and
-        // +0.4971042471042471 in `fact_objects[].data` — opposite signs,
-        // 2.84x apart, same field name, same response.
-        //
-        // Feed the actual quantity, and do NOT coalesce an absent one to 0:
-        // absent means "unavailable", NOT "least important"
-        // (@talchain/schemas src/boundary/enrichment.ts:239-241).
-        sensitivity_score: fs.sensitivity_score,
-        importance_rank: idx + 1,
-        elasticity: fs.elasticity,
-        direction: fs.direction === 'unknown' ? undefined : fs.direction,
-        confidence: fs.confidence,
-        attribution_stability: fs.attribution_stability,
-      })),
+      factor_sensitivity: mapFactorSensitivityToFactsInput(factorSensitivity),
       critiques: critiques?.map((c) => ({
         id: c.id ?? c.code,
         code: c.code,
@@ -6544,36 +6592,30 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             const label = deriveDriverLabel(f.influence_score);
             if (label !== undefined) f.driver_label = label;
           }
-          // (2) Set-aware rank-1 override: the SINGLE factor with the greatest
-          //     influence_score is 'biggest', UNCONDITIONAL of magnitude (matches
-          //     the UI getSemanticLabel rank-1 'biggest'/'strongest' band). Rank-1
-          //     is computed here — not in the pure per-factor helper — because it
-          //     needs every factor's influence (like dominant_factor). Ties on the
-          //     max resolve to the FIRST factor in the emitted order (deterministic);
-          //     an absent-influence factor is skipped. Not lever-skipped: a lever
-          //     legitimately has a driver_label (categorical over influence magnitude).
+          // (2) ⭐ Set-aware rank-1 override — FAMILY-4 S1b: 'biggest' is a
+          //     PROJECTION of the canonical driver order, not a second argmax.
           //
-          //     ⚠ KNOWN DIVERGENCE, DELIBERATELY LEFT (lane PLoT importance-authority,
-          //     25 Jul 2026 — ROADMAP row "Doctrine 039: what basis does
-          //     driver_label rank on?"). Because this crown is argmax over
-          //     `influence_score` and NOT lever-aware, it can — and on the live
-          //     wire does — land on an option-pinned lever the same response
-          //     publishes at `sensitivity_score: 0` / `elasticity: 0`, i.e. on a
-          //     DIFFERENT factor from `importance_rank: 1`, which IS lever-aware.
-          //     That divergence is NOT fixed here on purpose:
-          //       · 'biggest' is DEFINED by Doctrine 039 as the greatest
-          //         `influence_score`. Gating it would make the label contradict
-          //         the number published in the same row — trading one incoherence
-          //         for another — so it needs the doctrine's basis question
-          //         (already DOCTRINE-PENDING, Neil/UI, see src/lib/driver-label.ts)
-          //         answered first, not a unilateral producer change.
-          //       · Blast radius today is ZERO: censused 25 Jul at the tips
-          //         (UI 039f479a, CEE f00b8ef6) — `factor_sensitivity[].driver_label`
-          //         has NO read site in either consumer.
-          //     The divergence is PINNED (not merely commented) by
-          //     tests/importance-rank-lever-doctrine.fixture.test.ts so it cannot
-          //     drift silently while the ruling is pending.
-          const biggestIdx = indexOfBiggestDriver(factorSensitivity);
+          //     `factorSensitivity` has already been through
+          //     `applyLeverAwareImportanceOrder` above, so by Rule S3 ("one
+          //     order, and the array IS it") index 0 IS
+          //     `driver_order.ranked_factor_ids[0]`. Crowning it here — rather
+          //     than re-running an argmax over `influence_score` — is what makes
+          //     the five #1-naming surfaces one claim instead of five.
+          //
+          //     ⚠ THIS SUPERSEDES A DELIBERATE PRIOR RULING (lane PLoT
+          //     importance-authority, 25 Jul 2026). That lane left the crown
+          //     lever-blind on a "blast radius zero" census taken at tips that
+          //     have since moved, and on a definitional argument the amendment
+          //     re-derived and overturned — see src/lib/driver-label.ts for the
+          //     three reasons and what replaced each. The raw structural argmax
+          //     is NOT lost: it is still published as `influence_rank === 1`.
+          //
+          //     ⛔ This does NOT un-demote levers (amendment §4.4). The order is
+          //     unchanged; only which row the crown reads off it.
+          //
+          //     Pinned by tests/driver-order-projection.fixture.test.ts (all five
+          //     surfaces, end to end) and tests/doctrine-039-driver-label.test.ts.
+          const biggestIdx = indexOfCanonicalTopDriver(factorSensitivity);
           if (biggestIdx >= 0) factorSensitivity[biggestIdx].driver_label = 'biggest';
 
           const islOptions = processedIslResult?.options ?? processedIslResult?.results ?? [];

--- a/src/trust/factor-dominance.ts
+++ b/src/trust/factor-dominance.ts
@@ -1,11 +1,40 @@
 /**
  * Factor dominance detection (B1).
  *
- * Identifies when a single factor has disproportionate influence
- * over the decision outcome.
+ * Identifies when a single factor has disproportionate influence over the
+ * decision outcome.
  *
  * Thresholds ported from UI useResultsSectionData.ts:1601 unchanged:
- *   top factor influence > 0.5 AND ratio vs. second factor > 2:1
+ *   top factor influence > 0.5 AND ratio vs. the strongest rival > 2:1
+ *
+ * ## ⭐ FAMILY-4 S1b — the CANDIDATE is a projection; the GATES are unchanged
+ *
+ * This module used to pick its own candidate: sort every row by
+ * `influence_score` descending and crown the top one. That made it a sixth
+ * independent argmax, and a lever-blind one — `detectDominantFactor` contains
+ * no lever predicate at all. The design measured how close that came to firing
+ * (§4.3 F-D3):
+ *
+ * > *`dominant_factor` is ONE NUMBER away from crowning a lever. In the fixture
+ * > it is suppressed only because the ratio is `1 / 0.7243 = 1.38 ≤ 2`. Drop
+ * > `fac_dev_headcount.influence_score` to `0.40` ⇒ ratio `> 2` ⇒ the top-level
+ * > `dominant_factor` names the lever.*
+ *
+ * So the candidate is now **`factors[0]` — `driver_order.ranked_factor_ids[0]`,
+ * by Rule S3** ("one order, and the array IS it"). Two consequences worth being
+ * explicit about, because both are easy to get wrong:
+ *
+ *   · **The gates still SUPPRESS.** The `> 0.5` floor and the `> 2×` ratio are
+ *     untouched, and on the committed golden the canonical #1 fails the floor —
+ *     so this surface still emits nothing. The fix is not "always crown rank 1";
+ *     it is "only rank 1 is ever eligible, and it must still earn it".
+ *   · **The rival is the STRONGEST row anywhere in the order, not `factors[1]`.**
+ *     The canonical order demotes levers to the back while they keep their true
+ *     structural `influence_score`, so the second-largest number is frequently
+ *     NOT in second position. Comparing rank 1 only against rank 2 would call a
+ *     0.6 factor "dominant" while a 1.0 factor sat three rows down — a new
+ *     fabrication introduced by the fix. Comparing against the strongest rival
+ *     preserves the original meaning of "disproportionate".
  */
 
 export interface DominantFactor {
@@ -19,47 +48,55 @@ interface FactorEntry {
   influence_score?: number;
 }
 
+/** The influence floor a dominant factor must clear. Unchanged (UI-ported). */
+const DOMINANCE_INFLUENCE_MIN = 0.5;
+/** The margin over the strongest rival a dominant factor must clear. Unchanged. */
+const DOMINANCE_RATIO_MIN = 2;
+
 /**
  * Detect factor dominance from factor sensitivity results.
- * Returns the dominant factor if one exists, or undefined if none.
+ * Returns the dominant factor if one exists, or `undefined` if none.
  *
- * A factor is dominant when:
- * 1. Its influence_score > 0.5 (accounts for >50% of influence)
- * 2. Its influence_score is >2x the second factor's score (OR it's the only factor with influence)
+ * ⚠ **INPUT ORDER IS LOAD-BEARING.** `factors` must be the emitted
+ * `factor_sensitivity[]` array, i.e. the canonical driver order — `factors[0]`
+ * is the ONLY crownable candidate. (It used to be order-independent, because it
+ * sorted internally; that internal sort was the second argmax this slice
+ * removes.)
  *
- * Input order does not matter — factors are sorted internally.
+ * A factor is dominant when ALL of:
+ * 1. it heads the canonical order;
+ * 2. its `influence_score` is a finite number `> 0.5`;
+ * 3. it is more than 2× the strongest positive influence among the other rows
+ *    (or no other row carries a positive influence at all).
  */
 export function detectDominantFactor(factors: FactorEntry[] | undefined): DominantFactor | undefined {
   if (!factors || factors.length === 0) return undefined;
 
-  // Filter to factors with non-zero influence
-  const nonZero = factors
-    .filter(f => (f.influence_score ?? 0) > 0)
-    .sort((a, b) => (b.influence_score ?? 0) - (a.influence_score ?? 0));
+  // ── The candidate: rank 1 of the canonical order, and nothing else ────────
+  const top1 = factors[0];
+  const top1Score = top1.influence_score;
+  // Absent/non-finite influence is not "zero influence" — it is no measurement,
+  // and no measurement cannot clear a floor.
+  if (typeof top1Score !== 'number' || !Number.isFinite(top1Score)) return undefined;
+  if (top1Score <= DOMINANCE_INFLUENCE_MIN) return undefined;
 
-  if (nonZero.length === 0) return undefined;
-
-  const top1 = nonZero[0];
-  const top1Score = top1.influence_score ?? 0;
-
-  // Must exceed 50% influence threshold
-  if (top1Score <= 0.5) return undefined;
-
-  // Single non-zero factor: dominant by definition (ratio check trivially passes)
-  if (nonZero.length === 1) {
-    return {
-      factor_id: top1.factor_id,
-      factor_label: top1.factor_label ?? top1.factor_id,
-    };
-  }
-
-  const top2Score = nonZero[1].influence_score ?? 0;
-
-  // Ratio check: top factor must be >2x the second
-  if (top2Score > 0 && top1Score / top2Score <= 2) return undefined;
-
-  return {
+  const dominant: DominantFactor = {
     factor_id: top1.factor_id,
     factor_label: top1.factor_label ?? top1.factor_id,
   };
+
+  // ── The rival: the strongest influence ANYWHERE else in the order ─────────
+  const rivalScores = factors
+    .slice(1)
+    .map((f) => f.influence_score)
+    .filter((s): s is number => typeof s === 'number' && Number.isFinite(s) && s > 0);
+
+  // Sole factor with any influence: dominant by definition (the ratio check
+  // passes trivially, exactly as before).
+  if (rivalScores.length === 0) return dominant;
+
+  const strongestRival = Math.max(...rivalScores);
+  if (top1Score / strongestRival <= DOMINANCE_RATIO_MIN) return undefined;
+
+  return dominant;
 }

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -1998,17 +1998,32 @@ export interface FactorSensitivityResultV3 {
   /** Human-readable interpretation from ISL */
   interpretation?: string;
   /**
-   * Doctrine 039 (D-7) — producer-owned categorical driver-strength label over
-   * `influence_score` (normalised influence). 4-valued, to match the shape of
-   * the UI's `getSemanticLabel`: the set-aware rank-1 'biggest' band plus three
-   * magnitude bands (DOCTRINE-PENDING, Neil): >= DRIVER_LABEL_STRONG_MIN
-   * 'strong', >= DRIVER_LABEL_MODERATE_MIN 'moderate', else 'minor'. Exactly one
-   * factor per response is 'biggest' (the
-   * single greatest `influence_score`, unconditional of magnitude; ties → first
-   * in emitted order). ABSENT when `influence_score` is absent/non-finite (never
-   * fabricated from a missing value; not eligible to be 'biggest'). Basis flip
-   * (elasticity vs influence) + UI adoption remain UI-confirmation-gated. See
-   * `src/lib/driver-label.ts`.
+   * Doctrine 039 (D-7) — producer-owned categorical driver-strength label.
+   * 4-valued, matching the shape of the UI's `getSemanticLabel`.
+   *
+   * ⚠ THE TWO BANDS ANSWER DIFFERENT QUESTIONS, and read different fields:
+   *
+   * - `'strong' | 'moderate' | 'minor'` — MAGNITUDE, a pure function of this
+   *   row's own `influence_score` (normalised influence): >=
+   *   DRIVER_LABEL_STRONG_MIN 'strong', >= DRIVER_LABEL_MODERATE_MIN
+   *   'moderate', else 'minor'. Cut-points DOCTRINE-PENDING (Neil). ABSENT when
+   *   `influence_score` is absent/non-finite — never fabricated from a missing
+   *   measurement.
+   * - `'biggest'` — RANK. Exactly one factor per response carries it, and it is
+   *   **`driver_order.ranked_factor_ids[0]`** — PLoT's ONE canonical,
+   *   lever-aware order (family-4 S1b). Unconditional of magnitude, and applied
+   *   even when the row has no `influence_score`, because it answers "which
+   *   factor does this producer rank first?" — a question with an answer at any
+   *   magnitude.
+   *
+   * ⚠ It used to be the argmax over `influence_score`, which is NOT lever-aware
+   * and on the live wire crowned an option-pinned lever the same response
+   * publishes at `sensitivity_score: 0` / `elasticity: 0`. The raw structural
+   * argmax is still published, under its own honest name, as `influence_rank
+   * === 1`.
+   *
+   * Basis flip (elasticity vs influence) for the MAGNITUDE bands + UI adoption
+   * remain UI-confirmation-gated. See `src/lib/driver-label.ts`.
    */
   driver_label?: 'biggest' | 'strong' | 'moderate' | 'minor';
   /**

--- a/tests/b1-factor-dominance.test.ts
+++ b/tests/b1-factor-dominance.test.ts
@@ -1,7 +1,12 @@
 /**
  * B1 — Factor dominance detection tests.
- * Thresholds ported from UI useResultsSectionData.ts:1601:
- *   influence_score > 0.5 AND ratio vs. second factor > 2:1
+ * Thresholds ported from UI useResultsSectionData.ts:1601, UNCHANGED by S1b:
+ *   influence_score > 0.5 AND ratio vs. the strongest rival > 2:1
+ *
+ * ⭐ Family-4 S1b changed the CANDIDATE, not the gates: `factors[0]` (rank 1 of
+ * the canonical driver order) is the only crownable row. See
+ * `tests/driver-surface-projection.unit.test.ts` for the F-D3 leg that proves
+ * the lever can no longer be crowned.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -59,12 +64,34 @@ describe('detectDominantFactor', () => {
     expect(result).toEqual({ factor_id: 'fac_price', factor_label: 'fac_price' });
   });
 
-  it('handles unsorted input correctly', () => {
+  /**
+   * ⭐ PIN FLIPPED — this asserted *"handles unsorted input correctly"*, i.e.
+   * that the function re-sorted its input and crowned the influence argmax
+   * wherever it sat. That internal sort WAS the defect: it made this a sixth
+   * independent argmax, lever-blind, one number away from crowning a
+   * producer-zeroed lever (family-4 design §4.3 F-D3).
+   *
+   * The candidate is now `factors[0]` — `driver_order.ranked_factor_ids[0]` by
+   * Rule S3 — so input order is LOAD-BEARING and the old behaviour is exactly
+   * what must not happen.
+   */
+  it('input order is LOAD-BEARING: only rank 1 of the canonical order is crownable', () => {
+    // `fac_price` has the larger influence but is NOT rank 1. Under the old
+    // internal sort it was crowned; it must not be now.
     const result = detectDominantFactor([
       { factor_id: 'fac_quality', factor_label: 'Quality', influence_score: 0.1 },
       { factor_id: 'fac_price', factor_label: 'Price', influence_score: 0.7 },
     ]);
-    expect(result).toEqual({ factor_id: 'fac_price', factor_label: 'Price' });
+    expect(result).toBeUndefined();
+
+    // …and the SAME two rows, with the canonical order supplied, still crown
+    // correctly — so this is a projection, not a suppression.
+    expect(
+      detectDominantFactor([
+        { factor_id: 'fac_price', factor_label: 'Price', influence_score: 0.7 },
+        { factor_id: 'fac_quality', factor_label: 'Quality', influence_score: 0.1 },
+      ]),
+    ).toEqual({ factor_id: 'fac_price', factor_label: 'Price' });
   });
 
   it('ignores zero-influence factors for ratio check', () => {

--- a/tests/doctrine-039-driver-label.test.ts
+++ b/tests/doctrine-039-driver-label.test.ts
@@ -8,24 +8,30 @@
  *       influence_score >= 0.50 → 'strong'
  *       influence_score >= 0.20 → 'moderate'
  *       otherwise              → 'minor'
- *   - a set-aware rank-1 'biggest' band: the SINGLE factor with the greatest
- *     `influence_score` is 'biggest', UNCONDITIONAL of magnitude. Ties on the max
- *     resolve to the FIRST factor in the stable emitted order. A factor with
- *     absent/non-finite influence gets NO label and is NOT eligible to be
- *     'biggest'.
- * NOTE: matching the SHAPE does not yet let the UI drop `getSemanticLabel` — the
- * basis flip (elasticity vs influence) + UI adoption remain UI-confirmation-gated
- * (D-7). Absent/non-finite influence ⇒ NO label (honesty). Magnitude thresholds
- * are DOCTRINE-PENDING (Neil), one const each; 'biggest' is rank-1 unconditional
- * (DOCTRINE-PENDING Neil/UX — a magnitude floor can be added later).
+ *   - a set-aware rank-1 'biggest' band.
+ *
+ * ## ⭐ FAMILY-4 S1b — THE 'biggest' BAND CHANGED BASIS (2026-07-28)
+ *
+ * `'biggest'` USED to be argmax over `influence_score`, computed here. That
+ * selector was NOT lever-aware, and on the live wire it crowned the
+ * option-pinned lever the same response publishes at `sensitivity_score: 0` /
+ * `elasticity: 0` — while `importance_rank: 1` named a different factor.
+ *
+ * It is now a **PROJECTION of `driver_order.ranked_factor_ids[0]`** — PLoT's one
+ * canonical, lever-aware order — so the five #1-naming surfaces are one claim
+ * instead of five (amendment §4.3/§8-S1). The raw structural argmax is NOT lost:
+ * it is still published, under its own honest name, as `influence_rank === 1`.
+ *
+ * ⚠ The three MAGNITUDE bands are untouched, and so is their doctrine status:
+ * cut-points remain DOCTRINE-PENDING (Neil), one const each; the basis flip
+ * (elasticity vs influence) and UI adoption remain UI-confirmation-gated (D-7).
+ * What S1b settled is which ORDER a crown projects — not what a magnitude means.
  *
  * Describes:
  *  - unit: `deriveDriverLabel` — the pure 3-band magnitude helper (never 'biggest').
- *  - unit: `indexOfBiggestDriver` — the set-aware rank-1 selector (argmax / ties /
- *    single-factor / absent-not-eligible).
- *  - route: the 4-valued emit lands on the /v2/run wire, keyed off each factor's
- *    emitted influence_score, with exactly one 'biggest' on the rank-1 factor
- *    (driven with the live 07-07 capture).
+ *  - unit: `indexOfCanonicalTopDriver` — the rank-1 projection.
+ *  - route: the 4-valued emit lands on the /v2/run wire, with exactly one
+ *    'biggest' on the CANONICAL rank-1 factor (live 07-07 capture).
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
@@ -35,7 +41,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   deriveDriverLabel,
-  indexOfBiggestDriver,
+  indexOfCanonicalTopDriver,
   DRIVER_LABEL_STRONG_MIN,
   DRIVER_LABEL_MODERATE_MIN,
 } from '../src/lib/driver-label.js';
@@ -93,72 +99,62 @@ describe('deriveDriverLabel — ratified normalised-influence cut-points', () =>
 });
 
 // ---------------------------------------------------------------------------
-// Unit — set-aware rank-1 selector (the 'biggest' band)
+// Unit — the rank-1 PROJECTION (the 'biggest' band)
+//
+// ⭐ These replace the `indexOfBiggestDriver` block, which tested the argmax
+//    selector S1b removed (see the file header). Each assertion below is the
+//    same question asked of the new basis.
 // ---------------------------------------------------------------------------
 
-describe('indexOfBiggestDriver — set-aware rank-1 by influence_score', () => {
-  it('picks the index of the single greatest influence_score', () => {
+describe('indexOfCanonicalTopDriver — the rank-1 projection', () => {
+  it('⭐ names index 0 — the canonical order, NOT the influence argmax', () => {
+    // The old selector returned 1 here. The array is the canonical order
+    // (Rule S3), so the crown belongs to index 0 regardless of magnitude.
     const factors = [
-      { influence_score: 0.2 },
-      { influence_score: 0.9 }, // rank-1
+      { influence_score: 0.2 }, // canonical rank 1
+      { influence_score: 0.9 }, // bigger, but demoted — e.g. an option-pinned lever
       { influence_score: 0.5 },
     ];
-    expect(indexOfBiggestDriver(factors)).toBe(1);
+    expect(indexOfCanonicalTopDriver(factors)).toBe(0);
   });
 
-  it('argmax is magnitude-blind: a low-influence max is still rank-1 (biggest unconditional)', () => {
-    // Greatest influence here is 0.1 → magnitude band would be 'minor', yet it
-    // is still the rank-1 factor. The derive-pass stamps it 'biggest'
-    // unconditionally of magnitude.
-    const factors = [
-      { influence_score: 0.05 },
-      { influence_score: 0.1 }, // rank-1, but deriveDriverLabel(0.1) === 'minor'
-      { influence_score: 0.03 },
-    ];
-    const idx = indexOfBiggestDriver(factors);
-    expect(idx).toBe(1);
+  it('the crown is magnitude-BLIND: rank 1 is biggest even when its band is minor', () => {
+    // Unchanged property, new basis. `'biggest'` answers "which factor does
+    // this producer rank first?", which has an answer at any magnitude.
+    const factors = [{ influence_score: 0.1 }, { influence_score: 0.05 }];
+    const idx = indexOfCanonicalTopDriver(factors);
+    expect(idx).toBe(0);
     expect(deriveDriverLabel(factors[idx].influence_score)).toBe('minor');
   });
 
-  it('ties on the max → the FIRST factor in emitted order (deterministic)', () => {
-    const factors = [
-      { influence_score: 0.4 },
-      { influence_score: 0.8 }, // first occurrence of the max
-      { influence_score: 0.8 }, // tie — must NOT win
-      { influence_score: 0.1 },
-    ];
-    expect(indexOfBiggestDriver(factors)).toBe(1);
+  it('no ties to break — one order, one first element (deterministic by construction)', () => {
+    // The old argmax needed a documented tie rule because two rows could share
+    // the max. A projection of a total order cannot tie with itself.
+    const factors = [{ influence_score: 0.8 }, { influence_score: 0.8 }];
+    expect(indexOfCanonicalTopDriver(factors)).toBe(0);
   });
 
   it('single-factor → that factor (index 0) is rank-1', () => {
-    expect(indexOfBiggestDriver([{ influence_score: 0.42 }])).toBe(0);
+    expect(indexOfCanonicalTopDriver([{ influence_score: 0.42 }])).toBe(0);
   });
 
-  it('empty array → -1 (no eligible factor)', () => {
-    expect(indexOfBiggestDriver([])).toBe(-1);
+  it('empty array → -1 (no order, no crown)', () => {
+    expect(indexOfCanonicalTopDriver([])).toBe(-1);
   });
 
-  it('all influence absent/non-finite → -1 (none eligible to be biggest)', () => {
-    expect(
-      indexOfBiggestDriver([
-        { influence_score: undefined },
-        { influence_score: null },
-        { influence_score: NaN },
-        { influence_score: Infinity },
-        {},
-      ]),
-    ).toBe(-1);
-  });
-
-  it('a factor with absent influence is skipped even when it appears first', () => {
-    // The absent-influence factor at index 0 is NOT eligible; the real max is
-    // the finite 0.3 at index 2.
+  it('⚠ BEHAVIOUR CHANGE, deliberate: rank 1 is crowned even with absent influence', () => {
+    // The old selector returned -1 here, because it could not compute an
+    // argmax. `'biggest'` is now a RANK claim, and the producer HAS ranked
+    // these rows — so the crown lands, while the row still carries no
+    // MAGNITUDE band (deriveDriverLabel returns undefined and the caller omits
+    // the field before this override).
     const factors = [
-      { influence_score: undefined }, // ineligible
+      { influence_score: undefined },
       { influence_score: 0.1 },
-      { influence_score: 0.3 }, // rank-1 among the eligible
+      { influence_score: 0.3 },
     ];
-    expect(indexOfBiggestDriver(factors)).toBe(2);
+    expect(indexOfCanonicalTopDriver(factors)).toBe(0);
+    expect(deriveDriverLabel(factors[0].influence_score)).toBeUndefined();
   });
 });
 
@@ -272,29 +268,38 @@ describe('039 route: 4-valued driver_label lands on /v2/run factor_sensitivity',
     expect(biggest.length).toBe(1);
   });
 
-  it("the 'biggest' factor is the single greatest influence_score (rank-1)", () => {
-    // Argmax over the EMITTED influence_score, computed independently of the field.
+  /**
+   * ⭐ PIN FLIPPED. This read *"the 'biggest' factor is the single greatest
+   * influence_score (rank-1)"* — an accurate description of the argmax basis
+   * S1b replaced. The positive control below proves the two bases genuinely
+   * disagree on this capture, so the new assertion cannot pass for the old
+   * reason.
+   */
+  it("⭐ the 'biggest' factor is the CANONICAL rank 1, not the influence argmax", () => {
     const eligible = factors.filter(
       (f) => typeof f.influence_score === 'number' && Number.isFinite(f.influence_score),
     );
     expect(eligible.length).toBeGreaterThan(0);
     const maxScore = Math.max(...eligible.map((f) => f.influence_score));
     const argmax = factors.find((f) => f.influence_score === maxScore);
-    expect(argmax.driver_label).toBe('biggest');
-    // and no OTHER factor carries 'biggest'
+
+    // Positive control (trap 13): on this capture the two bases DISAGREE, so
+    // the assertion below can see the difference.
+    expect(argmax.factor_id, 'the two bases must differ or this test is vacuous').not.toBe(
+      factors[0].factor_id,
+    );
+
+    // Rule S3 — the emitted array IS the canonical order.
+    expect(factors[0].driver_label).toBe('biggest');
+    expect(argmax.driver_label).not.toBe('biggest');
     for (const f of factors) {
-      if (f !== argmax) expect(f.driver_label).not.toBe('biggest');
+      if (f !== factors[0]) expect(f.driver_label).not.toBe('biggest');
     }
   });
 
-  it('every NON-biggest driver_label matches the magnitude helper; the biggest is the argmax', () => {
-    const eligible = factors.filter(
-      (f) => typeof f.influence_score === 'number' && Number.isFinite(f.influence_score),
-    );
-    const maxScore = Math.max(...eligible.map((f) => f.influence_score));
-    const argmax = factors.find((f) => f.influence_score === maxScore);
+  it('every NON-biggest driver_label is still the pure magnitude band (the three bands are untouched)', () => {
     for (const f of factors) {
-      if (f === argmax) {
+      if (f === factors[0]) {
         expect(f.driver_label).toBe('biggest');
         continue;
       }
@@ -307,21 +312,24 @@ describe('039 route: 4-valued driver_label lands on /v2/run factor_sensitivity',
     }
   });
 
-  it('a mid-rank factor keeps its magnitude band (strong/moderate), not biggest', () => {
-    // In the 07-07 capture the mid factors are dev_headcount (~0.72 → strong)
-    // and hiring_cost (~0.50 → moderate). Whichever mid factors exist, none is
-    // 'biggest' and each equals its magnitude band.
+  it('⭐ the DEMOTED lever now carries its honest magnitude band instead of the crown', () => {
+    // This is the user-visible half of the fix: the factor the same response
+    // publishes at sensitivity_score 0 / elasticity 0 stops being labelled the
+    // biggest driver in the decision, and is labelled by its own number.
     const eligible = factors.filter(
       (f) => typeof f.influence_score === 'number' && Number.isFinite(f.influence_score),
     );
     const maxScore = Math.max(...eligible.map((f) => f.influence_score));
-    const mids = eligible.filter((f) => f.influence_score !== maxScore);
-    expect(mids.length).toBeGreaterThan(0);
-    for (const f of mids) {
+    const demoted = factors.filter((f) => f !== factors[0] && f.influence_score !== undefined);
+    expect(demoted.length).toBeGreaterThan(0);
+    for (const f of demoted) {
       expect(f.driver_label).not.toBe('biggest');
       expect(f.driver_label).toBe(deriveDriverLabel(f.influence_score));
       expect(['strong', 'moderate', 'minor']).toContain(f.driver_label);
     }
+    // …and specifically the old crown-holder, named by its own influence.
+    const oldCrown = factors.find((f) => f.influence_score === maxScore);
+    expect(oldCrown.driver_label).toBe(deriveDriverLabel(maxScore));
   });
 
   it('driver_label is one of the 4 ratified categories', () => {

--- a/tests/driver-order-attestation.fixture.test.ts
+++ b/tests/driver-order-attestation.fixture.test.ts
@@ -319,20 +319,38 @@ describe('/v2/run driver_order — canonical order + attestation (fixture isl-v2
   // THE TIE VERDICT — a producer verdict, and this build can only PROVE
   // non-separation. `true` is never emitted; `null` means UNRESOLVED.
   // ---------------------------------------------------------------------
-  it('positive control: the top pair is NOT an exact tie on the basis quantity, so null here is the UNRESOLVED branch', () => {
+  it('positive control: the top pair is COMPARABLE and NOT an exact tie, so the verdict below is the provisional branch', () => {
     const a = factors[0].influence_score;
     const b = factors[1].influence_score;
     expect(typeof a).toBe('number');
     expect(typeof b).toBe('number');
     expect(a, 'if these ever become equal the assertion below tests a different branch').not.toBe(b);
+    // The comparability guard must not be what decides this fixture: both rows
+    // are non-levers of the same species, so the arithmetic really does run.
+    expect(LEVER_IDS.has(factors[0].factor_id)).toBe(false);
+    expect(LEVER_IDS.has(factors[1].factor_id)).toBe(false);
+    expect(factors[0].source).toBe(factors[1].source);
   });
 
-  it('separability is UNRESOLVED (null), never a fabricated "separable" — no ratified driver threshold exists', () => {
-    expect(order.separability.top_pair_separable).toBeNull();
-    expect(order.separability.method).toBeNull();
-    // ⛔ The one value this producer must never emit without a ratified
-    // threshold. T3: one threshold, on the wire — not three in three repos.
-    expect(order.separability.top_pair_separable).not.toBe(true);
+  /**
+   * ⭐ PIN FLIPPED — this read *"separability is UNRESOLVED (null), never a
+   * fabricated 'separable'"*, correct at S1 where `true` was unreachable by
+   * construction. Paul ratified a PROVISIONAL default on 2026-07-28, so the
+   * golden's top pair is now DECIDED. What has NOT changed, and is asserted
+   * here, is that the verdict may never arrive without its provenance.
+   */
+  it('separability is now DECIDED on this fixture — and carries the statistic, threshold and provisional status', () => {
+    const a = factors[0].influence_score;
+    const b = factors[1].influence_score;
+    const relativeGap = (a - b) / a;
+    // Re-derived here from the payload, not read from the module under test.
+    expect(order.separability.top_pair_separable).toBe(relativeGap >= 0.1);
+    expect(order.separability.top_pair_separable).toBe(true);
+    expect(order.separability.method).toBe('relative_gap_0.10_provisional');
+    // ⛔ T3: one threshold, on the wire. A `true` with a null method would be an
+    // unauditable claim, and that remains forbidden.
+    expect(order.separability.method).not.toBeNull();
+    expect(order.separability.method).toContain('provisional');
   });
 
   // ---------------------------------------------------------------------
@@ -353,32 +371,53 @@ describe('/v2/run driver_order — canonical order + attestation (fixture isl-v2
     expect(top.influence_score).toBe(1);
   });
 
-  it('RESIDUAL (untouched by S1): driver_label \'biggest\' still DISAGREES with ranked_factor_ids[0]', () => {
+  /**
+   * ⭐ THE TWO RESIDUAL PINS BELOW ARE NOW AGREEMENT PINS — S1b CLOSED THEM.
+   *
+   * S1 wrote them as RESIDUALS on purpose: *"the RESIDUAL block pins the live
+   * divergences AS THEY ARE, so that (a) nobody believes S1 fixed them and
+   * (b) none of them can drift silently before the slice that reconciles
+   * them."* This is that slice, so each is flipped to the agreement it was
+   * holding a place for. The full five-surface law lives in
+   * `tests/driver-order-projection.fixture.test.ts`; these stay here so this
+   * spec's own residual table cannot go stale in-file.
+   */
+  it("CLOSED by S1b: driver_label 'biggest' AGREES with ranked_factor_ids[0]", () => {
     const biggest = factors.filter((f) => f.driver_label === 'biggest');
     expect(biggest).toHaveLength(1);
-    // It crowns the option-pinned lever the same response publishes at
-    // sensitivity_score 0 / elasticity 0. Reconciling it is a later slice.
-    expect(LEVER_IDS.has(biggest[0].factor_id)).toBe(true);
-    expect(biggest[0].factor_id).not.toBe(order.ranked_factor_ids[0]);
+    expect(biggest[0].factor_id).toBe(order.ranked_factor_ids[0]);
+    // It no longer crowns the option-pinned lever the same response publishes
+    // at sensitivity_score 0 / elasticity 0.
+    expect(LEVER_IDS.has(biggest[0].factor_id)).toBe(false);
   });
 
-  it('RESIDUAL (untouched by S1): m1_coaching.key_drivers[0] still DISAGREES with ranked_factor_ids[0]', () => {
+  it('CLOSED by S1b: m1_coaching.key_drivers[0] AGREES with ranked_factor_ids[0]', () => {
     const kd = body.m1_coaching?.key_drivers ?? [];
     expect(kd.length, 'key_drivers must be populated for this fixture').toBeGreaterThan(0);
     expect(kd[0].rank).toBe(1);
-    expect(kd[0].factor_id).not.toBe(order.ranked_factor_ids[0]);
+    expect(kd[0].factor_id).toBe(order.ranked_factor_ids[0]);
   });
 
-  it('RESIDUAL: decision_brief.top_drivers[0] AGREES here, but only via its own stamp-only predicate', () => {
+  it('CLOSED by S1b: decision_brief.top_drivers[0] agrees BY PROJECTION now, not by its stamp-only predicate', () => {
     const top = body.decision_brief?.top_drivers?.[0];
     expect(top, 'top_drivers must be populated for this fixture').toBeDefined();
     const rank1Row = factors.find((f) => f.factor_id === order.ranked_factor_ids[0]);
     expect(top.factor_label).toBe(rank1Row.factor_label);
+    // The VALUE is unchanged on this capture — the stamp happened to cover
+    // here. What changed is the derivation, and the separating input (an
+    // UNSTAMPED D-U lever, which the stamp misses) is in
+    // tests/driver-surface-projection.unit.test.ts.
   });
 
-  it('RESIDUAL: dominant_factor is suppressed on this fixture by its own >2 ratio gate, not by the canonical order', () => {
+  it('dominant_factor is suppressed on this fixture by its own >0.5 influence floor', () => {
     expect(body.dominant_factor).toBeUndefined();
-    const sorted = [...factors].map((f) => f.influence_score).sort((a, b) => b - a);
-    expect(sorted[0] / sorted[1], 'ratio must be <= 2, else this fixture stops covering the gate').toBeLessThanOrEqual(2);
+    // ⭐ THE SUPPRESSING GATE MOVED, and that is the S1b change: the candidate
+    // is now the canonical #1, which fails the influence FLOOR — where before
+    // the candidate was the raw argmax (the lever), suppressed only by the
+    // ratio gate at 1 / 0.7243 = 1.38. The F-D3 leg in
+    // tests/driver-surface-projection.unit.test.ts opens that ratio gate and
+    // proves the lever still cannot be crowned.
+    const rank1 = factors.find((f) => f.factor_id === order.ranked_factor_ids[0]);
+    expect(rank1.influence_score).toBeLessThanOrEqual(0.5);
   });
 });

--- a/tests/driver-order-projection.fixture.test.ts
+++ b/tests/driver-order-projection.fixture.test.ts
@@ -1,0 +1,339 @@
+/**
+ * ⭐ `/v2/run` — THE FIVE #1-SURFACES ARE PROJECTIONS OF `driver_order.ranked_factor_ids[0]`
+ * (family 4, slice S1b — the consumer half of "one order").
+ *
+ * ## What this pins, and why it is one test rather than five
+ *
+ * S1 (PLoT #287) made PLoT publish exactly ONE ordering (`driver_order`). It
+ * did NOT change the surfaces that crown, and on the committed golden three of
+ * the five named a different factor from `ranked_factor_ids[0]` — the
+ * option-pinned lever the same response publishes at `sensitivity_score: 0`,
+ * `elasticity: 0`, `zero_reason: 'intervention_override'`.
+ *
+ * The amendment's §8-S1 states the acceptance test verbatim:
+ *
+ * > `driver_label`, `dominant_factor`, `m1_coaching.key_drivers[].rank`,
+ * > `decision_brief.top_drivers[0]` and the facts-path `importance_rank` all
+ * > become **projections of `ranked_factor_ids`** — they stop being independent
+ * > argmaxes. […] checkable by a single test asserting all five name
+ * > `ranked_factor_ids[0]`.
+ *
+ * Five independent argmaxes over four different quantities cannot be kept in
+ * agreement by five independent tests — that is the hand-maintained mirror
+ * (CLAUDE.md trap 12) in test form. So the law is asserted ONCE, against the
+ * canonical order, for every surface present.
+ *
+ * ## ⚠ Method: the canonical order is re-derived FROM THE REQUEST
+ *
+ * Lever identity comes from the REQUEST's option interventions — the canonical
+ * D-U source — never from the response's own `zero_reason` stamp, and this spec
+ * deliberately does not import `src/lib/driver-order.ts`. An assertion that
+ * imports the module it checks proves only that the module agrees with itself.
+ *
+ * ## ⛔ WHAT THIS SLICE DOES NOT DO (amendment §4.4)
+ *
+ * The lever DEMOTION stays. `applyLeverAwareImportanceOrder` still pushes
+ * option-controlled levers to the back, and this slice does not un-demote them:
+ * today the demotion is the only thing keeping a producer-zeroed lever off
+ * rank 1, and ranking levers truthfully must wait for CEE's permission (S4) and
+ * the UI's consumption (S6). The `ADDITIVITY`/`§4.4` block at the foot pins
+ * that the demotion is still in force.
+ *
+ * Fixture: `tests/fixtures/isl-v2-live-20260707/` — the 2026-07-07 live
+ * capture, pinned by content, kept separate from anything tracking live (trap
+ * 12b: a control pinned to "current" decays into a tautology the first time
+ * "current" changes).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'isl-v2-live-20260707',
+);
+
+const capturePlain = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-staging-capture.json'), 'utf8'),
+);
+const requestA = JSON.parse(
+  readFileSync(join(FIXTURE_DIR, 'isl-v2-request.json'), 'utf8'),
+);
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(): Promise<{ data: T | null; error: string | null }> {
+    return { data: JSON.parse(JSON.stringify(capturePlain)) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+function buildPlotBody() {
+  return {
+    graph: {
+      nodes: requestA.graph.nodes.map((n: any) => ({
+        id: n.id,
+        kind: n.kind,
+        label: n.label,
+        ...(n.observed_state?.value !== undefined && n.observed_state?.value !== null
+          ? { observed_state: { value: n.observed_state.value } }
+          : {}),
+      })),
+      edges: requestA.graph.edges.map((e: any) => ({
+        from: e.from,
+        to: e.to,
+        exists_probability: e.exists_probability,
+        strength: { mean: e.strength.mean, std: e.strength.std },
+      })),
+    },
+    options: requestA.options.map((o: any) => ({
+      id: o.id,
+      label: o.label,
+      interventions: Object.fromEntries(
+        Object.entries(o.interventions).map(([nodeId, value]) => [
+          nodeId,
+          { value, source: 'user_specified' },
+        ]),
+      ),
+    })),
+    goal_node_id: requestA.goal_node_id,
+    seed: String(requestA.seed),
+  };
+}
+
+/**
+ * The option-pinned levers, derived from the REQUEST — the canonical D-U source
+ * of lever identity, never the response's own `zero_reason` stamp.
+ */
+const LEVER_IDS: ReadonlySet<string> = new Set(
+  requestA.options.flatMap((o: any) => Object.keys(o.interventions ?? {})),
+);
+
+/**
+ * The DECLARED canonical ordering rule, re-implemented independently of
+ * `src/lib/driver-order.ts`: a STABLE partition over the producer's emitted
+ * assembly order placing every non-lever ahead of every lever.
+ */
+function canonicalOrderByRule(rows: any[]): string[] {
+  const nonLevers = rows.filter((f) => !LEVER_IDS.has(f.factor_id)).map((f) => f.factor_id);
+  const levers = rows.filter((f) => LEVER_IDS.has(f.factor_id)).map((f) => f.factor_id);
+  return [...nonLevers, ...levers];
+}
+
+describe('/v2/run — the five #1-surfaces PROJECT ranked_factor_ids[0] (fixture isl-v2-live-20260707)', () => {
+  let app: FastifyInstance;
+  let body: any;
+  let factors: any[];
+  let order: any;
+  /** The ONE answer every surface below must give. Derived, not hard-coded. */
+  let canonicalTopId: string;
+  let canonicalTopRow: any;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    // Explicit, never inherited from NODE_ENV — the facts leg below is one of
+    // the five surfaces and must not silently vanish (design §5 gate note).
+    process.env.ENABLE_FACTS_ASSEMBLY = '1';
+    app = await createServer();
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: buildPlotBody(),
+    });
+    expect(res.statusCode).toBe(200);
+    body = JSON.parse(res.body);
+    factors = body.factor_sensitivity as any[];
+    order = body.driver_order;
+    canonicalTopId = order.ranked_factor_ids[0];
+    canonicalTopRow = factors.find((f) => f.factor_id === canonicalTopId);
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ---------------------------------------------------------------------
+  // POSITIVE CONTROLS — trap 13. Every assertion below must be able to SEE
+  // a disagreement before it is allowed to assert agreement.
+  // ---------------------------------------------------------------------
+  it('positive control: the canonical order exists, is lever-aware, and its #1 is NOT the raw influence argmax', () => {
+    expect(order, 'driver_order must be emitted').toBeDefined();
+    expect(order.basis).toBe('graph_structural');
+    expect(order.ranked_factor_ids).toEqual(canonicalOrderByRule(factors));
+    expect(canonicalTopRow, 'ranked_factor_ids[0] must name a real emitted row').toBeDefined();
+
+    // ⭐ THE WHOLE POINT. If the canonical #1 were also the raw influence
+    // argmax, every assertion below would hold for the wrong reason and this
+    // spec would be vacuous — it would pass against the pre-S1b code.
+    const rawArgmax = [...factors]
+      .sort((a, b) => (b.influence_score ?? -Infinity) - (a.influence_score ?? -Infinity))[0];
+    expect(
+      rawArgmax.factor_id,
+      'raw influence argmax equals the canonical #1 — this spec cannot detect the defect it exists for',
+    ).not.toBe(canonicalTopId);
+    expect(LEVER_IDS.has(rawArgmax.factor_id), 'the raw argmax is the option-pinned lever').toBe(true);
+    expect(LEVER_IDS.has(canonicalTopId), 'the canonical #1 is NOT a lever').toBe(false);
+  });
+
+  it('positive control: the lever the old crowns named is the one this response ZEROES', () => {
+    const lever = factors.find((f) => f.factor_id !== canonicalTopId && LEVER_IDS.has(f.factor_id));
+    expect(lever).toBeDefined();
+    expect(lever.sensitivity_score).toBe(0);
+    expect(lever.elasticity).toBe(0);
+    expect(lever.zero_reason).toBe('intervention_override');
+    // …and it still carries the biggest structural influence, which is exactly
+    // why an influence-argmax crown lands on it.
+    expect(lever.influence_score).toBeGreaterThan(canonicalTopRow.influence_score);
+  });
+
+  // ---------------------------------------------------------------------
+  // ⭐ THE LAW — all five name ranked_factor_ids[0]
+  // ---------------------------------------------------------------------
+  it("⭐ SURFACE 1/5 — driver_label 'biggest' names ranked_factor_ids[0]", () => {
+    const biggest = factors.filter((f) => f.driver_label === 'biggest');
+    expect(biggest, "exactly one row may carry 'biggest'").toHaveLength(1);
+    expect(biggest[0].factor_id).toBe(canonicalTopId);
+    // …and therefore never the producer-zeroed lever.
+    expect(LEVER_IDS.has(biggest[0].factor_id)).toBe(false);
+  });
+
+  it('⭐ SURFACE 2/5 — m1_coaching.key_drivers[0] names ranked_factor_ids[0]', () => {
+    const kd = body.m1_coaching?.key_drivers ?? [];
+    expect(kd.length, 'key_drivers must be populated for this fixture').toBeGreaterThan(0);
+    expect(kd[0].rank).toBe(1);
+    expect(kd[0].factor_id).toBe(canonicalTopId);
+  });
+
+  it('⭐ SURFACE 2/5 (whole list) — key_drivers is the canonical order truncated, not a second sort', () => {
+    const kd = body.m1_coaching?.key_drivers ?? [];
+    expect(kd.map((d: any) => d.factor_id)).toEqual(order.ranked_factor_ids.slice(0, kd.length));
+    kd.forEach((d: any, i: number) => expect(d.rank).toBe(i + 1));
+  });
+
+  it('⭐ SURFACE 3/5 — dominant_factor, when emitted, names ranked_factor_ids[0] (and here its own gate suppresses it)', () => {
+    if (body.dominant_factor !== undefined) {
+      expect(body.dominant_factor.factor_id).toBe(canonicalTopId);
+    } else {
+      // Absence must be the GATE's doing, not a silent drop. The canonical #1
+      // fails the >0.5 influence floor on this capture — assert that, so the
+      // branch is named rather than assumed (the F-D3 leg in
+      // tests/factor-dominance-projection.unit.test.ts covers the emitting side).
+      expect(canonicalTopRow.influence_score).toBeLessThanOrEqual(0.5);
+    }
+  });
+
+  it('⭐ SURFACE 4/5 — decision_brief.top_drivers[0] names ranked_factor_ids[0]', () => {
+    const top = body.decision_brief?.top_drivers?.[0];
+    expect(top, 'top_drivers must be populated for this fixture').toBeDefined();
+    expect(top.factor_label).toBe(canonicalTopRow.factor_label);
+  });
+
+  it('⭐ SURFACE 4/5 (whole list) — top_drivers follows the canonical order over non-levers, not a second |elasticity| sort', () => {
+    const labels = (body.decision_brief?.top_drivers ?? []).map((d: any) => d.factor_label);
+    const expected = order.ranked_factor_ids
+      .filter((id: string) => !LEVER_IDS.has(id))
+      .map((id: string) => factors.find((f) => f.factor_id === id))
+      .filter((f: any) => f.elasticity !== undefined && f.elasticity !== null)
+      .map((f: any) => f.factor_label);
+    expect(labels).toEqual(expected.slice(0, labels.length));
+  });
+
+  it('⭐ SURFACE 5/5 — the facts-path importance_rank 1 names ranked_factor_ids[0]', () => {
+    const facts = (body.fact_objects ?? []).filter(
+      (f: any) => f.data?.type === 'factor_sensitivity',
+    );
+    expect(facts.length, 'fact_objects must carry factor_sensitivity facts').toBeGreaterThan(0);
+    const rank1 = facts.filter((f: any) => f.data.importance_rank === 1);
+    expect(rank1, 'exactly one fact may hold importance_rank 1').toHaveLength(1);
+    expect(rank1[0].data.node_id).toBe(canonicalTopId);
+  });
+
+  it('⭐ SURFACE 5/5 — the facts-path rank is SOURCED from the canonical rank, not re-derived positionally', () => {
+    const facts = (body.fact_objects ?? []).filter(
+      (f: any) => f.data?.type === 'factor_sensitivity',
+    );
+    for (const fact of facts) {
+      const row = factors.find((f) => f.factor_id === fact.data.node_id);
+      expect(row, `fact ${fact.data.node_id} must name an emitted row`).toBeDefined();
+      expect(
+        fact.data.importance_rank,
+        `${fact.data.node_id}: facts rank disagrees with factor_sensitivity[].importance_rank`,
+      ).toBe(row.importance_rank);
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // ⭐ THE SINGLE ASSERTION §8-S1 ASKS FOR — stated once, over all five
+  // ---------------------------------------------------------------------
+  it('⭐ ALL FIVE #1-naming surfaces present in this payload name the SAME factor', () => {
+    const named: Record<string, string | undefined> = {
+      "driver_label 'biggest'": factors.find((f) => f.driver_label === 'biggest')?.factor_id,
+      'm1_coaching.key_drivers[0]': body.m1_coaching?.key_drivers?.[0]?.factor_id,
+      dominant_factor: body.dominant_factor?.factor_id,
+      'decision_brief.top_drivers[0]': (() => {
+        const label = body.decision_brief?.top_drivers?.[0]?.factor_label;
+        return label === undefined
+          ? undefined
+          : factors.find((f) => f.factor_label === label)?.factor_id;
+      })(),
+      'fact_objects importance_rank 1': (body.fact_objects ?? []).find(
+        (f: any) => f.data?.type === 'factor_sensitivity' && f.data.importance_rank === 1,
+      )?.data?.node_id,
+    };
+    // A surface absent from this payload is not a disagreement — but at least
+    // four must be PRESENT or this assertion is testing almost nothing.
+    const present = Object.entries(named).filter(([, v]) => v !== undefined);
+    expect(present.length, `only ${present.length} of 5 surfaces present`).toBeGreaterThanOrEqual(4);
+    for (const [surface, id] of present) {
+      expect(id, `${surface} does not name the canonical #1`).toBe(canonicalTopId);
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // ⛔ §4.4 — the lever demotion is UNCHANGED by this slice
+  // ---------------------------------------------------------------------
+  it('§4.4: levers are still DEMOTED (not un-demoted, not removed) — the order still ranks every non-lever first', () => {
+    const positions = order.ranked_factor_ids.map((id: string) => LEVER_IDS.has(id));
+    expect(positions.indexOf(true)).toBeGreaterThan(positions.lastIndexOf(false));
+    expect(order.lever_policy).toBe('du_union');
+    expect(order.lever_ids.length).toBeGreaterThan(0);
+    // MARKED, not hidden: every lever is still IN the emitted array.
+    for (const id of order.lever_ids) expect(order.ranked_factor_ids).toContain(id);
+  });
+
+  it('§4.4: influence_rank/influence_score still carry the raw graph order — no re-sort was introduced', () => {
+    const top = factors.find((f) => f.influence_rank === 1);
+    expect(LEVER_IDS.has(top.factor_id)).toBe(true);
+    expect(top.influence_score).toBe(1);
+  });
+});

--- a/tests/driver-order-separability.unit.test.ts
+++ b/tests/driver-order-separability.unit.test.ts
@@ -215,6 +215,18 @@ describe('fail-honest: the default decides only when both values are present and
     const s = separabilityOf([row('a', { influence_score: 0 }), row('b', { influence_score: -0.2 })]);
     expect(s.top_pair_separable).toBeNull();
   });
+
+  it('⭐ a NEGATIVE runner-up is off the basis scale — unresolved, never a confident "separable"', () => {
+    // `influence_score` is |influence| / maxAbsInfluence, so this is unreachable
+    // on a live payload — but without the guard the relative gap would be
+    // (0.5 − −0.2)/0.5 = 1.4 and the producer would publish a confident `true`
+    // about a pair that is not on this scale at all. A fabrication is a
+    // fabrication whether or not today's inputs can reach it.
+    expect((0.5 - -0.2) / 0.5).toBeGreaterThan(PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP);
+    const s = separabilityOf([row('a', { influence_score: 0.5 }), row('b', { influence_score: -0.2 })]);
+    expect(s.top_pair_separable).toBeNull();
+    expect(s.method).toBeNull();
+  });
 });
 
 // ===========================================================================

--- a/tests/driver-order-separability.unit.test.ts
+++ b/tests/driver-order-separability.unit.test.ts
@@ -1,0 +1,289 @@
+/**
+ * ⭐ `driver_order.separability` — the PROVISIONAL separability default
+ * (family 4, the tie verdict of amendment §6.3).
+ *
+ * ## What changed, and what did NOT
+ *
+ * S1 (PLoT #287) shipped `top_pair_separable` that could only ever emit a
+ * PROVEN `false` (exact tie) or `null`. `true` was unreachable at those bytes,
+ * deliberately: deciding *separable* needs a threshold, and no threshold for
+ * the DRIVER order had been ratified.
+ *
+ * Paul ratified a PROVISIONAL default on 2026-07-28 (do not wait for Neil's
+ * statistic). This spec pins what that default may and may not do:
+ *
+ *   · it decides ONLY when both basis values are present, finite and ordered —
+ *     absence still yields `null`, and `null` still means UNRESOLVED (T2);
+ *   · the exact-tie path is BYTE-UNCHANGED, method string included;
+ *   · the method string NAMES the statistic, the threshold and its provisional
+ *     status, so a consumer can never hold the verdict without its provenance
+ *     (T3: one threshold, on the wire — not three in three repos);
+ *   · it refuses to decide across the LEVER PARTITION or across two row
+ *     SPECIES, because in neither state is the emitted order a sort on the
+ *     quantity being compared.
+ *
+ * ## ⚠ The number is DERIVED, not copied
+ *
+ * The threshold is bound to `NEAR_TIE_THRESHOLD` — the repo's one ratified
+ * near-tie magnitude — rather than hand-written as `0.10`, so the two cannot
+ * drift apart silently (trap 12). The binding is ALSO pinned to the literal
+ * `0.10` below: if someone changes the options-side constant for an unrelated
+ * product reason, that must be a LOUD failure here, not a silent move of the
+ * driver verdict.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildDriverOrder,
+  PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP,
+  SEPARABILITY_METHOD_EXACT_TIE,
+  SEPARABILITY_METHOD_RELATIVE_GAP,
+  type DriverOrderFactorRow,
+} from '../src/lib/driver-order.js';
+import { NEAR_TIE_THRESHOLD } from '../src/trust/result-coherence.js';
+
+function row(
+  factor_id: string,
+  extra: Partial<DriverOrderFactorRow> = {},
+): DriverOrderFactorRow {
+  return { factor_id, source: 'graph', influence_score: 0.5, ...extra };
+}
+
+const GRAPH_PATH = 'graph+isl_merge';
+
+function separabilityOf(
+  factors: DriverOrderFactorRow[],
+  structuralLeverIds: ReadonlySet<string> = new Set(),
+) {
+  return buildDriverOrder({
+    factors,
+    structuralLeverIds,
+    factorSensitivitySource: GRAPH_PATH,
+    islSuppressedAttributions: undefined,
+  })!.separability;
+}
+
+// ===========================================================================
+// The threshold's provenance
+// ===========================================================================
+describe('the provisional threshold is DERIVED from the repo convention, and fails loud on drift', () => {
+  it('is bound to NEAR_TIE_THRESHOLD — not a second near-tie number invented for drivers', () => {
+    expect(PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP).toBe(NEAR_TIE_THRESHOLD);
+  });
+
+  it('⚠ and is ALSO pinned to 0.10 — a change to the options-side constant must RED here, not move this verdict silently', () => {
+    expect(PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP).toBe(0.1);
+  });
+
+  it('the method string carries statistic + threshold + provisional status, derived from the constant', () => {
+    expect(SEPARABILITY_METHOD_RELATIVE_GAP).toBe('relative_gap_0.10_provisional');
+    expect(SEPARABILITY_METHOD_RELATIVE_GAP).toContain('provisional');
+    expect(SEPARABILITY_METHOD_EXACT_TIE).toBe('basis_value_exact_tie');
+  });
+});
+
+// ===========================================================================
+// The exact-tie path — UNCHANGED
+// ===========================================================================
+describe('the exact-tie path is unchanged by the default', () => {
+  it('⭐ an EXACT tie is still a PROVEN non-separation, under its own method name', () => {
+    const s = separabilityOf([row('a', { influence_score: 0.42 }), row('b', { influence_score: 0.42 })]);
+    expect(s.top_pair_separable).toBe(false);
+    expect(s.method).toBe(SEPARABILITY_METHOD_EXACT_TIE);
+    // NOT relabelled as a relative-gap verdict: an exact tie needs no threshold
+    // and must not inherit a provisional one.
+    expect(s.method).not.toBe(SEPARABILITY_METHOD_RELATIVE_GAP);
+  });
+
+  it('an exact tie at ZERO is still an exact tie, not a divide-by-zero', () => {
+    const s = separabilityOf([row('a', { influence_score: 0 }), row('b', { influence_score: 0 })]);
+    expect(s.top_pair_separable).toBe(false);
+    expect(s.method).toBe(SEPARABILITY_METHOD_EXACT_TIE);
+  });
+});
+
+// ===========================================================================
+// ⭐ The default itself
+// ===========================================================================
+describe('the provisional default decides separability when — and only when — it can', () => {
+  it('⭐ RED before this slice: a gap comfortably above the threshold is SEPARABLE', () => {
+    // (0.50 - 0.30) / 0.50 = 0.40 ≥ 0.10
+    const s = separabilityOf([row('a', { influence_score: 0.5 }), row('b', { influence_score: 0.3 })]);
+    expect(s.top_pair_separable).toBe(true);
+    expect(s.method).toBe(SEPARABILITY_METHOD_RELATIVE_GAP);
+  });
+
+  it('⭐ a gap below the threshold is NOT separable — and says which method decided it', () => {
+    // (0.500 - 0.475) / 0.500 = 0.05 < 0.10
+    const s = separabilityOf([row('a', { influence_score: 0.5 }), row('b', { influence_score: 0.475 })]);
+    expect(s.top_pair_separable).toBe(false);
+    expect(s.method).toBe(SEPARABILITY_METHOD_RELATIVE_GAP);
+  });
+
+  it('the comparison is INCLUSIVE: a relative gap of exactly 0.10 is SEPARABLE', () => {
+    // (10 - 9) / 10 is exactly the double 0.1 — no rounding in the way, so this
+    // pins the operator (`>=`) rather than a floating-point accident.
+    expect((10 - 9) / 10).toBe(PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP);
+    const s = separabilityOf([row('a', { influence_score: 10 }), row('b', { influence_score: 9 })]);
+    expect(s.top_pair_separable).toBe(true);
+  });
+
+  it('⚠ DISCLOSED LIMITATION: at the last bit the verdict is a floating-point coin-toss', () => {
+    // (1 - 0.9) / 1 evaluates to 0.09999999999999998, so a pair a human would
+    // call "exactly at the threshold" lands on the NOT-separable side, while
+    // (0.4 - 0.36) / 0.4 = 0.10000000000000009 lands on the other.
+    //
+    // This is not a bug to paper over with an epsilon — it is what a gap
+    // between two point estimates is worth near its own threshold, and it is
+    // one more reason `method` says `provisional`. Pinned so the behaviour is
+    // KNOWN rather than discovered by a consumer.
+    expect((1 - 0.9) / 1).toBeLessThan(PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP);
+    expect(
+      separabilityOf([row('a', { influence_score: 1 }), row('b', { influence_score: 0.9 })])
+        .top_pair_separable,
+    ).toBe(false);
+    expect(
+      separabilityOf([row('a', { influence_score: 0.4 }), row('b', { influence_score: 0.36 })])
+        .top_pair_separable,
+    ).toBe(true);
+  });
+
+  it('⭐ the statistic is RELATIVE, not absolute — the same ratio decides the same way at any scale', () => {
+    // The basis quantity is normalised by the MAX row (|influence| /
+    // maxAbsInfluence), and after the lever demotion the max row need not be in
+    // the pair at all. An ABSOLUTE gap would therefore be moved by a number
+    // outside the comparison; a relative gap is invariant to it.
+    const big = separabilityOf([row('a', { influence_score: 0.5 }), row('b', { influence_score: 0.4 })]);
+    const small = separabilityOf([row('a', { influence_score: 0.05 }), row('b', { influence_score: 0.04 })]);
+    expect(big.top_pair_separable).toBe(true);
+    expect(small.top_pair_separable).toBe(true);
+    expect(small.method).toBe(big.method);
+
+    // The control: an absolute-gap rule at 0.10 would have called the second
+    // pair NOT separable. Prove the two rules genuinely disagree here, so this
+    // assertion is not passing for an unrelated reason.
+    expect(0.05 - 0.04).toBeLessThan(PROVISIONAL_TOP_PAIR_SEPARABILITY_MIN_RELATIVE_GAP);
+  });
+
+  it('a rival at zero against a positive leader is separable (relative gap 1.0)', () => {
+    const s = separabilityOf([row('a', { influence_score: 0.3 }), row('b', { influence_score: 0 })]);
+    expect(s.top_pair_separable).toBe(true);
+  });
+});
+
+// ===========================================================================
+// FAIL-HONEST — absence is still UNRESOLVED
+// ===========================================================================
+describe('fail-honest: the default decides only when both values are present and finite', () => {
+  it('an ABSENT basis value is neither a tie nor a separation — unresolved', () => {
+    const s = separabilityOf([row('a', { influence_score: undefined }), row('b', { influence_score: 0.3 })]);
+    expect(s.top_pair_separable).toBeNull();
+    expect(s.method).toBeNull();
+  });
+
+  it('a NULL basis value on the runner-up is unresolved, never coalesced to 0', () => {
+    // A `?? 0` here would read as "the rival has no influence" and publish a
+    // confident `true`. Absent means unavailable, not zero.
+    const s = separabilityOf([row('a', { influence_score: 0.9 }), row('b', { influence_score: null })]);
+    expect(s.top_pair_separable).toBeNull();
+    expect(s.method).toBeNull();
+  });
+
+  it('a NON-FINITE basis value is unresolved', () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const s = separabilityOf([row('a', { influence_score: bad }), row('b', { influence_score: 0.3 })]);
+      expect(s.top_pair_separable, `influence_score ${bad}`).toBeNull();
+    }
+  });
+
+  it('a single row has no top PAIR — unresolved, not separable', () => {
+    expect(separabilityOf([row('only')]).top_pair_separable).toBeNull();
+  });
+
+  it("an empty order carries no verdict at all (basis 'none')", () => {
+    const o = buildDriverOrder({
+      factors: [],
+      structuralLeverIds: new Set(),
+      factorSensitivitySource: GRAPH_PATH,
+      islSuppressedAttributions: undefined,
+    })!;
+    expect(o.basis).toBe('none');
+    expect(o.separability).toEqual({ top_pair_separable: null, method: null });
+  });
+
+  it('a non-positive leader cannot form a relative gap — unresolved, not a fabricated verdict', () => {
+    const s = separabilityOf([row('a', { influence_score: 0 }), row('b', { influence_score: -0.2 })]);
+    expect(s.top_pair_separable).toBeNull();
+  });
+});
+
+// ===========================================================================
+// ⭐ THE PARTITION-STRADDLE EDGE (S1 review LOW) — fail closed
+// ===========================================================================
+describe('the verdict refuses to compare across the lever partition, or across two species', () => {
+  it('positive control: the straddling pair really is out of order on the basis quantity', () => {
+    // One non-lever, one lever. The lever keeps its real structural influence
+    // (only sensitivity/elasticity/VOI are zeroed), and it is bigger — so the
+    // emitted order does NOT descend on `influence_score` across this pair.
+    const rows = [row('driver', { influence_score: 0.4 }), row('lever', { influence_score: 1 })];
+    expect(rows[1].influence_score!).toBeGreaterThan(rows[0].influence_score!);
+  });
+
+  it('⭐ rows 0/1 on OPPOSITE sides of the lever partition ⇒ UNRESOLVED, never a verdict', () => {
+    const s = separabilityOf(
+      [row('driver', { influence_score: 0.4 }), row('lever', { influence_score: 1 })],
+      new Set(['lever']),
+    );
+    expect(s.top_pair_separable).toBeNull();
+    expect(s.method).toBeNull();
+  });
+
+  it('⭐ an EXACT tie across the partition is NOT a proven tie either — the two were never ordered together', () => {
+    // The sharpest form of the edge: equal numbers on opposite sides of a
+    // partition are a coincidence, not a measured non-separation.
+    const s = separabilityOf(
+      [row('driver', { influence_score: 0.42 }), row('lever', { influence_score: 0.42 })],
+      new Set(['lever']),
+    );
+    expect(s.top_pair_separable).toBeNull();
+    expect(s.method).toBeNull();
+  });
+
+  it('BOTH rows levers (an all-lever order) is the SAME partition — the verdict is allowed', () => {
+    const s = separabilityOf(
+      [row('lever_a', { influence_score: 0.9 }), row('lever_b', { influence_score: 0.2 })],
+      new Set(['lever_a', 'lever_b']),
+    );
+    expect(s.top_pair_separable).toBe(true);
+  });
+
+  it('⭐ two SPECIES (a graph row and an ISL-only row) are incommensurable ⇒ UNRESOLVED', () => {
+    const s = separabilityOf([
+      row('graph_row', { source: 'graph', influence_score: 0.9 }),
+      row('isl_row', { source: 'isl', influence_score: 0.2 }),
+    ]);
+    expect(s.top_pair_separable).toBeNull();
+    expect(s.method).toBeNull();
+  });
+
+  it('a mixed array whose TOP PAIR is single-species still gets a verdict (the guard is about the pair)', () => {
+    const o = buildDriverOrder({
+      factors: [
+        row('graph_a', { source: 'graph', influence_score: 0.9 }),
+        row('graph_b', { source: 'graph', influence_score: 0.2 }),
+        row('isl_tail', { source: 'isl', influence_score: 0.1 }),
+      ],
+      structuralLeverIds: new Set(),
+      factorSensitivitySource: GRAPH_PATH,
+      islSuppressedAttributions: undefined,
+    })!;
+    expect(o.species).toBe('mixed_graph_isl');
+    expect(o.separability.top_pair_separable).toBe(true);
+  });
+
+  it('an out-of-order pair within ONE partition is still unresolved — the order is not a sort on this quantity', () => {
+    const s = separabilityOf([row('a', { influence_score: 0.2 }), row('b', { influence_score: 0.9 })]);
+    expect(s.top_pair_separable).toBeNull();
+    expect(s.method).toBeNull();
+  });
+});

--- a/tests/driver-order.unit.test.ts
+++ b/tests/driver-order.unit.test.ts
@@ -220,15 +220,30 @@ describe('buildDriverOrder — the tie verdict', () => {
     expect(o.separability.method).toBe('basis_value_exact_tie');
   });
 
-  it('⛔ a strict inequality is UNRESOLVED, never "separable" — no ratified driver threshold exists (T3)', () => {
+  /**
+   * ⭐ PIN FLIPPED — this assertion previously read *"a strict inequality is
+   * UNRESOLVED, never separable"*, and it was correct at S1: no driver
+   * threshold had been ratified, so the producer could not decide.
+   *
+   * Paul ratified a PROVISIONAL default on 2026-07-28. The strict-inequality
+   * branch now DECIDES, under a method name that says so. The half of the old
+   * pin that still stands — the producer must never decide without naming its
+   * threshold — is asserted here instead, and the fail-closed branches keep
+   * their own pins above and in
+   * `tests/driver-order-separability.unit.test.ts`.
+   */
+  it('a strict inequality is now DECIDED — but never without naming the threshold that decided it (T3)', () => {
     const o = buildDriverOrder({
       factors: [row('a', { influence_score: 0.9 }), row('b', { influence_score: 0.01 })],
       structuralLeverIds: new Set(),
       factorSensitivitySource: GRAPH_PATH,
       islSuppressedAttributions: undefined,
     })!;
-    expect(o.separability.top_pair_separable).toBeNull();
-    expect(o.separability.method).toBeNull();
+    expect(o.separability.top_pair_separable).toBe(true);
+    expect(o.separability.method).toBe('relative_gap_0.10_provisional');
+    // ⛔ A verdict without a method would be a bare boolean a consumer could
+    // not audit — the exact defect T3 exists to kill.
+    expect(o.separability.method).not.toBeNull();
   });
 
   it('a single row has no top PAIR — unresolved, not separable', () => {

--- a/tests/driver-quantity-register.derived.test.ts
+++ b/tests/driver-quantity-register.derived.test.ts
@@ -1,0 +1,161 @@
+/**
+ * ⭐ THE DERIVED PRODUCER REGISTER GATE (family 4, amendment §3.2 leg 1).
+ *
+ * > *"a test that enumerates every numeric field on a driver-bearing row […]
+ * > **from the schema objects themselves — never from a list** — and fails on
+ * > any field that has no declared `{role, disposition, unit, sign}` entry. A
+ * > new quantity is then a RED, not a silent fifteenth."*
+ *
+ * The instrument is `tools/derive-driver-quantities.mjs` (AST over the contract
+ * type declarations, same dependency and same reasoning as
+ * `tools/gen-structural-keys.mjs`). This spec is the fail-loud half.
+ *
+ * ## Why the vacuity controls come FIRST
+ *
+ * Every assertion here is of the form "the derived domain and the register
+ * agree". Two sets agree trivially when both are empty — so an extraction that
+ * silently returned nothing would turn this whole gate green while covering
+ * nothing at all. That is the exact shape of the guarantee-theatre this family
+ * exists to hunt, so the derivation is REQUIRED to throw rather than degrade,
+ * and the controls below prove it does.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DRIVER_QUANTITY_REGISTER,
+  DRIVER_QUANTITY_EXEMPTIONS,
+} from '../src/lib/driver-quantity-register.js';
+
+const derive = await import('../tools/derive-driver-quantities.mjs');
+
+describe('the register DOMAIN is derived from the contract types, and cannot silently shrink', () => {
+  // -----------------------------------------------------------------------
+  // VACUITY CONTROLS — trap 13. Prove the extraction can SEE something.
+  // -----------------------------------------------------------------------
+  it('positive control: the extraction finds a non-trivial domain across BOTH declared row types', () => {
+    const fields = derive.deriveDriverQuantityFields();
+    expect(fields.length, 'an empty domain would make every assertion below vacuous').toBeGreaterThan(5);
+    const types = new Set(fields.map((f: any) => f.type));
+    expect(types).toEqual(new Set(derive.DRIVER_ROW_TYPES.map((t: any) => t.type)));
+  });
+
+  it('positive control: the extraction reads TYPES, not names — it finds a NESTED quantity too', () => {
+    // `confidence_components.sampling_stability` lives one level down inside an
+    // inline object literal. A grep for `: number` at the top level would miss
+    // it, and so would any hand-written list that forgot to recurse.
+    const keys = derive.deriveDriverQuantityKeys();
+    expect(keys).toContain('FactorSensitivityResultV3.confidence_components.sampling_stability');
+  });
+
+  it('positive control: it discriminates — non-numeric members are NOT in the domain', () => {
+    const keys: string[] = derive.deriveDriverQuantityKeys();
+    // If the extraction collected every property regardless of type, the gate
+    // would be measuring the wrong thing (and would demand a `unit` for a
+    // string id).
+    for (const notAQuantity of [
+      'FactorSensitivityResultV3.factor_id',
+      'FactorSensitivityResultV3.direction',
+      'FactorSensitivityResultV3.driver_label',
+      'FactorSensitivityResultV3.attribution_stability',
+      'EdgeSensitivityResultV3.interpretation',
+    ]) {
+      expect(keys, `${notAQuantity} is not a quantity`).not.toContain(notAQuantity);
+    }
+  });
+
+  it('⛔ UNPARSEABLE FAILS LOUD — a missing type THROWS rather than yielding an empty domain', async () => {
+    // The failure mode that would make this gate worthless: the type is renamed
+    // or deleted, the extraction returns [], and "every derived field has an
+    // entry" passes by testing nothing. Prove it throws instead.
+    const original = [...derive.DRIVER_ROW_TYPES];
+    try {
+      derive.DRIVER_ROW_TYPES.length = 0;
+      derive.DRIVER_ROW_TYPES.push({ file: 'src/types/engine-v3.ts', type: 'ThisTypeDoesNotExistV9' });
+      expect(() => derive.deriveDriverQuantityFields()).toThrow(/not found/i);
+
+      derive.DRIVER_ROW_TYPES.length = 0;
+      derive.DRIVER_ROW_TYPES.push({ file: 'src/types/does-not-exist.ts', type: 'Whatever' });
+      expect(() => derive.deriveDriverQuantityFields()).toThrow(/cannot read/i);
+    } finally {
+      derive.DRIVER_ROW_TYPES.length = 0;
+      derive.DRIVER_ROW_TYPES.push(...original);
+    }
+    // …and the domain is intact afterwards, so this control cannot poison the
+    // assertions that follow.
+    expect(derive.deriveDriverQuantityFields().length).toBeGreaterThan(5);
+  });
+
+  // -----------------------------------------------------------------------
+  // ⭐ THE GATE — both directions
+  // -----------------------------------------------------------------------
+  it('⭐ every derived numeric quantity has a declared {role, disposition, unit, sign} entry', () => {
+    const keys: string[] = derive.deriveDriverQuantityKeys();
+    const missing = keys.filter(
+      (k) => !(k in DRIVER_QUANTITY_REGISTER) && !(k in DRIVER_QUANTITY_EXEMPTIONS),
+    );
+    expect(
+      missing,
+      `unregistered driver quantities — declare them in src/lib/driver-quantity-register.ts:\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('⭐ and the reverse: no register entry names a field the contract no longer has', () => {
+    // A stale row is the same defect facing the other way — it makes the
+    // register read as complete while describing something that is gone.
+    const keys = new Set<string>(derive.deriveDriverQuantityKeys());
+    const stale = Object.keys(DRIVER_QUANTITY_REGISTER).filter((k) => !keys.has(k));
+    expect(stale, `register rows for fields that no longer exist:\n  ${stale.join('\n  ')}`).toEqual([]);
+  });
+
+  it('a quantity is registered OR exempt, never both — an exemption must not hide a live declaration', () => {
+    const both = Object.keys(DRIVER_QUANTITY_REGISTER).filter((k) => k in DRIVER_QUANTITY_EXEMPTIONS);
+    expect(both).toEqual([]);
+  });
+
+  it('exemptions are EMITTED as data (§3.2 point 3), never argued in prose', () => {
+    // Empty today — and the emptiness is the claim. What matters is that the
+    // mechanism EXISTS and is machine-readable, so "considered and excluded" is
+    // distinguishable from "never found".
+    expect(DRIVER_QUANTITY_EXEMPTIONS).toBeDefined();
+    expect(typeof DRIVER_QUANTITY_EXEMPTIONS).toBe('object');
+    for (const [key, value] of Object.entries(DRIVER_QUANTITY_EXEMPTIONS)) {
+      expect(value.reason.length, `${key} must state its exclusion reason`).toBeGreaterThan(20);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // ENTRY QUALITY — the part a type cannot state must actually be stated
+  // -----------------------------------------------------------------------
+  it('every entry states a REAL unit — "unknown" is a finding, not an answer', () => {
+    for (const [key, entry] of Object.entries(DRIVER_QUANTITY_REGISTER)) {
+      expect(entry.unit, `${key}: unit`).toBeTruthy();
+      expect(entry.unit.toLowerCase(), `${key}: unit must not be a placeholder`).not.toMatch(
+        /^(unknown|tbd|n\/a|todo)$/,
+      );
+      expect(entry.note.length, `${key}: note must be checkable against the bytes`).toBeGreaterThan(30);
+    }
+  });
+
+  it('the two quantities that share the sensitivity_score/elasticity confusion are declared DIFFERENTLY', () => {
+    // The family's sharpest live defect was elasticity published under the name
+    // sensitivity_score — opposite sign, 2.84× apart, one response. If the
+    // register described them identically it would not have caught it.
+    const s = DRIVER_QUANTITY_REGISTER['FactorSensitivityResultV3.sensitivity_score'];
+    const e = DRIVER_QUANTITY_REGISTER['FactorSensitivityResultV3.elasticity'];
+    expect(s.unit).not.toBe(e.unit);
+  });
+
+  it('the DESIGNATIONS are declared as designations, not as measurements', () => {
+    // §3.1: the harm is a designation published as a measurement (ISL's
+    // importance_score was a linear function of rank). Ranks are ordinals.
+    for (const key of [
+      'FactorSensitivityResultV3.importance_rank',
+      'FactorSensitivityResultV3.influence_rank',
+      'EdgeSensitivityResultV3.importance_rank',
+    ]) {
+      expect(DRIVER_QUANTITY_REGISTER[key].role, key).toBe('designation');
+      expect(DRIVER_QUANTITY_REGISTER[key].unit, key).toBe('rank_ordinal');
+      expect(DRIVER_QUANTITY_REGISTER[key].sign, key).toBe('positive_ordinal');
+    }
+  });
+});

--- a/tests/driver-surface-projection.unit.test.ts
+++ b/tests/driver-surface-projection.unit.test.ts
@@ -1,0 +1,271 @@
+/**
+ * S1b unit legs — the three #1-surfaces whose divergence the committed golden
+ * CANNOT see, proven at the units instead.
+ *
+ * ## Why this file exists (trap 13, stated the other way round)
+ *
+ * `tests/driver-order-projection.fixture.test.ts` proves the end-to-end law on
+ * the 2026-07-07 capture. On that capture only TWO of the five surfaces
+ * disagree with `ranked_factor_ids[0]`; the other three agree — but they agree
+ * **by coincidence**, and S1's own residual table says so:
+ *
+ * | surface | why it agrees on the golden |
+ * |---|---|
+ * | `dominant_factor` | suppressed by its own `>2` ratio gate — *"ONE NUMBER away from crowning a lever"* (design F-D3) |
+ * | `decision_brief.top_drivers[0]` | *"the stamp happens to cover"* — its predicate is stamp-only, which UNDER-covers |
+ * | facts-path `importance_rank` | positional `idx + 1`, which *"mirrors the array, so agrees by accident"* |
+ *
+ * A fixture that agrees by coincidence cannot RED on the defect, and a fix
+ * merged against it would be untested by construction (trap 11: no slice merges
+ * until reverting the fix turns something RED). Each leg below therefore builds
+ * the ONE separating input that breaks the coincidence — the smallest possible
+ * perturbation of the real capture, not a hand-invented toy.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { detectDominantFactor } from '../src/trust/factor-dominance.js';
+import { assembleBrief } from '../src/assembly/decision-brief.js';
+import { mapFactorSensitivityToFactsInput } from '../src/routes/v2/run.js';
+
+const GOLDEN = JSON.parse(
+  readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      'fixtures',
+      'isl-v2-live-20260707',
+      'plot-v2-run.golden.json',
+    ),
+    'utf8',
+  ),
+);
+
+/** The emitted rows, in the emitted (= canonical) order. Rule S3. */
+const GOLDEN_ROWS: any[] = GOLDEN.factor_sensitivity;
+const CANONICAL_TOP_ID: string = GOLDEN.driver_order.ranked_factor_ids[0];
+const LEVER_IDS: string[] = GOLDEN.driver_order.lever_ids;
+
+// ===========================================================================
+// LEG 1 — F-D3: `dominant_factor` is ONE NUMBER away from crowning a lever
+// ===========================================================================
+describe('F-D3 — dominant_factor must not crown a lever when the ratio gate opens', () => {
+  /**
+   * The separating input, verbatim from the design's §4.3 F-D3:
+   *
+   * > drop `fac_dev_headcount.influence_score` from `0.7243` to `0.40`
+   * > ⇒ ratio `1 / 0.40 = 2.5 > 2` ⇒ the top-level `dominant_factor` names the
+   * > lever.
+   *
+   * Everything else is the real capture. One number moves.
+   */
+  const F_D3_ID = 'fac_dev_headcount';
+  const F_D3_MUTANT_INFLUENCE = 0.4;
+
+  function fd3Rows(): any[] {
+    return GOLDEN_ROWS.map((f) =>
+      f.factor_id === F_D3_ID ? { ...f, influence_score: F_D3_MUTANT_INFLUENCE } : { ...f },
+    );
+  }
+
+  it('positive control: the mutant really does open the >2 ratio gate that the golden closes', () => {
+    const rawDesc = (rows: any[]) =>
+      [...rows].map((f) => f.influence_score).sort((a, b) => b - a);
+
+    const golden = rawDesc(GOLDEN_ROWS);
+    expect(golden[0] / golden[1], 'golden ratio must be <= 2 (gate CLOSED)').toBeLessThanOrEqual(2);
+
+    const mutant = rawDesc(fd3Rows());
+    expect(mutant[0] / mutant[1], 'mutant ratio must be > 2 (gate OPEN)').toBeGreaterThan(2);
+
+    // …and the row the raw argmax names is the option-pinned lever.
+    const rawArgmax = [...fd3Rows()].sort((a, b) => b.influence_score - a.influence_score)[0];
+    expect(LEVER_IDS).toContain(rawArgmax.factor_id);
+    expect(rawArgmax.influence_score).toBeGreaterThan(0.5); // clears the influence floor too
+  });
+
+  it('positive control: the mutant leaves the CANONICAL order untouched — only the gate moves', () => {
+    // The lever partition is structural, not value-based, so demoting one
+    // lever's influence cannot reorder the canonical array. If it could, this
+    // leg would be testing two changes at once.
+    expect(fd3Rows().map((f) => f.factor_id)).toEqual(GOLDEN_ROWS.map((f) => f.factor_id));
+  });
+
+  it('⭐ RED before S1b: dominant_factor names ranked_factor_ids[0] or nothing — NEVER a lever', () => {
+    const df = detectDominantFactor(fd3Rows());
+    if (df !== undefined) {
+      expect(df.factor_id, 'dominant_factor must project the canonical #1').toBe(CANONICAL_TOP_ID);
+    }
+    // The load-bearing half: whatever it does, it may not crown a factor this
+    // same response publishes at sensitivity_score 0 / elasticity 0.
+    expect(
+      df === undefined || !LEVER_IDS.includes(df.factor_id),
+      `dominant_factor crowned the option-pinned lever ${df?.factor_id}`,
+    ).toBe(true);
+  });
+
+  it('the >0.5 influence floor still SUPPRESSES — the projection did not turn the gate off', () => {
+    // The canonical #1 on this capture is below the floor, so the honest answer
+    // is "no dominant factor", not "the strongest thing I could find".
+    const top = GOLDEN_ROWS.find((f) => f.factor_id === CANONICAL_TOP_ID);
+    expect(top.influence_score).toBeLessThanOrEqual(0.5);
+    expect(detectDominantFactor(fd3Rows())).toBeUndefined();
+    expect(detectDominantFactor(GOLDEN_ROWS.map((f) => ({ ...f })))).toBeUndefined();
+  });
+
+  it('the gate still FIRES when the canonical #1 genuinely dominates (the fix is not "always undefined")', () => {
+    const rows = [
+      { factor_id: 'fac_alpha', factor_label: 'Alpha', influence_score: 0.9 },
+      { factor_id: 'fac_beta', factor_label: 'Beta', influence_score: 0.3 },
+    ];
+    expect(detectDominantFactor(rows)?.factor_id).toBe('fac_alpha');
+  });
+
+  it('a rival DEMOTED below rank 1 still counts against the ratio — dominance is over the whole set', () => {
+    // A lever sits at the BACK of the canonical order but keeps its real
+    // structural influence. Comparing rank 1 only against rank 2 would call a
+    // 0.6 factor "dominant" while a 1.0 factor sat three rows down.
+    const rows = [
+      { factor_id: 'fac_alpha', factor_label: 'Alpha', influence_score: 0.6 },
+      { factor_id: 'fac_beta', factor_label: 'Beta', influence_score: 0.1 },
+      { factor_id: 'fac_lever', factor_label: 'Lever', influence_score: 1.0 },
+    ];
+    expect(detectDominantFactor(rows)).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// LEG 2 — `decision_brief.top_drivers[0]`: stamp-only UNDER-covers
+// ===========================================================================
+describe('decision_brief.top_drivers projects the canonical order, not a stamp-only re-sort', () => {
+  /**
+   * The separating input is the live `fac_salary_cost` case recorded at
+   * `src/lib/intervention-override.ts:9-15`: a lever pinned by a NON-FIRST
+   * option arrives with a nonzero measured elasticity and NO
+   * `zero_reason: 'intervention_override'` stamp. `filterInterventionOverrides`
+   * (stamp-only) lets it through; the D-U union does not.
+   */
+  const UNSTAMPED_LEVER = 'fac_salary_cost';
+
+  /** Canonical order: non-levers first, the unstamped lever demoted to the back. */
+  const rows: any[] = [
+    { factor_id: 'fac_hiring_cost', factor_label: 'Hiring Cost', elasticity: 0.5, influence_score: 0.5, importance_rank: 1, direction: 'negative' },
+    { factor_id: 'fac_team_maturity', factor_label: 'Team Maturity', elasticity: 0.4, influence_score: 0.4, importance_rank: 2, direction: 'positive' },
+    // ⚠ NO zero_reason — the stamp does not cover it. Highest |elasticity|.
+    { factor_id: UNSTAMPED_LEVER, factor_label: 'Salary Cost', elasticity: 0.9, influence_score: 0.9, importance_rank: 3, direction: 'negative' },
+  ];
+
+  const driverOrder = {
+    version: 1 as const,
+    basis: 'graph_structural' as const,
+    ranked_factor_ids: rows.map((f) => f.factor_id),
+    species: 'single' as const,
+    lever_policy: 'du_union' as const,
+    lever_ids: [UNSTAMPED_LEVER],
+    separability: { top_pair_separable: null, method: null },
+    rank_stability: { max_rank_flip_rate: null, min_attribution_stability: null },
+  };
+
+  /** The minimum `assembleBrief` needs before it will return a brief at all. */
+  const briefPreconditions = {
+    analysis_status: 'computed',
+    critiques: [],
+    option_comparison: [
+      { option_id: 'opt_a', label: 'A', win_probability: 0.7, status: 'computed' },
+      { option_id: 'opt_b', label: 'B', win_probability: 0.3, status: 'computed' },
+    ],
+    robustness: { level: 'moderate' },
+    meta: { seed_used: '4242' },
+  };
+
+  function build(input: Record<string, unknown> = {}) {
+    return assembleBrief({
+      ...briefPreconditions,
+      factor_sensitivity: rows as any,
+      driver_order: driverOrder as any,
+      ...input,
+    } as any);
+  }
+
+  it('positive control: the stamp really does miss this lever, and it really would win an |elasticity| sort', () => {
+    const lever = rows.find((f) => f.factor_id === UNSTAMPED_LEVER)!;
+    expect(lever.zero_reason, 'the separating property: NO stamp').toBeUndefined();
+    const byElasticity = [...rows].sort((a, b) => Math.abs(b.elasticity) - Math.abs(a.elasticity));
+    expect(byElasticity[0].factor_id).toBe(UNSTAMPED_LEVER);
+    expect(driverOrder.ranked_factor_ids[0]).not.toBe(UNSTAMPED_LEVER);
+  });
+
+  it('⭐ RED before S1b: top_drivers[0] names ranked_factor_ids[0], never the unstamped lever', () => {
+    const brief = build();
+    expect(brief?.top_drivers?.[0]?.factor_label).toBe('Hiring Cost');
+  });
+
+  it('the unstamped lever is EXCLUDED from top_drivers entirely (it is not a tunable driver)', () => {
+    const brief = build();
+    expect(brief?.top_drivers?.map((d) => d.factor_label)).not.toContain('Salary Cost');
+  });
+
+  it('top_drivers follows the canonical order over the surviving non-levers', () => {
+    const brief = build();
+    expect(brief?.top_drivers?.map((d) => d.factor_label)).toEqual(['Hiring Cost', 'Team Maturity']);
+  });
+
+  it('fails CLOSED when no order is attested: absent driver_order ⇒ the stamp-only legacy path, unchanged', () => {
+    // S1b must not make an OLDER caller worse. Without `driver_order` the brief
+    // keeps exactly its pre-S1b behaviour rather than silently treating "no
+    // levers named" as "no levers exist".
+    const brief = assembleBrief({
+      ...briefPreconditions,
+      factor_sensitivity: rows as any,
+    } as any);
+    expect(brief?.top_drivers?.[0]?.factor_label).toBe('Salary Cost');
+  });
+});
+
+// ===========================================================================
+// LEG 3 — the facts path: a POSITION is not a RANK
+// ===========================================================================
+describe('the facts path SOURCES importance_rank from the canonical rank, not from the array position', () => {
+  /**
+   * On every live payload the emitted array order IS the canonical order
+   * (Rule S3), so `idx + 1` and `importance_rank` coincide and no end-to-end
+   * fixture can tell them apart. The separating input is therefore an array
+   * whose position and rank DISAGREE — which is exactly the state a future
+   * re-order would produce, and the state under which a positional derivation
+   * silently publishes a different #1 into `fact_objects`.
+   */
+  const rowsRankDisagreesWithPosition: any[] = [
+    { factor_id: 'fac_b', factor_label: 'B', importance_rank: 2, sensitivity_score: 0.2, elasticity: 0.2 },
+    { factor_id: 'fac_a', factor_label: 'A', importance_rank: 1, sensitivity_score: 0.9, elasticity: 0.9 },
+  ];
+
+  it('positive control: position and rank really do disagree in this input', () => {
+    expect(rowsRankDisagreesWithPosition[0].importance_rank).not.toBe(1);
+    expect(rowsRankDisagreesWithPosition[1].importance_rank).toBe(1);
+  });
+
+  it('⭐ RED before S1b: rank 1 follows importance_rank, not the array index', () => {
+    const mapped = mapFactorSensitivityToFactsInput(rowsRankDisagreesWithPosition);
+    expect(mapped.find((m) => m.importance_rank === 1)?.node_id).toBe('fac_a');
+    expect(mapped.find((m) => m.node_id === 'fac_b')?.importance_rank).toBe(2);
+  });
+
+  it('a row with no producer rank falls back to its position in the CANONICAL array, and nothing else', () => {
+    const mapped = mapFactorSensitivityToFactsInput([
+      { factor_id: 'fac_x', sensitivity_score: 0.1 },
+      { factor_id: 'fac_y', sensitivity_score: 0.2 },
+    ] as any);
+    expect(mapped.map((m) => m.importance_rank)).toEqual([1, 2]);
+  });
+
+  it('agrees with the committed golden — the change is provenance, and it is value-identical there', () => {
+    const mapped = mapFactorSensitivityToFactsInput(GOLDEN_ROWS as any);
+    expect(mapped.map((m) => m.node_id)).toEqual(GOLDEN_ROWS.map((f) => f.factor_id));
+    expect(mapped.map((m) => m.importance_rank)).toEqual(
+      GOLDEN_ROWS.map((f) => f.importance_rank),
+    );
+    expect(mapped.find((m) => m.importance_rank === 1)?.node_id).toBe(CANONICAL_TOP_ID);
+  });
+});

--- a/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
+++ b/tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json
@@ -517,7 +517,7 @@
       "rank_flip_rate": 0.3,
       "stability_method": "bootstrap_20",
       "importance_basis": "graph_structural",
-      "driver_label": "moderate",
+      "driver_label": "biggest",
       "evpi_percentage_points": 0,
       "evpi_method": "heuristic",
       "evidence_hint": false
@@ -589,7 +589,7 @@
       "rank_flip_rate": 0,
       "stability_method": "bootstrap_20",
       "importance_basis": "graph_structural",
-      "driver_label": "biggest",
+      "driver_label": "strong",
       "range_derivation_source": "default"
     },
     {
@@ -643,8 +643,8 @@
       "fac_dev_headcount"
     ],
     "separability": {
-      "top_pair_separable": null,
-      "method": null
+      "top_pair_separable": true,
+      "method": "relative_gap_0.10_provisional"
     },
     "rank_stability": {
       "max_rank_flip_rate": 0.3,
@@ -968,31 +968,13 @@
     },
     "key_drivers": [
       {
-        "factor_id": "fac_tech_lead",
-        "factor_label": "Tech Lead in Place",
-        "influence_score": 1,
-        "normalised_impact": 1,
-        "impact_display": "Very High",
-        "direction": "positive",
-        "rank": 1
-      },
-      {
-        "factor_id": "fac_dev_headcount",
-        "factor_label": "Developer Headcount Added",
-        "influence_score": 0.724,
-        "normalised_impact": 0.72,
-        "impact_display": "High",
-        "direction": "positive",
-        "rank": 2
-      },
-      {
         "factor_id": "fac_hiring_cost",
         "factor_label": "Hiring and Salary Cost",
         "influence_score": 0.497,
         "normalised_impact": 0.5,
         "impact_display": "Medium",
         "direction": "negative",
-        "rank": 3
+        "rank": 1
       },
       {
         "factor_id": "fac_team_maturity",
@@ -1000,6 +982,24 @@
         "influence_score": 0.39,
         "normalised_impact": 0.39,
         "impact_display": "Medium",
+        "direction": "positive",
+        "rank": 2
+      },
+      {
+        "factor_id": "fac_tech_lead",
+        "factor_label": "Tech Lead in Place",
+        "influence_score": 1,
+        "normalised_impact": 1,
+        "impact_display": "Very High",
+        "direction": "positive",
+        "rank": 3
+      },
+      {
+        "factor_id": "fac_dev_headcount",
+        "factor_label": "Developer Headcount Added",
+        "influence_score": 0.724,
+        "normalised_impact": 0.72,
+        "impact_display": "High",
         "direction": "positive",
         "rank": 4
       }
@@ -1646,7 +1646,7 @@
     "decision_brief_assembled": true,
     "review_cards_count": 0,
     "evidence_priority_card_present": false,
-    "response_content_hash": "rch_v2:67bdba00c5e65476"
+    "response_content_hash": "rch_v2:685c70b9bb0ec52d"
   },
   "meta": {
     "seed_used": "2034401427",

--- a/tests/importance-rank-lever-doctrine.fixture.test.ts
+++ b/tests/importance-rank-lever-doctrine.fixture.test.ts
@@ -212,36 +212,43 @@ describe('/v2/run importance-authority coherence (fixture isl-v2-live-20260707)'
   });
 
   // ---------------------------------------------------------------------
-  // PINNED DIVERGENCE — deliberately NOT fixed by this lane.
+  // ⭐ DIVERGENCE CLOSED — family-4 S1b (2026-07-28).
   //
-  // `driver_label: 'biggest'` (Doctrine 039 / D-7) is argmax over
-  // `influence_score` and is NOT lever-aware, so it disagrees with
-  // `importance_rank: 1`. Left alone on purpose: gating it would make the label
-  // contradict the number in its own row, its BASIS is already an open doctrine
-  // row owned by Neil/UI (src/lib/driver-label.ts), and blast radius is zero —
-  // censused 25 Jul at UI 039f479a / CEE f00b8ef6, `driver_label` has NO read
-  // site in either consumer.
+  // This block pinned `driver_label: 'biggest'` AS DIVERGENT: argmax over
+  // `influence_score`, not lever-aware, landing on the lever while
+  // `importance_rank: 1` named a different factor. It was left that way
+  // deliberately, on three reasons — a definitional one, an open Neil/UI
+  // doctrine row, and a "blast radius zero" consumer census taken 25 Jul at UI
+  // `039f479a` / CEE `f00b8ef6`.
   //
-  // This test exists so the divergence CANNOT drift silently while the ruling is
-  // pending: if someone changes either rule, this goes RED and forces a decision.
+  // The amendment re-derived all three and overturned them (see
+  // `src/lib/driver-label.ts` for what replaced each; the census in particular
+  // is a hand-maintained mirror taken at tips that have since moved —
+  // CLAUDE.md trap 12 — and was NOT inherited). The pin did exactly its job:
+  // it made this a decision instead of a drift.
   // ---------------------------------------------------------------------
-  it("PINNED DIVERGENCE: 'biggest' still follows argmax(influence_score) and therefore still lands on the lever", () => {
+  it("CLOSED: 'biggest' now PROJECTS importance_rank 1 and therefore never lands on the lever", () => {
     const biggest = factors.filter((f) => f.driver_label === 'biggest');
     expect(biggest.length, "exactly one factor carries the 'biggest' crown").toBe(1);
-    const maxInfluence = Math.max(...factors.map((f) => f.influence_score));
-    expect(biggest[0].influence_score).toBe(maxInfluence);
-    // ⚠ The crown IS on a lever, and that lever publishes zero sensitivity.
-    expect(LEVER_IDS.has(biggest[0].factor_id)).toBe(true);
-    expect(biggest[0].sensitivity_score).toBe(0);
-    // ⚠ …and it is NOT the factor this same response ranks importance_rank 1.
     const rank1 = factors.find((f) => f.importance_rank === 1);
-    expect(biggest[0].factor_id).not.toBe(rank1.factor_id);
+    expect(biggest[0].factor_id).toBe(rank1.factor_id);
+    // ⚠ Not on a lever, and not on a factor publishing zero sensitivity.
+    expect(LEVER_IDS.has(biggest[0].factor_id)).toBe(false);
+    expect(biggest[0].sensitivity_score).not.toBe(0);
+
+    // The raw structural argmax is NOT lost — it is still published under its
+    // own honest name, and this fixture proves the two really do differ.
+    const maxInfluence = Math.max(...factors.map((f) => f.influence_score));
+    const argmax = factors.find((f) => f.influence_score === maxInfluence);
+    expect(argmax.factor_id).not.toBe(biggest[0].factor_id);
+    expect(argmax.influence_rank).toBe(1);
+    expect(LEVER_IDS.has(argmax.factor_id)).toBe(true);
   });
 
   it('every non-biggest driver_label is still the pure magnitude band over influence_score', () => {
-    const maxInfluence = Math.max(...factors.map((f) => f.influence_score));
+    const rank1 = factors.find((f) => f.importance_rank === 1);
     for (const f of factors) {
-      if (f.influence_score === maxInfluence) continue;
+      if (f.factor_id === rank1.factor_id) continue;
       expect(['strong', 'moderate', 'minor'], f.factor_id).toContain(f.driver_label);
     }
   });

--- a/tests/isl-v2-golden-response.pin.test.ts
+++ b/tests/isl-v2-golden-response.pin.test.ts
@@ -343,9 +343,22 @@ describe('/v2/run golden byte-identity pin (well-formed V2 envelope, build 9a22a
       'fac_dev_headcount',
     ]);
     expect(order.lever_ids).toEqual(['fac_tech_lead', 'fac_dev_headcount']);
-    // ⛔ No fabricated separability: this build can PROVE a tie, never a
-    // separation, so the verdict here is UNRESOLVED and consumers fail closed.
-    expect(order.separability).toEqual({ top_pair_separable: null, method: null });
+    // ⭐ S1b PIN FLIP. At S1 this read `{ top_pair_separable: null, method:
+    // null }` — correct then, because `true` was unreachable by construction.
+    // Paul ratified a PROVISIONAL default on 2026-07-28, so the top pair of
+    // this fixture is now DECIDED. Re-derived from the golden's own rows below
+    // so the pin cannot drift from the data it describes.
+    const [a, b] = (rawBody.factor_sensitivity as any[]).map((f) => f.influence_score);
+    expect((a - b) / a).toBeGreaterThanOrEqual(0.1);
+    expect(order.separability).toEqual({
+      top_pair_separable: true,
+      method: 'relative_gap_0.10_provisional',
+    });
+    // ⛔ A verdict must never arrive without the method that produced it (T3),
+    // and the method must keep saying `provisional` until Neil's statistic
+    // lands — a consumer that reads it as ratified is making a claim this
+    // producer has not made.
+    expect(order.separability.method).toContain('provisional');
     expect(order.rank_stability).toEqual({
       max_rank_flip_rate: 0.3,
       min_attribution_stability: 'negligible',
@@ -356,8 +369,9 @@ describe('/v2/run golden byte-identity pin (well-formed V2 envelope, build 9a22a
     // flips, an "additive" slice has changed the UI freshness token.
     expect(rawBody.response_hash).toBe('60e3ac213554be4f');
     // `response_content_hash` hashes the public semantic surface and therefore
-    // SHOULD move for exactly this addition. Pinned to the post-S1 value so
-    // the next content change is also forced to be deliberate.
-    expect(rawBody._meta.response_content_hash).toBe('rch_v2:67bdba00c5e65476');
+    // SHOULD move — S1b changes which factor three crowns name, which is a
+    // CONTENT change by design. Re-pinned (was `rch_v2:67bdba00c5e65476` at
+    // S1) so the next content change is also forced to be deliberate.
+    expect(rawBody._meta.response_content_hash).toBe('rch_v2:685c70b9bb0ec52d');
   });
 });

--- a/tests/stamp-only-lever-predicate.census.test.ts
+++ b/tests/stamp-only-lever-predicate.census.test.ts
@@ -1,0 +1,190 @@
+/**
+ * ⭐ DERIVED CENSUS — every surface still using the STAMP-ONLY lever predicate.
+ *
+ * ## Why this exists, and what it is atoning for
+ *
+ * There are two lever predicates in this codebase (`src/lib/intervention-override.ts`):
+ *
+ *   · the **D-U union** (`isOptionControlledLever` / `interventionTargetIdsFromOptions`)
+ *     — canonical: a factor ANY option intervenes on is a lever, stamped or not;
+ *   · the **ISL stamp** (`isInterventionOverride` / `filterInterventionOverrides`
+ *     / `interventionOverrideFactorIds`) — a SYMPTOM, which **under-covers**. ISL
+ *     stamps only elasticity≈0 first-option pins, so a lever pinned by a
+ *     non-first option arrives unstamped with a nonzero measured elasticity and
+ *     survives the filter (the live `fac_salary_cost` case,
+ *     `intervention-override.ts:9-15`).
+ *
+ * Family-4 S1b moved `decision_brief.top_drivers` off the stamp and onto
+ * `driver_order.lever_ids`. The other stamp-only sites were left in place, out
+ * of scope — and the PROJECTION REGISTER in `src/lib/driver-order.ts` recorded
+ * that fact as a **hand-written sentence naming two of them.**
+ *
+ * ⚠ **That sentence was wrong the moment it was written**: an adversarial review
+ * of PR #288 found at least four more. It was the exact defect this codebase
+ * names as its dominant one — *"a list a human must remember to sync WILL drift,
+ * and the drift reads as complete"* (CLAUDE.md trap 12) — reproduced inside the
+ * register that exists to prevent it, and wrong at birth rather than by decay.
+ *
+ * So the census is no longer prose. It is EXTRACTED from the sources here, and
+ * this spec fails loud in BOTH directions:
+ *
+ *   · a file that starts using the stamp-only predicate ⇒ RED (a new surface
+ *     cannot quietly join the under-covering set);
+ *   · a file that stops ⇒ RED (so a slice that migrates one to the D-U union
+ *     must delete its row, and the register cannot claim a debt already paid).
+ *
+ * ## ⛔ This spec asserts NOTHING about whether stamp-only is correct
+ *
+ * Several of these sites may be perfectly fine — some are mitigated on the
+ * primary path because the merge already applied the D-U union upstream. This
+ * spec makes the SET visible and stable; adjudicating each row is the later
+ * slice `lever_policy: 'stamp_only'` was reserved for.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+/** The stamp-only predicate surface. The D-U union members are NOT here. */
+const STAMP_ONLY_IDENTIFIERS = [
+  'isInterventionOverride',
+  'filterInterventionOverrides',
+  'interventionOverrideFactorIds',
+] as const;
+
+/**
+ * Modules that DEFINE or RE-EXPORT the predicate rather than consuming it.
+ * Naming a definition site as a consumer would be noise; these are structural
+ * and a reviewer can check them in one line.
+ */
+const DEFINITION_MODULES = new Set([
+  'lib/intervention-override.ts', // the single definition
+  'coaching/sensitivity-filter.ts', // a pure re-export shim
+]);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Strip comments — a mention in prose is not a call site.
+ *
+ * ⚠ Deliberately does NOT strip imports or re-exports, and that is a finding
+ * rather than an omission. An earlier revision did, until a mutant showed the
+ * lines were **unfalsifiable**: breaking them changed no result, because
+ * `import { X } from '…'` and `export { X } from '…'` can never contain the
+ * form `X(` that the detector matches. Defensive code that cannot fail is the
+ * same theatre this spec exists to hunt (CLAUDE.md trap 15 — *"your own script
+ * is not exempt"*), so it is gone rather than kept for comfort. Import lines are
+ * additionally moot here because a module that imports the predicate without
+ * calling it is not a consumer.
+ */
+function executableText(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments (incl. JSDoc)
+    .replace(/^\s*\/\/.*$/gm, ''); // line comments
+}
+
+/** @returns sorted `"<relative path>"` of every module that CALLS a stamp-only predicate. */
+function deriveStampOnlyConsumers(): string[] {
+  const hits = new Set<string>();
+  for (const file of walk(SRC)) {
+    const rel = relative(SRC, file).split(/[\\/]/).join('/');
+    if (DEFINITION_MODULES.has(rel)) continue;
+    const body = executableText(readFileSync(file, 'utf8'));
+    if (STAMP_ONLY_IDENTIFIERS.some((id) => new RegExp(`\\b${id}\\s*\\(`).test(body))) {
+      hits.add(rel);
+    }
+  }
+  return [...hits].sort();
+}
+
+/**
+ * The census AS MEASURED at PR #288's head. Every row is a real call site,
+ * derived and then reviewed — not a remembered list.
+ *
+ * ⚠ If this fails: do not "fix" it by editing this array to match. Work out
+ * WHICH surface changed and whether it should have, then update the array and
+ * the reason in the same commit.
+ */
+const EXPECTED_STAMP_ONLY_CONSUMERS: Readonly<Record<string, string>> = {
+  'assembly/decision-brief.ts':
+    'buildWhatWouldChange, the value-defaulted disclosure block, and the LEGACY fallback in buildTopDrivers (used only when driver_order is absent — the S1b path uses lever_ids).',
+  'coaching/critiques.ts':
+    'filters factor sensitivity before critique generation, and tests the stamp directly when classifying a factor.',
+  'coaching/headlines.ts':
+    'selects "tunable" factors for headline copy, twice.',
+  'lib/factor-influence.ts':
+    'MITIGATED — the stamp is OR-ed with the structural lever flag, so this site is effectively D-U at the call.',
+  'routes/v2/run.ts':
+    'the ISL-ingest filter in transformFactorSensitivity, and the evidence-priority review card.',
+};
+
+describe('stamp-only lever predicate — derived census', () => {
+  it('positive control: the extraction finds real call sites across several modules', () => {
+    const consumers = deriveStampOnlyConsumers();
+    // An empty or near-empty result would make the comparison below vacuous.
+    expect(consumers.length, 'extraction found nothing — the census is vacuous').toBeGreaterThan(2);
+    // The definition module must be excluded, or every result is trivially "yes".
+    expect(consumers).not.toContain('lib/intervention-override.ts');
+  });
+
+  /**
+   * ⭐ This control was VACUOUS in its first revision, and a mutant caught it.
+   *
+   * It originally asserted only that `lib/driver-order.ts` — which mentions
+   * these identifiers in prose — stays out of the derived set. But no comment in
+   * this repo happens to contain the exact form `identifier(`, so **breaking
+   * the comment stripper entirely still left that assertion green.** An absence
+   * assertion that cannot see a presence is testing nothing (CLAUDE.md trap 13),
+   * and this one was guarding the census's own discrimination.
+   *
+   * The stripper is now exercised DIRECTLY, on synthetic input built to contain
+   * exactly what the real sources do not.
+   */
+  it('positive control: comment stripping works — a mention is not a call site, and a real call survives', () => {
+    const mentionsOnly = [
+      '/** doc: filterInterventionOverrides(rows) is the stamp-only filter */',
+      '// note: isInterventionOverride(f) under-covers',
+      '/*\n * multi-line: interventionOverrideFactorIds(rows)\n */',
+      'export const unrelated = 1;',
+    ].join('\n');
+    const stripped = executableText(mentionsOnly);
+    for (const id of STAMP_ONLY_IDENTIFIERS) {
+      expect(
+        new RegExp(`\\b${id}\\s*\\(`).test(stripped),
+        `${id}: a mention in a comment was counted as a call site`,
+      ).toBe(false);
+    }
+
+    // …and the stripper must NOT eat real code, or the census would report an
+    // empty set and pass by finding nothing.
+    const realCall = executableText('const t = filterInterventionOverrides(rows);');
+    expect(/\bfilterInterventionOverrides\s*\(/.test(realCall)).toBe(true);
+  });
+
+  it('⭐ the set of stamp-only consumers is exactly the reviewed census — no additions, no silent departures', () => {
+    expect(deriveStampOnlyConsumers()).toEqual(Object.keys(EXPECTED_STAMP_ONLY_CONSUMERS).sort());
+  });
+
+  it('every census row carries a reason a reviewer can check against the bytes', () => {
+    for (const [file, reason] of Object.entries(EXPECTED_STAMP_ONLY_CONSUMERS)) {
+      expect(reason.length, `${file}: reason too thin to be checkable`).toBeGreaterThan(30);
+    }
+  });
+
+  it('⭐ decision_brief top_drivers is OFF the stamp on the S1b path — the debt this slice actually paid', () => {
+    // The census row for decision-brief.ts must remain true for the LEGACY path
+    // only. If `lever_ids` ever stops being consulted, this goes RED.
+    const brief = readFileSync(join(SRC, 'assembly', 'decision-brief.ts'), 'utf8');
+    expect(brief).toContain('new Set(driverOrder.lever_ids)');
+  });
+});

--- a/tools/derive-driver-quantities.mjs
+++ b/tools/derive-driver-quantities.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Derive the DOMAIN of the driver-quantity register (amendment §3.2).
+ *
+ * ## Why this is derived and not written down
+ *
+ * The amendment's own headline census dropped items between two sections of one
+ * document, written in one sitting, by one author who was actively looking for
+ * them:
+ *
+ * > *The count is itself a hand-maintained mirror […] a list a human must
+ * > remember to sync WILL drift, and the drift reads as complete.*
+ * > ⇒ **"The authority table must not ship as a table. It must ship as a
+ * > DERIVED REGISTER with a fail-loud gate."**
+ *
+ * So the DOMAIN — *which* numeric quantities ride on a driver-bearing row — is
+ * extracted from the contract type declarations themselves, by AST, never from
+ * a list. The REGISTER (`src/lib/driver-quantity-register.ts`) supplies the
+ * things a type cannot state: `{role, disposition, unit, sign}`. A new numeric
+ * field is then a RED in `tests/driver-quantity-register.derived.test.ts`, not
+ * a silent fifteenth quantity.
+ *
+ * Same instrument, same reasoning and the same `typescript` dependency as
+ * `tools/gen-structural-keys.mjs`, which derives the structural key set from
+ * these same files.
+ *
+ * ## ⛔ UNPARSEABLE FAILS LOUD
+ *
+ * Every failure mode of this extraction — file missing, type renamed or
+ * deleted, an interface that yields zero members — THROWS. It must never
+ * return an empty or partial domain, because an empty domain makes the gate
+ * pass by testing nothing (trap 13: an absence assertion that cannot see a
+ * presence).
+ *
+ * Side-effect free on import: this module only reads.
+ *
+ * Usage: node tools/derive-driver-quantities.mjs   (prints the derived domain)
+ */
+import ts from 'typescript';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * The DRIVER-BEARING ROW TYPES. These are the shapes a consumer ranks, bands or
+ * crowns on — the amendment's `FactorSensitivityV2` / `EdgeSensitivityV2` /
+ * `SensitiveFactorV2` stated at PLoT's own names.
+ *
+ * ⚠ This list names the TYPES, not the fields. Naming a type is a structural
+ * choice a reviewer can check in one line; naming fields would be the mirror
+ * this module exists to avoid.
+ */
+export const DRIVER_ROW_TYPES = [
+  { file: 'src/types/engine-v3.ts', type: 'FactorSensitivityResultV3' },
+  { file: 'src/types/engine-v3.ts', type: 'EdgeSensitivityResultV3' },
+];
+
+/** Does this type node admit a `number`? Unwraps unions, parens and arrays. */
+function admitsNumber(node) {
+  if (node === undefined) return false;
+  if (ts.isParenthesizedTypeNode(node)) return admitsNumber(node.type);
+  if (ts.isUnionTypeNode(node)) return node.types.some(admitsNumber);
+  if (ts.isArrayTypeNode(node)) return admitsNumber(node.elementType);
+  return node.kind === ts.SyntaxKind.NumberKeyword;
+}
+
+/** The source text of a type node, whitespace-collapsed, for the report. */
+function typeText(node, source) {
+  return node === undefined
+    ? 'unknown'
+    : source.text.slice(node.pos, node.end).trim().replace(/\s+/g, ' ');
+}
+
+function collectNumericMembers(members, source, typeName, prefix, out) {
+  for (const member of members) {
+    if (!ts.isPropertySignature(member) || member.name === undefined) continue;
+    const name = member.name.getText?.(source) ?? source.text.slice(member.name.pos, member.name.end).trim();
+    const field = prefix === '' ? name : `${prefix}.${name}`;
+    const type = member.type;
+
+    // Recurse into INLINE object literals (e.g. `confidence_components`), so a
+    // quantity cannot hide from the register one level down.
+    if (type !== undefined && ts.isTypeLiteralNode(type)) {
+      collectNumericMembers(type.members, source, typeName, field, out);
+      continue;
+    }
+    if (admitsNumber(type)) {
+      out.push({
+        type: typeName,
+        field,
+        ts_type: typeText(type, source),
+        optional: member.questionToken !== undefined,
+      });
+    }
+  }
+}
+
+/**
+ * Derive every numeric field carried by a driver-bearing row.
+ *
+ * @returns {{type: string, field: string, ts_type: string, optional: boolean}[]}
+ *   sorted by `type` then `field` — a stable domain a test can diff.
+ * @throws if any declared type cannot be found or yields no members.
+ */
+export function deriveDriverQuantityFields() {
+  const derived = [];
+  for (const { file, type: typeName } of DRIVER_ROW_TYPES) {
+    const path = join(ROOT, file);
+    let text;
+    try {
+      text = readFileSync(path, 'utf8');
+    } catch (cause) {
+      // UNPARSEABLE ⇒ LOUD. Never fall through to an empty domain.
+      throw new Error(`driver-quantity domain: cannot read ${file}`, { cause });
+    }
+    const source = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true);
+
+    let decl;
+    source.forEachChild((node) => {
+      if (ts.isInterfaceDeclaration(node) && node.name.text === typeName) decl = node;
+    });
+    if (decl === undefined) {
+      throw new Error(
+        `driver-quantity domain: interface ${typeName} not found in ${file}. ` +
+          'It was renamed, deleted or converted to a type alias — the register ' +
+          'domain is now unverifiable and must not silently shrink.',
+      );
+    }
+    if (decl.members.length === 0) {
+      throw new Error(`driver-quantity domain: interface ${typeName} parsed with ZERO members (${file})`);
+    }
+
+    const before = derived.length;
+    collectNumericMembers(decl.members, source, typeName, '', derived);
+    if (derived.length === before) {
+      throw new Error(
+        `driver-quantity domain: ${typeName} yielded NO numeric fields. A ` +
+          'driver-bearing row with no quantities is not a state this contract ' +
+          'has — treat it as a parse failure, not as an empty result.',
+      );
+    }
+  }
+  derived.sort((a, b) => (a.type === b.type ? a.field.localeCompare(b.field) : a.type.localeCompare(b.type)));
+  return derived;
+}
+
+/** Stable `"Type.field"` keys — the join between the domain and the register. */
+export function deriveDriverQuantityKeys() {
+  return deriveDriverQuantityFields().map((f) => `${f.type}.${f.field}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  for (const f of deriveDriverQuantityFields()) {
+    console.log(`${f.type}.${f.field}${f.optional ? '?' : ''}: ${f.ts_type}`);
+  }
+}


### PR DESCRIPTION
**Family 4, slice S1b — the consumer half of "one order"** (amendment §8-S1 remainder, ROADMAP 1.344), plus the Paul-ratified **provisional separability default** (28 Jul).

S1 (#287) made PLoT publish exactly one canonical driver ordering. It changed none of the surfaces that crown, and on the committed golden two of them named the **option-pinned lever the same response publishes at `sensitivity_score: 0`, `elasticity: 0`, `zero_reason: 'intervention_override'`**. This PR makes all five #1-naming surfaces projections of `ranked_factor_ids[0]`, and gives `separability` a provisional verdict instead of a permanent `null`.

**Advances:** finish-line criterion 7 (differentiated science surface) and criterion 1 (family-4 drivers) — the canonical driver order is now what a user actually sees.

---

## Part 1 — the provisional separability default

### The statistic, and its provenance

| | |
|---|---|
| **Statistic** | relative gap `(first − second) / first` on the basis quantity (`influence_score`) across the top pair of the canonical order |
| **Threshold** | `0.10` — **bound to `NEAR_TIE_THRESHOLD`** (`src/trust/result-coherence.ts:25`), the repo's one ratified near-tie magnitude, already used by `computeNearTie` and by the brief's `'very_close'` band |
| **On the wire** | `method: 'relative_gap_0.10_provisional'` — derived from the constant via `.toFixed(2)`, so the string cannot drift from the number it describes |
| **Ratification** | 🟡 PROVISIONAL. Neil owns the replacement; the one-line overrule is documented at the function |

The number is **bound, not copied** (trap 12), and the binding is *also* pinned to the literal `0.10` — so if the options-side constant is ever changed for an unrelated product reason that is a LOUD failure here rather than a silent move of the driver verdict.

### ⚠ Refuting the brief: the existing convention is ABSOLUTE, not relative

The brief said *"a 0.10 **relative-gap** threshold exists in the codebase — find it, cite it."* **It does not.** `NEAR_TIE_THRESHOLD` is applied as an **absolute** gap between two `win_probability` values (`src/routes/v2/run.ts`: `const gap = topWinProb - secondWinProb; const isTie = gap < NEAR_TIE_THRESHOLD`), and its own comment says *"gap between top two options < 10%"*. There is no relative-gap convention in this repo.

So I reused the **number** and deliberately changed the **form**, for a reason specific to this quantity rather than to taste:

`influence_score` is `|influence| / maxAbsInfluence` (`src/lib/factor-influence.ts:547`) — **normalised by the largest row, which after the lever demotion need not be in the compared pair at all.** On the committed golden the max row *is* the demoted lever (`influence_score: 1`), while the two rows actually compared sit at `0.497` and `0.390`. Had that lever's raw influence been twice as large, both would halve to `0.249 / 0.195`: **same underlying data, absolute gap collapsing 0.107 → 0.053, verdict flipping** on a number outside the comparison. The relative gap is invariant to that rescaling (0.2145 either way). `win_probability` has no such problem — it is normalised across the options being compared — which is why the same constant is right and the same form is not.

### The requirements, discharged

| Req | Where |
|---|---|
| (a) labelled PROVISIONAL, names the pending Neil ratification + the one-line overrule | `src/lib/driver-order.ts` — the `DriverOrderSeparability` doc and the `PROVISIONAL_…` const |
| (b) `method` states statistic + threshold + provenance | `relative_gap_0.10_provisional`, derived from the constant |
| (c) exact-tie path unchanged | checked **first**, keeps `basis_value_exact_tie`; mutant **M12** proves relabelling it REDs |
| (d) fail-honest preserved | absent / null / non-finite ⇒ `null`; mutant **M13** proves a `?? 0` REDs |
| (e) partition-straddle LOW | **addressed** — see below |

### (e) The partition-straddle edge — addressed, not accepted

S1 compared rows 0/1 of the **final** order, i.e. after `applyLeverAwareImportanceOrder` partitions levers to the back. Those rows are not necessarily adjacent in any sort on `influence_score`:

- **Across the lever partition** — a lever keeps its true structural influence (only sensitivity/elasticity/VOI are zeroed) and is frequently the largest. With one non-lever and one lever, `b > a` and the gap is meaningless. Worse, an **exact equality across the partition would have published `basis_value_exact_tie` — "proven not separable" — for a coincidence between two rows the producer never compared.**
- **Across two species** — in `mixed_graph_isl`, graph rows carry path-analysis influence and appended ISL rows carry Monte-Carlo uncertainty importance, under the same field name.

Both now fail **closed to `null`**, deliberately not to `false`: `false` is a positive claim the producer has not earned. The guard can only ever *remove* a verdict. A residual is accepted knowingly and stated at the function: the guard proves the pair is **comparable**, not that the estimates are statistically distinguishable — that is Neil's question, and it is why `method` says `provisional`.

### Also disclosed rather than papered over

Near its own threshold the verdict is a floating-point coin-toss — `(1 − 0.9)/1 = 0.09999999999999998` lands NOT separable while `(0.4 − 0.36)/0.4 = 0.10000000000000009` lands separable. Pinned as a **disclosed limitation** (no epsilon added): it is what a gap between two point estimates is worth at the last bit, and one more argument for the provisional label.

---

## Part 2 — the five #1-surfaces become projections

| # | Surface | Before | After |
|---|---|---|---|
| 1 | `driver_label === 'biggest'` | argmax `influence_score`, lever-blind — **crowned the lever** | `ranked_factor_ids[0]` |
| 2 | `m1_coaching.key_drivers[0]` | `abs(influence_score ?? elasticity ?? 0)` sort — **crowned the lever** | `importance_rank` ascending (stable) |
| 3 | `dominant_factor` | internal argmax over unfiltered rows | `factors[0]` only; **gates unchanged** |
| 4 | `decision_brief.top_drivers[0]` | stamp-only lever predicate + a second `\|elasticity\|` sort | canonical order minus `driver_order.lever_ids` (D-U union) |
| 5 | facts-path `importance_rank` | positional `idx + 1` | `fs.importance_rank` (extracted as `mapFactorSensitivityToFactsInput`, so the claim is testable) |

Two details worth review attention:

- **`dominant_factor`'s rival is the strongest row anywhere in the order, not `factors[1]`.** The canonical order demotes levers while they keep their true influence, so the second-largest number is often not in second position. Comparing rank 1 only to rank 2 would call a 0.6 factor "dominant" while a 1.0 factor sat three rows down — *a new fabrication introduced by the fix*. Pinned.
- **`top_drivers` fails CLOSED on absence.** With no `driver_order` the brief keeps exactly its pre-S1b behaviour; absence of an attestation is not permission to publish a lever.

### ⛔ §4.4 honoured — the lever demotion stays

`applyLeverAwareImportanceOrder` is untouched. Levers are still demoted and MARKED, never un-demoted; the raw structural argmax is still published under its own honest name as `influence_rank === 1`. Pinned by two assertions in the projection spec.

### This supersedes a deliberate prior ruling, on re-derived grounds

`importance-authority.ts:117-140` left `driver_label` divergent on three reasons. All three are addressed in `src/lib/driver-label.ts` rather than waved past — and note the third, *"blast radius zero — no consumer reads `driver_label`"*, was a census taken 25 Jul at tips that have since moved. **Not inherited** (trap 12); and the argument cuts the other way regardless — a field with no readers is the cheapest possible moment to correct it.

---

## ⭐ The flip enumeration — every golden change, and why each is the canonical order asserting itself

The complete diff of `tests/fixtures/isl-v2-live-20260707/plot-v2-run.golden.json` is **five hunks and nothing else**:

| # | Change | Verdict |
|---|---|---|
| 1 | `fac_hiring_cost.driver_label`: `moderate` → **`biggest`** | ✅ The canonical #1 takes the crown. |
| 2 | `fac_tech_lead.driver_label`: `biggest` → **`strong`** | ✅ **The intended product fix.** The lever loses the crown and is labelled by its own number (`influence_score: 1` ⇒ `strong`, the unchanged magnitude band). This factor publishes `sensitivity_score: 0`, `elasticity: 0`, `zero_reason: 'intervention_override'` in the same response — it was being displayed as the biggest driver in the decision. |
| 3 | `driver_order.separability`: `{null, null}` → **`{true, relative_gap_0.10_provisional}`** | ✅ Part 1. Re-derived in the pin from the golden's own rows: `(0.4971 − 0.3905)/0.4971 = 0.2145 ≥ 0.10`. |
| 4 | `m1_coaching.key_drivers` reordered `[tech_lead, dev_headcount, hiring_cost, team_maturity]` → **`[hiring_cost, team_maturity, tech_lead, dev_headcount]`**, ranks reassigned 1–4 | ✅ Exactly `ranked_factor_ids`. Both levers move to the back; no row added, dropped or revalued. |
| 5 | `_meta.response_content_hash` moves | ✅ Correct — it hashes the public semantic surface, and the surface changed. Re-pinned. |

**What did NOT move, and was checked:**

- `response_hash` — **unmoved** (`60e3ac213554be4f`). It canonicalises the *request*; a crown change must not move the UI's freshness token.
- `factor_sensitivity[]` — array order, `importance_rank`, `influence_rank`, and every numeric value **unchanged**.
- `decision_brief.top_drivers` — **unchanged in value.** The stamp happened to cover on this capture; only the derivation changed. The separating input (an **unstamped** D-U lever, which the stamp misses) is a unit leg.
- `fact_objects` — **unchanged in value.** Position and rank coincide on every live payload by Rule S3; only the provenance changed.
- `dominant_factor` — **still absent.** But the *suppressing gate moved*, and that is itself the fix: the candidate is now the canonical #1, which fails the `> 0.5` influence floor, where before the candidate was the lever, suppressed only by the ratio gate at `1 / 0.7243 = 1.38`. The F-D3 leg opens that ratio gate and proves the lever still cannot be crowned.

---

## RED-first evidence (at the pre-fix bytes)

| Spec | RED |
|---|---|
| `driver-order-projection.fixture.test.ts` | **4 failed / 9 passed** — `driver_label` and `key_drivers[0]` both `fac_tech_lead`, expected `fac_hiring_cost` |
| `driver-order-separability.unit.test.ts` | **12 failed** — constants absent, every provisional branch `null` |
| `driver-surface-projection.unit.test.ts` | **8 failed** — F-D3 crowned `fac_tech_lead`; `top_drivers[0]` was the unstamped lever `Salary Cost`; the facts mapper did not exist |

The three surfaces that already agreed on the golden are covered at the units, because **a fixture that agrees by coincidence cannot RED on the defect** — each leg builds the one separating input that breaks the coincidence, all sourced from the real capture rather than hand-invented.

## Mutants — every one bites (throwaway worktree OUTSIDE the repo root, removed before gates)

| Mutant | Result |
|---|---|
| M1 separability default removed | 12 failed |
| M2 comparability guard removed | 2 failed |
| M3 threshold drifted 0.10 → 0.20 | 5 failed |
| M4 `driver_label` crown reverted to argmax | 12 failed |
| M5 `key_drivers` reverted to impact sort | 6 failed |
| M6b `factor-dominance.ts` reverted to **pre-S1b bytes** | 3 failed |
| M7 `top_drivers` reverted to stamp-only | 3 failed |
| M8 facts rank reverted to positional | 1 failed |
| M9 new unregistered numeric quantity added | 1 failed |
| M10 register entry made stale (field renamed) | 2 failed |
| M11 derivation stops recursing into nested literals | 2 failed |
| M12 exact-tie relabelled provisional | 3 failed |
| M13 fail-honest broken (`?? 0`) | 1 failed |

**Reported honestly:** my first M6 was **malformed** — I restored the internal sort but left `factors.slice(1)`, so `top1` fell inside its own rival set and the gate self-suppressed. It showed 0 failures. That was a bad mutant, not a weak test; **M6b** reverts the whole file to its pre-S1b bytes and bites.

## §3.2 — the derived producer register

`tools/derive-driver-quantities.mjs` extracts, **by AST**, every numeric field on `FactorSensitivityResultV3` and `EdgeSensitivityResultV3` (14, including one nested a level down inside an inline object literal). `src/lib/driver-quantity-register.ts` declares `{role, disposition, unit, sign, note}` for each. The gate fails in **both** directions — an unregistered quantity and a stale entry — and **UNPARSEABLE fails loud**: a missing file or renamed type *throws*, never returns an empty domain that would make the gate pass by testing nothing. Same instrument and same `typescript` dependency as the existing `tools/gen-structural-keys.mjs`. Exemptions are **emitted as data** (empty today, and the emptiness is the claim).

## The other two S1-review LOWs, ridden

- **ISL-only-path `lever_policy` wording** — `lever_policy` names the **predicate**, not the treatment, and the treatment differs by path: levers are *demoted* on the graph path and *removed upstream* on the ISL-only fallback. Now stated, with the consequence spelled out: **`lever_ids: []` means "no lever is IN this order", never "this decision has no levers".**
- **The latent `factorSensitivitySource ?? 'isl'` default** — `SensitivityData.factorSensitivitySource` and `.structuralLeverIds` are now **required**, so the only place the value can be absent is the genuine raw-ISL fallback branch (where `'isl'` is a derived fact, not a default). A future path omitting it is now a compile error instead of a silently wrong `basis`.

---

## Gates

| Gate | Result |
|---|---|
| `bash scripts/pre-push-validate.sh` | ✅ **PASS 6/6** |
| `npm test` | ✅ **6318 passed, 0 failed** (583 files) |
| `npm run typecheck` | ✅ clean |
| `npm run spec:lint` | ✅ 0 errors (4 pre-existing warnings) |
| `node tools/gen-structural-keys.mjs --check` | ✅ up to date |
| **Baseline `36b3309` in a separate clone** | ✅ 6256 passed, 0 failed — so every delta is mine |

### Known reds, re-derived at these bytes rather than cited

- **`validate-structure` — RED, and pre-existing.** This PR touches `contracts/openapi.yaml` so the job will run. Re-proven against the pristine baseline: `tools/validate-openapi-structure.js` **passes on both**; the red is the Redocly step, at **37 errors / 28 warnings on baseline and 37 errors / 28 warnings on this branch**, with an **empty delta on the finding set**.
- **`npm run lint` — 86 warnings, 0 errors, on baseline AND branch.** Unchanged; nothing absorbed, nothing added.
- **Branch protection re-derived at push time:** `HTTP 404 "Branch not protected"` ⇒ `staging` is unprotected, so the push is the gate.
- One flake observed and dismissed with evidence: `tests/rate-limit.ipv6.test.ts` timed out in a server-spawn hook on one pre-push run; it passes in isolation on **both** this branch and the pristine baseline, and the re-run was clean.

---

## What a reviewer should attack

1. **The chosen form (relative, not absolute).** The max-normalisation argument is the whole case; if `influence_score`'s normaliser is ever changed, this reasoning needs redoing.
2. **`dominant_factor`'s strongest-rival comparison** — the one place the fix could have introduced a *new* fabrication, and the reason it is not `factors[1]`.
3. **Crowning rank 1 when its `influence_score` is absent.** Deliberate: `'biggest'` is now a rank claim, and the producer *has* ranked those rows. The row still carries no magnitude band. Pinned, and flagged as a behaviour change.
4. **Whether `top_drivers` should have kept the `|elasticity|` sort within non-levers.** It is value-identical on the golden; I dropped the second sort because "PLoT owns exactly one ordering" is the point of the slice.

**Do not merge without review.** Deploys to staging on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
