### PR TITLE
DO NOT MERGE — fix(plot) 2.165a/b: un-invert fallback switch_probability, repair release.yml, bound withdrawn-route bodies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
 
       - name: Test
         run: npm test
-        env:
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/src/integrations/isl/adapters/robustness-analysis.ts
+++ b/src/integrations/isl/adapters/robustness-analysis.ts
@@ -575,6 +575,69 @@ export function createFallbackRobustnessAnalysis(
  *
  * Used when ISL call fails but we have local computeSensitivityAll results.
  *
+ * ✅ FABRICATION REMOVED — `switch_probability` on BOTH arms (ROADMAP 2.165a,
+ * 2026-07-30). This is the residue of the 2.160 fix: that lane corrected
+ * `normalizeRobustEdge` and the `NormalizedEdgeInfo` doc-comment (which now
+ * reads "HIGHER MEANS MORE FRAGILE") but did not reach this fallback path,
+ * where the identical inverted reading was still live.
+ *
+ * WHAT USED TO BE HERE — inverted on BOTH arms, in opposite directions:
+ *
+ *   fragile_edges  selected by |elasticity| > 0.5,  assigned
+ *                  `1 - Math.min(1, Math.abs(elasticity))`
+ *                  // comment: "Higher elasticity = lower stability"
+ *                  → the MORE fragile the edge, the LOWER its
+ *                    switch_probability. At |elasticity| = 1 — maximally
+ *                    fragile — it emitted 0, the SAFEST value on the scale.
+ *   robust_edges   selected by |elasticity| <= 0.2, assigned `1`
+ *                  // comment: "Robust edges have full stability"
+ *                  → the MOST robust edges got the MAXIMUM of the fragility
+ *                    scale, the most alarming value available. This is
+ *                    byte-for-byte the fabrication #290 removed from
+ *                    `normalizeRobustEdge` above, in a second location.
+ *
+ * ROOT CAUSE: both comments reason in "stability"; the field means FRAGILITY.
+ * `switch_probability` is the probability that flipping the edge SWITCHES the
+ * recommended option, so "full stability" is switch_probability ≈ 0, not 1. The
+ * authority for the direction is executable, not prose: `classifyEdgeSeverity`
+ * (>0.7 critical, >0.5 error) and the doctrine-013 `deriveFragileEdgeVisible`
+ * gate (`sp > 0.15`) are both monotonically INCREASING in this field, and
+ * `EnrichmentRobustnessEdgeSchema` in @talchain/schemas states it in the
+ * contract itself: "Higher means MORE fragile".
+ *
+ * WHY OMIT RATHER THAN RE-ORIENT — the decision, and its cost:
+ *   1. WRONG QUANTITY, not merely wrong sign. `switch_probability` is an ISL
+ *      decision-theoretic output. `elasticity` from PLoT's local
+ *      `computeSensitivityAll` is a sensitivity heuristic — different quantity,
+ *      different units, uncalibrated to any probability. `min(1, |elasticity|)`
+ *      would be correctly ORIENTED and still manufactured; re-orienting buys a
+ *      number that is no more measured than the one being deleted.
+ *   2. IT WOULD PUBLISH DERIVED VERDICTS. Any value here feeds
+ *      `classifyEdgeSeverity` and the doctrine-013 `visible` gate, so a
+ *      re-oriented heuristic would emit `severity: 'critical'` and
+ *      `visible: true` — badges that assert a computed switch probability that
+ *      was never computed. Absent derives NEITHER (both helpers return
+ *      `undefined`), which is the honest outcome.
+ *   3. ON THIS PATH THE ABSENCE IS LITERALLY TRUE. ISL is unavailable; nothing
+ *      computed a switch probability. The house rule — absent ≠ 0 ≠ 1, absent
+ *      means NOT COMPUTED — is exactly the right statement to make.
+ *   4. NOTHING REAL IS LOST. The heuristic's actual finding is *which edges
+ *      look fragile*, and that survives intact as array MEMBERSHIP (the > 0.5 /
+ *      <= 0.2 filters are unchanged), alongside the already-present
+ *      `edges_provenance: 'plot:computeSensitivityAll'`,
+ *      `edge_sensitivity_status: 'fallback_local_heuristic'` and
+ *      `source: 'unavailable'`, which already declare this result a local
+ *      heuristic. `overall_robustness` and `robustness_score` are also
+ *      unchanged — see the note on `deriveRobustnessScore` for why their
+ *      superficially-similar inversion is CORRECT.
+ *
+ * CONTRACT-LEGALITY: `switch_probability` is optional from @talchain/schemas
+ * 0.28.0 (this repo vendors 0.30.0), and only `edge_id`/`from_id`/`to_id` are
+ * required — so unlike the 2.160 case there was no egress-contract blocker to
+ * clear. Pinned by tests/gates/numeric-safety-deep-scan.test.ts §D4, including
+ * the inverse assertions (the old values asserted ABSENT) and a positive
+ * control proving both arms are still populated.
+ *
  * @param localEdges - Edge sensitivity from local heuristic
  * @param latencyMs - Local computation latency
  * @returns Result with local edge sensitivity
@@ -598,13 +661,16 @@ export function createLocalHeuristicResult(
     // Robustness - derive from local edges
     overall_robustness: deriveRobustnessFromEdges(localEdges),
     robustness_score: deriveRobustnessScore(localEdges),
+    // switch_probability is deliberately OMITTED on BOTH arms — see the
+    // ✅ FABRICATION REMOVED note on this function for the full reasoning.
+    // Array MEMBERSHIP still carries the heuristic's actual finding; only the
+    // manufactured probability is gone.
     fragile_edges: localEdges
       .filter((e) => Math.abs(e.elasticity) > 0.5)
       .map((e): NormalizedEdgeInfo => ({
         edge_id: e.edge_id,
         from_id: e.from,
         to_id: e.to,
-        switch_probability: 1 - Math.min(1, Math.abs(e.elasticity)), // Higher elasticity = lower stability
       })),
     robust_edges: localEdges
       .filter((e) => Math.abs(e.elasticity) <= 0.2)
@@ -612,7 +678,6 @@ export function createLocalHeuristicResult(
         edge_id: e.edge_id,
         from_id: e.from,
         to_id: e.to,
-        switch_probability: 1, // Robust edges have full stability
       })),
 
     // Metadata
@@ -622,7 +687,14 @@ export function createLocalHeuristicResult(
 }
 
 /**
- * Derive robustness label from edge sensitivity scores
+ * Derive robustness label from edge sensitivity scores.
+ *
+ * ORIENTATION CHECKED, NOT INVERTED (ROADMAP 2.165a). High elasticity → the
+ * 'fragile' label, which is correct: this field is ROBUSTNESS-oriented and names
+ * its own direction, so there is no scale to confuse. Deliberately recorded
+ * because the sibling `switch_probability` derivations on this same fallback
+ * path WERE inverted, and the next reader should not have to re-derive that
+ * these two are fine.
  */
 function deriveRobustnessFromEdges(
   edges: EdgeSensitivityEntry[]
@@ -637,13 +709,27 @@ function deriveRobustnessFromEdges(
 }
 
 /**
- * Derive robustness score from edge sensitivity
+ * Derive robustness score from edge sensitivity.
+ *
+ * ORIENTATION CHECKED, NOT INVERTED (ROADMAP 2.165a) — and this is the function
+ * that explains how 2.165a happened. The `1 - avgElasticity` below is CORRECT:
+ * `robustness_score` is ROBUSTNESS-oriented, so the field name flips the scale
+ * relative to elasticity and the inversion is required.
+ *
+ * The bug was that same idiom COPIED onto `switch_probability`, which is
+ * FRAGILITY-oriented — same direction as elasticity — so there the `1 -` turned
+ * a correct reading into an inverted one. Two adjacent fields, opposite
+ * orientations, one shared inversion habit. When adding a field here, ask which
+ * way its NAME points before reusing this expression.
+ *
+ * Both this and `deriveRobustnessFromEdges` are pinned against a re-flip by
+ * the "shared-inversion check" case in numeric-safety-deep-scan §D4.
  */
 function deriveRobustnessScore(edges: EdgeSensitivityEntry[]): number {
   if (edges.length === 0) return 0.5;
 
   const avgElasticity = edges.reduce((sum, e) => sum + Math.abs(e.elasticity), 0) / edges.length;
 
-  // Invert: high elasticity = low robustness
+  // Invert: high elasticity = low robustness (correct — see the note above)
   return Math.max(0, Math.min(1, 1 - avgElasticity));
 }

--- a/src/routes/v1/analysis-conditional-recommend.ts
+++ b/src/routes/v1/analysis-conditional-recommend.ts
@@ -36,10 +36,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, VACUOUS_ANALYSIS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, VACUOUS_ANALYSIS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerConditionalRecommendRoute(app: FastifyInstance) {
-  app.post('/v1/analysis/conditional-recommend', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/analysis/conditional-recommend', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/analysis/conditional-recommend', VACUOUS_ANALYSIS_REASON)
   );
 }

