### PR TITLE
fix(isl): retry from remaining budget + bounded Retry-After capture (ROADMAP 2.202 fix ①)

### DIFF
--- a/src/integrations/isl/client.ts
+++ b/src/integrations/isl/client.ts
@@ -8,7 +8,7 @@
  * - Error classification
  */
 
-import { ISLHttpError, ISLTimeoutError, ISLNetworkError, isRetryableError, parseRetryAfterMs, type ISLError422 } from './errors.js';
+import { ISLHttpError, ISLTimeoutError, ISLNetworkError, ISLResponseProcessingError, isRetryableError, parseRetryAfterMs, type ISLError422 } from './errors.js';
 import { decideIslRetry, type ISLRetryBudget } from './retry-budget.js';
 import type { ISLHealthResponse } from './types/isl-types.js';
 import { computeOlumiHash } from '../../util/canonical.js';
@@ -170,6 +170,9 @@ export class ISLClient {
       const controller = new AbortController();
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       let onExternalAbort: (() => void) | undefined;
+      // ROADMAP 2.202 (review item C): true once ISL has returned a 2xx AND its
+      // body has been read — i.e. the compute already happened.
+      let responseCompleted = false;
 
       try {
         timeoutId = setTimeout(
@@ -267,6 +270,13 @@ export class ISLClient {
         // Lane PLoT-R3 (2.13): read the raw text first so responseDigest covers
         // the EXACT bytes received, then parse (same JSON, same errors as .json()).
         const responseText = await response.text();
+        // ROADMAP 2.202 (review item C): past this point ISL has COMPUTED the
+        // analysis and handed us the bytes. Anything that fails from here is a
+        // PLoT-side processing fault, and re-issuing the analysis cannot fix
+        // it — see the catch below. `response.text()` stays OUTSIDE the flag
+        // because a socket reset mid-body is a genuine transport failure and
+        // IS worth retrying.
+        responseCompleted = true;
         const responseData = JSON.parse(responseText) as T;
         const islEchoedRequestId = response.headers.get('x-request-id') ?? null;
         const responseHash = computeOlumiHash(responseData);
@@ -305,6 +315,18 @@ export class ISLClient {
         } else if (rawError instanceof ISLHttpError) {
           // Already typed
           wrappedError = rawError;
+        } else if (responseCompleted) {
+          // ROADMAP 2.202, review item C — NARROWED.
+          //
+          // ISL already returned 2xx and we already have its bytes, so the
+          // analysis HAS been computed; a failure here (JSON.parse, hashing,
+          // bookkeeping) is ours. The generic `else` below wraps it as an
+          // ISLNetworkError, which isRetryableError reports as RETRYABLE — and
+          // 2.202 is precisely what makes those retries reachable. Left alone,
+          // a post-compute parse failure would re-issue the WHOLE analysis and
+          // multiply load on the very governor whose contention this change
+          // exists to survive.
+          wrappedError = new ISLResponseProcessingError(endpoint, rawError);
         } else {
           // Unknown error - wrap as network error
           wrappedError = new ISLNetworkError(endpoint, rawError);

--- a/src/integrations/isl/client.ts
+++ b/src/integrations/isl/client.ts
@@ -8,12 +8,15 @@
  * - Error classification
  */
 
-import { ISLHttpError, ISLTimeoutError, ISLNetworkError, isRetryableError, type ISLError422 } from './errors.js';
+import { ISLHttpError, ISLTimeoutError, ISLNetworkError, isRetryableError, parseRetryAfterMs, type ISLError422 } from './errors.js';
+import { decideIslRetry, type ISLRetryBudget } from './retry-budget.js';
 import type { ISLHealthResponse } from './types/isl-types.js';
 import { computeOlumiHash } from '../../util/canonical.js';
 import { recordIslSuccess, recordIslFailure, shouldAllowIslCall } from '../isl-circuit-breaker.js';
 import { recordDownstreamCall, sanitizePayloadForDebug, computePayloadDigest } from '../../util/downstream-tracker.js';
-import { ISL_TIMEOUT_MS, ISL_HEALTH_CHECK_TIMEOUT_MS, resolveIslMaxRetries, islRetryBackoffMs } from '../../config/timeouts.js';
+// ROADMAP 2.202: the backoff series now lives behind decideIslRetry (which
+// still derives it from islRetryBackoffMs — the single source is unchanged).
+import { ISL_TIMEOUT_MS, ISL_HEALTH_CHECK_TIMEOUT_MS, resolveIslMaxRetries } from '../../config/timeouts.js';
 
 /**
  * ISL client configuration
@@ -50,6 +53,18 @@ export interface ISLRequestOptions {
    * `AbortError`), preserving the existing AbortError→ISLTimeoutError mapping.
    */
   signal?: AbortSignal;
+  /**
+   * ROADMAP 2.202 — the caller's remaining wall-clock budget for THIS request.
+   *
+   * When supplied, the retry decision is made from the budget that actually
+   * remains after each failure instead of from a worst-case attempt count fixed
+   * up front — which is what made the (already-correct) 429 retry unreachable
+   * on the /v2/run base call. When omitted, retry behaviour is exactly as
+   * before: bounded by `config.maxRetries` with exponential backoff.
+   *
+   * See `./retry-budget.ts` for the full rationale.
+   */
+  budget?: ISLRetryBudget;
 }
 
 /**
@@ -93,9 +108,14 @@ export class ISLClient {
    * @throws ISLHttpError on non-2xx responses
    */
   async request<T>(options: ISLRequestOptions): Promise<ISLRequestResult<T>> {
-    const { endpoint, body, requestId, signal: externalSignal } = options;
+    const { endpoint, body, requestId, signal: externalSignal, budget } = options;
     // Pin response version via query param (in addition to header)
     const url = `${this.config.baseUrl}${endpoint}?response_version=2`;
+
+    // ROADMAP 2.202 — start of the client's own clock. `budget.remainingMs` is
+    // measured against THIS instant, so the caller never has to share a clock
+    // with the client (run.ts measures with performance.now(); we use Date.now()).
+    const requestStartedAt = Date.now();
 
     // Log the exact URL called (excluding API key) for debugging
     this.log('info', {
@@ -201,6 +221,11 @@ export class ISLClient {
           const errorBody = await response.text();
           // Capture echoed request ID even on error responses for chain tracing
           const errorEchoedRequestId = response.headers.get('x-request-id') ?? null;
+          // ROADMAP 2.202: capture ISL's `Retry-After` hint. Previously the
+          // response headers were read for `x-request-id` ONLY, so the governor's
+          // RETRY_AFTER_SECONDS=5 on a 429 was discarded and any retry could only
+          // guess. `undefined` when absent/unparseable → our own backoff is used.
+          const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
           // Record failed downstream call with payloads for debug
           recordDownstreamCall({
             service: 'isl',
@@ -221,19 +246,19 @@ export class ISLClient {
           if (response.status === 422) {
             try {
               const islError = JSON.parse(errorBody) as ISLError422;
-              const err = new ISLHttpError(response.status, errorBody, endpoint, islError);
+              const err = new ISLHttpError(response.status, errorBody, endpoint, islError, retryAfterMs);
               (err as any).islEchoedRequestId = errorEchoedRequestId;
               throw err;
             } catch (parseErr) {
               if (parseErr instanceof ISLHttpError) throw parseErr;
               // If parsing fails, throw generic error
-              const err = new ISLHttpError(response.status, errorBody, endpoint);
+              const err = new ISLHttpError(response.status, errorBody, endpoint, undefined, retryAfterMs);
               (err as any).islEchoedRequestId = errorEchoedRequestId;
               throw err;
             }
           }
 
-          const err = new ISLHttpError(response.status, errorBody, endpoint);
+          const err = new ISLHttpError(response.status, errorBody, endpoint, undefined, retryAfterMs);
           (err as any).islEchoedRequestId = errorEchoedRequestId;
           throw err;
         }
@@ -288,7 +313,24 @@ export class ISLClient {
         lastError = wrappedError;
 
         const retryable = isRetryableError(wrappedError);
-        const isLastAttempt = attempt === this.config.maxRetries;
+
+        // ROADMAP 2.202 — decide from the budget that ACTUALLY remains, not from
+        // a worst-case attempt count fixed before the first byte was sent. The
+        // old gate was `attempt === this.config.maxRetries`, and /v2/run's
+        // up-front clamp resolved that cap to 1, so a 133ms 429 became a typed
+        // failure with ~69.8s of budget unspent. With no `budget` supplied the
+        // decision degenerates to exactly that previous behaviour.
+        const retryAfterHintMs =
+          wrappedError instanceof ISLHttpError ? wrappedError.retryAfterMs : undefined;
+        const decision = decideIslRetry({
+          retryable,
+          attempt,
+          maxAttempts: this.config.maxRetries,
+          elapsedMs: Date.now() - requestStartedAt,
+          perAttemptTimeoutMs: this.config.timeoutMs,
+          retryAfterMs: retryAfterHintMs,
+          budget,
+        });
 
         this.log('warn', {
           event: 'isl_request_failed',
@@ -312,9 +354,29 @@ export class ISLClient {
         // this caller's fault, not the service being down, and must never open
         // the breaker for everyone else — which also means ISL's current 404
         // storm on /api/v1/analysis/* cannot spuriously open it.
-        if (!retryable || isLastAttempt) {
+        if (!decision.retry) {
           if (retryable) {
             recordIslFailure();
+          }
+          // ROADMAP 2.202 — make governor contention observable. The diagnosis of
+          // record had to reconstruct this from Render log forensics across three
+          // services; this row says, at the moment of the decision, exactly why a
+          // retryable failure was NOT retried. `budget_exhausted` is the rate to
+          // watch: it means the budget, not the classifier, ended the call.
+          if (retryable) {
+            this.log('warn', {
+              event: 'isl_retry_declined',
+              endpoint,
+              attempt,
+              max_retries: this.config.maxRetries,
+              reason: decision.reason,
+              status: wrappedError instanceof ISLHttpError ? wrappedError.status : undefined,
+              retry_after_ms: retryAfterHintMs,
+              remaining_budget_ms: decision.remainingMs,
+              projected_cost_ms: decision.projectedCostMs,
+              budget_supplied: budget !== undefined,
+              request_id: requestId,
+            });
           }
           // Record failed downstream call on final attempt (only for non-HTTP errors, HTTP errors already recorded)
           if (!(wrappedError instanceof ISLHttpError)) {
@@ -334,9 +396,31 @@ export class ISLClient {
           break;
         }
 
-        // Exponential backoff (single source: islRetryBackoffMs) — 1s, 2s, 4s… capped at 5s.
-        const backoffMs = islRetryBackoffMs(attempt);
-        await this.sleep(backoffMs);
+        // ROADMAP 2.202 — the retry is happening. Emit BEFORE the sleep so the
+        // row is visible even if the process dies during the wait, and so the
+        // rate of governor contention (and whether ISL's own hint was honoured)
+        // is observable without cross-service log forensics.
+        this.log('warn', {
+          event: 'isl_retry_scheduled',
+          endpoint,
+          attempt,
+          next_attempt: attempt + 1,
+          max_retries: this.config.maxRetries,
+          reason: decision.reason,
+          status: wrappedError instanceof ISLHttpError ? wrappedError.status : undefined,
+          delay_ms: decision.delayMs,
+          backoff_ms: decision.backoffMs,
+          retry_after_ms: retryAfterHintMs,
+          retry_after_honoured: decision.retryAfterHonoured,
+          remaining_budget_ms: decision.remainingMs,
+          projected_cost_ms: decision.projectedCostMs,
+          request_id: requestId,
+        });
+
+        // Delay chosen by decideIslRetry: max(ISL's Retry-After, our exponential
+        // backoff 1s/2s/4s… capped at 5s). Retry-After is a MINIMUM wait, so it
+        // can lengthen the delay but never shorten it below our own backoff.
+        await this.sleep(decision.delayMs);
       } finally {
         if (timeoutId !== undefined) clearTimeout(timeoutId);
         if (onExternalAbort && externalSignal) {

--- a/src/integrations/isl/errors.ts
+++ b/src/integrations/isl/errors.ts
@@ -57,21 +57,73 @@ export interface ISLCritique {
 }
 
 /**
+ * Parse an RFC 7231 `Retry-After` header into milliseconds.
+ *
+ * ROADMAP 2.202. ISL's compute governor answers `caller_concurrency_exceeded`
+ * with a 429 and a `Retry-After` hint (`RETRY_AFTER_SECONDS = 5`), and PLoT
+ * discarded it entirely — `ISLHttpError` captured status/body/endpoint/islError
+ * and no headers at all. The one piece of actionable guidance ISL emits never
+ * reached the retry decision, so a retry could only ever guess.
+ *
+ * Both wire forms are accepted:
+ *   • delta-seconds — `Retry-After: 5`      → 5_000
+ *   • HTTP-date     — `Retry-After: <date>` → max(0, date − now)
+ *
+ * Returns `undefined` for absent, blank, or unparseable values, so the caller
+ * falls back to its own exponential backoff rather than to a fabricated delay.
+ * A past HTTP-date clamps to 0 (retry immediately), never negative.
+ */
+export function parseRetryAfterMs(
+  raw: string | null | undefined,
+  nowMs: number = Date.now(),
+): number | undefined {
+  if (raw === null || raw === undefined) return undefined;
+  const value = raw.trim();
+  if (value === '') return undefined;
+
+  // delta-seconds: a bare non-negative integer.
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value);
+    return Number.isFinite(seconds) ? seconds * 1_000 : undefined;
+  }
+
+  // Any OTHER bare numeric form (`-5`, `+5`, `1.5`) is valid in neither wire
+  // form. It must be rejected explicitly: `Date.parse('-5')` succeeds — it reads
+  // the string as a YEAR — so falling through to the date branch would turn a
+  // malformed header into a multi-millennium delay.
+  if (/^[+-]?\d*\.?\d+$/.test(value)) return undefined;
+
+  // HTTP-date.
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return undefined;
+  return Math.max(0, parsed - nowMs);
+}
+
+/**
  * HTTP error from ISL service
  */
 export class ISLHttpError extends Error {
   /** Structured 422 error (if available) */
   public islError?: ISLError422;
 
+  /**
+   * ROADMAP 2.202 — `Retry-After` from the response, in ms, when ISL sent one
+   * (see {@link parseRetryAfterMs}). `undefined` = no usable hint; the retry
+   * decision then falls back to PLoT's own exponential backoff.
+   */
+  public retryAfterMs?: number;
+
   constructor(
     public status: number,
     public body: string,
     public endpoint: string,
-    islError?: ISLError422
+    islError?: ISLError422,
+    retryAfterMs?: number
   ) {
     super(`ISL request to ${endpoint} failed with status ${status}`);
     this.name = 'ISLHttpError';
     this.islError = islError;
+    this.retryAfterMs = retryAfterMs;
   }
 
   /**

--- a/src/integrations/isl/errors.ts
+++ b/src/integrations/isl/errors.ts
@@ -235,6 +235,34 @@ export class ISLNetworkError extends Error {
 }
 
 /**
+ * A PLoT-side failure that happened AFTER ISL returned a 2xx — unparseable body,
+ * hashing/bookkeeping failure, etc.
+ *
+ * ROADMAP 2.202, review item C. The client's catch wraps any unrecognised error
+ * as an {@link ISLNetworkError}, which `isRetryableError` reports as RETRYABLE.
+ * That was harmless while the base call was clamped to a single attempt, but
+ * 2.202 makes retries reachable — so without this class a failure occurring
+ * after ISL had already COMPUTED the analysis would re-issue the whole
+ * analysis, multiplying load on the very governor whose contention this change
+ * exists to survive.
+ *
+ * ISL did its job; the fault is on our side of the wire and re-running the
+ * computation cannot fix it. Deliberately absent from `isRetryableError`, so it
+ * is NOT retryable.
+ */
+export class ISLResponseProcessingError extends Error {
+  constructor(
+    public endpoint: string,
+    public cause?: Error
+  ) {
+    super(
+      `ISL response from ${endpoint} could not be processed: ${cause?.message ?? 'unknown'}`,
+    );
+    this.name = 'ISLResponseProcessingError';
+  }
+}
+
+/**
  * ISL service unavailable (circuit breaker open, etc.)
  */
 export class ISLUnavailableError extends Error {

--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -20,6 +20,7 @@
 import { ISLClient, getISLClientConfig } from './client.js';
 import { ISLTimeoutError, ISLNetworkError, ISLHttpError, isRetryableError } from './errors.js';
 import type { ISLCritique } from './errors.js';
+import type { ISLRetryBudget } from './retry-budget.js';
 import {
   adaptValidationResponse,
   createFallbackValidation,
@@ -205,7 +206,8 @@ export interface ISLService {
     requestId: string,
     timeoutMs?: number,
     maxRetries?: number,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    budget?: ISLRetryBudget
   ): Promise<ISLAnalysisResult<T>>;
 }
 
@@ -636,7 +638,8 @@ export function createISLService(): ISLService {
       requestId: string,
       timeoutMs?: number,
       maxRetries?: number,
-      signal?: AbortSignal
+      signal?: AbortSignal,
+      budget?: ISLRetryBudget
     ): Promise<ISLAnalysisResult<T>> {
       const startMs = Date.now();
 
@@ -662,9 +665,12 @@ export function createISLService(): ISLService {
       if (timeoutMs !== undefined) {
         currentConfig.timeoutMs = timeoutMs;
       }
-      // Per-call retry cap (A3 remediation item 4): the base /v2/run robustness
-      // call passes this so its retries × per-attempt timeout cannot outlive the
-      // request budget. Omitted → the config default (ISL_MAX_RETRIES, 3).
+      // Per-call retry cap. Since ROADMAP 2.202 this is an UPPER BOUND only —
+      // the base /v2/run robustness call also passes `budget`, and the real bound
+      // on that call is the remaining wall-clock budget, checked after each
+      // failure (see ./retry-budget.ts). Callers that pass no budget (flip probes
+      // F3, thresholds F9) are unchanged: this cap is still their sole bound.
+      // Omitted → the config default (ISL_MAX_RETRIES, 3).
       if (maxRetries !== undefined) {
         currentConfig.maxRetries = Math.max(1, Math.floor(maxRetries));
       }
@@ -676,6 +682,7 @@ export function createISLService(): ISLService {
           body,
           requestId,
           signal,
+          budget,
         });
 
         return {
@@ -814,4 +821,10 @@ export { validateBeforeISL, buildParameterUncertainties } from './preflight.js';
 // Note: ISLAnalysisResult is already exported via interface definition above
 
 export { ISLClient, type ISLClientConfig } from './client.js';
-export { ISLHttpError } from './errors.js';
+export { ISLHttpError, parseRetryAfterMs } from './errors.js';
+export {
+  decideIslRetry,
+  DEFAULT_RETRY_SAFETY_MARGIN_MS,
+  type ISLRetryBudget,
+  type ISLRetryDecision,
+} from './retry-budget.js';

--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -821,7 +821,7 @@ export { validateBeforeISL, buildParameterUncertainties } from './preflight.js';
 // Note: ISLAnalysisResult is already exported via interface definition above
 
 export { ISLClient, type ISLClientConfig } from './client.js';
-export { ISLHttpError, parseRetryAfterMs } from './errors.js';
+export { ISLHttpError, ISLResponseProcessingError, parseRetryAfterMs } from './errors.js';
 export {
   decideIslRetry,
   DEFAULT_RETRY_SAFETY_MARGIN_MS,

--- a/src/integrations/isl/retry-budget.ts
+++ b/src/integrations/isl/retry-budget.ts
@@ -31,9 +31,13 @@
  *   • slow fail → budget already consumed, projection does not fit → NO RETRY
  *     (this is precisely the property the old up-front clamp existed to
  *     protect, and it is preserved exactly)
- *   • an absurd `Retry-After: 3600` self-limits: the projection is 3.6 M ms,
- *     which cannot fit, so it terminates with the typed failure. No arbitrary
- *     cap is needed, and none is invented.
+ *   • an absurd `Retry-After: 3600` self-limits ON THE BUDGETED PATH: the
+ *     projection is 3.6 M ms, which cannot fit, so it terminates with the typed
+ *     failure. No arbitrary cap is needed there, and none is invented.
+ *     ⚠ That self-limiting is a property of the BUDGET, not of the parser — so
+ *     the no-budget path must not honour `Retry-After` at all, and does not
+ *     (see the `!budget` branch). Getting this wrong is what the first cut of
+ *     2.202 did, and it is the one HIGH the adversarial review found.
  *
  * An attempt is only ever STARTED when its FULL per-attempt timeout still fits,
  * so the total can never overrun the caller's budget.
@@ -44,7 +48,8 @@
  * own comment says it avoids.
  *
  * BLAST RADIUS: when no budget is supplied the decision degenerates to EXACTLY
- * the previous behaviour (attempt cap + exponential backoff). Only the /v2/run
+ * the previous behaviour — attempt cap + our own exponential backoff, and
+ * `Retry-After` deliberately ignored. Only the /v2/run
  * base robustness call passes a budget; flip probes, thresholds and health are
  * untouched.
  */
@@ -161,17 +166,34 @@ export function decideIslRetry(input: ISLRetryDecisionInput): ISLRetryDecision {
   if (!retryable) return no('not_retryable');
   if (attempt >= maxAttempts) return no('attempt_cap');
 
-  // No budget supplied → EXACTLY the previous behaviour. This is what keeps the
-  // change scoped to the base call.
+  // No budget supplied → EXACTLY the previous behaviour, and that means the
+  // BACKOFF, not `Retry-After`.
+  //
+  // ⚠ This branch is load-bearing and was WRONG in the first cut of 2.202
+  // (caught in adversarial review of PR #295). `delayMs` above is
+  // `max(retryAfterMs, backoffMs)`, and returning it here honoured
+  // `Retry-After` with NO BOUND on a path that has no budget to bound it —
+  // `Retry-After: 3600` meant the client slept for an hour, in a sleep that
+  // observes no AbortSignal. The exposure was live, not theoretical: /v1/run
+  // calls validateCausal + analyseRobustness with maxRetries = 3 and no budget
+  // against the very endpoint whose governor 429 carries `Retry-After: 5` — so
+  // the first cut would have added ~7 s per call under exactly the contention
+  // this change exists to fix.
+  //
+  // Only the budgeted path may honour `Retry-After`, because only there is the
+  // resulting delay checked against something. Here we sleep our own bounded
+  // backoff (≤ ISL_RETRY_BACKOFF_CAP_MS), which is what the pre-2.202 client
+  // did — making "no budget = previous behaviour" literally true rather than
+  // approximately true.
   if (!budget) {
     return {
       retry: true,
-      delayMs,
+      delayMs: backoffMs,
       reason: 'attempts_remaining',
-      retryAfterHonoured,
+      retryAfterHonoured: false,
       backoffMs,
       remainingMs: undefined,
-      projectedCostMs,
+      projectedCostMs: backoffMs + perAttemptTimeoutMs,
     };
   }
 

--- a/src/integrations/isl/retry-budget.ts
+++ b/src/integrations/isl/retry-budget.ts
@@ -1,0 +1,194 @@
+/**
+ * ISL retry budgeting — ROADMAP 2.202.
+ *
+ * THE DEFECT THIS REPLACES
+ * -----------------------
+ * `ISLClient.request` bounded retries with a TOTAL-ATTEMPT COUNT fixed before
+ * the first byte was sent, and `/v2/run` derived that count from WORST-CASE
+ * timeouts:
+ *
+ *   worstCaseMs(2, 60_000) = 121_000  >  ~69_800 remaining  →  1 attempt
+ *
+ * So the base robustness call got ZERO retries. When ISL's compute governor
+ * rejected a 3rd concurrent analysis with a 429 that came back in **133 ms**,
+ * PLoT converted it straight to a typed-failure envelope with **~69.8 s of the
+ * request budget unspent** — and CEE mapped that to an HTTP 500 the tester saw.
+ * The 429 classifier (`ISLHttpError.isRetryable`) was already correct; the retry
+ * was structurally unreachable.
+ *
+ * The policy was DURATION-BLIND: it priced every failure at a full per-attempt
+ * timeout, so a failure that consumed 0.2% of the budget was treated exactly
+ * like one that consumed all of it.
+ *
+ * THE REPLACEMENT
+ * ---------------
+ * Decide AFTER the failure, from the budget that ACTUALLY remains: project the
+ * next attempt's cost (`delay + per-attempt timeout`) and retry iff that
+ * projection plus a safety margin still fits.
+ *
+ * Everything is derived — there is no "is this failure fast?" constant:
+ *   • fast 429  → 133 ms spent, ~69.8 s left, projection ~65 s → RETRY
+ *   • slow fail → budget already consumed, projection does not fit → NO RETRY
+ *     (this is precisely the property the old up-front clamp existed to
+ *     protect, and it is preserved exactly)
+ *   • an absurd `Retry-After: 3600` self-limits: the projection is 3.6 M ms,
+ *     which cannot fit, so it terminates with the typed failure. No arbitrary
+ *     cap is needed, and none is invented.
+ *
+ * An attempt is only ever STARTED when its FULL per-attempt timeout still fits,
+ * so the total can never overrun the caller's budget.
+ *
+ * DELIBERATELY NOT DONE: the retry's per-attempt timeout is not re-clamped
+ * downward to squeeze an extra attempt into a shrinking budget. That would
+ * truncate a slow-but-successful call — the exact harm the base-call clamp's
+ * own comment says it avoids.
+ *
+ * BLAST RADIUS: when no budget is supplied the decision degenerates to EXACTLY
+ * the previous behaviour (attempt cap + exponential backoff). Only the /v2/run
+ * base robustness call passes a budget; flip probes, thresholds and health are
+ * untouched.
+ */
+
+import { islRetryBackoffMs } from '../../config/timeouts.js';
+
+/**
+ * The wall-clock budget a caller lends to one ISL request, for retry decisions.
+ */
+export interface ISLRetryBudget {
+  /**
+   * Wall-clock ms still available to this call at the moment `request()` is
+   * entered. The client converts it to an absolute deadline against its own
+   * clock, so the caller never has to share a clock with the client.
+   */
+  remainingMs: number;
+  /**
+   * Reserve kept unspent so the caller can still assemble and return its
+   * response after the last attempt. Defaults to
+   * {@link DEFAULT_RETRY_SAFETY_MARGIN_MS}.
+   */
+  safetyMarginMs?: number;
+}
+
+/**
+ * Default reserve left unspent by the retry decision. Matches the 1 s safety
+ * margin `/v2/run` already subtracts when clamping the base call's per-attempt
+ * timeout, so the two guards agree rather than drifting apart.
+ */
+export const DEFAULT_RETRY_SAFETY_MARGIN_MS = 1_000;
+
+/** Why the retry decision came out the way it did (telemetry + tests). */
+export type ISLRetryReason =
+  /** Error class is not retryable (4xx other than 429). */
+  | 'not_retryable'
+  /** The configured total-attempt cap is spent. */
+  | 'attempt_cap'
+  /** Retryable and the next attempt fits the remaining budget. */
+  | 'budget_available'
+  /** Retryable, attempts remain, but the next attempt does NOT fit the budget. */
+  | 'budget_exhausted'
+  /** No budget supplied — legacy behaviour: attempts remain, so retry. */
+  | 'attempts_remaining';
+
+export interface ISLRetryDecision {
+  retry: boolean;
+  /** ms to sleep before the next attempt (0 when not retrying). */
+  delayMs: number;
+  reason: ISLRetryReason;
+  /** True when ISL's `Retry-After` (not our backoff) set the delay. */
+  retryAfterHonoured: boolean;
+  /** Our own exponential backoff for this attempt, before Retry-After. */
+  backoffMs: number;
+  /** Budget left at the decision point — `undefined` when none was supplied. */
+  remainingMs?: number;
+  /** `delayMs + perAttemptTimeoutMs` — what the next attempt could cost. */
+  projectedCostMs: number;
+}
+
+export interface ISLRetryDecisionInput {
+  /** Did the error classifier say this failure is retryable? */
+  retryable: boolean;
+  /** 1-indexed attempt that just failed. */
+  attempt: number;
+  /** Total attempts allowed (the `maxRetries` cap). */
+  maxAttempts: number;
+  /** ms elapsed since `request()` was entered. */
+  elapsedMs: number;
+  /** Per-attempt timeout the next attempt would use. */
+  perAttemptTimeoutMs: number;
+  /** ISL's `Retry-After` in ms, when it sent a usable one. */
+  retryAfterMs?: number;
+  /** Caller's budget. Omitted → legacy attempt-cap-only behaviour. */
+  budget?: ISLRetryBudget;
+}
+
+/**
+ * Decide whether to retry a failed ISL attempt, and how long to wait first.
+ *
+ * Pure: no clocks, no I/O. Every input is passed in so the decision can be
+ * pinned directly, without driving a server.
+ */
+export function decideIslRetry(input: ISLRetryDecisionInput): ISLRetryDecision {
+  const {
+    retryable,
+    attempt,
+    maxAttempts,
+    elapsedMs,
+    perAttemptTimeoutMs,
+    retryAfterMs,
+    budget,
+  } = input;
+
+  const backoffMs = islRetryBackoffMs(attempt);
+
+  // `Retry-After` is a MINIMUM wait, not an instruction to wait less: never
+  // retry sooner than the server asked, and never sooner than our own backoff.
+  const retryAfterUsable =
+    typeof retryAfterMs === 'number' && Number.isFinite(retryAfterMs) && retryAfterMs >= 0;
+  const delayMs = retryAfterUsable ? Math.max(retryAfterMs, backoffMs) : backoffMs;
+  const retryAfterHonoured = retryAfterUsable && retryAfterMs > backoffMs;
+  const projectedCostMs = delayMs + perAttemptTimeoutMs;
+
+  const no = (reason: ISLRetryReason): ISLRetryDecision => ({
+    retry: false,
+    delayMs: 0,
+    reason,
+    retryAfterHonoured: false,
+    backoffMs,
+    remainingMs: budget ? budget.remainingMs - elapsedMs : undefined,
+    projectedCostMs,
+  });
+
+  if (!retryable) return no('not_retryable');
+  if (attempt >= maxAttempts) return no('attempt_cap');
+
+  // No budget supplied → EXACTLY the previous behaviour. This is what keeps the
+  // change scoped to the base call.
+  if (!budget) {
+    return {
+      retry: true,
+      delayMs,
+      reason: 'attempts_remaining',
+      retryAfterHonoured,
+      backoffMs,
+      remainingMs: undefined,
+      projectedCostMs,
+    };
+  }
+
+  const safetyMarginMs = budget.safetyMarginMs ?? DEFAULT_RETRY_SAFETY_MARGIN_MS;
+  const remainingMs = budget.remainingMs - elapsedMs;
+
+  // Start an attempt only when its FULL per-attempt timeout still fits, so the
+  // total can never outlive the caller's budget.
+  if (projectedCostMs + safetyMarginMs > remainingMs) return no('budget_exhausted');
+
+  return {
+    retry: true,
+    delayMs,
+    reason: 'budget_available',
+    retryAfterHonoured,
+    backoffMs,
+    remainingMs,
+    projectedCostMs,
+  };
+}

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -6083,31 +6083,47 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             Math.max(BASE_CALL_MIN_TIMEOUT_MS, Math.floor(baseCallRemainingMs - baseCallSafetyMarginMs)),
           );
           const configuredMaxRetries = Math.max(1, getISLClientConfig().maxRetries);
-          // Largest attempt count whose HONEST worst case (attempts × per-attempt
-          // + the 1s+2s… backoff the client sleeps between them) still fits the
-          // remaining budget — never < 1, never > the configured cap. The prior
-          // `floor(remaining / timeout)` counted bare timeout slices and omitted
-          // the backoff; worstCaseMs is the single source now shared with the
-          // telemetry below, the startup budget warn, and their tests. At the 70s
-          // default this still resolves to 1 attempt (no behaviour change) — it
-          // only stops the accounting from lying.
-          let baseCallMaxRetries = 1;
-          while (
-            baseCallMaxRetries < configuredMaxRetries &&
-            worstCaseMs(baseCallMaxRetries + 1, baseCallTimeoutMs) <= baseCallRemainingMs
-          ) {
-            baseCallMaxRetries++;
-          }
-          if (baseCallTimeoutMs < ISL_TIMEOUT_MS || baseCallMaxRetries < configuredMaxRetries) {
+          // ROADMAP 2.202 — THE ATTEMPT COUNT IS NO LONGER FIXED UP FRONT.
+          //
+          // This used to pick the largest attempt count whose HONEST worst case
+          // (attempts × per-attempt + the 1s+2s… backoff) fitted the remaining
+          // budget. That arithmetic is correct and the comment here conceded its
+          // outcome: "at the 70s default this still resolves to 1 attempt". One
+          // attempt means ZERO retries — so when ISL's compute governor rejected
+          // a 3rd concurrent analysis with a 429 that returned in **133 ms**,
+          // PLoT emitted a typed-failure envelope with **~69.8 s of the budget
+          // unspent**, and CEE mapped it to the HTTP 500 the tester saw.
+          //
+          // The flaw was DURATION-BLINDNESS: pricing every failure at a full
+          // per-attempt timeout treats a 133 ms reject exactly like a 60 s one.
+          //
+          // Now: pass the configured cap as an UPPER BOUND and hand the client
+          // the budget that actually remains. After each failure the client
+          // projects the next attempt's real cost (delay + per-attempt timeout)
+          // and retries only if it still fits — see integrations/isl/retry-budget.ts.
+          //
+          // The invariant the old clamp protected is UNCHANGED and is now
+          // enforced at runtime rather than by static arithmetic: an attempt is
+          // only ever STARTED when its full per-attempt timeout still fits the
+          // budget, so the base call cannot outlive the caller. A slow failure
+          // that consumes the budget still gets no retry.
+          const baseCallBudget = {
+            remainingMs: Math.max(0, Math.floor(baseCallRemainingMs)),
+            safetyMarginMs: baseCallSafetyMarginMs,
+          };
+          if (baseCallTimeoutMs < ISL_TIMEOUT_MS) {
             req.log.info({
               event: 'base_isl_call_budget_clamped',
               request_id: requestId,
               isl_timeout_ms: ISL_TIMEOUT_MS,
               clamped_timeout_ms: baseCallTimeoutMs,
               configured_max_retries: configuredMaxRetries,
-              clamped_max_retries: baseCallMaxRetries,
               remaining_budget_ms: Math.round(baseCallRemainingMs),
-              worst_case_total_ms: worstCaseMs(baseCallMaxRetries, baseCallTimeoutMs),
+              // Worst case for ONE attempt — the only total guaranteed up front
+              // now that further attempts are gated on the live budget. Retained
+              // (rather than the old whole-ladder figure) so this row cannot
+              // imply an attempt ladder that the client may never run.
+              single_attempt_worst_case_ms: worstCaseMs(1, baseCallTimeoutMs),
             });
           }
           const response = await islService.callAnalysisEndpoint<any>(
@@ -6115,7 +6131,9 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             islRequest,
             requestId,
             baseCallTimeoutMs,
-            baseCallMaxRetries
+            configuredMaxRetries,
+            undefined,
+            baseCallBudget
           );
 
           if (response.data) {

--- a/tests/plot-2202-isl-429-retry.route.test.ts
+++ b/tests/plot-2202-isl-429-retry.route.test.ts
@@ -1,0 +1,246 @@
+/**
+ * ⭐ ROADMAP 2.202 — THE RED-FIRST PIN. End-to-end through route → service →
+ * real ISLClient → the wire, against a fake ISL that answers 429 then 200.
+ *
+ * THE DEFECT (diagnosis-run-analysis-500s.md §1/§2/§4, byte-verified):
+ * ISL's compute governor rejects the 3rd concurrent analysis with a 429
+ * (`caller_concurrency_exceeded`, ANALYSIS_WORKERS = 2 — and PLoT holds ONE API
+ * key for the whole product, so a per-caller fairness gate is a global 2-slot
+ * cap). The 429 came back in **133 ms**. PLoT classified it retryable — and then
+ * did not retry, because /v2/run clamped the base call's attempt count from
+ * WORST-CASE timeouts before the call (`worstCaseMs(2, 60_000) = 121_000 >
+ * 69_800` → 1 attempt). PLoT emitted a typed-failure envelope with **~69.8 s of
+ * the request budget unspent**; CEE mapped it to the HTTP 500 the tester saw
+ * (4 of 20 chip-click run_analysis attempts on the 31 Jul probe).
+ *
+ * RED AGAINST THE PRE-FIX CODE: the route passed `maxRetries = 1`, so the fake
+ * ISL received exactly ONE request and /v2/run answered
+ * `analysis_status: 'failed'` + `ISL_CALL_FAILED` + a status_reason naming
+ * HTTP 429. Verbatim RED transcript in the lane evidence file.
+ *
+ * This drives the REAL client on purpose. A mocked `islService` would bypass
+ * `ISLClient.request` — i.e. bypass the retry loop under test — and prove
+ * nothing (trap 16: a mock proves presence-in-repo, never presence-on-the-wire).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createServer as createHttpServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { FastifyInstance } from 'fastify';
+import { createServer } from '../src/createServer.js';
+
+const BASE_ROBUSTNESS_PATH = '/api/v1/robustness/analyze/v2';
+
+/** Minimal ISL success body for the base robustness call. */
+const ISL_OK = {
+  options: [
+    { option_id: 'opt1', outcome: { mean: 0.8, std: 0.1, p10: 0.6, p50: 0.8, p90: 0.95, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 1, win_probability: 0.7, probability_of_goal: 0.65 },
+    { option_id: 'opt2', outcome: { mean: 0.7, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 2, win_probability: 0.3, probability_of_goal: 0.55 },
+  ],
+  factor_sensitivity: [],
+  robustness: { score: 0.82, label: 'robust', fragile_edges: [], robust_edges: [], edge_e_values: [] },
+};
+
+/** Single factor / two options — deliberately below the flip-probe trigger, so
+ *  the only ISL traffic is the BASE call and the test stays fast. */
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'factor-a', kind: 'factor', label: 'Marketing', observed_state: { value: 0.6 } },
+  ],
+  edges: [{ from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+};
+const OPTIONS = [
+  { id: 'opt1', label: 'A', interventions: { 'factor-a': 0.8 } },
+  { id: 'opt2', label: 'B', interventions: { 'factor-a': 0.3 } },
+];
+
+let islServer: Server;
+let islPort: number;
+/** How many 429s the fake ISL should serve before switching to 200. */
+let rejectionsRemaining = 0;
+/** Base-endpoint hits, in order. */
+let baseHits: number[] = [];
+/** When true the fake ISL answers a NON-retryable 400 (negative control). */
+let nonRetryable400 = false;
+
+describe('2.202 — a fast ISL 429 is retried from the budget that actually remains', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    islServer = createHttpServer((req, res) => {
+      const path = (req.url ?? '').split('?')[0];
+      // Drain the body so keep-alive sockets are reusable.
+      req.resume();
+      req.on('end', () => {
+        if (path === BASE_ROBUSTNESS_PATH) {
+          baseHits.push(Date.now());
+          if (nonRetryable400) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ detail: 'bad request' }));
+            return;
+          }
+          if (rejectionsRemaining > 0) {
+            rejectionsRemaining--;
+            // ISL's governor shape: 429 + a JSON detail. NO Retry-After header
+            // here on purpose — this arm proves the BUDGET drives the retry,
+            // independent of any hint. Retry-After is pinned separately in
+            // tests/plot-2202-isl-retry-after.client.test.ts.
+            res.writeHead(429, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ detail: 'caller_concurrency_exceeded' }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(ISL_OK));
+          return;
+        }
+        // Any other ISL endpoint the route may touch: benign 200.
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({}));
+      });
+    });
+    await new Promise<void>((resolve) => islServer.listen(0, '127.0.0.1', () => resolve()));
+    islPort = (islServer.address() as AddressInfo).port;
+
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.ISL_ENABLE = '1';
+    process.env.ISL_BASE_URL = `http://127.0.0.1:${islPort}`;
+    process.env.ISL_API_KEY = 'test-key';
+    delete process.env.ISL_MAX_RETRIES; // production default: 3
+    delete process.env.REQUEST_BUDGET_MS; // production default: 70s
+
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    islServer.closeAllConnections?.();
+    await new Promise<void>((resolve) => islServer.close(() => resolve()));
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    delete process.env.ISL_ENABLE;
+    delete process.env.ISL_BASE_URL;
+    delete process.env.ISL_API_KEY;
+    delete process.env.REQUEST_BUDGET_MS;
+  });
+
+  beforeEach(() => {
+    baseHits = [];
+    rejectionsRemaining = 0;
+    delete process.env.REQUEST_BUDGET_MS;
+  });
+
+  async function run() {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: 's2202' }),
+    });
+    return { statusCode: res.statusCode, body: JSON.parse(res.body) as any };
+  }
+
+  const critiqueCodes = (body: any): string[] =>
+    (body.critiques ?? []).map((c: any) => c.code);
+
+  it('POSITIVE CONTROL — the harness can SEE a clean run: 1 hit, no failure envelope', async () => {
+    // Trap 13: before asserting "the 429 no longer fails", prove this harness
+    // produces a PASS when there is nothing to retry. Without this, the
+    // success assertions below could pass by testing nothing.
+    rejectionsRemaining = 0;
+    const { statusCode, body } = await run();
+    expect(statusCode).toBe(200);
+    expect(baseHits).toHaveLength(1);
+    expect(body.analysis_status).not.toBe('failed');
+    expect(critiqueCodes(body)).not.toContain('ISL_CALL_FAILED');
+  }, 30_000);
+
+  it('POSITIVE CONTROL — the harness can SEE a failure: a NON-retryable 4xx still fails fast', async () => {
+    // The other half of the control. A 400 is not retryable, so it must still
+    // produce the typed-failure envelope after exactly ONE hit — proving the
+    // success assertions are not simply unable to observe a failure, and that
+    // the fix did not widen retries to non-classified statuses.
+    const original = rejectionsRemaining;
+    rejectionsRemaining = 0;
+    const previousHandlerHits = baseHits.length;
+    // Temporarily answer 400 by exhausting nothing and swapping the flag below.
+    nonRetryable400 = true;
+    try {
+      const { statusCode, body } = await run();
+      expect(statusCode).toBe(200); // V2 contract: failure is a 200 envelope
+      expect(baseHits.length - previousHandlerHits).toBe(1);
+      expect(body.analysis_status).toBe('failed');
+      expect(critiqueCodes(body)).toContain('ISL_CALL_FAILED');
+    } finally {
+      nonRetryable400 = false;
+      rejectionsRemaining = original;
+    }
+  }, 30_000);
+
+  it('⭐ RED-FIRST — 429 then 200 under ample budget: TWO attempts and a SUCCESS envelope', async () => {
+    rejectionsRemaining = 1;
+    const t0 = Date.now();
+    const { statusCode, body } = await run();
+    const elapsed = Date.now() - t0;
+
+    // The behaviour the tester feels: the analysis completes.
+    expect(statusCode).toBe(200);
+    expect(body.analysis_status).not.toBe('failed');
+    expect(critiqueCodes(body)).not.toContain('ISL_CALL_FAILED');
+    expect(JSON.stringify(body)).not.toContain('HTTP 429');
+
+    // The mechanism: exactly two attempts on the wire, one backoff apart.
+    // PRE-FIX this was ONE hit and a typed-failure envelope naming HTTP 429.
+    expect(baseHits).toHaveLength(2);
+    const gapMs = baseHits[1] - baseHits[0];
+    expect(gapMs).toBeGreaterThanOrEqual(900); // the 1s exponential backoff
+    expect(gapMs).toBeLessThan(4_000);
+
+    // ~69.8s of budget remained after a 133ms reject in production; here the
+    // whole recovery costs about one backoff.
+    expect(elapsed).toBeLessThan(20_000);
+  }, 40_000);
+
+  it('recovers from TWO consecutive 429s (1s then 2s backoff) — still inside budget', async () => {
+    rejectionsRemaining = 2;
+    const { statusCode, body } = await run();
+    expect(statusCode).toBe(200);
+    expect(body.analysis_status).not.toBe('failed');
+    expect(baseHits).toHaveLength(3);
+    expect(baseHits[1] - baseHits[0]).toBeGreaterThanOrEqual(900); // 1s
+    expect(baseHits[2] - baseHits[1]).toBeGreaterThanOrEqual(1_900); // 2s
+  }, 40_000);
+
+  it('⭐ BUDGET EXHAUSTION still yields the typed failure — bounded, no infinite retry', async () => {
+    // A budget too small to fit another attempt must terminate with exactly the
+    // pre-existing typed-failure envelope. This is the arm that proves the fix
+    // did not trade a 500 for a hang.
+    process.env.REQUEST_BUDGET_MS = '1500';
+    rejectionsRemaining = 99; // ISL never recovers
+    const t0 = Date.now();
+    const { statusCode, body } = await run();
+    const elapsed = Date.now() - t0;
+
+    expect(statusCode).toBe(200); // V2 contract: failed = 200 envelope
+    expect(body.analysis_status).toBe('failed');
+    expect(critiqueCodes(body)).toContain('ISL_CALL_FAILED');
+    expect(String(body.status_reason ?? '')).toContain('429');
+    expect(body.retryable).toBe(true);
+
+    // Bounded: it did not burn the attempt cap, and it did not hang.
+    expect(baseHits.length).toBeLessThanOrEqual(2);
+    expect(elapsed).toBeLessThan(15_000);
+  }, 40_000);
+
+  it('a persistent 429 under the FULL budget stops at the configured attempt cap (3), never loops', async () => {
+    rejectionsRemaining = 99;
+    const { statusCode, body } = await run();
+    expect(statusCode).toBe(200);
+    expect(body.analysis_status).toBe('failed');
+    // The cap is still a hard upper bound on top of the budget bound.
+    expect(baseHits.length).toBeLessThanOrEqual(3);
+    expect(baseHits.length).toBeGreaterThanOrEqual(1);
+  }, 60_000);
+});

--- a/tests/plot-2202-isl-retry-after.client.test.ts
+++ b/tests/plot-2202-isl-retry-after.client.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { createServer as createHttpServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { ISLClient } from '../src/integrations/isl/client.js';
-import { ISLHttpError } from '../src/integrations/isl/errors.js';
+import { ISLHttpError, ISLResponseProcessingError, isRetryableError } from '../src/integrations/isl/errors.js';
 import { islRetryBackoffMs } from '../src/config/timeouts.js';
 
 const ENDPOINT = '/api/v1/robustness/analyze/v2';
@@ -150,6 +150,49 @@ describe('2.202 — Retry-After is captured on ISLHttpError and honoured by the 
     expect(elapsed).toBeGreaterThanOrEqual(2_800);
   }, 30_000);
 
+  it('⭐ NO BUDGET — Retry-After is ignored; the client sleeps its own backoff (A1)', async () => {
+    // THE HIGH from the PR #295 adversarial review, pinned end-to-end on the
+    // real client. Every caller EXCEPT the /v2/run base call passes no budget:
+    // /v1/run's validateCausal + analyseRobustness run with maxRetries = 3 and
+    // no budget against the very endpoint whose governor 429 carries
+    // `Retry-After: 5`. The first cut honoured that hint with nothing bounding
+    // it, so this call slept 5s per retry (and a hostile/misconfigured
+    // `Retry-After: 3600` slept the hour, uninterruptibly).
+    rejectionsRemaining = 1;
+    retryAfterHeader = '3';
+    const t0 = Date.now();
+    const res = await client({ maxRetries: 3 }).request<{ ok: boolean }>({
+      endpoint: ENDPOINT,
+      body: {},
+      requestId: 'rid-nobudget',
+      // budget deliberately omitted — the pre-2.202 caller shape.
+    });
+    const elapsed = Date.now() - t0;
+
+    expect(res.data).toEqual({ ok: true });
+    expect(hits).toBe(2);
+    // ~1s (our backoff), NOT ~3s (the server's hint). This is the assertion
+    // that distinguishes "previous behaviour exactly" from "approximately".
+    expect(elapsed).toBeLessThan(2_000);
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+  }, 30_000);
+
+  it('⭐ NO BUDGET — an absurd Retry-After cannot stall the call (A1)', async () => {
+    // Without a budget there is nothing to reject the hint, so ignoring it is
+    // the ONLY thing keeping this bounded. Pre-A1 this slept for an hour and
+    // the test timed out.
+    rejectionsRemaining = 1;
+    retryAfterHeader = '3600';
+    const t0 = Date.now();
+    const res = await client({ maxRetries: 3 }).request<{ ok: boolean }>({
+      endpoint: ENDPOINT, body: {}, requestId: 'rid-nobudget-absurd',
+    });
+    const elapsed = Date.now() - t0;
+    expect(res.data).toEqual({ ok: true });
+    expect(hits).toBe(2);
+    expect(elapsed).toBeLessThan(2_000);
+  }, 30_000);
+
   it('an absurd Retry-After does NOT get slept — it fails the budget check and terminates', async () => {
     rejectionsRemaining = 99;
     retryAfterHeader = '3600'; // one hour
@@ -167,6 +210,94 @@ describe('2.202 — Retry-After is captured on ISLHttpError and honoured by the 
     expect((caught as ISLHttpError).status).toBe(429);
     expect(hits).toBe(1);
     expect(elapsed).toBeLessThan(5_000); // did not sleep for an hour
+  }, 20_000);
+});
+
+describe('2.202 review item C — a failure AFTER ISL computed must not re-issue the analysis', () => {
+  let badServer: Server;
+  let badPort: number;
+  let badHits = 0;
+  /** >0 → serve a retryable 429 first (used by the positive control). */
+  let controlRejections = 0;
+
+  beforeAll(async () => {
+    badServer = createHttpServer((req, res) => {
+      req.resume();
+      req.on('end', () => {
+        badHits++;
+        if (controlRejections > 0) {
+          controlRejections--;
+          res.writeHead(429, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ detail: 'caller_concurrency_exceeded' }));
+          return;
+        }
+        if (controlMode) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+        // 200 OK — ISL DID the work — but the body is not JSON.
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{"options": [ THIS IS NOT JSON');
+      });
+    });
+    await new Promise<void>((resolve) => badServer.listen(0, '127.0.0.1', () => resolve()));
+    badPort = (badServer.address() as AddressInfo).port;
+  });
+
+  /** When true the server returns well-formed JSON (control arm). */
+  let controlMode = false;
+
+  function badClient() {
+    return new ISLClient({
+      baseUrl: `http://127.0.0.1:${badPort}`,
+      apiKey: 'test-key',
+      timeoutMs: 2_000,
+      maxRetries: 3,
+    });
+  }
+
+  afterAll(async () => {
+    badServer.closeAllConnections?.();
+    await new Promise<void>((resolve) => badServer.close(() => resolve()));
+  });
+
+  beforeEach(() => { badHits = 0; controlRejections = 0; controlMode = false; });
+
+  it('⭐ an unparseable 2xx body is NOT retryable — one attempt, no recompute', async () => {
+    // Before 2.202 the catch wrapped any unrecognised error (incl. a JSON.parse
+    // SyntaxError) as an ISLNetworkError, which isRetryableError reports as
+    // RETRYABLE. That was inert while the base call was clamped to one attempt;
+    // 2.202 makes those retries reachable, so without the narrowing this would
+    // re-issue the WHOLE analysis — multiplying load on the very governor whose
+    // contention this change exists to survive.
+    let caught: unknown;
+    try {
+      await badClient().request({
+        endpoint: ENDPOINT, body: {}, requestId: 'rid-badjson',
+        budget: { remainingMs: 60_000 }, // ample — a retry WOULD fit if allowed
+      });
+    } catch (e) { caught = e; }
+
+    expect(caught).toBeInstanceOf(ISLResponseProcessingError);
+    expect(isRetryableError(caught)).toBe(false);
+    // The load-bearing assertion: ISL was asked to compute exactly ONCE.
+    expect(badHits).toBe(1);
+  }, 20_000);
+
+  it('CONTROL — the harness CAN see a retry against the SAME server and client config', async () => {
+    // Trap 13: without this, `badHits === 1` above could hold because nothing in
+    // this setup ever retries. Identical client, identical server, identical
+    // budget — only the failure CLASS differs (retryable 429 vs post-compute
+    // parse fault) — and the count goes to 2.
+    controlRejections = 1;
+    controlMode = true;
+    const res = await badClient().request<{ ok: boolean }>({
+      endpoint: ENDPOINT, body: {}, requestId: 'rid-c-control',
+      budget: { remainingMs: 60_000 },
+    });
+    expect(res.data).toEqual({ ok: true });
+    expect(badHits).toBe(2);
   }, 20_000);
 });
 

--- a/tests/plot-2202-isl-retry-after.client.test.ts
+++ b/tests/plot-2202-isl-retry-after.client.test.ts
@@ -1,0 +1,239 @@
+/**
+ * ROADMAP 2.202 — WALL-CLOCK proof that ISL's `Retry-After` reaches the retry
+ * decision, driving the REAL ISLClient against a real socket.
+ *
+ * THE DEFECT (diagnosis-run-analysis-500s.md §4): `ISLHttpError` captured
+ * `status`, `body`, `endpoint`, `islError` — and no headers. The response
+ * headers were read for `x-request-id` ONLY. So ISL's governor answering
+ * `RETRY_AFTER_SECONDS = 5` on its `caller_concurrency_exceeded` 429 emitted the
+ * one piece of actionable guidance in the whole chain, and PLoT discarded it.
+ *
+ * The timing arm is the load-bearing one: it distinguishes "slept for the
+ * server's 3s hint" from "slept for our own 1s backoff", which is the only way
+ * to prove the header was actually HONOURED rather than merely parsed.
+ *
+ * RED against the pre-fix code on both arms — transcript in the lane evidence file.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createServer as createHttpServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { ISLClient } from '../src/integrations/isl/client.js';
+import { ISLHttpError } from '../src/integrations/isl/errors.js';
+import { islRetryBackoffMs } from '../src/config/timeouts.js';
+
+const ENDPOINT = '/api/v1/robustness/analyze/v2';
+const PER_ATTEMPT_TIMEOUT_MS = 2_000;
+
+let server: Server;
+let port: number;
+let hits = 0;
+/** Value the fake ISL puts in the Retry-After header (undefined → omit). */
+let retryAfterHeader: string | undefined;
+/** How many 429s to serve before switching to 200. */
+let rejectionsRemaining = 0;
+
+function client(overrides: Partial<{ maxRetries: number; timeoutMs: number }> = {}) {
+  return new ISLClient({
+    baseUrl: `http://127.0.0.1:${port}`,
+    apiKey: 'test-key',
+    timeoutMs: overrides.timeoutMs ?? PER_ATTEMPT_TIMEOUT_MS,
+    maxRetries: overrides.maxRetries ?? 3,
+  });
+}
+
+describe('2.202 — Retry-After is captured on ISLHttpError and honoured by the retry', () => {
+  beforeAll(async () => {
+    server = createHttpServer((req, res) => {
+      req.resume();
+      req.on('end', () => {
+        hits++;
+        if (rejectionsRemaining > 0) {
+          rejectionsRemaining--;
+          const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+          if (retryAfterHeader !== undefined) headers['Retry-After'] = retryAfterHeader;
+          res.writeHead(429, headers);
+          res.end(JSON.stringify({ detail: 'caller_concurrency_exceeded' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    hits = 0;
+    rejectionsRemaining = 0;
+    retryAfterHeader = undefined;
+  });
+
+  it('CAPTURE — a 429 carrying Retry-After surfaces it as retryAfterMs on the thrown error', async () => {
+    rejectionsRemaining = 99;
+    retryAfterHeader = '5'; // ISL governor RETRY_AFTER_SECONDS
+    // maxRetries = 1 → one attempt, so the error is thrown unmodified.
+    let caught: unknown;
+    try {
+      await client({ maxRetries: 1 }).request({ endpoint: ENDPOINT, body: {}, requestId: 'rid-capture' });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ISLHttpError);
+    const err = caught as ISLHttpError;
+    expect(err.status).toBe(429);
+    expect(err.isRetryable()).toBe(true);
+    // PRE-FIX: this property did not exist — the header was never read.
+    expect(err.retryAfterMs).toBe(5_000);
+    expect(hits).toBe(1);
+  }, 20_000);
+
+  it('CONTROL — the same 429 WITHOUT the header leaves retryAfterMs undefined', async () => {
+    // Trap 13: proves the assertion above reads the header rather than a
+    // constant that would be present either way.
+    rejectionsRemaining = 99;
+    retryAfterHeader = undefined;
+    let caught: unknown;
+    try {
+      await client({ maxRetries: 1 }).request({ endpoint: ENDPOINT, body: {}, requestId: 'rid-nohdr' });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ISLHttpError);
+    expect((caught as ISLHttpError).retryAfterMs).toBeUndefined();
+  }, 20_000);
+
+  it('⭐ HONOURED — the client waits the server\'s 3s hint, not its own 1s backoff', async () => {
+    rejectionsRemaining = 1;
+    retryAfterHeader = '3';
+    expect(islRetryBackoffMs(1)).toBe(1_000); // what it would wait without the hint
+
+    const t0 = Date.now();
+    const res = await client({ maxRetries: 3 }).request<{ ok: boolean }>({
+      endpoint: ENDPOINT,
+      body: {},
+      requestId: 'rid-honoured',
+      budget: { remainingMs: 60_000 },
+    });
+    const elapsed = Date.now() - t0;
+
+    expect(res.data).toEqual({ ok: true });
+    expect(hits).toBe(2);
+    // The discriminating assertion: >= ~3s can only come from the 3s hint.
+    // PRE-FIX (backoff only) this landed at ~1s and the assertion FAILS.
+    expect(elapsed).toBeGreaterThanOrEqual(2_900);
+    expect(elapsed).toBeLessThan(10_000);
+  }, 30_000);
+
+  it('Retry-After never SHORTENS the wait below our own backoff', async () => {
+    // Attempt 2's backoff is 2s; a `Retry-After: 0` must not talk us into a
+    // hot retry loop against a service that is already rejecting us.
+    rejectionsRemaining = 2;
+    retryAfterHeader = '0';
+    const t0 = Date.now();
+    const res = await client({ maxRetries: 3 }).request<{ ok: boolean }>({
+      endpoint: ENDPOINT,
+      body: {},
+      requestId: 'rid-floor',
+      budget: { remainingMs: 60_000 },
+    });
+    const elapsed = Date.now() - t0;
+    expect(res.data).toEqual({ ok: true });
+    expect(hits).toBe(3);
+    // 1s + 2s of our own backoff must still have been slept.
+    expect(elapsed).toBeGreaterThanOrEqual(2_800);
+  }, 30_000);
+
+  it('an absurd Retry-After does NOT get slept — it fails the budget check and terminates', async () => {
+    rejectionsRemaining = 99;
+    retryAfterHeader = '3600'; // one hour
+    const t0 = Date.now();
+    let caught: unknown;
+    try {
+      await client({ maxRetries: 3 }).request({
+        endpoint: ENDPOINT, body: {}, requestId: 'rid-absurd',
+        budget: { remainingMs: 60_000 },
+      });
+    } catch (e) { caught = e; }
+    const elapsed = Date.now() - t0;
+
+    expect(caught).toBeInstanceOf(ISLHttpError);
+    expect((caught as ISLHttpError).status).toBe(429);
+    expect(hits).toBe(1);
+    expect(elapsed).toBeLessThan(5_000); // did not sleep for an hour
+  }, 20_000);
+});
+
+describe('2.202 — a SLOW failure must NOT buy a retry (the property the old clamp protected)', () => {
+  let hangServer: Server;
+  let hangPort: number;
+
+  beforeAll(async () => {
+    hangServer = createHttpServer(() => { /* accept and never respond */ });
+    await new Promise<void>((resolve) => hangServer.listen(0, '127.0.0.1', () => resolve()));
+    hangPort = (hangServer.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    hangServer.closeAllConnections?.();
+    await new Promise<void>((resolve) => hangServer.close(() => resolve()));
+  });
+
+  function hangClient(timeoutMs: number) {
+    return new ISLClient({
+      baseUrl: `http://127.0.0.1:${hangPort}`,
+      apiKey: 'test-key',
+      timeoutMs,
+      maxRetries: 3,
+    });
+  }
+
+  it('POSITIVE CONTROL — with AMPLE budget the same slow failure DOES retry', async () => {
+    // Trap 13: the "did not retry" claim below is vacuous unless this harness
+    // can see a retry at all. 3 attempts × 300ms + 1s + 2s backoff ≈ 3.9s.
+    const t0 = Date.now();
+    await expect(
+      hangClient(300).request({
+        endpoint: ENDPOINT, body: {}, requestId: 'rid-slow-control',
+        budget: { remainingMs: 60_000 },
+      }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeGreaterThan(3 * 300 + 2_000);
+  }, 30_000);
+
+  it('⭐ a failure that consumed the budget gets NO retry — bounded to one attempt', async () => {
+    // 500ms attempt, 1200ms budget: after the timeout ~700ms remain, and the
+    // next attempt would cost 1s backoff + 500ms + 1s margin. Does not fit.
+    const t0 = Date.now();
+    await expect(
+      hangClient(500).request({
+        endpoint: ENDPOINT, body: {}, requestId: 'rid-slow-bounded',
+        budget: { remainingMs: 1_200 },
+      }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - t0;
+    // One attempt only — no backoff sleep, no second attempt.
+    expect(elapsed).toBeLessThan(1_800);
+  }, 20_000);
+
+  it('⭐ the retry never outlives the supplied budget', async () => {
+    // The invariant that replaces the old up-front worst-case arithmetic.
+    const BUDGET_MS = 3_000;
+    const t0 = Date.now();
+    await expect(
+      hangClient(400).request({
+        endpoint: ENDPOINT, body: {}, requestId: 'rid-budget-bound',
+        budget: { remainingMs: BUDGET_MS },
+      }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeLessThanOrEqual(BUDGET_MS);
+  }, 20_000);
+});

--- a/tests/plot-2202-retry-budget-decision.test.ts
+++ b/tests/plot-2202-retry-budget-decision.test.ts
@@ -20,11 +20,23 @@ import {
   DEFAULT_RETRY_SAFETY_MARGIN_MS,
 } from '../src/integrations/isl/retry-budget.js';
 import { parseRetryAfterMs, ISLHttpError } from '../src/integrations/isl/errors.js';
-import { islRetryBackoffMs, worstCaseMs } from '../src/config/timeouts.js';
+import {
+  islRetryBackoffMs,
+  worstCaseMs,
+  ISL_TIMEOUT_MS,
+  ISL_RETRY_BACKOFF_CAP_MS,
+  resolveRequestBudgetMs,
+} from '../src/config/timeouts.js';
 
-/** The live production shape from the diagnosis. */
-const PROD_BUDGET_MS = 70_000;
-const PROD_PER_ATTEMPT_MS = 60_000;
+/**
+ * The live production shape from the diagnosis — DERIVED from the real
+ * constants, not restated as literals (trap 12: a hand-copied mirror drifts
+ * silently, and drift always reads as green). These used to be `70_000` and
+ * `60_000` written out by hand, which meant a one-line bump of ISL_TIMEOUT_MS
+ * could disable the whole fix with the entire suite still green.
+ */
+const PROD_BUDGET_MS = resolveRequestBudgetMs(); // REQUEST_BUDGET_MS, 70s default
+const PROD_PER_ATTEMPT_MS = ISL_TIMEOUT_MS; // 60s default
 const OBSERVED_429_ELAPSED_MS = 133; // measured: PLoT's boundary.response downstream elapsed_ms
 const ISL_RETRY_AFTER_MS = 5_000; // ISL governor RETRY_AFTER_SECONDS = 5
 
@@ -48,6 +60,44 @@ describe('decideIslRetry — the fast-429 case that was structurally unreachable
     // ~69.9s remained. The projection (5s wait + 60s attempt) fits with room.
     expect(d.remainingMs).toBe(PROD_BUDGET_MS - OBSERVED_429_ELAPSED_MS);
     expect(d.projectedCostMs).toBe(ISL_RETRY_AFTER_MS + PROD_PER_ATTEMPT_MS);
+  });
+
+  it('⭐ HEADROOM — the fix only works while a 5s wait + a full attempt still fits the budget', () => {
+    // ⚠ CROSS-REPO COUPLING, and it is TIGHT. The fix depends on an arithmetic
+    // relation between THREE independently-owned numbers:
+    //   • ISL_RETRY_AFTER_MS   — owned by ISL (compute_governor RETRY_AFTER_SECONDS = 5)
+    //   • ISL_TIMEOUT_MS       — owned by PLoT config (60s)
+    //   • REQUEST_BUDGET_MS    — owned by PLoT config (70s), env-overridable
+    // Live headroom at the defaults is only ~8.9s. A one-line bump of
+    // ISL_TIMEOUT_MS to >=64s silently disables the retry — the decision would
+    // return `budget_exhausted` for the exact 133ms 429 this change exists to
+    // retry — and every other test here would stay GREEN, because they pin the
+    // decision function rather than this relation. That is the trap-12 shape:
+    // the failure reads as green.
+    //
+    // So pin the relation itself. If this goes RED, the fix is OFF in
+    // production and the numbers must be re-derived together, not one at a time.
+    const headroomMs =
+      PROD_BUDGET_MS - OBSERVED_429_ELAPSED_MS
+      - (ISL_RETRY_AFTER_MS + PROD_PER_ATTEMPT_MS + DEFAULT_RETRY_SAFETY_MARGIN_MS);
+    expect(
+      headroomMs,
+      `2.202 is DISABLED at these constants: a ${ISL_RETRY_AFTER_MS}ms Retry-After plus a ` +
+      `${PROD_PER_ATTEMPT_MS}ms attempt plus the ${DEFAULT_RETRY_SAFETY_MARGIN_MS}ms margin does not ` +
+      `fit ${PROD_BUDGET_MS}ms of budget. Re-derive ISL_TIMEOUT_MS / REQUEST_BUDGET_MS together.`,
+    ).toBeGreaterThan(0);
+
+    // …and prove the relation is what actually drives the decision, so this is
+    // not an assertion about arithmetic that nothing consults.
+    expect(
+      decideIslRetry({
+        retryable: true, attempt: 1, maxAttempts: 3,
+        elapsedMs: OBSERVED_429_ELAPSED_MS,
+        perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
+        retryAfterMs: ISL_RETRY_AFTER_MS,
+        budget: { remainingMs: PROD_BUDGET_MS },
+      }).retry,
+    ).toBe(true);
   });
 
   it('WITNESS for the old policy: the up-front worst-case count allowed only 1 attempt', () => {
@@ -174,6 +224,53 @@ describe('decideIslRetry — blast radius: no budget supplied = previous behavio
     expect(d.reason).toBe('attempts_remaining');
     expect(d.delayMs).toBe(islRetryBackoffMs(1));
     expect(d.remainingMs).toBeUndefined();
+  });
+
+  it('⭐ IGNORES Retry-After entirely — an unbounded hint must not reach an unbounded path', () => {
+    // THE HIGH FROM THE PR #295 ADVERSARIAL REVIEW. The first cut computed
+    // delayMs = max(retryAfterMs, backoffMs) BEFORE the !budget branch and
+    // returned it there, so `Retry-After: 3600` on a path with no budget to
+    // bound it meant a ONE-HOUR uninterruptible sleep.
+    //
+    // Live exposure, not theoretical: /v1/run calls validateCausal +
+    // analyseRobustness with maxRetries = 3 and NO budget, against the very
+    // endpoint whose governor 429 carries `Retry-After: 5`. The first cut would
+    // have added ~7 s per call under exactly the contention 2.202 fixes.
+    const absurd = decideIslRetry({
+      retryable: true,
+      attempt: 1,
+      maxAttempts: 3,
+      elapsedMs: 0,
+      perAttemptTimeoutMs: 60_000,
+      retryAfterMs: 3_600_000, // one hour
+      budget: undefined,
+    });
+    expect(absurd.retry).toBe(true);
+    expect(absurd.delayMs).toBe(islRetryBackoffMs(1)); // 1s, NOT 3_600_000
+    expect(absurd.retryAfterHonoured).toBe(false);
+    expect(absurd.projectedCostMs).toBe(islRetryBackoffMs(1) + 60_000);
+
+    // The realistic case is the one that actually bit: ISL's own 5s hint.
+    const governor = decideIslRetry({
+      retryable: true, attempt: 1, maxAttempts: 3, elapsedMs: 0,
+      perAttemptTimeoutMs: 60_000, retryAfterMs: 5_000, budget: undefined,
+    });
+    expect(governor.delayMs).toBe(1_000); // our backoff, not the 5s hint
+    expect(governor.retryAfterHonoured).toBe(false);
+  });
+
+  it('the no-budget delay is bounded by our backoff CAP for every attempt', () => {
+    // The structural guarantee that replaces "trust the server's number": with
+    // no budget, the delay can never exceed ISL_RETRY_BACKOFF_CAP_MS, whatever
+    // ISL asks for.
+    for (const attempt of [1, 2, 3, 4, 5]) {
+      const d = decideIslRetry({
+        retryable: true, attempt, maxAttempts: 99, elapsedMs: 0,
+        perAttemptTimeoutMs: 1_000, retryAfterMs: 86_400_000, budget: undefined,
+      });
+      expect(d.delayMs).toBe(islRetryBackoffMs(attempt));
+      expect(d.delayMs).toBeLessThanOrEqual(ISL_RETRY_BACKOFF_CAP_MS);
+    }
   });
 
   it('and still stops at the cap — maxRetries = 1 means one attempt (F3/F9 optional phases)', () => {

--- a/tests/plot-2202-retry-budget-decision.test.ts
+++ b/tests/plot-2202-retry-budget-decision.test.ts
@@ -1,0 +1,276 @@
+/**
+ * ROADMAP 2.202 — unit pins for the retry-budget decision and Retry-After parsing.
+ *
+ * THE DEFECT (diagnosis-run-analysis-500s.md §4): the ISL retry bound was a
+ * TOTAL-ATTEMPT COUNT fixed before the first byte was sent, derived from
+ * WORST-CASE timeouts. At the 70s budget with a 60s per-attempt timeout,
+ * `worstCaseMs(2, 60_000) = 121_000 > 69_800` → 1 attempt → ZERO retries. ISL's
+ * compute governor then rejected a 3rd concurrent analysis with a 429 that
+ * returned in 133 ms, and PLoT emitted a typed-failure envelope with ~69.8 s of
+ * budget unspent. `ISLHttpError.isRetryable()` already returned true for 429 —
+ * the retry was correct and structurally unreachable.
+ *
+ * These are the fast, pure pins. The wall-clock proof that the real client
+ * actually performs the retry lives in tests/plot-2202-isl-retry-budget.client.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  decideIslRetry,
+  DEFAULT_RETRY_SAFETY_MARGIN_MS,
+} from '../src/integrations/isl/retry-budget.js';
+import { parseRetryAfterMs, ISLHttpError } from '../src/integrations/isl/errors.js';
+import { islRetryBackoffMs, worstCaseMs } from '../src/config/timeouts.js';
+
+/** The live production shape from the diagnosis. */
+const PROD_BUDGET_MS = 70_000;
+const PROD_PER_ATTEMPT_MS = 60_000;
+const OBSERVED_429_ELAPSED_MS = 133; // measured: PLoT's boundary.response downstream elapsed_ms
+const ISL_RETRY_AFTER_MS = 5_000; // ISL governor RETRY_AFTER_SECONDS = 5
+
+describe('decideIslRetry — the fast-429 case that was structurally unreachable', () => {
+  it('RETRIES the observed 133ms 429 under the real production budget', () => {
+    // The exact live numbers. This is the whole point of 2.202.
+    const d = decideIslRetry({
+      retryable: true,
+      attempt: 1,
+      maxAttempts: 3,
+      elapsedMs: OBSERVED_429_ELAPSED_MS,
+      perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
+      retryAfterMs: ISL_RETRY_AFTER_MS,
+      budget: { remainingMs: PROD_BUDGET_MS },
+    });
+
+    expect(d.retry).toBe(true);
+    expect(d.reason).toBe('budget_available');
+    expect(d.delayMs).toBe(ISL_RETRY_AFTER_MS); // honoured, not our 1s backoff
+    expect(d.retryAfterHonoured).toBe(true);
+    // ~69.9s remained. The projection (5s wait + 60s attempt) fits with room.
+    expect(d.remainingMs).toBe(PROD_BUDGET_MS - OBSERVED_429_ELAPSED_MS);
+    expect(d.projectedCostMs).toBe(ISL_RETRY_AFTER_MS + PROD_PER_ATTEMPT_MS);
+  });
+
+  it('WITNESS for the old policy: the up-front worst-case count allowed only 1 attempt', () => {
+    // Not a test of new code — it pins WHY the retry was unreachable, so the
+    // regression that reintroduces up-front counting is legible here.
+    expect(worstCaseMs(2, PROD_PER_ATTEMPT_MS)).toBeGreaterThan(PROD_BUDGET_MS);
+    // …while the ACTUAL cost of the failure was three orders of magnitude less.
+    expect(OBSERVED_429_ELAPSED_MS).toBeLessThan(PROD_BUDGET_MS / 100);
+  });
+});
+
+describe('decideIslRetry — the budget bound (no infinite retry, no budget overrun)', () => {
+  it('refuses when the next attempt does not fit the remaining budget', () => {
+    const d = decideIslRetry({
+      retryable: true,
+      attempt: 1,
+      maxAttempts: 3,
+      elapsedMs: 60_000, // a SLOW failure that consumed the budget
+      perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
+      budget: { remainingMs: PROD_BUDGET_MS },
+    });
+    expect(d.retry).toBe(false);
+    expect(d.reason).toBe('budget_exhausted');
+    expect(d.delayMs).toBe(0);
+  });
+
+  it('⭐ preserves the property the OLD up-front clamp existed to protect', () => {
+    // A slow failure must never buy a retry that outlives the caller. Sweep the
+    // whole elapsed range: once the projection stops fitting, it never restarts.
+    let firstRefusalAt: number | undefined;
+    for (let elapsedMs = 0; elapsedMs <= PROD_BUDGET_MS; elapsedMs += 500) {
+      const d = decideIslRetry({
+        retryable: true,
+        attempt: 1,
+        maxAttempts: 3,
+        elapsedMs,
+        perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
+        budget: { remainingMs: PROD_BUDGET_MS },
+      });
+      if (!d.retry) {
+        firstRefusalAt ??= elapsedMs;
+        expect(d.reason).toBe('budget_exhausted');
+      } else {
+        // Monotonic: no retry is ever granted after the first refusal.
+        expect(firstRefusalAt).toBeUndefined();
+        // And a granted retry ALWAYS leaves room for the full attempt.
+        expect(d.projectedCostMs + DEFAULT_RETRY_SAFETY_MARGIN_MS).toBeLessThanOrEqual(d.remainingMs!);
+      }
+    }
+    expect(firstRefusalAt, 'the budget bound must bite somewhere in the sweep').toBeDefined();
+  });
+
+  it('an attempt is only ever granted when its FULL per-attempt timeout still fits', () => {
+    // The invariant that makes overrunning the caller impossible by construction.
+    for (const elapsedMs of [0, 1_000, 5_000, 8_000, 8_999, 9_000]) {
+      const d = decideIslRetry({
+        retryable: true,
+        attempt: 1,
+        maxAttempts: 5,
+        elapsedMs,
+        perAttemptTimeoutMs: 5_000,
+        budget: { remainingMs: 12_000 },
+      });
+      if (d.retry) {
+        expect(elapsedMs + d.delayMs + 5_000).toBeLessThanOrEqual(12_000);
+      }
+    }
+  });
+
+  it('still honours the configured attempt cap even with unlimited budget', () => {
+    const d = decideIslRetry({
+      retryable: true,
+      attempt: 3,
+      maxAttempts: 3,
+      elapsedMs: 0,
+      perAttemptTimeoutMs: 1_000,
+      budget: { remainingMs: Number.MAX_SAFE_INTEGER },
+    });
+    expect(d.retry).toBe(false);
+    expect(d.reason).toBe('attempt_cap');
+  });
+
+  it('never retries a non-retryable failure, however much budget remains', () => {
+    const d = decideIslRetry({
+      retryable: false,
+      attempt: 1,
+      maxAttempts: 3,
+      elapsedMs: 0,
+      perAttemptTimeoutMs: 1_000,
+      budget: { remainingMs: PROD_BUDGET_MS },
+    });
+    expect(d.retry).toBe(false);
+    expect(d.reason).toBe('not_retryable');
+  });
+
+  it('an absurd Retry-After self-limits — no arbitrary cap is invented', () => {
+    // Retry-After: 3600 → the projection cannot fit, so the call terminates with
+    // the typed failure instead of sleeping for an hour.
+    const d = decideIslRetry({
+      retryable: true,
+      attempt: 1,
+      maxAttempts: 3,
+      elapsedMs: 133,
+      perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
+      retryAfterMs: 3_600_000,
+      budget: { remainingMs: PROD_BUDGET_MS },
+    });
+    expect(d.retry).toBe(false);
+    expect(d.reason).toBe('budget_exhausted');
+  });
+});
+
+describe('decideIslRetry — blast radius: no budget supplied = previous behaviour exactly', () => {
+  it('retries on attempts-remaining with the plain exponential backoff (flip probes / thresholds)', () => {
+    const d = decideIslRetry({
+      retryable: true,
+      attempt: 1,
+      maxAttempts: 3,
+      elapsedMs: 999_999, // irrelevant without a budget — exactly as before
+      perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
+      budget: undefined,
+    });
+    expect(d.retry).toBe(true);
+    expect(d.reason).toBe('attempts_remaining');
+    expect(d.delayMs).toBe(islRetryBackoffMs(1));
+    expect(d.remainingMs).toBeUndefined();
+  });
+
+  it('and still stops at the cap — maxRetries = 1 means one attempt (F3/F9 optional phases)', () => {
+    const d = decideIslRetry({
+      retryable: true,
+      attempt: 1,
+      maxAttempts: 1,
+      elapsedMs: 0,
+      perAttemptTimeoutMs: 250,
+      budget: undefined,
+    });
+    expect(d.retry).toBe(false);
+    expect(d.reason).toBe('attempt_cap');
+  });
+});
+
+describe('Retry-After: a MINIMUM wait — it can lengthen the delay, never shorten it', () => {
+  it('uses Retry-After when it exceeds our backoff', () => {
+    const d = decideIslRetry({
+      retryable: true, attempt: 1, maxAttempts: 3, elapsedMs: 0,
+      perAttemptTimeoutMs: 1_000, retryAfterMs: 5_000,
+      budget: { remainingMs: 60_000 },
+    });
+    expect(d.delayMs).toBe(5_000);
+    expect(d.retryAfterHonoured).toBe(true);
+  });
+
+  it('keeps our backoff when Retry-After is SHORTER (never retry sooner than our own policy)', () => {
+    const d = decideIslRetry({
+      retryable: true, attempt: 2, maxAttempts: 3, elapsedMs: 0,
+      perAttemptTimeoutMs: 1_000, retryAfterMs: 100,
+      budget: { remainingMs: 60_000 },
+    });
+    expect(islRetryBackoffMs(2)).toBe(2_000);
+    expect(d.delayMs).toBe(2_000);
+    expect(d.retryAfterHonoured).toBe(false);
+  });
+
+  it('falls back to the backoff series when ISL sent no usable hint', () => {
+    for (const attempt of [1, 2, 3]) {
+      const d = decideIslRetry({
+        retryable: true, attempt, maxAttempts: 9, elapsedMs: 0,
+        perAttemptTimeoutMs: 100, retryAfterMs: undefined,
+        budget: { remainingMs: 600_000 },
+      });
+      expect(d.delayMs).toBe(islRetryBackoffMs(attempt));
+      expect(d.retryAfterHonoured).toBe(false);
+    }
+  });
+});
+
+describe('parseRetryAfterMs — RFC 7231 both forms', () => {
+  it('delta-seconds', () => {
+    expect(parseRetryAfterMs('5')).toBe(5_000); // ISL governor RETRY_AFTER_SECONDS
+    expect(parseRetryAfterMs('0')).toBe(0);
+    expect(parseRetryAfterMs('  5  ')).toBe(5_000);
+  });
+
+  it('HTTP-date, measured against the supplied now', () => {
+    const now = Date.parse('2026-07-31T09:00:00Z');
+    expect(parseRetryAfterMs('Fri, 31 Jul 2026 09:00:07 GMT', now)).toBe(7_000);
+  });
+
+  it('a PAST HTTP-date clamps to 0, never negative', () => {
+    const now = Date.parse('2026-07-31T09:00:00Z');
+    expect(parseRetryAfterMs('Fri, 31 Jul 2026 08:59:00 GMT', now)).toBe(0);
+  });
+
+  it('absent / blank / unparseable → undefined, so the caller falls back to its own backoff', () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs('')).toBeUndefined();
+    expect(parseRetryAfterMs('   ')).toBeUndefined();
+    expect(parseRetryAfterMs('soon')).toBeUndefined();
+  });
+
+  it('⚠ a bare signed/decimal number is rejected — Date.parse would read it as a YEAR', () => {
+    // `Date.parse('-5')` SUCCEEDS (year -5), so without an explicit reject a
+    // malformed header becomes a multi-millennium delay rather than a fallback
+    // to our own backoff. Guards the exact hole found writing this pin.
+    expect(parseRetryAfterMs('-5')).toBeUndefined();
+    expect(parseRetryAfterMs('+5')).toBeUndefined();
+    expect(parseRetryAfterMs('1.5')).toBeUndefined();
+  });
+});
+
+describe('ISLHttpError carries Retry-After (it was dropped entirely before 2.202)', () => {
+  it('exposes retryAfterMs and still classifies 429 as retryable', () => {
+    const err = new ISLHttpError(429, '{"detail":"caller_concurrency_exceeded"}',
+      '/api/v1/robustness/analyze/v2', undefined, 5_000);
+    expect(err.retryAfterMs).toBe(5_000);
+    expect(err.isRetryable()).toBe(true);
+  });
+
+  it('is undefined when ISL sent no hint (unchanged for every other error path)', () => {
+    const err = new ISLHttpError(500, 'boom', '/api/v1/robustness/analyze/v2');
+    expect(err.retryAfterMs).toBeUndefined();
+    expect(err.isRetryable()).toBe(true);
+  });
+});

--- a/tests/plot-remediation.base-call-budget.route.test.ts
+++ b/tests/plot-remediation.base-call-budget.route.test.ts
@@ -163,8 +163,16 @@ describe('item 4 — base ISL robustness call clamped to the request budget', ()
     expect(c.budget!.remainingMs).toBeLessThanOrEqual(70_000);
     // A reserve is kept unspent so the route can still build its response.
     expect(c.budget!.safetyMarginMs).toBeGreaterThan(0);
-    // And one full attempt plus the margin fits inside it — the invariant that
-    // makes overrunning the caller impossible by construction.
+    // And at the DEFAULT budget one full attempt plus the margin fits inside it.
+    //
+    // ⚠ Stated narrowly on purpose (review item E). An earlier draft called this
+    // "impossible by construction", which overstates what the code gives: the
+    // per-attempt timeout is floored at BASE_CALL_MIN_TIMEOUT_MS (1s), so at a
+    // sufficiently small REQUEST_BUDGET_MS the floor wins and the first attempt
+    // CAN exceed the remaining budget. What IS guaranteed everywhere is weaker
+    // and still sufficient: no RETRY is ever started unless its full per-attempt
+    // timeout fits, so the retry ladder cannot outlive the caller — the first
+    // attempt is bounded by the clamp, not by this arithmetic.
     expect(c.timeoutMs! + c.budget!.safetyMarginMs!).toBeLessThanOrEqual(c.budget!.remainingMs);
   });
 

--- a/tests/plot-remediation.base-call-budget.route.test.ts
+++ b/tests/plot-remediation.base-call-budget.route.test.ts
@@ -1,14 +1,35 @@
 /**
- * A3 remediation item 4 (2026-07-18) — the base /v2/run ISL robustness call is
- * clamped to the remaining request budget so its retries cannot outlive the
- * caller. Unclamped it was ISL_TIMEOUT_MS (60s) per attempt × ISL_MAX_RETRIES
- * (3) ≈ 180s worst case, past the UI's 120s client timeout — losing the WHOLE
- * analysis. This test captures the (timeoutMs, maxRetries) the route passes to
- * callAnalysisEndpoint for the base robustness endpoint and asserts the
- * worst-case total (maxRetries × per-attempt timeout) is bounded.
+ * A3 remediation item 4 (2026-07-18) — the base /v2/run ISL robustness call must
+ * not outlive the caller. Unclamped it was ISL_TIMEOUT_MS (60s) per attempt ×
+ * ISL_MAX_RETRIES (3) ≈ 180s worst case, past the UI's 120s client timeout —
+ * losing the WHOLE analysis.
  *
- * RED against the pre-fix code: the base call passed NO timeoutMs/maxRetries
- * (undefined → config default 60s × 3 = 180s worst case). See mutation transcript.
+ * ⚠ RE-POINTED 2026-07-31 (ROADMAP 2.202). THE INVARIANT IS UNCHANGED; THE
+ * MECHANISM THAT ENFORCES IT CHANGED, AND THIS FILE PINNED THE MECHANISM.
+ *
+ * As written, this file asserted `worstCaseMs(maxRetries, timeoutMs) <= 70_000`
+ * on the attempt count the route passed up front. That is exactly the
+ * duration-blind, worst-case accounting 2.202 removes: it priced a 133 ms ISL
+ * 429 at a full 60 s per-attempt timeout, so the count resolved to 1, the
+ * (correct) 429 retry was structurally unreachable, and /v2/run returned a
+ * typed-failure envelope with ~69.8 s of budget unspent — the HTTP 500 the
+ * tester saw (diagnosis-run-analysis-500s.md §4).
+ *
+ * Left unchanged this file would have gone RED against its own fix while
+ * appearing to defend it — the mutant the diagnosis warned about for ISL's
+ * fix ② ("re-point it in the same change or it blocks the fix"). So it is
+ * re-pointed to the NEW enforcement, which is strictly stronger because it is
+ * checked at runtime against the live budget rather than by static arithmetic:
+ *
+ *   • the route still passes a per-attempt timeout clamped to the budget;
+ *   • the route now also passes a `budget`, never larger than the request
+ *     budget, and the client starts an attempt only when its FULL per-attempt
+ *     timeout still fits — so the base call still cannot outlive the caller;
+ *   • ONE attempt's worst case still fits the budget and the UI's 120s.
+ *
+ * The wall-clock proof that the runtime bound actually bites (a slow failure
+ * gets no retry; total never exceeds the budget) is in
+ * tests/plot-2202-isl-retry-after.client.test.ts, which drives the real client.
  *
  * Harness modelled on tests/lane3-stability-bands-carrythrough.test.ts.
  */
@@ -20,8 +41,9 @@ import { ISL_TIMEOUT_MS, worstCaseMs } from '../src/config/timeouts.js';
 const BASE_ROBUSTNESS_ENDPOINT = '/api/v1/robustness/analyze/v2';
 const UI_CLIENT_TIMEOUT_MS = 120_000; // the binding caller hop
 
-// Records the per-call (timeoutMs, maxRetries) for the base robustness call.
-const captured: Array<{ endpoint: string; timeoutMs?: number; maxRetries?: number }> = [];
+// Records the per-call (timeoutMs, maxRetries, budget) for the base robustness call.
+interface Budget { remainingMs: number; safetyMarginMs?: number }
+const captured: Array<{ endpoint: string; timeoutMs?: number; maxRetries?: number; budget?: Budget }> = [];
 
 const ISL_DATA = {
   options: [
@@ -42,8 +64,8 @@ const mockISLService = {
   async analyseRobustness() { return { ...ISL_DATA, source: 'isl' as const, latency_ms: 42 }; },
   async analyseFactorSensitivity() { return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.82, latency_ms: 0, source: 'unavailable' as const }; },
   async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
-  async callAnalysisEndpoint<T>(endpoint: string, _body: unknown, _requestId: string, timeoutMs?: number, maxRetries?: number): Promise<{ data: T | null; error: string | null }> {
-    captured.push({ endpoint, timeoutMs, maxRetries });
+  async callAnalysisEndpoint<T>(endpoint: string, _body: unknown, _requestId: string, timeoutMs?: number, maxRetries?: number, _signal?: AbortSignal, budget?: Budget): Promise<{ data: T | null; error: string | null }> {
+    captured.push({ endpoint, timeoutMs, maxRetries, budget });
     return { data: ISL_DATA as T, error: null };
   },
 };
@@ -111,28 +133,51 @@ describe('item 4 — base ISL robustness call clamped to the request budget', ()
     expect(c.maxRetries!).toBeGreaterThanOrEqual(1);
   });
 
-  it('worst-case total (maxRetries × per-attempt) is under the UI 120s timeout at the default budget', async () => {
+  it('ONE attempt still fits the budget and the UI 120s timeout', async () => {
     delete process.env.REQUEST_BUDGET_MS; // default 70s
     await run();
     const c = baseCall();
-    // Honest accounting (F11): include the 1s+2s… backoff the client sleeps
-    // between attempts — the previous `maxRetries × timeoutMs` omitted it and so
-    // could not see the very omission this cluster fixes.
-    const worstCase = worstCaseMs(c.maxRetries!, c.timeoutMs!);
-    // Pre-fix worst case was 60_000 × 3 = 180_000 (> 120_000). Now bounded.
-    expect(worstCase).toBeLessThan(UI_CLIENT_TIMEOUT_MS);
-    // …and within the request budget envelope (70s default).
-    expect(worstCase).toBeLessThanOrEqual(70_000);
+    // Honest accounting (F11): worstCaseMs includes the backoff slept BETWEEN
+    // attempts. For a single attempt that is just the per-attempt timeout — the
+    // only total that is guaranteed up front now that further attempts are
+    // gated on the LIVE budget (2.202) rather than counted in advance.
+    const singleAttempt = worstCaseMs(1, c.timeoutMs!);
+    // Pre-clamp this was the unclamped 60s default against whatever remained.
+    expect(singleAttempt).toBeLessThan(UI_CLIENT_TIMEOUT_MS);
+    expect(singleAttempt).toBeLessThanOrEqual(70_000);
+  });
+
+  it('⭐ 2.202 — the route hands the client the budget that actually remains', async () => {
+    // The replacement for the up-front worst-case attempt count. Without this
+    // the client falls back to count-only bounding and the 429 retry is
+    // unreachable again — the exact defect 2.202 removes.
+    delete process.env.REQUEST_BUDGET_MS; // default 70s
+    await run();
+    const c = baseCall();
+    expect(c.budget, 'base call must receive a retry budget').toBeDefined();
+    expect(typeof c.budget!.remainingMs).toBe('number');
+    expect(Number.isFinite(c.budget!.remainingMs)).toBe(true);
+    // Derived from the request budget, never invented: it is what is LEFT of the
+    // 70s default after the work already done, so ≤ 70s and > 0.
+    expect(c.budget!.remainingMs).toBeGreaterThan(0);
+    expect(c.budget!.remainingMs).toBeLessThanOrEqual(70_000);
+    // A reserve is kept unspent so the route can still build its response.
+    expect(c.budget!.safetyMarginMs).toBeGreaterThan(0);
+    // And one full attempt plus the margin fits inside it — the invariant that
+    // makes overrunning the caller impossible by construction.
+    expect(c.timeoutMs! + c.budget!.safetyMarginMs!).toBeLessThanOrEqual(c.budget!.remainingMs);
   });
 
   it('a tighter runtime budget clamps harder (mirror of the flip-block clamp)', async () => {
     process.env.REQUEST_BUDGET_MS = '30000';
     await run();
     const c = baseCall();
-    const worstCase = worstCaseMs(c.maxRetries!, c.timeoutMs!);
     expect(c.timeoutMs!).toBeLessThanOrEqual(30_000);
-    expect(worstCase).toBeLessThanOrEqual(30_000);
-    expect(worstCase).toBeLessThan(UI_CLIENT_TIMEOUT_MS);
+    expect(worstCaseMs(1, c.timeoutMs!)).toBeLessThanOrEqual(30_000);
+    expect(worstCaseMs(1, c.timeoutMs!)).toBeLessThan(UI_CLIENT_TIMEOUT_MS);
+    // The budget the client is given shrinks with it — so the retry bound
+    // tracks the real budget rather than a value fixed at the default.
+    expect(c.budget!.remainingMs).toBeLessThanOrEqual(30_000);
     delete process.env.REQUEST_BUDGET_MS;
   });
 });


### PR DESCRIPTION
**ROADMAP 2.202, fix ①** — the cheapest repair for the `run_analysis` 500 class.
Diagnosis of record: `PHASE0-EVIDENCE-2026-07-28/diagnosis-run-analysis-500s.md` §4 + §7 FIX 1.
Lane evidence (RED-first, mutations, gate): `PHASE0-EVIDENCE-2026-07-28/fix-plot-retry-budget-2202.md`.

`DO-NOT-MERGE` prefix per the lane brief — review gate, not a merge block on CI.

## The defect

ISL's compute governor caps concurrent analyses **per API key** at `ANALYSIS_WORKERS` (2). PLoT holds
**one key for the whole product**, so that per-caller fairness gate is a *global* 2-slot cap — and one
analysis's ~10 flip probes can occupy both by itself. The 3rd concurrent analysis gets
`429 caller_concurrency_exceeded` back in **133 ms**.

PLoT already classified 429 as retryable (`ISLHttpError.isRetryable`) — and did not retry, because
`/v2/run` chose the base call's attempt count **up front, from worst-case timeouts**:

```
worstCaseMs(2, 60_000) = 121_000  >  ~69_800 remaining  →  1 attempt  →  zero retries
```

So PLoT emitted a typed-failure envelope with **~69.8 s of the request budget unspent**, and CEE
mapped it to the HTTP 500 the tester saw — 4 of 20 chip-click `run_analysis` attempts on the 31 Jul
probe. The retry machinery was correct and **structurally unreachable**.

The flaw was **duration-blindness**: pricing every failure at a full per-attempt timeout treats a
133 ms reject exactly like a 60 s one.

## The fix

Decide **after** the failure, from the budget that **actually remains**: project the next attempt's
real cost (`delay + per-attempt timeout`) and retry iff it still fits. No "is this failure fast?"
constant — every term is derived, and the delay is `max(Retry-After, our backoff)`.

- **`errors.ts`** — `parseRetryAfterMs` (RFC 7231 delta-seconds *and* HTTP-date) and
  `ISLHttpError.retryAfterMs`. ISL sends `Retry-After: 5` on the governor 429 and PLoT **discarded it
  entirely**: response headers were read for `x-request-id` only. Treated as a **minimum** wait — it
  can lengthen the delay, never shorten it below our own backoff.
- **`retry-budget.ts`** (new) — `decideIslRetry`, pure and directly pinnable.
- **`client.ts`** — `ISLRequestOptions.budget`; the retry gate is `decideIslRetry` instead of
  `attempt === maxRetries`; `isl_retry_scheduled` / `isl_retry_declined` telemetry so governor
  contention is observable **without** cross-service log forensics (the diagnosis needed three
  services' Render logs to see this at all).
- **`run.ts`** — the base call passes the configured cap as an *upper bound* plus the live remaining
  budget.

## Preserved deliberately

- A **slow** failure that consumed the budget still gets **no** retry — the property the old up-front
  clamp existed to protect. Pinned wall-clock, with a positive control proving the harness can see a
  retry when one is due.
- An attempt is only ever **started** when its **full** per-attempt timeout still fits, so the base
  call cannot outlive the caller.
- Budget exhaustion still yields the existing typed-failure envelope. No hang, no infinite retry.
- **No widening to non-classified statuses** — a 400 still fails fast after one attempt (pinned).
- **Blast radius is the base call alone**: with no budget supplied the decision degenerates to
  *exactly* the previous behaviour, so flip probes (F3), thresholds (F9) and health are untouched.
  Their existing tests pass unmodified.
- The retry's per-attempt timeout is **not** re-clamped downward to squeeze in an extra attempt —
  that would truncate a slow-but-successful call, the exact harm the base-call clamp's own comment
  says it avoids.

## ⚠ One existing test was RE-POINTED — disclosed, not buried

`tests/plot-remediation.base-call-budget.route.test.ts` asserted
`worstCaseMs(maxRetries, timeoutMs) <= 70_000` **on the up-front attempt count** — it pinned the
duration-blind *mechanism*, not the invariant. Left alone it would have gone RED against its own fix
(`worstCaseMs(3, 60_000) = 183_000`) while appearing to defend it — exactly the mutant the diagnosis
flagged for ISL's fix ②.

The invariant is unchanged and is now enforced **at runtime against the live budget** rather than by
static arithmetic. Its two surviving assertions were GREEN both before and after, so the re-point did
not hollow the file out — and the new wall-clock arms make a stronger claim than the old arithmetic
could.

## Verification

- **RED-first**, pre-fix worktree at base tip `867c92d1`, `src/` untouched: the headline pin fails with
  `expected [ 1785493732893 ] to have a length of 2 but got 1` — **one** request on the wire — and
  `/v2/run` answers `analysis_status: 'failed'`. The live production shape, reproduced.
- **Both positive controls pass pre-fix** (the harness can see a clean run *and* a failure), so the
  success assertions are not vacuous.
- **Three mutants, non-overlapping bites:** remove the budget bound → 9 RED / 3 files (including a
  genuine budget overrun and the client actually beginning to sleep a `Retry-After: 3600`); remove the
  `Retry-After` capture → 3 RED / 1 file; restore the up-front clamp → 4 RED / 2 files.
  All in throwaway worktrees **outside** the clone root (trap 9c), removed before the gate run.
- **Authoritative gate** `bash scripts/pre-push-validate.sh`: **PASSED**, 6/6 checks,
  **6402 passed | 28 skipped, 0 failures**.

## Not done here

**ISL is not touched** — gate 2 queue-vs-reject is fix ② and is rowed separately.
**CEE is not touched** — downstream 429 = `BUSY` rather than `INTERNAL_ERROR` is fix ③ and rides a
CEE lane. This PR removes most of the tester-visible harm; it does not make the residual failure
*honest*, which is fix ③'s job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)