### PR TITLE
Remove live switch_probability fabrication in coaching normaliser (Codex P1-5)

### DIFF
--- a/src/coaching/assumptions-ledger.ts
+++ b/src/coaching/assumptions-ledger.ts
@@ -179,9 +179,11 @@ function extractISLAssumptions(inputs: CoachingInputs): AssumptionRecord[] {
   const thresholds = getThresholds();
 
   // Fragile edges are high-impact assumptions
-  // Use centralized threshold for consistency with other coaching components
+  // Use centralized threshold for consistency with other coaching components.
+  // Presence branch (Codex P1-5): only a MEASURED switchProb may generate a
+  // "% chance of flipping decision" record — absence renders nothing.
   for (const edge of inputs.fragileEdges) {
-    if (edge.switchProb >= thresholds.headline_fragile_edge_min) {
+    if (typeof edge.switchProb === 'number' && edge.switchProb >= thresholds.headline_fragile_edge_min) {
       const dedupKey = `isl_engine:flagged:edge:${edge.edgeId}:switch_probability`;
 
       assumptions.push({

--- a/src/coaching/headlines.ts
+++ b/src/coaching/headlines.ts
@@ -21,6 +21,18 @@ const HEADLINE_TEMPLATES = {
 } as const;
 
 /**
+ * Presence guard (Codex P1-5): only an edge with a MEASURED switchProb may
+ * qualify as a headline/context fragile edge. Absent means NOT COMPUTED (never
+ * a coalesced 0), so unmeasured edges never pass a threshold filter and never
+ * reach a rendered percentage.
+ */
+function hasMeasuredSwitchProb<T extends { switchProb?: number }>(
+  e: T
+): e is T & { switchProb: number } {
+  return typeof e.switchProb === 'number';
+}
+
+/**
  * Sort options by win probability descending, treating a non-finite probability
  * (NaN / ±Infinity from a degenerate ISL Monte Carlo run) as the LOWEST rank.
  * Using subtraction directly would return NaN for non-finite inputs, leaving the
@@ -88,6 +100,7 @@ export function generateHeadlines(inputs: CoachingInputs): StoryHeadlines {
   // high_uncertainty (no lever named, no fragile edge forced).
   const leverIds = inputs.interventionTargetIds ?? new Set<string>();
   const topFragile = fragileEdges
+    .filter(hasMeasuredSwitchProb)
     .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min && !isLeverSourcedEdge(e.fromId, leverIds))
     .sort((a, b) => b.switchProb - a.switchProb)[0];
 
@@ -212,9 +225,10 @@ function computeTopGapInfluence(factors: Array<{ confidence?: number; elasticity
   return Math.max(...withVoI, 0); // Return max VoI directly
 }
 
-export function getFragileEdgeContext(fragileEdges: Array<{ edgeId: string; displayLabel: string; switchProb: number; altWinnerLabel: string | null; altWinnerId: string | null }>): FragileEdgeContext | undefined {
+export function getFragileEdgeContext(fragileEdges: Array<{ edgeId: string; displayLabel: string; switchProb?: number; altWinnerLabel: string | null; altWinnerId: string | null }>): FragileEdgeContext | undefined {
   const thresholds = getThresholds();
   const top = fragileEdges
+    .filter(hasMeasuredSwitchProb)
     .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min)
     .sort((a, b) => b.switchProb - a.switchProb)[0];
 
@@ -266,6 +280,7 @@ export function detectHeadlineType(inputs: CoachingInputs): HeadlineType {
   // too, so the headline TYPE stays consistent with the (filtered) headline text.
   const leverIds = inputs.interventionTargetIds ?? new Set<string>();
   const topFragile = fragileEdges
+    .filter(hasMeasuredSwitchProb)
     .filter((e) => e.switchProb >= thresholds.headline_fragile_edge_min && !isLeverSourcedEdge(e.fromId, leverIds))
     .sort((a, b) => b.switchProb - a.switchProb)[0];
 

--- a/src/coaching/next-actions.ts
+++ b/src/coaching/next-actions.ts
@@ -70,19 +70,26 @@ export function generateNextActions(
     });
   }
 
-  // Priority 3: Fragile edges
+  // Priority 3: Fragile edges. Presence branch (Codex P1-5): the rendered
+  // "X% chance this flips the decision" claim requires a MEASURED
+  // switch_probability — an unmeasured edge must never surface a percentage
+  // (previously a coalesced marginal/0 could be rendered here under the
+  // switch-probability wording).
+  const topFragileEdge = context.topFragileEdge;
+  const topFragileSwitchProb = topFragileEdge?.switchProb;
   if (
-    context.topFragileEdge &&
-    context.topFragileEdge.switchProb > thresholds.action_fragile_edge_threshold &&
+    topFragileEdge &&
+    typeof topFragileSwitchProb === 'number' &&
+    topFragileSwitchProb > thresholds.action_fragile_edge_threshold &&
     actions.length < 3
   ) {
     actions.push({
       priority: 3,
-      action: `Validate the ${context.topFragileEdge.displayLabel} assumption`,
-      rationale: `${Math.round(context.topFragileEdge.switchProb * 100)}% chance this flips the decision to ${context.topFragileEdge.altWinnerLabel}`,
+      action: `Validate the ${topFragileEdge.displayLabel} assumption`,
+      rationale: `${Math.round(topFragileSwitchProb * 100)}% chance this flips the decision to ${topFragileEdge.altWinnerLabel}`,
       target_type: 'edge',
-      target_id: context.topFragileEdge.edgeId,
-      target_label: context.topFragileEdge.displayLabel,
+      target_id: topFragileEdge.edgeId,
+      target_label: topFragileEdge.displayLabel,
     });
   }
 

--- a/src/coaching/normalise-inputs.ts
+++ b/src/coaching/normalise-inputs.ts
@@ -78,9 +78,22 @@ export function normaliseCoachingInputs(
         zero_reason: f.zero_reason,
       }));
 
-  // Normalise fragile edges with human-readable labels
-  // Prefer switch_probability (UI field) with fallback to marginal_switch_probability
-  // Sort by switch probability descending (highest first) for reliable [0] access
+  // Normalise fragile edges with human-readable labels.
+  //
+  // switch_probability honesty (Codex P1-5, house pattern #292/#269): the
+  // schemas 0.30.0 contract says "Absence means NOT COMPUTED — never 0 and
+  // never 1 ... Consumers MUST branch on presence, never coalesce". This map
+  // previously did `switch_probability ?? marginal_switch_probability ?? 0` —
+  // aliasing a DIFFERENT ISL quantity (marginal = P(flip | only this edge
+  // varies), its own Monte Carlo) into the switch-probability slot
+  // (P(alternative wins | edge weak)) and fabricating the SAFEST possible
+  // verdict (0) for unmeasured edges. Now: switchProb is emitted ONLY when ISL
+  // measured switch_probability; absent propagates as absent, and every
+  // consumer branches on presence. If coaching ever wants the marginal signal,
+  // it needs its own field name and its own wording — never this slot.
+  //
+  // Sort: measured switchProb descending (highest first) for reliable [0]
+  // access; unmeasured edges sort LAST (no fabricated rank from a made-up 0).
   const fragileEdges: NormalisedFragileEdge[] = (
     islResult.robustness?.fragile_edges ?? []
   )
@@ -98,15 +111,24 @@ export function normaliseCoachingInputs(
         fromLabel,
         toLabel,
         displayLabel: `${fromLabel} → ${toLabel}`,
-        // Prefer switch_probability (aligned with UI) over marginal_switch_probability
-        switchProb: edge.switch_probability ?? edge.marginal_switch_probability ?? 0,
+        // ONLY a measured, finite switch_probability populates switchProb.
+        // No marginal alias, no `?? 0` — absence propagates as absence.
+        ...(typeof edge.switch_probability === 'number' && Number.isFinite(edge.switch_probability)
+          ? { switchProb: edge.switch_probability }
+          : {}),
         altWinnerId: edge.alternative_winner_id ?? null,
         altWinnerLabel: edge.alternative_winner_id
           ? options.find((o) => o.id === edge.alternative_winner_id)?.label ?? edge.alternative_winner_id
           : null,
       };
     })
-    .sort((a: NormalisedFragileEdge, b: NormalisedFragileEdge) => b.switchProb - a.switchProb);
+    .sort((a: NormalisedFragileEdge, b: NormalisedFragileEdge) => {
+      // Measured desc; unmeasured last (presence branch, not a coalesced 0 —
+      // -Infinity is an ordering sentinel only and never leaves this comparator).
+      const av = typeof a.switchProb === 'number' ? a.switchProb : Number.NEGATIVE_INFINITY;
+      const bv = typeof b.switchProb === 'number' ? b.switchProb : Number.NEGATIVE_INFINITY;
+      return bv - av;
+    });
 
   // Normalise options with ISL outcome data
   // Sort by win probability descending (highest first) for reliable [0] access

--- a/src/coaching/readiness-signals.ts
+++ b/src/coaching/readiness-signals.ts
@@ -196,9 +196,11 @@ function computeModelRobustness(
     });
   }
 
-  // Penalty for fragile edges
+  // Penalty for fragile edges. Presence branch (Codex P1-5): only a MEASURED
+  // switchProb can count an edge as fragile; unmeasured edges neither count
+  // nor read as "0 = safe".
   const highFragileCount = inputs.fragileEdges.filter(
-    (e) => e.switchProb > thresholds.action_fragile_edge_threshold
+    (e) => typeof e.switchProb === 'number' && e.switchProb > thresholds.action_fragile_edge_threshold
   ).length;
 
   if (highFragileCount > 0) {

--- a/src/coaching/readiness-tone.ts
+++ b/src/coaching/readiness-tone.ts
@@ -65,8 +65,14 @@ export function deriveReadinessTone(
     reasons.push('LOW_STABILITY');
   }
 
+  // Presence branch (Codex P1-5): only a MEASURED switchProb can establish a
+  // material fragile edge; unmeasured edges are silent here, never "0 = safe".
   const topFragile = pickTopFragile(fragileEdges);
-  if (topFragile !== undefined && topFragile.switchProb > thresholds.action_fragile_edge_threshold) {
+  if (
+    topFragile !== undefined &&
+    typeof topFragile.switchProb === 'number' &&
+    topFragile.switchProb > thresholds.action_fragile_edge_threshold
+  ) {
     reasons.push('MATERIAL_FRAGILE_EDGE');
   }
 
@@ -124,11 +130,14 @@ export function deriveReadinessTone(
 function pickTopFragile(
   fragileEdges: CoachingInputs['fragileEdges'],
 ): CoachingInputs['fragileEdges'][number] | undefined {
-  if (fragileEdges.length === 0) return undefined;
-  let top = fragileEdges[0];
-  for (let i = 1; i < fragileEdges.length; i++) {
-    const candidate = fragileEdges[i];
-    if (candidate !== undefined && top !== undefined && candidate.switchProb > top.switchProb) {
+  // Presence branch (Codex P1-5): only edges with a MEASURED switchProb
+  // compete for "top fragile" — an unmeasured edge has no rank, so it can
+  // never be picked (and previously, as a fabricated 0, could be picked only
+  // to silently fail the material-edge threshold above).
+  let top: CoachingInputs['fragileEdges'][number] | undefined;
+  for (const candidate of fragileEdges) {
+    if (typeof candidate.switchProb !== 'number') continue;
+    if (top === undefined || typeof top.switchProb !== 'number' || candidate.switchProb > top.switchProb) {
       top = candidate;
     }
   }

--- a/src/coaching/types.ts
+++ b/src/coaching/types.ts
@@ -29,8 +29,14 @@ export interface NormalisedFragileEdge {
   fromLabel: string;           // Human-readable
   toLabel: string;             // Human-readable
   displayLabel: string;        // "{fromLabel} → {toLabel}"
-  /** Switch probability (prefers switch_probability, falls back to marginal_switch_probability) */
-  switchProb: number;
+  /**
+   * Measured ISL switch_probability ONLY (P(alternative wins | edge weak)).
+   * ABSENT means NOT COMPUTED — never 0, never an aliased
+   * marginal_switch_probability (a different quantity: P(flip | only this edge
+   * varies)). Per the schemas 0.30.0 contract, consumers MUST branch on
+   * presence and MUST omit anything derived from it when absent (Codex P1-5).
+   */
+  switchProb?: number;
   altWinnerId: string | null;
   altWinnerLabel: string | null;
 }
@@ -84,7 +90,7 @@ export interface FragileEdgeContext {
   edgeId: string;
   label: string;                // Human-readable "{fromLabel} → {toLabel}"
   altWinner: string;           // Winner label or ID
-  switchProb: number;          // 0-1
+  switchProb: number;          // 0-1 — MEASURED only: context is built solely from edges with a measured switchProb
   switchProbDisplay: string;   // "23%"
 }
 

--- a/tests/coaching/m1-coaching.test.ts
+++ b/tests/coaching/m1-coaching.test.ts
@@ -822,7 +822,7 @@ describe('Fragility Fallback Behavior', () => {
     expect(inputs.fragileEdges[0].switchProb).toBe(0.35);
   });
 
-  it('falls back to marginal_switch_probability when switch_probability is missing', () => {
+  it('does NOT alias marginal_switch_probability when switch_probability is missing (Codex P1-5: different quantity — absence stays absent)', () => {
     const graph = createMinimalGraph();
     const options = createMinimalOptions();
     const islResult = {
@@ -842,10 +842,10 @@ describe('Fragility Fallback Behavior', () => {
     };
 
     const inputs = normaliseCoachingInputs(graph, options, islResult);
-    expect(inputs.fragileEdges[0].switchProb).toBe(0.28);
+    expect(inputs.fragileEdges[0].switchProb).toBeUndefined();
   });
 
-  it('defaults to 0 when both probability fields are missing', () => {
+  it('leaves switchProb ABSENT when both probability fields are missing (Codex P1-5: never a fabricated 0)', () => {
     const graph = createMinimalGraph();
     const options = createMinimalOptions();
     const islResult = {
@@ -864,7 +864,7 @@ describe('Fragility Fallback Behavior', () => {
     };
 
     const inputs = normaliseCoachingInputs(graph, options, islResult);
-    expect(inputs.fragileEdges[0].switchProb).toBe(0);
+    expect(inputs.fragileEdges[0].switchProb).toBeUndefined();
   });
 
   it('sorts fragile edges by switchProb descending', () => {

--- a/tests/coaching/switchprob-absence-honesty.test.ts
+++ b/tests/coaching/switchprob-absence-honesty.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Codex P1-5 — switch_probability absence honesty in the coaching normaliser.
+ *
+ * Contract (@talchain/schemas 0.30.0, EnrichmentRobustnessEdgeSchema.switch_probability):
+ *   "Absence means NOT COMPUTED — never 0 and never 1. A measured 0 is a real
+ *    measurement and must be preserved. Higher means MORE fragile ... Consumers
+ *    MUST branch on presence, never coalesce, and MUST omit anything derived
+ *    from it."
+ *
+ * The defect these tests pin against: normalise-inputs.ts coalesced
+ *   `edge.switch_probability ?? edge.marginal_switch_probability ?? 0`
+ * — (a) aliasing a DIFFERENT ISL quantity (marginal_switch_probability =
+ * P(flip | only this edge varies), its own Monte Carlo) into the
+ * switch-probability slot (P(alternative wins | edge weak)), and (b) fabricating
+ * the SAFEST possible verdict (0) for unmeasured edges. Downstream the aliased
+ * value was rendered literally as "X% chance this flips the decision"
+ * (next-actions.ts) and re-emitted on the wire under the switch_probability
+ * name (m1-coaching.ts top_fragile_edge).
+ *
+ * House pattern (#292/#269): absence propagates as absence. These tests were
+ * proven RED against the fabricating code before the fix (see PR).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateM1Coaching } from '../../src/coaching/m1-coaching.js';
+import { normaliseCoachingInputs } from '../../src/coaching/normalise-inputs.js';
+import type { EngineGraphV3, OptionV3 } from '../../src/coaching/types.js';
+
+const makeGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'f1', kind: 'factor', label: 'Cost', category: 'controllable' },
+    { id: 'f2', kind: 'factor', label: 'Market Risk', category: 'external' },
+  ],
+  edges: [
+    { from: 'f1', to: 'goal', strength: { mean: 0.8, std: 0.1 } },
+    { from: 'f2', to: 'goal', strength: { mean: -0.6, std: 0.15 } },
+  ],
+});
+
+const makeOptions = (): OptionV3[] => [
+  { id: 'opt1', label: 'Option A', winProbability: 0.75, expectedOutcome: 120 },
+  { id: 'opt2', label: 'Option B', winProbability: 0.25, expectedOutcome: 80 },
+];
+
+// 0.9 is deliberately above every fragility threshold in play
+// (headline_fragile_edge_min 0.15, action_fragile_edge_threshold 0.20): if the
+// alias/coalesce ever returns, this value WILL surface as a rendered
+// percentage and these pins go RED.
+const makeIslResult = (fragileEdge: Record<string, unknown>) => ({
+  options: [
+    { id: 'opt1', label: 'Option A', win_probability: 0.75, outcome: { mean: 120, p10: 100, p90: 140 } },
+    { id: 'opt2', label: 'Option B', win_probability: 0.25, outcome: { mean: 80, p10: 60, p90: 100 } },
+  ],
+  factor_sensitivity: [
+    { node_id: 'f1', label: 'Cost', importance_rank: 1, elasticity: 0.45, influence_score: 0.85, confidence: 0.6, direction: 'positive' },
+    { node_id: 'f2', label: 'Market Risk', importance_rank: 2, elasticity: -0.35, influence_score: 0.65, confidence: 0.3, direction: 'negative' },
+  ],
+  robustness: {
+    fragile_edges: [fragileEdge],
+    recommendation_stability: 0.75,
+  },
+});
+
+describe('switch_probability absence honesty (Codex P1-5)', () => {
+  it('does NOT alias marginal_switch_probability into switchProb — absence stays absent', () => {
+    const inputs = normaliseCoachingInputs(makeGraph(), makeOptions(), makeIslResult({
+      edge_id: 'f1→goal',
+      from_id: 'f1',
+      to_id: 'goal',
+      // No switch_probability — ISL did not compute it for this edge.
+      marginal_switch_probability: 0.9,
+      alternative_winner_id: 'opt2',
+    }));
+
+    expect(inputs.fragileEdges).toHaveLength(1);
+    expect(inputs.fragileEdges[0]!.switchProb).toBeUndefined();
+  });
+
+  it('does NOT fabricate 0 when both probability fields are missing', () => {
+    const inputs = normaliseCoachingInputs(makeGraph(), makeOptions(), makeIslResult({
+      edge_id: 'f1→goal',
+      from_id: 'f1',
+      to_id: 'goal',
+      alternative_winner_id: 'opt2',
+    }));
+
+    expect(inputs.fragileEdges).toHaveLength(1);
+    expect(inputs.fragileEdges[0]!.switchProb).toBeUndefined();
+  });
+
+  it('preserves a MEASURED 0 (a real measurement, per the 0.30.0 contract)', () => {
+    const inputs = normaliseCoachingInputs(makeGraph(), makeOptions(), makeIslResult({
+      edge_id: 'f1→goal',
+      from_id: 'f1',
+      to_id: 'goal',
+      switch_probability: 0,
+      marginal_switch_probability: 0.9, // must NOT displace the measured 0
+      alternative_winner_id: 'opt2',
+    }));
+
+    expect(inputs.fragileEdges[0]!.switchProb).toBe(0);
+  });
+
+  it('drops non-finite switch_probability values instead of passing them through', () => {
+    const inputs = normaliseCoachingInputs(makeGraph(), makeOptions(), makeIslResult({
+      edge_id: 'f1→goal',
+      from_id: 'f1',
+      to_id: 'goal',
+      switch_probability: Number.NaN,
+      alternative_winner_id: 'opt2',
+    }));
+
+    expect(inputs.fragileEdges[0]!.switchProb).toBeUndefined();
+  });
+
+  it('END-TO-END: an edge with ONLY marginal_switch_probability renders NO percentage anywhere', () => {
+    const coaching = generateM1Coaching(makeGraph(), makeOptions(), makeIslResult({
+      edge_id: 'f1→goal',
+      from_id: 'f1',
+      to_id: 'goal',
+      marginal_switch_probability: 0.9,
+      alternative_winner_id: 'opt2',
+    }));
+
+    expect(coaching).not.toBeNull();
+    const serialised = JSON.stringify(coaching);
+
+    // The aliased marginal (90%) must not surface under flip-chance wording,
+    // in any rendered string, or on the wire-named field.
+    expect(serialised).not.toContain('90%');
+    expect(serialised).not.toMatch(/% chance this flips/);
+    expect(serialised).not.toMatch(/% chance of flipping/);
+    expect(coaching!.top_fragile_edge?.switch_probability).toBeUndefined();
+  });
+
+  it('POSITIVE CONTROL (trap 13): a MEASURED switch_probability DOES render as a percentage', () => {
+    const coaching = generateM1Coaching(makeGraph(), makeOptions(), makeIslResult({
+      edge_id: 'f1→goal',
+      from_id: 'f1',
+      to_id: 'goal',
+      switch_probability: 0.9,
+      alternative_winner_id: 'opt2',
+    }));
+
+    expect(coaching).not.toBeNull();
+    const serialised = JSON.stringify(coaching);
+
+    // Proves the absence assertions above are capable of seeing a presence:
+    // the same pipeline, fed a measured value, DOES produce the strings the
+    // absence test asserts missing.
+    expect(serialised).toContain('90%');
+    expect(coaching!.top_fragile_edge?.switch_probability).toBe(0.9);
+  });
+});


### PR DESCRIPTION
## DO NOT MERGE — staging verification only

Codex audit item **P1-5**, verified at the bytes and fixed per the #292/#269 house pattern: **absence propagates as absence — never a fabricated 0, never an aliased quantity.**

## The defect (verified live at staging tip `1f7d396c`)

`src/coaching/normalise-inputs.ts` coalesced:

```ts
switchProb: edge.switch_probability ?? edge.marginal_switch_probability ?? 0,
```

Two fabrications in one expression:

1. **Alias.** `marginal_switch_probability` is a *different ISL quantity* — P(flip | only this edge varies), its own Monte Carlo with its own baseline (`robustness_analyzer_v2.py:128`) — silently substituted for `switch_probability` = P(alternative wins | edge weak) (`:127`). ISL really does emit edges with only the marginal (`:2185-2186`, `:2205-2206`), so the alias branch fires on real responses.
2. **Fabricated 0.** On the higher-means-more-fragile scale, 0 is the *safest possible verdict*, manufactured for unmeasured edges — suppressing readiness-tone, headline, readiness-signal and next-action fragility signals.

The value was rendered literally — `next-actions.ts`: "**X% chance this flips the decision to Y**"; `assumptions-ledger.ts`: "X% chance of flipping decision" — and re-emitted on the wire under the `switch_probability` name (`m1_coaching.top_fragile_edge`).

**Live chain** (trap 16): `POST /v2/run` → `registerRunV2Route` (`run.ts:4343`) → `generateM1Coaching` (`run.ts:6945`, unconditional) → `normaliseCoachingInputs` (`m1-coaching.ts:102`) → the line above.

**Contract** (vendored `@talchain/schemas` 0.30.0, `EnrichmentRobustnessEdgeSchema.switch_probability`): "Absence means NOT COMPUTED — never 0 and never 1. A measured 0 is a real measurement and must be preserved. … Consumers MUST branch on presence, never coalesce, and MUST omit anything derived from it." PLoT's own #292-era adapter comment says coalescing "re-creates the fabrication at the reader" — which is exactly what this reader did. **The class was not closed by #292; it is now closed at this reader too.**

## The fix

- **Producer**: `switchProb` emitted only for a measured finite `switch_probability`. The marginal alias **dies** (if coaching ever wants that signal, it needs its own field name and its own wording — rowable follow-up, deliberately not done here). Sort ranks measured desc, unmeasured last.
- **Type**: `NormalisedFragileEdge.switchProb?: number` — under `strict: true` the compiler enumerated the complete consumer manifest. All coaching consumers now branch on presence; unmeasured edges are silent, and no percentage can render without a measurement. `FragileEdgeContext.switchProb` stays a required number (constructed from measured edges only).
- A measured 0 is preserved (real measurement, per contract).

## Evidence

- **RED-first**: new `tests/coaching/switchprob-absence-honesty.test.ts` run against the unfixed tip → **4 failed** exactly on the fabrication (aliased 0.9 surfaced; fabricated 0; NaN passthrough; end-to-end "90%" rendered from a marginal-only edge). Two controls green before and after: measured-0 preservation, and a trap-13 **positive control** proving the absence assertions can see a presence (a measured 0.9 DOES render "90%").
- **Two old pins that pinned the fabrication** ("falls back to marginal…", "defaults to 0…") flipped to the honest expectations.
- **Mutation-check** (throwaway detached worktree *outside* the clone root, removed before gate runs — traps 9/9c): mutant `?? marginal ?? 0` → 4 pins RED; `?? 0` only → 3 RED; alias only → 3 RED. All bite.
- **Gates**: `npx tsc --noEmit` exit 0 and full `npm test` exit 0, both at the unfixed head (baseline) and after the fix (details in `PHASE0-EVIDENCE-2026-07-28/plot-codex-p1-5-6.md`).

## Observed sibling (not fixed here — rowable)

`src/lib/factor-influence.ts:654,699-700` still coalesces both fields at the wire-type reader; with both unmeasured, `computeFlipRiskCategory` classifies the factor `'negligible'` ("Minimal flip risk") — the same class in aggregate form. Diagnosis recorded in the evidence file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