--- a/src/routes/v1/analysis-dominance.ts
+++ b/src/routes/v1/analysis-dominance.ts
@@ -36,10 +36,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, VACUOUS_ANALYSIS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, VACUOUS_ANALYSIS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerDominanceAnalysisRoute(app: FastifyInstance) {
-  app.post('/v1/analysis/dominance', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/analysis/dominance', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/analysis/dominance', VACUOUS_ANALYSIS_REASON)
   );
 }

--- a/src/routes/v1/analysis-multi-criteria.ts
+++ b/src/routes/v1/analysis-multi-criteria.ts
@@ -36,10 +36,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, VACUOUS_ANALYSIS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, VACUOUS_ANALYSIS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerMultiCriteriaAnalysisRoute(app: FastifyInstance) {
-  app.post('/v1/analysis/multi-criteria', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/analysis/multi-criteria', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/analysis/multi-criteria', VACUOUS_ANALYSIS_REASON)
   );
 }

--- a/src/routes/v1/analysis-optimise.ts
+++ b/src/routes/v1/analysis-optimise.ts
@@ -64,10 +64,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, VACUOUS_ANALYSIS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, VACUOUS_ANALYSIS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerAnalysisOptimiseRoute(app: FastifyInstance) {
-  app.post('/v1/analysis/optimise', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/analysis/optimise', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/analysis/optimise', VACUOUS_ANALYSIS_REASON)
   );
 }

--- a/src/routes/v1/analysis-pareto.ts
+++ b/src/routes/v1/analysis-pareto.ts
@@ -36,10 +36,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, VACUOUS_ANALYSIS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, VACUOUS_ANALYSIS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerParetoAnalysisRoute(app: FastifyInstance) {
-  app.post('/v1/analysis/pareto', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/analysis/pareto', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/analysis/pareto', VACUOUS_ANALYSIS_REASON)
   );
 }

--- a/src/routes/v1/analysis-risk-adjust.ts
+++ b/src/routes/v1/analysis-risk-adjust.ts
@@ -36,10 +36,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, VACUOUS_ANALYSIS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, VACUOUS_ANALYSIS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerRiskAdjustRoute(app: FastifyInstance) {
-  app.post('/v1/analysis/risk-adjust', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/analysis/risk-adjust', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/analysis/risk-adjust', VACUOUS_ANALYSIS_REASON)
   );
 }

--- a/src/routes/v1/analysis-thresholds.ts
+++ b/src/routes/v1/analysis-thresholds.ts
@@ -36,10 +36,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, VACUOUS_ANALYSIS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, VACUOUS_ANALYSIS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerThresholdsRoute(app: FastifyInstance) {
-  app.post('/v1/analysis/thresholds', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/analysis/thresholds', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/analysis/thresholds', VACUOUS_ANALYSIS_REASON)
   );
 }

--- a/src/routes/v1/counterfactual.ts
+++ b/src/routes/v1/counterfactual.ts
@@ -90,10 +90,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, PLACEHOLDER_ESTIMATE_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, PLACEHOLDER_ESTIMATE_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerCounterfactualRoute(app: FastifyInstance) {
-  app.post('/v1/counterfactual', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/counterfactual', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/counterfactual', PLACEHOLDER_ESTIMATE_REASON)
   );
 }

