### PR TITLE
docs(policy-tree-validation): correct header claiming a deleted route is "registered and live"

### DIFF
--- a/src/util/policy-tree-validation.ts
+++ b/src/util/policy-tree-validation.ts
@@ -16,9 +16,43 @@
  * This is the same defect class PR #265 fixed for `sequential_metadata`. That
  * fix made `validateSequentialGraph` total and gave it a home in
  * `src/util/sequential-validation.ts`; this is its sibling, and it lives beside
- * it for the same reason — `/v1/analysis/policy-tree` is registered and live, so
- * a second consumer of a policy tree is foreseeable, and it must not have to
- * re-validate by hand or re-derive the `{code, field, message}` envelope.
+ * it for the same reason: a policy tree arrives as untrusted wire input whose
+ * declared TypeScript type is not enforced at the wire, so the check belongs
+ * somewhere a consumer can call rather than re-validate by hand and re-derive
+ * the `{code, field, message}` envelope.
+ *
+ * ## Why this module exists — and it is NOT the route named below
+ *
+ * This module validates the policy-tree SHAPE for **`/v1/explain/policy`**.
+ * That is its entire reason to exist, and that route is the SOLE consumer:
+ * `src/routes/v1/explain-policy.ts` is the only importer of
+ * `validatePolicyTreeShape` in the repo (complete manifest, derived at
+ * `05529e42`: one `import`, one call site, two `Precondition:` references).
+ * `/v1/explain/policy` is registered and auth-gated and is NOT affected by the
+ * deletion recorded below — do not conflate the two routes.
+ *
+ * ## ⚠ CORRECTED 28 Jul 2026 — this header used to justify itself with a route
+ * ## that no longer exists
+ *
+ * The paragraph above previously read *"`/v1/analysis/policy-tree` is
+ * registered and live, so a second consumer of a policy tree is foreseeable"*.
+ * **That claim was false.** `/v1/analysis/policy-tree` was deleted as vacuous
+ * on 26 Jul 2026 — it produced no option-discriminating output, and ISL owns
+ * the real sequential capability. `src/routes/v1/types/proxy.types.ts`,
+ * `src/util/sequential-validation.ts`, `src/trust/types.ts` and the Phase-4
+ * tests all recorded that deletion; this file alone kept the pre-deletion
+ * sentence, so the module's stated justification outlived the thing it named.
+ *
+ * Live-probed 28 Jul 2026 against staging tip `05529e42`: `GET` and `POST`
+ * `/v1/analysis/policy-tree` → **404**, and `/v1/analysis/sequential` → **404**,
+ * against positive control `POST /v1/run` → 401 (the gate is real, so 404 is
+ * absence and not an auth artefact) and negative control
+ * `POST /v1/does-not-exist-xyz` → 404.
+ *
+ * **Do not "restore" `/v1/analysis/policy-tree` on the strength of finding its
+ * name here.** It was removed deliberately, nothing in this module depends on
+ * it, and this module is not orphaned by its removal: the foreseen "second
+ * consumer" is not what keeps this code alive — `/v1/explain/policy` is.
  *
  * ## Layering
  *


### PR DESCRIPTION
Record-integrity fix. `src/util/policy-tree-validation.ts` justified its own existence with a route that no longer exists.

## The stale claim

Header line 19 read: *"`/v1/analysis/policy-tree` is registered and live, so a second consumer of a policy tree is foreseeable"*.

That route was **deleted as vacuous on 26 Jul 2026** (no option-discriminating output; ISL owns the real sequential capability). Live-probed 28 Jul 2026 at staging tip `05529e42`:

| Probe | Result |
|---|---|
| `GET`+`POST /v1/analysis/policy-tree` | **404** |
| `GET`+`POST /v1/analysis/sequential` | **404** |
| positive control `POST /v1/run` | 401 (gate is real, so 404 = absence, not auth) |
| negative control `POST /v1/does-not-exist-xyz` | 404 |

## The util is NOT orphaned — the code stays

The deleted route was never its consumer. `/v1/explain/policy` is, it still exists, and it is auth-gated. Complete importer manifest derived at `05529e42` — `src/routes/v1/explain-policy.ts` is the **sole** importer of `validatePolicyTreeShape`:

- `:14` import - `:325` call site - `:150`, `:201` `Precondition:` references

The header now states that true reason, and explicitly warns against "restoring" the deleted route on the strength of finding its name in this file.

## Repo-wide sweep — this was the only stale instance

Every other mention already records the deletion correctly:

| Location | Verdict |
|---|---|
| `src/util/policy-tree-validation.ts:19` | **STALE — fixed here** |
| `src/util/sequential-validation.ts:19` | correct (records deletion) |
| `src/trust/types.ts:689` | correct (records deletion) |
| `src/routes/v1/types/proxy.types.ts:879` | correct (records deletion) |
| `tests/phase4-proxy.test.ts:6` | correct (records deletion) |
| `tests/sequential-malformed-stages.regression.test.ts:14` | correct (records deletion) |
| `contracts/openapi.yaml:4526` | correct — refers to **ISL** sequential, not a PLoT route |
| `tests/fixtures/isl-pinned/isl-openapi.json:7130` | correct — ISL pinned spec |

**The OpenAPI spec is clean**: `contracts/openapi.yaml` documents neither deleted route as a PLoT path (verified against the full list of path keys). `"registered and live"` appears exactly once in the repo — the line fixed here.

Sweep scope: `src`, `tests`, `docs`, `contracts`, `tools`, `evidence`, `scripts`, `handoff`, `tmp_release`, `vendor`, and all root files. Deliberately excluded: `.tooling/` (vendored Node toolchain, 4,728 C headers) and `artifact/` (dated Evidence-Packs from Sept-Oct 2025 — immutable historical records that predate the deletion and must not be retro-edited).

## Evidence

- **typecheck** (`tsc -p tsconfig.json --noEmit`): exit 0, **0 errors**
- **lint**: 86 warnings / 0 errors — identical to the pre-existing standing red; the edited file contributes **zero**
- **targeted suites green**: 4 files, **55 tests** passed
- **Comment-only**: the diff contains **zero** non-comment lines (mechanically checked), and the block comment is balanced
- **MUTATION CHECK** (throwaway worktree *outside* the repo root, removed before gates): neutralising the `validatePolicyTreeShape` call in `explain-policy.ts` turns **12 tests RED** in `explain-policy-malformed-tree.regression.test.ts` — proving the util is load-bearing, not merely imported

This PR does not touch `contracts/`, so the standing `validate-structure` spec-touching red should not apply.

Held for orchestrator review.

Generated with [Claude Code](https://claude.com/claude-code)