--- a/src/routes/v1/refuse-unavailable.ts
+++ b/src/routes/v1/refuse-unavailable.ts
@@ -58,6 +58,50 @@ export const PLACEHOLDER_ESTIMATE_REASON =
   'route published placeholder arithmetic over request inputs, not a computed estimate — no model was evaluated and the graph was never read; see ROADMAP 2.105';
 
 /**
+ * Body-size ceiling for a withdrawn route, in bytes.
+ *
+ * WHY A WITHDRAWN ROUTE NEEDS ITS OWN LIMIT (efficiency review, 2026-07-30).
+ * All ten withdrawn routes registered with NO route options, so the
+ * server-wide `bodyLimit` (128KB) applied to every one of them. That is pure
+ * waste on a path that reads no body at all: Fastify parses the ENTIRE payload
+ * before any `preHandler` runs, so each spammed 128KB request cost roughly
+ * 505µs of parsing and ~131KB of garbage to produce a response whose content
+ * does not depend on a single byte of it.
+ *
+ * AND THE RATE LIMITER CANNOT SHIELD IT. The limiter is a `preHandler`, so its
+ * 429 is decided AFTER the parse has already happened — the cost is paid before
+ * the request can be rejected. A route-level limit is the only control that
+ * acts at the parser, which is where the cost is. This is the same posture the
+ * live routes already take (`/v1/diff`, `/v1/critique`: `bodyLimit: 64 * 1024`);
+ * withdrawn routes can be far tighter because they read nothing.
+ *
+ * WHY 1KB RATHER THAN 0. A withdrawn route should still answer its typed 501 to
+ * an ordinary, well-formed probe — that refusal, and the caller telemetry it
+ * records, is the entire reason the path is still mounted. 1KB admits a normal
+ * probe and turns a spammed oversized body into a cheap 413 at the parser.
+ *
+ * A CONSEQUENCE WORTH KNOWING: above this limit a withdrawn route answers 413,
+ * not the 501 refusal, and `recordRefusal` does NOT run for it — the request
+ * never reaches the handler. That is the correct trade (the caller learns the
+ * body was rejected, and an oversized body is not a capability probe), but it
+ * does mean the refusal counters undercount abusive traffic by construction.
+ * Pinned by the bodyLimit block in tests/analysis-routes.refusal.test.ts.
+ */
+export const WITHDRAWN_ROUTE_BODY_LIMIT_BYTES = 1024;
+
+/**
+ * Shared Fastify route options for every withdrawn route.
+ *
+ * ONE object, ten registrations — deliberately not ten copies of the same
+ * literal. A hand-repeated limit is a mirror that drifts the moment one route is
+ * edited; importing a single const means the value cannot disagree with itself,
+ * and the test can assert against the same const rather than a copy of it.
+ */
+export const WITHDRAWN_ROUTE_OPTIONS = {
+  bodyLimit: WITHDRAWN_ROUTE_BODY_LIMIT_BYTES,
+} as const;
+
+/**
  * Refuse, and record who asked.
  *
  * Instrumentation is the point of keeping the route mounted, so it happens

--- a/src/routes/v1/score.ts
+++ b/src/routes/v1/score.ts
@@ -43,10 +43,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, FABRICATED_NUMERICS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, FABRICATED_NUMERICS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerScoreRoute(app: FastifyInstance) {
-  app.post('/v1/score', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/score', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/score', FABRICATED_NUMERICS_REASON)
   );
 }

--- a/src/routes/v1/sensitivity.ts
+++ b/src/routes/v1/sensitivity.ts
@@ -38,10 +38,10 @@
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { refuseUnavailable, FABRICATED_NUMERICS_REASON } from './refuse-unavailable.js';
+import { refuseUnavailable, FABRICATED_NUMERICS_REASON, WITHDRAWN_ROUTE_OPTIONS } from './refuse-unavailable.js';
 
 export async function registerSensitivityRoute(app: FastifyInstance) {
-  app.post('/v1/sensitivity', async (req: FastifyRequest, reply: FastifyReply) =>
+  app.post('/v1/sensitivity', WITHDRAWN_ROUTE_OPTIONS, async (req: FastifyRequest, reply: FastifyReply) =>
     refuseUnavailable(req, reply, '/v1/sensitivity', FABRICATED_NUMERICS_REASON)
   );
 }

--- a/tests/analysis-routes.refusal.test.ts
+++ b/tests/analysis-routes.refusal.test.ts
@@ -47,6 +47,7 @@ import { createServer } from '../src/createServer.js';
 import {
   getRouteCallerSnapshot,
   resetRouteCallerTelemetry,
+  REFUSED_ROUTES,
 } from '../src/observability/routeCallerTelemetry.js';
 import { WITHDRAWN_ROUTE_BODY_LIMIT_BYTES } from '../src/routes/v1/refuse-unavailable.js';
 
@@ -344,6 +345,32 @@ describe.each(WITHDRAWN)('$route — withdrawn', ({ route, payload, reason }) =>
 });
 
 describe('cross-cutting', () => {
+  it('PARITY: these fixtures cover exactly the declared withdrawn-route set (trap 12)', () => {
+    // The third of three hand-maintained copies of the withdrawn-route set (the
+    // others being the ten app.post registrations and REFUSED_ROUTES in the
+    // telemetry module). Without this, adding an eleventh withdrawn route and
+    // forgetting it HERE means nothing ever asserts that it refuses — and every
+    // test in this file still passes, so the omission reads as green.
+    //
+    // Compared against the already-exported REFUSED_ROUTES rather than a new
+    // list, so this introduces no fourth copy. The registrations-vs-REFUSED_ROUTES
+    // half of the parity is derived from source in
+    // tests/gates/withdrawn-route-parity.test.ts.
+    const covered = WITHDRAWN.map((w) => w.route).sort();
+    const declared = [...REFUSED_ROUTES].sort();
+
+    expect(
+      declared.filter((r) => !covered.includes(r)),
+      'declared withdrawn but NOT covered by any fixture here — nothing proves it refuses',
+    ).toEqual([]);
+    expect(
+      covered.filter((r) => !declared.includes(r)),
+      'a fixture here targets a route not declared withdrawn',
+    ).toEqual([]);
+    expect(covered).toEqual(declared);
+    expect(new Set(covered).size, 'duplicate fixture for the same route').toBe(covered.length);
+  });
+
   it('POSITIVE CONTROL: a surviving route on the same app still answers 200', async () => {
     // Without this, a server that 501'd everything would pass every assertion
     // above. /v1/limits is a live, unrelated route.

--- a/tests/analysis-routes.refusal.test.ts
+++ b/tests/analysis-routes.refusal.test.ts
@@ -48,6 +48,7 @@ import {
   getRouteCallerSnapshot,
   resetRouteCallerTelemetry,
 } from '../src/observability/routeCallerTelemetry.js';
+import { WITHDRAWN_ROUTE_BODY_LIMIT_BYTES } from '../src/routes/v1/refuse-unavailable.js';
 
 /** The seven VACUOUS routes, each with a request that was well-formed for it. */
 const VACUOUS: Array<{ route: string; payload: Record<string, unknown> }> = [
@@ -367,5 +368,103 @@ describe('cross-cutting', () => {
     // The pre-change thresholds route alone ran 2 sweeps x 2 options of Monte
     // Carlo. Ten refusals must be trivially fast.
     expect(Date.now() - t0).toBeLessThan(2000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route-level bodyLimit (efficiency review, 2026-07-30).
+//
+// All ten registered with NO route options, so the server-wide 128KB bodyLimit
+// applied to routes that read no body at all. Fastify parses the whole payload
+// BEFORE any preHandler, so the rate limiter cannot shield this: its 429 is
+// decided after the cost has already been paid. The limit has to act at the
+// parser, which is what a route-level bodyLimit does.
+//
+// The route list is REUSED from WITHDRAWN above rather than re-listed here — a
+// second hand-written list of the same ten routes is a mirror that drifts, and
+// the drift would read as green (a route dropped from the copy is simply never
+// checked). Likewise the size is imported from the source const, not retyped.
+// ---------------------------------------------------------------------------
+describe('withdrawn routes — route-level bodyLimit', () => {
+  /** Imported, never retyped: a copied literal could silently disagree. */
+  const LIMIT = WITHDRAWN_ROUTE_BODY_LIMIT_BYTES;
+
+  /** Comfortably over the limit, far under the 128KB server-wide default —
+   *  so a 413 here can ONLY come from the route-level limit. That is what makes
+   *  this test prove the route option rather than the server default. */
+  const oversized = JSON.stringify({ pad: 'x'.repeat(LIMIT * 8) });
+
+  it.each(WITHDRAWN.map((w) => w.route))(
+    '%s answers 413 for an oversized body, and the refusal handler never runs',
+    async (route) => {
+      const res = await app.inject({
+        method: 'POST',
+        url: route,
+        headers: { 'content-type': 'application/json' },
+        payload: oversized,
+      });
+
+      expect(res.statusCode, `${route} must reject at the parser`).toBe(413);
+
+      // The handler is what emits the typed refusal and records it. Its absence
+      // is the whole point: the request was rejected at the parser, before
+      // reaching it, which is where the saving is.
+      expect(res.body).not.toContain('ANALYSIS_UNAVAILABLE');
+      expect(res.json().code, 'a 413 is a BAD_INPUT, not a capability refusal').toBe('BAD_INPUT');
+
+      // ⚠ WHICH COUNTER PROVES "THE HANDLER NEVER RAN" — the two are NOT
+      // interchangeable, and this test was first written against the wrong one.
+      //
+      //   refused_total          incremented ONLY by recordRefusal(), i.e. only
+      //                          when the refusal HANDLER executes. This is the
+      //                          one that proves the handler was skipped.
+      //   refused_routes.by_route derived in getRouteCallerSnapshot() from the
+      //                          general REQUEST counters, filtered to the
+      //                          withdrawn-route set. It counts REQUESTS that
+      //                          arrived, handler or no handler — so it is 1
+      //                          after a 413, entirely correctly: the request
+      //                          did arrive and telemetry did see it.
+      //
+      // Asserting by_route[route] was undefined here failed against correct
+      // code. Keeping the distinction written down because "the request was
+      // counted but the refusal was not" is precisely the state a route-level
+      // bodyLimit creates, and a future reader will reach for the wrong counter.
+      expect(getRouteCallerSnapshot().refused_total, 'no refusal was recorded').toBe(0);
+      expect(
+        getRouteCallerSnapshot().refused_routes.by_route[route],
+        'the request itself is still observed — only the refusal is skipped',
+      ).toBe(1);
+    },
+  );
+
+  it('POSITIVE CONTROL: a body UNDER the limit still gets the 501 refusal and is still counted', async () => {
+    // Trap 13. Without this, a route that 413'd (or 404'd) everything would pass
+    // every assertion above, and a limit set absurdly low — or to 0 — would look
+    // like a successful optimisation while silently withdrawing the refusal and
+    // the caller telemetry that are the reason these paths stay mounted.
+    for (const { route, payload } of WITHDRAWN) {
+      const body = JSON.stringify(payload);
+      expect(
+        Buffer.byteLength(body),
+        `${route} fixture must be under the ${LIMIT}B limit for this control to mean anything`,
+      ).toBeLessThan(LIMIT);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: route,
+        headers: { 'content-type': 'application/json' },
+        payload: body,
+      });
+      expect(res.statusCode, `${route} must still refuse, not 413`).toBe(501);
+      expect(res.json().code).toBe('ANALYSIS_UNAVAILABLE');
+    }
+    expect(getRouteCallerSnapshot().refused_total).toBe(WITHDRAWN.length);
+  });
+
+  it('the limit is genuinely BELOW the server-wide default — otherwise it changes nothing', () => {
+    // A route-level limit equal to or above the server default is decoration:
+    // the parse cost this change exists to remove would still be paid in full.
+    expect(LIMIT).toBeLessThan(128 * 1024);
+    expect(LIMIT).toBeGreaterThan(0);
   });
 });

--- a/tests/cil-phase0-fragile-edges.test.ts
+++ b/tests/cil-phase0-fragile-edges.test.ts
@@ -269,7 +269,12 @@ describe('CIL Phase 0 — Task 1: fragile_edges shape consistency', () => {
       expect(typeof fe.edge_id).toBe('string');
       expect(typeof fe.from_id).toBe('string');
       expect(typeof fe.to_id).toBe('string');
-      expect(typeof fe.switch_probability).toBe('number');
+      // switch_probability is NOT part of this shape assertion any more
+      // (ROADMAP 2.165a). This line read `expect(typeof fe.switch_probability)
+      // .toBe('number')`, which pinned the PRESENCE of a value that was
+      // fabricated from elasticity on an inverted scale. The object-vs-string
+      // claim this test exists to make is carried by the three id fields above.
+      expect(fe).not.toHaveProperty('switch_probability');
     });
 
     it('createLocalHeuristicResult with no fragile edges → []', () => {

--- a/tests/gates/numeric-safety-deep-scan.test.ts
+++ b/tests/gates/numeric-safety-deep-scan.test.ts
@@ -997,12 +997,18 @@ describe('absence gate §C · POSITIVE CONTROL — a genuine ISL verdict still r
 //       /v1/run only.
 //   D3  normalizeRobustEdges — `?? 1`, plus its string-format twin which
 //       hardcoded `switch_probability: 1` from a bare "from->to" string.
+//   D4  createLocalHeuristicResult — the ISL-unavailable local-heuristic
+//       fallback, which derived `switch_probability` from `elasticity` on an
+//       INVERTED scale on BOTH arms (ROADMAP 2.165a). Same root cause as D3:
+//       the code reasoned in "stability" while the field means FRAGILITY.
 // ---------------------------------------------------------------------------
 
 const { enrichFactorSensitivity } =
   await import('../../src/integrations/isl/adapters/robustness-enrichment.js');
-const { adaptRobustnessAnalysisResponse, normalizeRobustEdges, createFallbackRobustnessAnalysis } =
+const { adaptRobustnessAnalysisResponse, normalizeRobustEdges, createFallbackRobustnessAnalysis, createLocalHeuristicResult } =
   await import('../../src/integrations/isl/adapters/robustness-analysis.js');
+const { classifyEdgeSeverity, deriveFragileEdgeVisible } =
+  await import('../../src/trust/edge-severity.js');
 
 const D_GRAPH: any = { nodes: [{ id: 'fac_price', label: 'Price' }], edges: [] };
 
@@ -1142,5 +1148,145 @@ describe('absence gate §D3 · robust edges never fabricate switch_probability',
     const out = normalizeRobustEdges([{ edge_id: 'x->y', switch_probability: 0.3 }] as any);
     expect(out.edges[0].switch_probability).toBe(0.3);
     expect(out.edges[0].edge_id).toBe('x->y');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §D4 · the ISL-unavailable LOCAL-HEURISTIC fallback never fabricates
+//        switch_probability — and never did so on an INVERTED scale.
+//        ROADMAP 2.165a, 2026-07-30.
+//
+// THE DEFECT (both arms of `createLocalHeuristicResult`):
+//
+//   fragile_edges  selected by |elasticity| > 0.5,  got `1 - min(1,|elasticity|)`
+//                  → the MOST fragile edge (|e|→1) got switch_probability → 0,
+//                    i.e. the LEAST fragile reading on the scale.
+//   robust_edges   selected by |elasticity| <= 0.2, got `1`
+//                  → the MOST robust edges got the MAXIMUM of the fragility
+//                    scale — the single most alarming value available.
+//
+// Both comments said "stability" ("lower stability", "full stability"). That is
+// the whole root cause: `switch_probability` is FRAGILITY-oriented, so reasoning
+// about it as stability inverts every derivation. It is the same inverted
+// reading behind the fabricated `1` that §D3 removed from normalizeRobustEdge.
+//
+// WHY OMIT RATHER THAN RE-ORIENT: `switch_probability` is *the probability that
+// flipping this edge switches the recommended option* — an ISL decision-theoretic
+// quantity. `elasticity` from PLoT's local `computeSensitivityAll` is a
+// sensitivity heuristic: different quantity, different units, uncalibrated to any
+// probability. A correctly-ORIENTED derivation would still be a manufactured
+// probability, and it would feed `classifyEdgeSeverity` and the doctrine-013
+// `visible` gate — so it would publish a 'critical' badge and visible=true
+// asserting a switch probability nobody computed. On this path ISL is
+// UNAVAILABLE, so "not computed" is literally true, and the house rule (absent
+// ≠ 0 ≠ 1) says absent is how that is said. The heuristic's actual finding —
+// which edges look fragile — is still carried, losslessly, by ARRAY MEMBERSHIP.
+// ---------------------------------------------------------------------------
+
+describe('absence gate §D4 · the local-heuristic fallback never fabricates switch_probability', () => {
+  /** |elasticity| 0.8 → fragile arm (>0.5); 0.1 → robust arm (<=0.2). */
+  const HEURISTIC_EDGES: any = [
+    { edge_id: 'fac_price::goal', from: 'fac_price', to: 'goal', elasticity: 0.8, interpretation: 'High sensitivity' },
+    { edge_id: 'fac_stable::goal', from: 'fac_stable', to: 'goal', elasticity: 0.1, interpretation: 'Low sensitivity' },
+  ];
+
+  it('the FRAGILE arm carries NO switch_probability (an elasticity heuristic is not a switch probability)', () => {
+    const out = createLocalHeuristicResult(HEURISTIC_EDGES, 50);
+    expect(out.fragile_edges).toHaveLength(1);
+    expect(out.fragile_edges[0]).not.toHaveProperty('switch_probability');
+    expect(out.fragile_edges[0].switch_probability).toBeUndefined();
+  });
+
+  it('the ROBUST arm carries NO switch_probability — the fabricated `1` is asserted ABSENT', () => {
+    const out = createLocalHeuristicResult(HEURISTIC_EDGES, 50);
+    expect(out.robust_edges).toHaveLength(1);
+    expect(out.robust_edges[0]).not.toHaveProperty('switch_probability');
+    expect(Object.keys(out.robust_edges[0])).not.toContain('switch_probability');
+  });
+
+  it('RETRO-GUARD: no NUMBER reaches either arm, across the whole elasticity range', () => {
+    // ⚠ HOW THIS TEST WAS FIRST WRITTEN WRONG — kept because it is trap 13 in
+    // miniature, committed inside a control written to prevent trap 13. The
+    // first version asserted `expect(...switch_probability).not.toBe(0.2)` to
+    // pin the historical `1 - min(1,|elasticity|)` at |e|=0.8. That assertion is
+    // VACUOUS: in IEEE-754, `1 - 0.8` is 0.19999999999999996, NOT 0.2, so the
+    // exact-equality guard PASSED with the defect fully present. An
+    // absence/retro assertion over floats must never rest on `toBe`.
+    //
+    // The claim that actually matters is categorical, not numeric: NO number at
+    // all. Sweeping the range also covers the worst inversion, |elasticity| = 1
+    // — maximally fragile by the heuristic, which the old expression mapped to
+    // switch_probability 0, i.e. the SAFEST reading on the fragility scale.
+    for (const elasticity of [0.51, 0.6, 0.8, 0.95, 1, 1.5, -0.9]) {
+      const out = createLocalHeuristicResult(
+        [{ edge_id: 'a::b', from: 'a', to: 'b', elasticity, interpretation: '' }] as any, 0);
+      expect(out.fragile_edges, `|${elasticity}| must select the fragile arm`).toHaveLength(1);
+      expect(typeof out.fragile_edges[0].switch_probability, `fragile arm, elasticity=${elasticity}`).not.toBe('number');
+    }
+    for (const elasticity of [0, 0.05, 0.2, -0.2]) {
+      const out = createLocalHeuristicResult(
+        [{ edge_id: 'a::b', from: 'a', to: 'b', elasticity, interpretation: '' }] as any, 0);
+      expect(out.robust_edges, `|${elasticity}| must select the robust arm`).toHaveLength(1);
+      expect(typeof out.robust_edges[0].switch_probability, `robust arm, elasticity=${elasticity}`).not.toBe('number');
+    }
+  });
+
+  it('ORIENTATION AUTHORITY: severity and the doctrine-013 visible gate are both INCREASING in switch_probability', () => {
+    // This is the machine-checked form of the claim the fix rests on: HIGHER
+    // switch_probability = MORE fragile. It is why `1` on a robust edge was the
+    // most alarming possible value and why `1 - |elasticity|` on a fragile edge
+    // was the least. If a future lane re-orients these thresholds, this test —
+    // not prose — is what tells them §D4's reasoning has to be revisited.
+    expect(classifyEdgeSeverity(0.9)).toBe('critical');
+    expect(classifyEdgeSeverity(0.6)).toBe('error');
+    expect(classifyEdgeSeverity(0.1)).toBe('warning');
+    expect(deriveFragileEdgeVisible(0.9)).toBe(true);
+    expect(deriveFragileEdgeVisible(0.01)).toBe(false);
+    // ...and absent derives NEITHER, which is why omitting sp is safe here.
+    expect(classifyEdgeSeverity(undefined)).toBeUndefined();
+    expect(deriveFragileEdgeVisible(undefined)).toBeUndefined();
+  });
+
+  it('POSITIVE CONTROL: the heuristic still SELECTS — omission removed the number, not the finding', () => {
+    // Trap 13. Both §D4 absence assertions above would pass vacuously if the
+    // arrays were empty. Prove the fixture actually populates both arms, and
+    // that the surviving fields are intact, so the absence assertions are
+    // proving an absence *inside a present object*.
+    const out = createLocalHeuristicResult(HEURISTIC_EDGES, 50);
+    expect(out.fragile_edges.map((e: any) => e.edge_id)).toEqual(['fac_price::goal']);
+    expect(out.robust_edges.map((e: any) => e.edge_id)).toEqual(['fac_stable::goal']);
+    expect(out.fragile_edges[0].from_id).toBe('fac_price');
+    expect(out.fragile_edges[0].to_id).toBe('goal');
+    // The refusal is carried machine-readably, as on the D2 fallback.
+    expect(out.source).toBe('unavailable');
+    expect(out.edge_sensitivity_status).toBe('fallback_local_heuristic');
+    expect(out.edges_provenance).toBe('plot:computeSensitivityAll');
+  });
+
+  it('the ROBUSTNESS-oriented derivations on this same path are NOT inverted (shared-inversion check)', () => {
+    // Deliberate contrast, kept adjacent to the defect. `overall_robustness` and
+    // `robustness_score` are ROBUSTNESS-oriented, so their `1 - elasticity`
+    // inversion is CORRECT — the field name flips the scale. `switch_probability`
+    // is FRAGILITY-oriented, so the same idiom copied onto it is a bug. This test
+    // pins that the 2.165a fix did not "helpfully" flip the correct ones too.
+    const fragile = createLocalHeuristicResult(
+      [{ edge_id: 'a::b', from: 'a', to: 'b', elasticity: 0.9, interpretation: '' }] as any, 0);
+    expect(fragile.overall_robustness, 'high elasticity → fragile LABEL').toBe('fragile');
+    expect(fragile.robustness_score, 'high elasticity → LOW robustness score').toBeCloseTo(0.1, 5);
+
+    const robust = createLocalHeuristicResult(
+      [{ edge_id: 'a::b', from: 'a', to: 'b', elasticity: 0.2, interpretation: '' }] as any, 0);
+    expect(robust.overall_robustness).toBe('robust');
+    expect(robust.robustness_score, 'low elasticity → HIGH robustness score').toBeCloseTo(0.8, 5);
+  });
+
+  it('omitting it keeps the fallback response contract-legal under the vendored envelope', () => {
+    const out = createLocalHeuristicResult(HEURISTIC_EDGES, 50);
+    const assessment = assessEnrichmentContract({
+      robustness: { fragile_edges: out.fragile_edges, robust_edges: out.robust_edges },
+    });
+    expect(assessment.ok, 'omitted switch_probability must not violate the vendored envelope').toBe(
+      true,
+    );
   });
 });

--- a/tests/gates/withdrawn-route-parity.test.ts
+++ b/tests/gates/withdrawn-route-parity.test.ts
@@ -1,0 +1,175 @@
+/**
+ * DERIVE-OR-RED parity gate for the withdrawn-route set (trap 12, altitude
+ * sweep A-5). ROADMAP 2.165, 2026-07-30.
+ *
+ * THE DEFECT CLASS. The set of withdrawn routes existed in THREE independent
+ * hand-maintained copies, and nothing connected them:
+ *
+ *   1. THE REGISTRATIONS — ten `app.post('<path>', …)` calls across
+ *      src/routes/v1/*.ts, each also repeating its own path as the third
+ *      argument to `refuseUnavailable`. This is the only copy that is TRUE by
+ *      construction: it is what is actually mounted.
+ *   2. THE TELEMETRY SET — `REFUSED_ROUTES` in
+ *      src/observability/routeCallerTelemetry.ts, which decides whether a
+ *      request is counted in `refusedCounters` (with its own smaller cap) or in
+ *      the ordinary counters, and which routes appear in
+ *      `refused_routes.by_route` on /health.
+ *   3. THE TEST FIXTURES — the VACUOUS/FABRICATING/PLACEHOLDER arrays in
+ *      tests/analysis-routes.refusal.test.ts, i.e. what is actually PROVEN to
+ *      refuse.
+ *
+ * WHY THE DRIFT WOULD READ AS GREEN — which is what makes this worth a gate.
+ * Add an eleventh withdrawn route and register it (copy 1), and every existing
+ * test still passes. But:
+ *   - omit it from copy 2 and its traffic is filed in the ORDINARY counters, so
+ *     it never appears in `refused_routes` on /health — the caller telemetry
+ *     that is the entire stated reason for keeping these paths mounted rather
+ *     than deleting them is silently absent for the newest one;
+ *   - omit it from copy 3 and nothing ever asserts it refuses at all.
+ * Both failures are invisible: no test goes red, and /health looks healthy.
+ * This is the vitest-flags-mock / KNOWN_OLUMI_TOP_LEVEL_KEYS shape exactly —
+ * a list a human must remember to sync, whose drift always reads as green.
+ *
+ * THE FIX APPLIED HERE. Copy 1 is DERIVED, not listed: this gate scans the
+ * route sources for the registrations, so the side that is true by construction
+ * needs no maintenance and cannot drift. Copies 2 and 3 must remain declared —
+ * `REFUSED_ROUTES` is consumed inside the telemetry module that
+ * `refuse-unavailable` imports, so deriving it from the routes would be
+ * circular; and the fixtures carry per-route payloads and reasons that are real
+ * test data, not a mirror. So both are pinned to the derived set by parity
+ * assertions that RED on drift. No FOURTH list is introduced: every assertion
+ * here compares against the derived set or against the already-exported
+ * `REFUSED_ROUTES`.
+ *
+ * The companion assertion for copy 3 lives in analysis-routes.refusal.test.ts
+ * (its fixtures are local to that file), and is the same shape.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { REFUSED_ROUTES } from '../../src/observability/routeCallerTelemetry.js';
+
+const ROUTES_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/routes/v1',
+);
+
+/**
+ * Derive the withdrawn-route registrations from source.
+ *
+ * RULE: a file that calls `refuseUnavailable(` IS a withdrawn route, and the
+ * paths it withdraws are the string literals it registers with `app.post(`.
+ * Both halves come from the code that actually runs, so a newly-added withdrawn
+ * route is picked up with no list to update.
+ *
+ * `readFileSync` + a regex rather than a TS parse is deliberate: the shape being
+ * matched is a single-quoted literal in the first argument position, which is
+ * enforced by the repo's own lint/format. A parser would add a dependency to
+ * read one token. Note `refuse-unavailable.ts` itself mentions the paths in
+ * prose only and registers nothing, so it is excluded by the `app.post` half
+ * rather than by name.
+ */
+function deriveRegisteredWithdrawnRoutes(): { routes: string[]; files: string[] } {
+  const routes: string[] = [];
+  const files: string[] = [];
+
+  for (const entry of readdirSync(ROUTES_DIR).sort()) {
+    if (!entry.endsWith('.ts')) continue;
+    const src = readFileSync(path.join(ROUTES_DIR, entry), 'utf8');
+    if (!src.includes('refuseUnavailable(')) continue;
+
+    const registered = [...src.matchAll(/app\.post\(\s*'([^']+)'/g)].map((m) => m[1]!);
+    if (registered.length === 0) continue; // helper module, not a route
+
+    files.push(entry);
+    routes.push(...registered);
+  }
+
+  return { routes, files };
+}
+
+const derived = deriveRegisteredWithdrawnRoutes();
+
+describe('withdrawn-route parity gate · the three lists cannot drift apart', () => {
+  it('SCANNER CONTROL: the derivation actually found the route sources', () => {
+    // Trap 13, and the most important test in this file. Every parity assertion
+    // below is of the form "derived === declared". If the scanner silently
+    // returned nothing — a moved directory, a renamed helper, a reformatted
+    // registration — those comparisons would collapse to [] === [] and this
+    // whole gate would pass by testing NOTHING, while reporting green. A gate
+    // that cannot fail is the theatre this repo hunts in the product.
+    expect(derived.files.length, 'no withdrawn-route source files were found').toBeGreaterThan(0);
+    expect(derived.routes.length, 'no registrations were extracted').toBeGreaterThan(0);
+    // One registration per file is the current shape; a file registering two
+    // withdrawn paths is legitimate but should be noticed, not absorbed.
+    expect(derived.routes.length).toBe(derived.files.length);
+    for (const r of derived.routes) {
+      expect(r, `derived path looks malformed: ${r}`).toMatch(/^\/v1\//);
+    }
+  });
+
+  it('the TELEMETRY set matches the REGISTRATIONS exactly, in both directions', () => {
+    const registered = [...derived.routes].sort();
+    const declared = [...REFUSED_ROUTES].sort();
+
+    // Both directions, named separately, because the two failures are different
+    // bugs with different consequences:
+    //   missing from REFUSED_ROUTES -> the route's traffic is filed in the
+    //     ORDINARY counters and never surfaces in refused_routes on /health, so
+    //     the caller evidence these paths exist to collect is silently lost.
+    //   extra in REFUSED_ROUTES -> a live or deleted route is being reported as
+    //     a withdrawn one, which misstates /health.
+    expect(
+      registered.filter((r) => !declared.includes(r)),
+      'registered as withdrawn but MISSING from REFUSED_ROUTES — its refusals would not be counted',
+    ).toEqual([]);
+    expect(
+      declared.filter((r) => !registered.includes(r)),
+      'listed in REFUSED_ROUTES but NOT registered as a withdrawn route',
+    ).toEqual([]);
+
+    expect(registered).toEqual(declared);
+  });
+
+  it('no duplicates in either list — a double-count would inflate the refusal evidence', () => {
+    expect(new Set(derived.routes).size).toBe(derived.routes.length);
+    expect(new Set(REFUSED_ROUTES).size).toBe(REFUSED_ROUTES.length);
+  });
+
+  it('each derived route also declares the shared bodyLimit options object', () => {
+    // The 2.165 bodyLimit fix used ONE shared const across ten registrations
+    // precisely so it could not disagree with itself. This asserts a NEW
+    // withdrawn route cannot be registered without it — the drift that would
+    // otherwise silently reintroduce the 128KB server-wide default on a path
+    // that reads no body.
+    for (const entry of derived.files) {
+      const src = readFileSync(path.join(ROUTES_DIR, entry), 'utf8');
+      expect(src, `${entry} registers a withdrawn route without WITHDRAWN_ROUTE_OPTIONS`).toContain(
+        'WITHDRAWN_ROUTE_OPTIONS',
+      );
+    }
+  });
+
+  it('each route passes its OWN path to refuseUnavailable — the path is repeated per file', () => {
+    // Within a file the path appears twice: in app.post(...) and as the third
+    // argument to refuseUnavailable(...). That second copy is what lands in the
+    // log line, the 501 message and recordRefusal, so a copy-paste slip between
+    // the two would attribute one route's refusals to another — and no existing
+    // test compares them.
+    for (const entry of derived.files) {
+      const src = readFileSync(path.join(ROUTES_DIR, entry), 'utf8');
+      const registered = [...src.matchAll(/app\.post\(\s*'([^']+)'/g)].map((m) => m[1]!);
+      const reported = [
+        ...src.matchAll(/refuseUnavailable\(\s*req,\s*reply,\s*'([^']+)'/g),
+      ].map((m) => m[1]!);
+
+      expect(reported.length, `${entry}: no refuseUnavailable path literal found`).toBeGreaterThan(0);
+      expect(
+        [...reported].sort(),
+        `${entry}: the path reported to refuseUnavailable differs from the path registered`,
+      ).toEqual([...registered].sort());
+    }
+  });
+});

--- a/tests/gates/withdrawn-route-parity.test.ts
+++ b/tests/gates/withdrawn-route-parity.test.ts
@@ -60,34 +60,87 @@ const ROUTES_DIR = path.resolve(
  * Derive the withdrawn-route registrations from source.
  *
  * RULE: a file that calls `refuseUnavailable(` IS a withdrawn route, and the
- * paths it withdraws are the string literals it registers with `app.post(`.
- * Both halves come from the code that actually runs, so a newly-added withdrawn
- * route is picked up with no list to update.
+ * paths it withdraws are the path literals it registers with `app.post(`. Both
+ * halves come from the code that actually runs, so a newly-added withdrawn route
+ * is picked up with no list to update.
  *
- * `readFileSync` + a regex rather than a TS parse is deliberate: the shape being
- * matched is a single-quoted literal in the first argument position, which is
- * enforced by the repo's own lint/format. A parser would add a dependency to
- * read one token. Note `refuse-unavailable.ts` itself mentions the paths in
- * prose only and registers nothing, so it is excluded by the `app.post` half
- * rather than by name.
+ * QUOTE-AGNOSTIC, and the reason is a correction to this file's own first
+ * version (adversarial review of #292, finding F1). That version matched only
+ * SINGLE-quoted literals and justified it as "enforced by the repo's own
+ * lint/format". **That justification was false in its load-bearing word.**
+ * Measured at the bytes: `eslint.config.js` has no quote rule at all, and while
+ * `.prettierrc.json` does exist and does set `"singleQuote": true`, neither
+ * `format` nor `format:check` runs in any CI workflow or in
+ * scripts/pre-push-validate.sh — so the preference is expressed and never
+ * enforced. A gate must not rest on a config that no gate runs; that is the
+ * guarantee-theatre shape this repo hunts in the product. Accepts `'`, `"` and
+ * backtick.
+ *
+ * A NON-LITERAL PATH IS A HARD FAIL, NOT A SKIP — the other half of F1. The
+ * original code `continue`d when it extracted nothing, which was the escape
+ * hatch for the helper module but ALSO silently swallowed a withdrawal
+ * registered with a variable or interpolated path: extract zero, skip the file,
+ * and every parity assertion below still passes green while the advertised drift
+ * class walks through. The two cases are now distinguished by whether the file
+ * registers anything at all: no `app.post(` means a helper module (skip);
+ * `app.post(` present but no literal extracted means a registration this
+ * scanner cannot read (RED, via `nonconforming`). `refuse-unavailable.ts`
+ * mentions the paths in prose and registers nothing, so it is still excluded by
+ * the `app.post` half rather than by name.
+ *
+ * `readFileSync` + regex rather than a TS parse keeps this dependency-free for
+ * what is two tokens per registration; the hard-fail above is what makes the
+ * regex's limits loud instead of silent.
  */
-function deriveRegisteredWithdrawnRoutes(): { routes: string[]; files: string[] } {
-  const routes: string[] = [];
+const POST_REGISTRATION =
+  /app\.post\(\s*(['"`])([^'"`]+)\1\s*,\s*([A-Za-z_$][\w$]*)?/g;
+
+interface Registration {
+  file: string;
+  route: string;
+  /** Whether the shared options const is the SECOND argument to app.post. */
+  hasSharedOptions: boolean;
+}
+
+function deriveRegisteredWithdrawnRoutes(): {
+  registrations: Registration[];
+  routes: string[];
+  files: string[];
+  /** Files that register a route this scanner could not read — never silent. */
+  nonconforming: string[];
+} {
+  const registrations: Registration[] = [];
   const files: string[] = [];
+  const nonconforming: string[] = [];
 
   for (const entry of readdirSync(ROUTES_DIR).sort()) {
     if (!entry.endsWith('.ts')) continue;
     const src = readFileSync(path.join(ROUTES_DIR, entry), 'utf8');
     if (!src.includes('refuseUnavailable(')) continue;
 
-    const registered = [...src.matchAll(/app\.post\(\s*'([^']+)'/g)].map((m) => m[1]!);
-    if (registered.length === 0) continue; // helper module, not a route
+    const found = [...src.matchAll(POST_REGISTRATION)].map((m) => ({
+      file: entry,
+      route: m[2]!,
+      hasSharedOptions: m[3] === 'WITHDRAWN_ROUTE_OPTIONS',
+    }));
+
+    if (found.length === 0) {
+      // No registration AT ALL -> helper module, legitimately skipped.
+      // A registration the scanner cannot parse -> loud failure, not a skip.
+      if (src.includes('app.post(')) nonconforming.push(entry);
+      continue;
+    }
 
     files.push(entry);
-    routes.push(...registered);
+    registrations.push(...found);
   }
 
-  return { routes, files };
+  return {
+    registrations,
+    routes: registrations.map((r) => r.route),
+    files,
+    nonconforming,
+  };
 }
 
 const derived = deriveRegisteredWithdrawnRoutes();
@@ -102,6 +155,14 @@ describe('withdrawn-route parity gate · the three lists cannot drift apart', ()
     // that cannot fail is the theatre this repo hunts in the product.
     expect(derived.files.length, 'no withdrawn-route source files were found').toBeGreaterThan(0);
     expect(derived.routes.length, 'no registrations were extracted').toBeGreaterThan(0);
+    // F1: a withdrawn route registered with a path this scanner cannot read
+    // (variable, interpolated template, computed) must RED here rather than be
+    // silently skipped — a skip would let the exact drift this gate advertises
+    // pass green.
+    expect(
+      derived.nonconforming,
+      'file registers a route with a non-literal path the scanner cannot read — it would be skipped, not checked',
+    ).toEqual([]);
     // One registration per file is the current shape; a file registering two
     // withdrawn paths is legitimate but should be noticed, not absorbed.
     expect(derived.routes.length).toBe(derived.files.length);
@@ -138,17 +199,30 @@ describe('withdrawn-route parity gate · the three lists cannot drift apart', ()
     expect(new Set(REFUSED_ROUTES).size).toBe(REFUSED_ROUTES.length);
   });
 
-  it('each derived route also declares the shared bodyLimit options object', () => {
+  it('each REGISTRATION passes the shared bodyLimit options object to app.post', () => {
     // The 2.165 bodyLimit fix used ONE shared const across ten registrations
     // precisely so it could not disagree with itself. This asserts a NEW
     // withdrawn route cannot be registered without it — the drift that would
     // otherwise silently reintroduce the 128KB server-wide default on a path
     // that reads no body.
-    for (const entry of derived.files) {
-      const src = readFileSync(path.join(ROUTES_DIR, entry), 'utf8');
-      expect(src, `${entry} registers a withdrawn route without WITHDRAWN_ROUTE_OPTIONS`).toContain(
-        'WITHDRAWN_ROUTE_OPTIONS',
-      );
+    //
+    // ⚠ WHAT THIS ASSERTION USED TO BE, AND WHY IT DID NOT TEST ITS OWN NAME
+    // (adversarial review of #292, finding F2). The first version ran
+    // `expect(fileBytes).toContain('WITHDRAWN_ROUTE_OPTIONS')` — a substring
+    // check over the WHOLE FILE, which the surviving IMPORT LINE satisfies on
+    // its own. Strip the options argument from `app.post` but keep the import
+    // and the gate passed 5/5; only the behavioural 413 test caught it. So the
+    // system caught the mutant, but this named assertion did not, and a claim
+    // that passes for the wrong reason is the thing this file exists to prevent.
+    //
+    // Now anchored to the call: `hasSharedOptions` is true only when the const
+    // is the token immediately following the path literal in `app.post(`, i.e.
+    // the second argument position, per registration rather than per file.
+    for (const reg of derived.registrations) {
+      expect(
+        reg.hasSharedOptions,
+        `${reg.file}: app.post('${reg.route}', …) does not pass WITHDRAWN_ROUTE_OPTIONS as its options argument`,
+      ).toBe(true);
     }
   });
 
@@ -160,10 +234,13 @@ describe('withdrawn-route parity gate · the three lists cannot drift apart', ()
     // test compares them.
     for (const entry of derived.files) {
       const src = readFileSync(path.join(ROUTES_DIR, entry), 'utf8');
-      const registered = [...src.matchAll(/app\.post\(\s*'([^']+)'/g)].map((m) => m[1]!);
+      // Quote-agnostic on both sides, for the F1 reason recorded on the deriver.
+      const registered = derived.registrations
+        .filter((r) => r.file === entry)
+        .map((r) => r.route);
       const reported = [
-        ...src.matchAll(/refuseUnavailable\(\s*req,\s*reply,\s*'([^']+)'/g),
-      ].map((m) => m[1]!);
+        ...src.matchAll(/refuseUnavailable\(\s*req,\s*reply,\s*(['"`])([^'"`]+)\1/g),
+      ].map((m) => m[2]!);
 
       expect(reported.length, `${entry}: no refuseUnavailable path literal found`).toBeGreaterThan(0);
       expect(

--- a/tests/robustness-analysis.test.ts
+++ b/tests/robustness-analysis.test.ts
@@ -278,12 +278,21 @@ describe('createLocalHeuristicResult', () => {
     expect(result.fragile_edges[0].edge_id).toBe('fac_price::goal');
     expect(result.fragile_edges[0].from_id).toBe('fac_price');
     expect(result.fragile_edges[0].to_id).toBe('goal');
-    expect(result.fragile_edges[0].switch_probability).toBeCloseTo(0.2, 5); // 1 - 0.8
+    // switch_probability is OMITTED (ROADMAP 2.165a). This assertion previously
+    // read `.toBeCloseTo(0.2, 5) // 1 - 0.8` — it PINNED an inverted scale: the
+    // edge is here *because* |elasticity| > 0.5 makes it fragile, and higher
+    // switch_probability means MORE fragile, so 0.2 was the fragile edge being
+    // described as nearly stable. An elasticity heuristic is not a switch
+    // probability; absent means NOT COMPUTED. See numeric-safety-deep-scan §D4.
+    expect(result.fragile_edges[0]).not.toHaveProperty('switch_probability');
 
     // Low elasticity (0.1 <= 0.2) → robust
     expect(result.robust_edges).toHaveLength(1);
     expect(result.robust_edges[0].edge_id).toBe('fac_stable::goal');
-    expect(result.robust_edges[0].switch_probability).toBe(1);
+    // Was `.toBe(1)` — the maximum of the FRAGILITY scale, asserted on the arm
+    // selected for being robust. Same fabrication #290 removed from
+    // normalizeRobustEdge, in a second location.
+    expect(result.robust_edges[0]).not.toHaveProperty('switch_probability');
   });
 });
 


### PR DESCRIPTION
**DO NOT MERGE** — staging verification only.

Three items. `npx tsc --noEmit` clean; full suite **6355 passed / 28 skipped / 0 failed**; pre-push 6/6.

---

## Item 1 — ROADMAP 2.165a: `switch_probability` inverted on BOTH arms of the ISL-unavailable fallback

`createLocalHeuristicResult` (`src/integrations/isl/adapters/robustness-analysis.ts`):

| arm | selected because | assigned | effect |
|---|---|---|---|
| `fragile_edges` | `\|elasticity\| > 0.5` | `1 - Math.min(1, Math.abs(elasticity))` | the **more** fragile the edge, the **lower** the value. At `\|elasticity\| = 1` it emitted **0** — the *safest* reading on the scale. |
| `robust_edges` | `\|elasticity\| <= 0.2` | `1` | the **most robust** edges got the **maximum of the fragility scale** — byte-for-byte the fabrication #290 removed from `normalizeRobustEdge`, surviving in a second location. |

**Root cause:** both comments reasoned in *stability* (`"Higher elasticity = lower stability"`, `"Robust edges have full stability"`) while the field means **fragility**. This is the residue of the 2.160 fix — that lane corrected `normalizeRobustEdge` *and* the `NormalizedEdgeInfo` doc-comment (which now reads "HIGHER MEANS MORE FRAGILE") but did not reach this path.

**Orientation established three independent ways, all executable rather than prose:**
1. `classifyEdgeSeverity` (`src/trust/edge-severity.ts:27-29`) — `>0.7 critical`, `>0.5 error`: monotonically increasing.
2. `deriveFragileEdgeVisible` (`:59-66`) — doctrine-013 gate, `visible = sp > 0.15`: monotonically increasing.
3. `@talchain/schemas` 0.30.0 `EnrichmentRobustnessEdgeSchema` states it **in the contract itself**: *"Higher means MORE fragile"*, plus *"Absence means NOT COMPUTED — never 0 and never 1"*.

### Decision: OMIT, not re-orient

1. **Wrong quantity, not merely wrong sign.** `switch_probability` is an ISL decision-theoretic output; `elasticity` is a local sensitivity heuristic — different units, no calibration to a probability. A correctly-oriented `min(1, |elasticity|)` would be *equally manufactured*.
2. **It would publish derived verdicts.** Any value here feeds `classifyEdgeSeverity` and the doctrine-013 gate, so a re-oriented heuristic emits `severity: 'critical'` and `visible: true` — badges asserting a switch probability nobody computed. Absent derives **neither** (both helpers return `undefined`).
3. **The absence is literally true here.** ISL is unavailable; nothing computed a switch probability.
4. **Nothing real is lost.** The heuristic's finding is *which edges look fragile*, and that survives intact as array **membership** (filters unchanged), alongside the pre-existing `edges_provenance` / `edge_sensitivity_status: 'fallback_local_heuristic'` / `source: 'unavailable'`.

**Contract-legality:** optional since schemas 0.28.0 (0.30.0 vendored); only `edge_id`/`from_id`/`to_id` required — so unlike 2.160 there was **no egress blocker** to clear.

### Shared-inversion check — the other two are CORRECT and untouched

`deriveRobustnessFromEdges` and `deriveRobustnessScore` are **not** inverted. Their `1 - avgElasticity` is *required*, because those fields are **robustness**-oriented — the field name flips the scale. That contrast is now documented at both functions and pinned by a test, because it is exactly how the bug arose: the same inversion idiom copied onto a **fragility**-oriented field. Repo-wide sweep found no other elasticity→`switch_probability` derivation in `src/`.

**Blast radius, stated honestly:** `createLocalHeuristicResult` currently has **no production caller** (only the `adapters/index.ts` barrel + tests); `src/routes/v1/run.ts`'s own `fallback_local_heuristic` path emits `fragile_edges` as `string[]` with no `switch_probability`. So nothing reaches a wire today — but it is exported API, and the defect would activate the moment a caller is wired.

**Three existing tests ENSHRINED the inverted values** and are corrected here: `robustness-analysis.test.ts` pinned `0.2` and `1`; `cil-phase0-fragile-edges.test.ts` pinned presence.

---

## Item 2 — `release.yml`: invalid workflow file, failing on EVERY push

**Root cause (from `actionlint`, not inspection):**
```
.github/workflows/release.yml:30:13: expecting a single ${{...}} expression or
mapping value for "env" section, but found plain text node [syntax-check]
```
A dangling `env:` with no mapping value on the `Test` step. GitHub validates **every** workflow file on **every** push regardless of its `on:` triggers, so this release workflow — triggered by `workflow_dispatch` + `push: tags: ['v*']`, both pre-existing and unwidened by this PR — produced a failed run on every push to staging — 12/12 including pristine staging. It emitted **zero jobs and zero check-runs**, which is exactly why it is invisible to `gh pr checks` and only `gh run list --commit` shows it, and why `gh run view --log` returns *"log not found"*.

**Disposition: FIX.** The `on:` trigger is correct, the workflow is not obsolete, and it is not advisory — so neither deletion nor `continue-on-error` applied. Removing the dangling key is the whole fix. `actionlint` now exits 0.

### ⚠ TWO MORE invalid workflow files found — deliberately NOT fixed here

The same push produces path-named zero-job failures for **`warp-apply-from-issue.yml`** and **`warp-apply-manual.yml`** — a *different* YAML fault (`run: echo "Compare URL: ${{ … }}"`: a plain scalar cannot contain `": "`, so the colon parses as a mapping separator).

**They are left broken on purpose, and this is a security judgement, not an oversight.** `warp-apply-from-issue.yml` triggers on `issue_comment`, extracts a diff from the comment body, and pushes a branch with `contents: write`. Its YAML being invalid is currently the *only* thing preventing anyone who can comment on a PR from driving it. Fixing the syntax would **activate an arbitrary-patch-apply-and-push workflow** — so the correct disposition is almost certainly **deletion** (dead tooling: the script it calls, `.github/scripts/extract-diff-from-comment.js`, **does not exist**; only `validate-allowed-paths.js` is present; and there is a stray never-read `.github/.github/workflows/warp-bootstrap.yml`). That is a separate decision, and it has since been taken: **all three warp files plus the orphaned `validate-allowed-paths.js` are deleted in #293**, where the bootstrap turned out to be the important one (it is *valid* YAML and regenerates the whole apparatus, including CODEOWNERS).

---

## Item 3 — Withdrawn-route `bodyLimit` (efficiency review)

All ten withdrawn routes registered with **no route options**, so the server-wide **128KB** `bodyLimit` applied to paths that read **no body**. Fastify parses the full payload *before* any `preHandler`, so the rate limiter cannot shield it — its 429 is decided post-parse, after the cost is paid.

Adds route-level `bodyLimit: 1024` via **one shared exported const** (`WITHDRAWN_ROUTE_OPTIONS` in `refuse-unavailable.ts`) rather than ten copied literals — a repeated literal is a mirror that drifts, and the test asserts against the same const rather than a copy. Matches the posture live routes already take (`diff.ts` / `critique.ts`: 64KB).

Documented consequence: above the limit a withdrawn route answers 413, not the 501, and `recordRefusal` does not run — so refusal counters undercount abusive traffic by construction.

*Only this item was taken from the efficiency review; the other four nits remain banked.*

---

## Post-review hardening (`466a552`) — adversarial review F1 + F2

Both applied. Neither was reachable by a conforming change, but a new gate should not ship with a known bypass in the same round it closed four.

**F1 — the quote assumption, and a false justification.** The deriver matched only single-quoted `app.post` path literals, justified in-comment as *"enforced by the repo's own lint/format"*. **That was false in its load-bearing word,** and the reviewer's own premise was half wrong, so both halves are now recorded accurately: `eslint.config.js` has no quote rule (reviewer correct), but `.prettierrc.json` **does** exist and **does** set `"singleQuote": true` (the review said there was no prettier config). It makes no difference either way — neither `format` nor `format:check` runs in any CI workflow or in `scripts/pre-push-validate.sh`, so the preference is expressed and never *enforced*, and the gate rested on a config that no gate runs. Now quote-agnostic (`'`, `"`, backtick).

**F1, second half — a non-literal path was a silent SKIP.** `registered.length === 0 → continue` was the helper-module escape hatch, but it also swallowed a withdrawal registered with a variable or interpolated path: extract zero, skip the file, every parity assertion green, and the advertised drift class walks straight through. Now split on whether the file registers anything at all: no `app.post(` → helper module (skip); `app.post(` present with no readable literal → **RED**. Requires no name-based exclusion.

**F2 — the options assertion did not test its own name.** It was `expect(fileBytes).toContain('WITHDRAWN_ROUTE_OPTIONS')`, a whole-file substring check that the surviving **import line** satisfies on its own. Now anchored to the call: `hasSharedOptions` is true only when the const is the token immediately following the path literal (the second-argument position), asserted **per registration** rather than per file.

**Reviewer mutants re-run — both now RED at the gate, not only at the behavioural test:**

| mutant | before | after |
|---|---|---|
| double-quoted withdrawal missing from copies 2+3 | silently skipped, gate green | **RED** — *"MISSING from REFUSED_ROUTES"* |
| strip options from `app.post`, keep the import | gate passed 5/5 (only the 413 test caught it) | **RED** — *"does not pass WITHDRAWN_ROUTE_OPTIONS as its options argument"* |
| variable path `app.post(ROUTE, …)` | silently skipped | **RED** — *"non-literal path the scanner cannot read"* |
| control: helper module with no `app.post` | skipped | **still skipped** — the hard-fail does not over-trigger |

Gates at `466a552`: `tsc --noEmit` clean · full suite **6361 passed / 28 skipped / 0 failed** · pre-push 6/6.

## Mutation checks — 4 classes, all bite

Run in a throwaway worktree **outside** the clone root, removed before the gate run. Commit preceded every mutation.

| mutant | result |
|---|---|
| **A** restore both inverted expressions | **RED** — 5 failures across 3 files |
| **B** drop the *correct* `1 -` from `deriveRobustnessScore` | **RED** — the shared-inversion check |
| **C1** one route loses `WITHDRAWN_ROUTE_OPTIONS` | **RED** — that route's 413 case |
| **C2** limit → 1 byte (withdraws the refusal) | **RED** — the positive control |
| **C3** limit → 256KB (above server default; decoration) | **RED** — the below-default assertion |
| **D** restore the dangling `env:` | **RED** — `actionlint` exit 1 |

RED-first was proven for §D4 *before* the source fix (3 defect assertions failing, 4 invariant assertions correctly passing).

## Two test-construction errors found in my own controls — recorded in-place, not quietly fixed

Both trap-13 shaped, both left documented in the test file because the next reader will hit them:

1. The §D4 retro-guard first asserted `not.toBe(0.2)` against `1 - Math.min(1, Math.abs(0.8))` — which is **0.19999999999999996**, so it **passed with the defect fully present**. Replaced with a categorical `typeof` assertion swept across the elasticity range (including `|e| = 1`, the worst inversion).
2. The bodyLimit test first asserted `refused_routes.by_route[route]` was `undefined` after a 413. That **failed against correct code**: `refused_total` counts handler runs (0, as intended), while `refused_routes.by_route` is derived in `getRouteCallerSnapshot()` from the **request** counters and legitimately counts the request that arrived.

## Incidental finding, NOT fixed (already banked)

Confirmed at the bytes: `refusalsByRoute` (`routeCallerTelemetry.ts:146`) is **write-only** — `recordRefusal` populates it, but the snapshot builds `refused_routes.by_route` from the request counters instead, so per-route refusal counts are collected and never surfaced.

## Standing red left alone

`validate-structure`'s 37 tracked errors are untouched — `.redocly.lint-ignore.yaml` forbids absorbing them.

