### PR TITLE
fix(isl): clamp the RETRY attempt to the budget that remains — make 2.202 reachable (fix ①b)

### DIFF
--- a/src/config/timeouts.ts
+++ b/src/config/timeouts.ts
@@ -165,6 +165,27 @@ export function resolveIslMaxRetries(): number {
 }
 
 /**
+ * Floor on any per-attempt ISL timeout derived from a shrinking budget.
+ *
+ * ROADMAP 2.202 fix ①b — DE-MIRRORED. This `1_000` was a function-local literal
+ * in `/v2/run`'s base-call clamp (`const BASE_CALL_MIN_TIMEOUT_MS = 1_000`), and
+ * fix ①b needs the SAME floor at a second seam (the retry decision's rescue
+ * clamp, `integrations/isl/retry-budget.ts`). Two hand-written copies of a bound
+ * that must agree is the dominant defect class this programme names (trap 12), so
+ * it gets one home here and both seams import it.
+ *
+ * Meaning at each seam, and they differ — read both before changing the number:
+ *   • `/v2/run` FIRST attempt: a `Math.max` FLOOR. The first attempt is allowed to
+ *     exceed a tiny remaining budget rather than be given an unusable timeout.
+ *   • retry-budget RESCUE attempt: a VIABILITY THRESHOLD, never a `Math.max`. A
+ *     rescue attempt is granted only when the affordable timeout reaches this
+ *     value, and it is granted with the AFFORDABLE timeout — flooring UP there
+ *     would start an attempt that outlives the caller's budget, which is the one
+ *     invariant 2.202 must not break.
+ */
+export const BASE_CALL_MIN_TIMEOUT_MS = 1_000;
+
+/**
  * Exponential-backoff constants for ISL retries. isl/client.ts sleeps
  * `min(BASE · 2^(attempt-1), CAP)` AFTER each failed non-final attempt. Kept
  * here as the single source shared with the worst-case accounting below.

--- a/src/integrations/isl/client.ts
+++ b/src/integrations/isl/client.ts
@@ -160,6 +160,19 @@ export class ISLClient {
     const requestBodyText = JSON.stringify(body);
     const requestDigest = computePayloadDigest(requestBodyText, body);
 
+    // ROADMAP 2.202 fix ①b — the per-attempt timeout is now PER ATTEMPT, not a
+    // constant read off the config on every pass.
+    //
+    // The FIRST attempt always gets the caller's configured timeout: #295's
+    // refusal to narrow a call that might still succeed stands exactly where its
+    // reasoning holds. A RETRY may be narrowed by `decideIslRetry` to what the
+    // remaining budget can afford — see retry-budget.ts. Without this variable
+    // the decision could grant a rescue attempt and the client would then start
+    // it at the full configured width, overrunning the very budget the decision
+    // just checked; the clamp would be advisory, which is a guarantee that never
+    // executes — the defect class this programme names as dominant.
+    let attemptTimeoutMs = this.config.timeoutMs;
+
     for (let attempt = 1; attempt <= this.config.maxRetries; attempt++) {
       // Track start time outside try block for catch access
       const startTime = Date.now();
@@ -177,7 +190,7 @@ export class ISLClient {
       try {
         timeoutId = setTimeout(
           () => controller.abort(),
-          this.config.timeoutMs
+          attemptTimeoutMs
         );
         // Fold the caller's external cancellation signal into THIS attempt's
         // controller: if it is (or becomes) aborted, abort the in-flight fetch.
@@ -307,8 +320,10 @@ export class ISLClient {
         const rawError = error as Error;
 
         if (rawError.name === 'AbortError') {
-          // Timeout (AbortController abort)
-          wrappedError = new ISLTimeoutError(endpoint, this.config.timeoutMs);
+          // Timeout (AbortController abort). 2.202 fix ①b: report the timeout
+          // THIS attempt actually ran with — a clamped rescue attempt that times
+          // out must not claim the configured width it was never given.
+          wrappedError = new ISLTimeoutError(endpoint, attemptTimeoutMs);
         } else if (rawError.name === 'TypeError' || rawError.message?.includes('fetch')) {
           // Network error (DNS, connection refused, etc.)
           wrappedError = new ISLNetworkError(endpoint, rawError);
@@ -344,12 +359,18 @@ export class ISLClient {
         // decision degenerates to exactly that previous behaviour.
         const retryAfterHintMs =
           wrappedError instanceof ISLHttpError ? wrappedError.retryAfterMs : undefined;
+        // ROADMAP 2.202 fix ①b — ISL's own machine reason, parsed from the error
+        // body that until now had ZERO readers (trap 10's write-only column, in
+        // the one field naming WHY the governor rejected us). Carried into both
+        // retry rows below so the next contention diagnosis is a log read.
+        const islReason =
+          wrappedError instanceof ISLHttpError ? wrappedError.getReason() : undefined;
         const decision = decideIslRetry({
           retryable,
           attempt,
           maxAttempts: this.config.maxRetries,
           elapsedMs: Date.now() - requestStartedAt,
-          perAttemptTimeoutMs: this.config.timeoutMs,
+          perAttemptTimeoutMs: attemptTimeoutMs,
           retryAfterMs: retryAfterHintMs,
           budget,
         });
@@ -393,9 +414,16 @@ export class ISLClient {
               max_retries: this.config.maxRetries,
               reason: decision.reason,
               status: wrappedError instanceof ISLHttpError ? wrappedError.status : undefined,
+              // fix ①b: the governor's own token, e.g. caller_concurrency_exceeded.
+              isl_reason: islReason,
               retry_after_ms: retryAfterHintMs,
               remaining_budget_ms: decision.remainingMs,
               projected_cost_ms: decision.projectedCostMs,
+              // fix ①b: how wide an attempt the budget COULD have paid for. A
+              // decline with a healthy `affordable_timeout_ms` means the floor
+              // bit; a negative one means the budget is genuinely spent.
+              affordable_timeout_ms: decision.affordableTimeoutMs,
+              per_attempt_timeout_ms: attemptTimeoutMs,
               budget_supplied: budget !== undefined,
               request_id: requestId,
             });
@@ -430,14 +458,30 @@ export class ISLClient {
           max_retries: this.config.maxRetries,
           reason: decision.reason,
           status: wrappedError instanceof ISLHttpError ? wrappedError.status : undefined,
+          // fix ①b: the governor's own token, e.g. caller_concurrency_exceeded.
+          isl_reason: islReason,
           delay_ms: decision.delayMs,
           backoff_ms: decision.backoffMs,
           retry_after_ms: retryAfterHintMs,
           retry_after_honoured: decision.retryAfterHonoured,
           remaining_budget_ms: decision.remainingMs,
           projected_cost_ms: decision.projectedCostMs,
+          // fix ①b: the rescue clamp, made observable. `timeout_clamped: true`
+          // with `next_attempt_timeout_ms` < `per_attempt_timeout_ms` is the row
+          // that proves the retry is reachable under the deployed env posture —
+          // the direct live witness the probe found missing.
+          per_attempt_timeout_ms: attemptTimeoutMs,
+          next_attempt_timeout_ms: decision.attemptTimeoutMs,
+          timeout_clamped: decision.timeoutClamped,
+          affordable_timeout_ms: decision.affordableTimeoutMs,
           request_id: requestId,
         });
+
+        // ROADMAP 2.202 fix ①b — adopt the decision's per-attempt timeout for the
+        // NEXT pass. On every path except a clamped rescue this is the value we
+        // already had, so the first attempt and all no-budget callers are
+        // unchanged.
+        attemptTimeoutMs = decision.attemptTimeoutMs;
 
         // Delay chosen by decideIslRetry: max(ISL's Retry-After, our exponential
         // backoff 1s/2s/4s… capped at 5s). Retry-After is a MINIMUM wait, so it

--- a/src/integrations/isl/errors.ts
+++ b/src/integrations/isl/errors.ts
@@ -100,6 +100,83 @@ export function parseRetryAfterMs(
 }
 
 /**
+ * Longest machine reason we will carry into a log row. ISL's own reasons are
+ * short snake_case tokens (`caller_concurrency_exceeded`,
+ * `service_busy_queue_full`, `analysis_hard_deadline_exceeded`); the bound stops
+ * an unexpected upstream from turning one telemetry field into a body dump.
+ */
+export const ISL_ERROR_REASON_MAX_LEN = 120;
+
+/**
+ * Pull ISL's machine-readable cause out of an error response body.
+ *
+ * ROADMAP 2.202 fix ①b — THIS FUNCTION EXISTS TO GIVE `ISLHttpError.body` ITS
+ * FIRST READER. The 31 Jul live probe established, with a passing positive
+ * control, that `public body: string` was captured on every ISL error and read by
+ * NOTHING (`rg -a -n "\.body\b" src/ --glob '!**\/tests\/**' | rg -a -i isl` →
+ * zero matches at `b79c4829`). That is trap 10's write-only-column shape sitting
+ * in the one field that names WHY the governor rejected the call — so the probe
+ * had to reconstruct `caller_concurrency_exceeded` from cross-service Render
+ * forensics, and recorded its own `caller_concurrency_exceeded` log search as
+ * **vacuous**: PLoT never logged the body, so the zero rows proved nothing.
+ *
+ * ⚠ SHAPE DERIVED FROM ISL AT THE BYTES, NOT GUESSED (trap 18 / trap 16 —
+ * a fixture invented at this end "proves" whatever it was written to prove).
+ * Read read-only at `Talchain/Inference-Service-Layer@7c681fda` (`staging`,
+ * 2026-07-31):
+ *
+ *   src/services/compute_governor.py:161  raise Overload(429, "caller_concurrency_exceeded")
+ *   src/api/robustness.py:249-273         _overload_error_response(...) -> ErrorResponse(
+ *                                            code=RATE_LIMIT_EXCEEDED, message=...,
+ *                                            reason=overload.reason, ...)
+ *   src/api/robustness.py:362-370         JSONResponse(status_code=429,
+ *                                            content=body.model_dump(exclude_none=True),
+ *                                            headers={"Retry-After": ...})
+ *   src/models/responses.py:90-103        class ErrorResponse: code, message, reason?
+ *
+ * So the live 429 body is a FLAT object whose `reason` is the governor's token.
+ * `detail` is accepted too: that is FastAPI's default `HTTPException` shape, and
+ * it is what PLoT's own 2.202 fakes serve, so the parser reads both the real wire
+ * and the harness rather than silently only one of them.
+ *
+ * Returns `undefined` for absent / non-JSON / non-string / blank causes — a
+ * missing reason must read as missing, never as a fabricated one.
+ */
+export function parseIslErrorReason(body: string | null | undefined): string | undefined {
+  if (typeof body !== 'string' || body.trim() === '') return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== 'object') return undefined;
+
+  const obj = parsed as Record<string, unknown>;
+  const nestedError = obj.error;
+  const candidates: unknown[] = [
+    obj.reason, // ISL ErrorResponse.reason — the governor's own token
+    nestedError && typeof nestedError === 'object'
+      ? (nestedError as Record<string, unknown>).code
+      : undefined,
+    obj.code, // ISL ErrorResponse.code (coarser: RATE_LIMIT_EXCEEDED)
+    obj.detail, // FastAPI HTTPException default shape
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue;
+    // Strip control characters so one field cannot forge extra log lines.
+    const cleaned = candidate.replace(/[\u0000-\u001f\u007f]/g, ' ').trim();
+    if (cleaned === '') continue;
+    return cleaned.length > ISL_ERROR_REASON_MAX_LEN
+      ? `${cleaned.slice(0, ISL_ERROR_REASON_MAX_LEN)}…`
+      : cleaned;
+  }
+  return undefined;
+}
+
+/**
  * HTTP error from ISL service
  */
 export class ISLHttpError extends Error {
@@ -124,6 +201,23 @@ export class ISLHttpError extends Error {
     this.name = 'ISLHttpError';
     this.islError = islError;
     this.retryAfterMs = retryAfterMs;
+  }
+
+  /**
+   * ISL's machine-readable cause for this failure, parsed from {@link body}.
+   *
+   * ROADMAP 2.202 fix ①b. `body` was captured on every ISL error and read by
+   * nothing — see {@link parseIslErrorReason} for the probe's positive-controlled
+   * zero-reader proof. This is that reader, and the client carries its result
+   * into `isl_retry_scheduled` / `isl_retry_declined` so the NEXT diagnosis of
+   * governor contention is a log read rather than a three-service probe.
+   *
+   * Computed on demand (not in the constructor) so the parse cost is paid only
+   * where the value is used, and so every existing construction site is
+   * unchanged.
+   */
+  getReason(): string | undefined {
+    return parseIslErrorReason(this.body);
   }
 
   /**

--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -821,7 +821,7 @@ export { validateBeforeISL, buildParameterUncertainties } from './preflight.js';
 // Note: ISLAnalysisResult is already exported via interface definition above
 
 export { ISLClient, type ISLClientConfig } from './client.js';
-export { ISLHttpError, ISLResponseProcessingError, parseRetryAfterMs } from './errors.js';
+export { ISLHttpError, ISLResponseProcessingError, parseRetryAfterMs, parseIslErrorReason } from './errors.js';
 export {
   decideIslRetry,
   DEFAULT_RETRY_SAFETY_MARGIN_MS,

--- a/src/integrations/isl/retry-budget.ts
+++ b/src/integrations/isl/retry-budget.ts
@@ -39,22 +39,81 @@
  *     (see the `!budget` branch). Getting this wrong is what the first cut of
  *     2.202 did, and it is the one HIGH the adversarial review found.
  *
- * An attempt is only ever STARTED when its FULL per-attempt timeout still fits,
- * so the total can never overrun the caller's budget.
+ * An attempt is only ever STARTED when its per-attempt timeout still fits, so
+ * the total can never overrun the caller's budget.
  *
- * DELIBERATELY NOT DONE: the retry's per-attempt timeout is not re-clamped
- * downward to squeeze an extra attempt into a shrinking budget. That would
- * truncate a slow-but-successful call — the exact harm the base-call clamp's
- * own comment says it avoids.
+ * ⭐⭐ FIX ①b (2026-07-31) — THE RESCUE CLAMP. READ THIS BEFORE CHANGING ANYTHING
+ * ---------------------------------------------------------------------------
+ * Everything above shipped as PR #295 and was deployed as build `91bcac5`. A live
+ * probe under real governor contention then measured what it actually did:
+ * **0 of 9 contended requests rescued, and `isl_retry_scheduled` had never fired
+ * once in the build's entire life** (`isl_retry_declined` returned 35 rows on the
+ * identical query, so the zero was a real absence, not a broken search).
+ * Evidence: `PHASE0-EVIDENCE-2026-07-28/probe-2202-retry-under-contention.md`.
+ *
+ * WHY. Staging's Render dashboard sets `ISL_TIMEOUT_MS = 130_000` (repo default
+ * 60_000) and leaves `REQUEST_BUDGET_MS` unset (→ 70_000). /v2/run's base-call
+ * clamp then takes its SECOND arm and hands this decision a per-attempt timeout
+ * of `remaining − 1_000`, i.e. essentially the whole budget. Writing `T =
+ * ISL_TIMEOUT_MS`, `R = REQUEST_BUDGET_MS`, `A = Retry-After`, `m = margin`, the
+ * pre-①b gate `A + T + m <= R` fires only while `T <= R − A − m` = 64_000. Once
+ * `T >= R − m` the clamp's second arm wins and the requirement collapses to
+ * `A <= 0` — **no positive `Retry-After` can EVER fit, at any budget.** Staging
+ * is deep in that regime: the retry was not rate-limited or unlucky, it was
+ * arithmetically impossible on 100% of requests, with 6,409 green tests, 11/11
+ * green CI and a purpose-built headroom guard that derived its constant from
+ * `process.env` at TEST time and so measured the repo default, never the
+ * dashboard (trap 18: a constant correct in every test and wrong by 70 s live).
+ *
+ * THE FIX. A retry may now run with a per-attempt timeout clamped DOWN to what
+ * the budget can actually afford:
+ *
+ *     affordable = remaining − delay − margin
+ *     rescue     = min(perAttemptTimeout, affordable)
+ *     retry iff  rescue >= min(BASE_CALL_MIN_TIMEOUT_MS, perAttemptTimeout)
+ *
+ * ⚠ THIS IS THE THING #295 EXPLICITLY DECLINED, AND THE DECLINE WAS NOT WRONG —
+ * IT WAS SCOPED. #295 refused to clamp downward because it "would truncate a
+ * slow-but-successful call". That reasoning is correct for a FIRST attempt, whose
+ * alternative is a call that might still succeed if left alone. It does NOT
+ * transfer to a RESCUE attempt, whose alternative is not "a slower success" but a
+ * typed failure that has already been decided: the first attempt has failed, and
+ * without a retry the caller gets the 500. Truncating a rescue can only lose an
+ * outcome we were never going to get. So the clamp is applied to RETRIES ONLY —
+ * the first attempt's timeout is untouched, and #295's decline stands where its
+ * reasoning holds.
+ *
+ * WHY A FLOOR, AND WHY IT IS A THRESHOLD RATHER THAN A `Math.max`. Below some
+ * width a rescue attempt cannot complete anything and merely burns the remainder,
+ * so we decline instead — `budget_exhausted` still bites, just at a tighter,
+ * derived boundary. Flooring UP with `Math.max` would be the opposite of a
+ * bound: it would START an attempt whose timeout outlives the caller's budget,
+ * breaking the one invariant 2.202 must not break. And the floor is
+ * `min(BASE_CALL_MIN_TIMEOUT_MS, perAttemptTimeout)`, never the constant alone,
+ * so that a caller who chose a sub-second per-attempt timeout (flip probes,
+ * wall-clock tests) is not newly refused a retry it used to get.
+ *
+ * ⭐ THE RESULTING RULE IS A STRICT RELAXATION, and that is pinned as a property
+ * test: every decision the pre-①b rule GRANTED is still granted, with an
+ * IDENTICAL, unclamped timeout (if `perAttempt <= affordable` then `rescue =
+ * perAttempt`). ①b only ever converts a former `budget_exhausted` into a shorter
+ * rescue attempt. Nothing that used to retry now declines, and nothing that used
+ * to retry now runs shorter.
+ *
+ * DISCLOSED TRADE: a SLOW retryable failure now buys a short rescue attempt where
+ * before it bought none, so a doomed call can spend the rest of its budget before
+ * returning the typed failure. `safetyMarginMs` is still reserved and still
+ * unspent, so the caller can always assemble its response — the invariant that
+ * matters is preserved, the "slow failures return early" behaviour is not.
  *
  * BLAST RADIUS: when no budget is supplied the decision degenerates to EXACTLY
  * the previous behaviour — attempt cap + our own exponential backoff, and
- * `Retry-After` deliberately ignored. Only the /v2/run
- * base robustness call passes a budget; flip probes, thresholds and health are
- * untouched.
+ * `Retry-After` deliberately ignored. The rescue clamp lives entirely inside the
+ * budgeted branch, so it too reaches ONLY the /v2/run base robustness call; flip
+ * probes, thresholds and health are untouched.
  */
 
-import { islRetryBackoffMs } from '../../config/timeouts.js';
+import { islRetryBackoffMs, BASE_CALL_MIN_TIMEOUT_MS } from '../../config/timeouts.js';
 
 /**
  * The wall-clock budget a caller lends to one ISL request, for retry decisions.
@@ -105,8 +164,27 @@ export interface ISLRetryDecision {
   backoffMs: number;
   /** Budget left at the decision point — `undefined` when none was supplied. */
   remainingMs?: number;
-  /** `delayMs + perAttemptTimeoutMs` — what the next attempt could cost. */
+  /** `delayMs + attemptTimeoutMs` — what the next attempt could cost. */
   projectedCostMs: number;
+  /**
+   * ROADMAP 2.202 fix ①b — the per-attempt timeout the NEXT attempt must use.
+   *
+   * Equals the caller's `perAttemptTimeoutMs` on every path except a budgeted
+   * rescue that had to be clamped down to fit. The client MUST honour this for
+   * the retry it is about to start; ignoring it re-creates the pre-①b defect,
+   * because the whole point is that the attempt is narrower than the caller's
+   * configured timeout. On a decline it is the unclamped ask (no attempt runs).
+   */
+  attemptTimeoutMs: number;
+  /** True when {@link attemptTimeoutMs} was clamped below the caller's timeout. */
+  timeoutClamped: boolean;
+  /**
+   * `remaining − delay − margin` — the widest attempt the budget can afford at
+   * this instant. Negative when the budget is already spent. `undefined` on the
+   * no-budget path. Logged on a decline so "why did it not retry?" is answerable
+   * from one row instead of a probe.
+   */
+  affordableTimeoutMs?: number;
 }
 
 export interface ISLRetryDecisionInput {
@@ -153,14 +231,32 @@ export function decideIslRetry(input: ISLRetryDecisionInput): ISLRetryDecision {
   const retryAfterHonoured = retryAfterUsable && retryAfterMs > backoffMs;
   const projectedCostMs = delayMs + perAttemptTimeoutMs;
 
+  // Budget-derived figures, computed once so the decline path can report the
+  // SAME numbers the grant path decided on (fix ①b: a decline row that cannot
+  // say how wide an attempt the budget could afford is what forced the 31 Jul
+  // probe in the first place).
+  const safetyMarginMs = budget
+    ? budget.safetyMarginMs ?? DEFAULT_RETRY_SAFETY_MARGIN_MS
+    : undefined;
+  const remainingAtDecisionMs = budget ? budget.remainingMs - elapsedMs : undefined;
+  const affordableTimeoutMs =
+    remainingAtDecisionMs !== undefined && safetyMarginMs !== undefined
+      ? remainingAtDecisionMs - delayMs - safetyMarginMs
+      : undefined;
+
   const no = (reason: ISLRetryReason): ISLRetryDecision => ({
     retry: false,
     delayMs: 0,
     reason,
     retryAfterHonoured: false,
     backoffMs,
-    remainingMs: budget ? budget.remainingMs - elapsedMs : undefined,
+    remainingMs: remainingAtDecisionMs,
     projectedCostMs,
+    // No attempt runs, so report the unclamped ask — this keeps the decline
+    // row's `projected_cost_ms` reading exactly as it did before ①b.
+    attemptTimeoutMs: perAttemptTimeoutMs,
+    timeoutClamped: false,
+    affordableTimeoutMs,
   });
 
   if (!retryable) return no('not_retryable');
@@ -194,15 +290,29 @@ export function decideIslRetry(input: ISLRetryDecisionInput): ISLRetryDecision {
       backoffMs,
       remainingMs: undefined,
       projectedCostMs: backoffMs + perAttemptTimeoutMs,
+      // ⚠ NO RESCUE CLAMP HERE, deliberately. Clamping needs a budget to clamp
+      // against; with none there is nothing to derive a narrower timeout FROM,
+      // and inventing one would be the magic constant this module exists without.
+      attemptTimeoutMs: perAttemptTimeoutMs,
+      timeoutClamped: false,
+      affordableTimeoutMs: undefined,
     };
   }
 
-  const safetyMarginMs = budget.safetyMarginMs ?? DEFAULT_RETRY_SAFETY_MARGIN_MS;
-  const remainingMs = budget.remainingMs - elapsedMs;
+  const remainingMs = remainingAtDecisionMs!;
 
-  // Start an attempt only when its FULL per-attempt timeout still fits, so the
-  // total can never outlive the caller's budget.
-  if (projectedCostMs + safetyMarginMs > remainingMs) return no('budget_exhausted');
+  // ⭐ THE RESCUE CLAMP (fix ①b — see the module header for why #295's decline
+  // does not transfer to a retry). The widest attempt the budget can still pay
+  // for, after the delay we are about to sleep and the reserve we must not spend:
+  const affordableMs = affordableTimeoutMs!;
+  const rescueTimeoutMs = Math.min(perAttemptTimeoutMs, affordableMs);
+
+  // Viability threshold, NOT a `Math.max` floor — flooring up would start an
+  // attempt that outlives the caller. Bounded by the caller's own per-attempt
+  // timeout so a sub-second caller (flip probes, wall-clock tests) is never
+  // newly refused a retry the pre-①b rule would have granted.
+  const minViableTimeoutMs = Math.max(1, Math.min(BASE_CALL_MIN_TIMEOUT_MS, perAttemptTimeoutMs));
+  if (rescueTimeoutMs < minViableTimeoutMs) return no('budget_exhausted');
 
   return {
     retry: true,
@@ -211,6 +321,11 @@ export function decideIslRetry(input: ISLRetryDecisionInput): ISLRetryDecision {
     retryAfterHonoured,
     backoffMs,
     remainingMs,
-    projectedCostMs,
+    // The HONEST projection: what the attempt we are actually about to start
+    // will cost, not what an unclamped one would have.
+    projectedCostMs: delayMs + rescueTimeoutMs,
+    attemptTimeoutMs: rescueTimeoutMs,
+    timeoutClamped: rescueTimeoutMs < perAttemptTimeoutMs,
+    affordableTimeoutMs: affordableMs,
   };
 }

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -117,6 +117,7 @@ import {
   ISL_TIMEOUT_MS,
   worstCaseMs,
   OPTIONAL_PHASE_MAX_RETRIES,
+  BASE_CALL_MIN_TIMEOUT_MS,
 } from '../../config/timeouts.js';
 import { getISLClientConfig } from '../../integrations/isl/client.js';
 import { createISLInferenceFn, resolveFlipValues, resolveFlipProbeNSamples, resolveFlipOverallTimeoutMs, resolveFlipPerFactorTimeoutMs } from '../../analysis/flip-thresholds.js';
@@ -6077,7 +6078,10 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           // attempt; the clamp only bites the pathological retry storm.
           const baseCallRemainingMs = resolveRequestBudgetMs() - (performance.now() - startTime);
           const baseCallSafetyMarginMs = 1_000;
-          const BASE_CALL_MIN_TIMEOUT_MS = 1_000;
+          // ROADMAP 2.202 fix ①b: was a local literal here; now imported from
+          // config/timeouts.ts because the retry decision needs the SAME floor
+          // (see retry-budget.ts). Two hand-written copies of a bound that must
+          // agree is trap 12 — de-mirrored rather than duplicated.
           const baseCallTimeoutMs = Math.min(
             ISL_TIMEOUT_MS,
             Math.max(BASE_CALL_MIN_TIMEOUT_MS, Math.floor(baseCallRemainingMs - baseCallSafetyMarginMs)),

--- a/tests/plot-2202-retry-budget-decision.test.ts
+++ b/tests/plot-2202-retry-budget-decision.test.ts
@@ -62,7 +62,25 @@ describe('decideIslRetry — the fast-429 case that was structurally unreachable
     expect(d.projectedCostMs).toBe(ISL_RETRY_AFTER_MS + PROD_PER_ATTEMPT_MS);
   });
 
-  it('⭐ HEADROOM — the fix only works while a 5s wait + a full attempt still fits the budget', () => {
+  it('⭐ HEADROOM — a FULL-WIDTH retry only fits while a 5s wait + a full attempt does', () => {
+    // ⚠⚠ RE-POINTED 2026-07-31 BY FIX ①b. THIS GUARD'S CLAIM WENT FALSE, AND A
+    // FALSE ALARM IS WORSE THAN NO ALARM (trap 14: an honest label overwritten
+    // by a misleading one teaches every lane to stop looking).
+    //
+    // It used to say "2.202 is DISABLED at these constants" and it was RIGHT:
+    // pre-①b, once `ISL_TIMEOUT_MS >= REQUEST_BUDGET_MS − Retry-After − margin`
+    // the retry declined outright. That is precisely what staging did at
+    // `ISL_TIMEOUT_MS = 130_000` — and this guard, deriving from `process.env` at
+    // TEST time where the var is unset, measured the repo default 60_000 and
+    // reported ~8.9 s of comfortable headroom while the deployment sat 66 s the
+    // wrong side of the line (platform trap 18).
+    //
+    // Post-①b that relation no longer decides IF the retry happens — only
+    // whether it runs at FULL width or CLAMPED. So the message is corrected and
+    // an arm is added below proving the fix survives the violation. The
+    // regime-level pins live in tests/plot-2202b-rescue-clamp.decision.test.ts,
+    // which fixes the DEPLOYED constants as a dated measurement rather than
+    // re-deriving them from an environment that does not have them.
     // ⚠ CROSS-REPO COUPLING, and it is TIGHT. The fix depends on an arithmetic
     // relation between THREE independently-owned numbers:
     //   • ISL_RETRY_AFTER_MS   — owned by ISL (compute_governor RETRY_AFTER_SECONDS = 5)
@@ -82,22 +100,49 @@ describe('decideIslRetry — the fast-429 case that was structurally unreachable
       - (ISL_RETRY_AFTER_MS + PROD_PER_ATTEMPT_MS + DEFAULT_RETRY_SAFETY_MARGIN_MS);
     expect(
       headroomMs,
-      `2.202 is DISABLED at these constants: a ${ISL_RETRY_AFTER_MS}ms Retry-After plus a ` +
+      `At these constants a ${ISL_RETRY_AFTER_MS}ms Retry-After plus a FULL ` +
       `${PROD_PER_ATTEMPT_MS}ms attempt plus the ${DEFAULT_RETRY_SAFETY_MARGIN_MS}ms margin does not ` +
-      `fit ${PROD_BUDGET_MS}ms of budget. Re-derive ISL_TIMEOUT_MS / REQUEST_BUDGET_MS together.`,
+      `fit ${PROD_BUDGET_MS}ms of budget, so the retry runs CLAMPED rather than at full width. ` +
+      `Since 2.202 fix ①b that is degraded, not disabled — but re-derive ` +
+      `ISL_TIMEOUT_MS / REQUEST_BUDGET_MS together before accepting it.`,
     ).toBeGreaterThan(0);
 
     // …and prove the relation is what actually drives the decision, so this is
     // not an assertion about arithmetic that nothing consults.
-    expect(
-      decideIslRetry({
-        retryable: true, attempt: 1, maxAttempts: 3,
-        elapsedMs: OBSERVED_429_ELAPSED_MS,
-        perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
-        retryAfterMs: ISL_RETRY_AFTER_MS,
-        budget: { remainingMs: PROD_BUDGET_MS },
-      }).retry,
-    ).toBe(true);
+    const d = decideIslRetry({
+      retryable: true, attempt: 1, maxAttempts: 3,
+      elapsedMs: OBSERVED_429_ELAPSED_MS,
+      perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
+      retryAfterMs: ISL_RETRY_AFTER_MS,
+      budget: { remainingMs: PROD_BUDGET_MS },
+    });
+    expect(d.retry).toBe(true);
+    // With headroom, the attempt runs at FULL configured width — that is what
+    // the headroom buys, and the only thing this relation now controls.
+    expect(d.timeoutClamped).toBe(false);
+    expect(d.attemptTimeoutMs).toBe(PROD_PER_ATTEMPT_MS);
+  });
+
+  it('⭐ ①b — and when that headroom is GONE the retry is CLAMPED, not cancelled', () => {
+    // The arm that stops the guard above from ever again reading as "the fix is
+    // off". Violate the relation deliberately — a per-attempt timeout larger
+    // than the whole budget, i.e. the staging regime — and the decision must
+    // still retry, narrower. If this ever goes RED, ①b has been reverted and the
+    // 0-of-9 live outcome is back.
+    const overBudgetPerAttemptMs = PROD_BUDGET_MS + 60_000; // staging: 130s vs 70s
+    const d = decideIslRetry({
+      retryable: true, attempt: 1, maxAttempts: 3,
+      elapsedMs: OBSERVED_429_ELAPSED_MS,
+      perAttemptTimeoutMs: overBudgetPerAttemptMs,
+      retryAfterMs: ISL_RETRY_AFTER_MS,
+      budget: { remainingMs: PROD_BUDGET_MS },
+    });
+    expect(d.retry).toBe(true);
+    expect(d.reason).toBe('budget_available');
+    expect(d.timeoutClamped).toBe(true);
+    expect(d.attemptTimeoutMs).toBeLessThan(overBudgetPerAttemptMs);
+    expect(d.delayMs + d.attemptTimeoutMs + DEFAULT_RETRY_SAFETY_MARGIN_MS)
+      .toBeLessThanOrEqual(d.remainingMs!);
   });
 
   it('WITNESS for the old policy: the up-front worst-case count allowed only 1 attempt', () => {
@@ -110,23 +155,70 @@ describe('decideIslRetry — the fast-429 case that was structurally unreachable
 });
 
 describe('decideIslRetry — the budget bound (no infinite retry, no budget overrun)', () => {
-  it('refuses when the next attempt does not fit the remaining budget', () => {
+  it('refuses when not even a CLAMPED attempt fits the remaining budget', () => {
+    // ⚠⚠ RE-POINTED 2026-07-31 BY FIX ①b — DISCLOSED, NOT SILENTLY REWRITTEN.
+    //
+    // As written this arm used `elapsedMs: 60_000` against the 70s budget and
+    // asserted `budget_exhausted`, on the reasoning that "a SLOW failure that
+    // consumed the budget" must get no retry. Fix ①b deliberately changes that:
+    // with ~10s left, a rescue attempt clamped to ~8s DOES fit, and a rescue
+    // attempt's alternative is not a slower success but the typed failure the
+    // caller is already getting. So at 60_000 elapsed the decision now —
+    // correctly — RETRIES, and this arm would have gone RED against its own fix
+    // while appearing to defend it. That is exactly the mutant §4.5 of
+    // fix-plot-retry-budget-2202.md flagged, one lane later.
+    //
+    // The INVARIANT it protected is unchanged and still pinned, one arm below
+    // and across the ①b sweeps: no attempt is ever started whose timeout
+    // outlives the caller's budget. What moved is the boundary, from "the FULL
+    // per-attempt timeout must fit" to "a floored, affordable one must". So this
+    // arm is re-pointed to a budget that is GENUINELY spent — nothing fits, not
+    // even the floor — which is the claim the title was really making.
     const d = decideIslRetry({
       retryable: true,
       attempt: 1,
       maxAttempts: 3,
-      elapsedMs: 60_000, // a SLOW failure that consumed the budget
+      elapsedMs: 68_500, // 1.5s left: cannot pay a 1s backoff + 1s margin at all
       perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
       budget: { remainingMs: PROD_BUDGET_MS },
     });
     expect(d.retry).toBe(false);
     expect(d.reason).toBe('budget_exhausted');
     expect(d.delayMs).toBe(0);
+    expect(d.affordableTimeoutMs!).toBeLessThan(0);
+  });
+
+  it('⭐ ①b — the same SLOW failure now buys a CLAMPED rescue (the behaviour change, pinned)', () => {
+    // The arm above used to live at this input. Pinning the new outcome here
+    // means the change is asserted in both directions rather than quietly
+    // dropped: 10s remain, so a ~8s rescue attempt is started, and it still
+    // finishes inside the budget with the margin reserved.
+    const d = decideIslRetry({
+      retryable: true,
+      attempt: 1,
+      maxAttempts: 3,
+      elapsedMs: 60_000,
+      perAttemptTimeoutMs: PROD_PER_ATTEMPT_MS,
+      budget: { remainingMs: PROD_BUDGET_MS },
+    });
+    expect(d.retry).toBe(true);
+    expect(d.reason).toBe('budget_available');
+    expect(d.timeoutClamped).toBe(true);
+    expect(d.attemptTimeoutMs).toBeLessThan(PROD_PER_ATTEMPT_MS);
+    expect(d.delayMs + d.attemptTimeoutMs + DEFAULT_RETRY_SAFETY_MARGIN_MS)
+      .toBeLessThanOrEqual(d.remainingMs!);
   });
 
   it('⭐ preserves the property the OLD up-front clamp existed to protect', () => {
-    // A slow failure must never buy a retry that outlives the caller. Sweep the
-    // whole elapsed range: once the projection stops fitting, it never restarts.
+    // A retry must never outlive the caller. Sweep the whole elapsed range: once
+    // the projection stops fitting, it never restarts.
+    //
+    // ⚠ NOTE AFTER FIX ①b (2026-07-31): what is swept is now the CLAMPED
+    // projection, so the refusal boundary sits later than it did — a slow
+    // failure buys a shorter rescue rather than nothing. Both assertions below
+    // are unchanged and both still hold, because the bound they express
+    // ("projected + margin never exceeds remaining") is about the attempt that
+    // will actually run, not about the caller's configured width.
     let firstRefusalAt: number | undefined;
     for (let elapsedMs = 0; elapsedMs <= PROD_BUDGET_MS; elapsedMs += 500) {
       const d = decideIslRetry({
@@ -150,8 +242,24 @@ describe('decideIslRetry — the budget bound (no infinite retry, no budget over
     expect(firstRefusalAt, 'the budget bound must bite somewhere in the sweep').toBeDefined();
   });
 
-  it('an attempt is only ever granted when its FULL per-attempt timeout still fits', () => {
-    // The invariant that makes overrunning the caller impossible by construction.
+  it('an attempt is only ever granted when the timeout IT WILL RUN WITH still fits', () => {
+    // ⚠⚠ RE-POINTED 2026-07-31 BY FIX ①b — DISCLOSED, NOT SILENTLY REWRITTEN.
+    //
+    // As written, this asserted `elapsedMs + delayMs + 5_000 <= 12_000` — i.e. it
+    // priced the granted attempt at the CALLER'S CONFIGURED timeout. That is the
+    // pre-①b mechanism, not the invariant: at elapsedMs 8_000 the decision now
+    // grants a rescue clamped to ~2s, and the old assertion would read
+    // `8000 + 1000 + 5000 <= 12000` → RED, blocking its own fix.
+    //
+    // The invariant is, and always was, that no attempt is STARTED whose timeout
+    // outlives the caller's budget. It is now checked against
+    // `d.attemptTimeoutMs` — the width the attempt will actually run with, which
+    // the client is required to honour (pinned on the real socket in
+    // tests/plot-2202b-rescue-clamp.client.test.ts). This is strictly stronger
+    // than the old form: it fails if the decision ever hands back a timeout the
+    // budget cannot pay for, including an unclamped one.
+    let granted = 0;
+    let clamped = 0;
     for (const elapsedMs of [0, 1_000, 5_000, 8_000, 8_999, 9_000]) {
       const d = decideIslRetry({
         retryable: true,
@@ -161,10 +269,18 @@ describe('decideIslRetry — the budget bound (no infinite retry, no budget over
         perAttemptTimeoutMs: 5_000,
         budget: { remainingMs: 12_000 },
       });
-      if (d.retry) {
-        expect(elapsedMs + d.delayMs + 5_000).toBeLessThanOrEqual(12_000);
-      }
+      if (!d.retry) continue;
+      granted++;
+      if (d.timeoutClamped) clamped++;
+      expect(d.attemptTimeoutMs).toBeLessThanOrEqual(5_000); // never widened
+      expect(elapsedMs + d.delayMs + d.attemptTimeoutMs).toBeLessThanOrEqual(12_000);
+      expect(d.delayMs + d.attemptTimeoutMs + DEFAULT_RETRY_SAFETY_MARGIN_MS)
+        .toBeLessThanOrEqual(d.remainingMs!);
     }
+    // Both halves must be exercised or the loop proves less than it looks
+    // (trap 13): an unclamped grant AND a clamped one.
+    expect(granted).toBeGreaterThan(0);
+    expect(clamped, 'the sweep must reach the clamped band').toBeGreaterThan(0);
   });
 
   it('still honours the configured attempt cap even with unlimited budget', () => {

--- a/tests/plot-2202b-isl-error-reason.test.ts
+++ b/tests/plot-2202b-isl-error-reason.test.ts
@@ -1,0 +1,139 @@
+/**
+ * ROADMAP 2.202 fix ①b — `ISLHttpError.body` gets its FIRST READER.
+ *
+ * THE DEFECT: `ISLHttpError` has captured `public body: string` on every ISL
+ * error since it was written, and **nothing ever read it**. The 31 Jul live probe
+ * established that with a passing positive control, at a pinned SHA:
+ *
+ *   $ rg -a -c "body" src/integrations/isl/*.ts
+ *   errors.ts:4   index.ts:9   client.ts:18       ← POSITIVE CONTROL: search works
+ *   $ rg -a -n "\.body\b" src/ --glob '!**\/tests\/**' | rg -a -i isl
+ *   (no matches)                                  ← ZERO readers, at b79c4829
+ *
+ * That is trap 10's write-only column, sitting in the one field that names WHY
+ * ISL's compute governor rejected the call. The consequence was concrete: the
+ * probe's Render search for `caller_concurrency_exceeded` returned 0 rows and the
+ * probe had to record that zero as **VACUOUS** — PLoT never logged the body, so
+ * the search could not have found it either way. Diagnosis §8.3 stayed open for
+ * want of one field.
+ *
+ *   PROBE OF RECORD: PHASE0-EVIDENCE-2026-07-28/probe-2202-retry-under-contention.md §8
+ *
+ * ⚠ THE BODIES BELOW ARE DERIVED FROM ISL AT THE BYTES, NOT INVENTED HERE.
+ * A fixture written at this end proves whatever it was written to prove (trap 16
+ * / trap 18). Read read-only at `Talchain/Inference-Service-Layer@7c681fda`
+ * (`staging`, 2026-07-31):
+ *   • src/services/compute_governor.py:161 → `raise Overload(429, "caller_concurrency_exceeded")`
+ *   • src/services/compute_governor.py:159 → `raise Overload(503, "service_busy_queue_full")`
+ *   • src/api/robustness.py:249-273 → `ErrorResponse(code=…, message=…, reason=overload.reason, …)`
+ *   • src/api/robustness.py:362-370 → `JSONResponse(status_code=…, content=body.model_dump(exclude_none=True))`
+ *   • src/models/responses.py:90-103 → `class ErrorResponse: code: str; message: str; reason: Optional[str]`
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseIslErrorReason,
+  ISLHttpError,
+  ISL_ERROR_REASON_MAX_LEN,
+} from '../src/integrations/isl/errors.js';
+
+/**
+ * The LIVE 429 body, assembled from ISL's own `_overload_error_response` at the
+ * ref above. Flat object; `reason` carries the governor's token.
+ */
+const ISL_GOVERNOR_429_BODY = JSON.stringify({
+  code: 'RATE_LIMIT_EXCEEDED',
+  message: 'Too many concurrent analyses from this caller. Retry shortly.',
+  reason: 'caller_concurrency_exceeded',
+  recovery: {
+    hints: [
+      'Reduce the number of simultaneous /analyze requests you issue',
+      'Retry after the Retry-After interval',
+    ],
+    suggestion: 'Retry after Retry-After seconds',
+  },
+  retryable: true,
+  source: 'isl',
+  request_id: 'p2202-a-r1-2',
+});
+
+/** The service-wide 503 from the same helper — a different reason, same shape. */
+const ISL_GOVERNOR_503_BODY = JSON.stringify({
+  code: 'SERVICE_UNAVAILABLE',
+  message: 'Analysis service is at compute capacity. Retry shortly.',
+  reason: 'service_busy_queue_full',
+  retryable: true,
+  source: 'isl',
+});
+
+describe('2.202 ①b — parseIslErrorReason names the governor cause the probe could not read', () => {
+  it('⭐ the REAL ISL 429 body yields `caller_concurrency_exceeded`', () => {
+    expect(parseIslErrorReason(ISL_GOVERNOR_429_BODY)).toBe('caller_concurrency_exceeded');
+  });
+
+  it('the 503 arm yields its own distinct reason — not a constant that matches anything', () => {
+    // Trap 13's discrimination requirement: a parser that returned the same
+    // token for every body would pass the test above and be useless.
+    expect(parseIslErrorReason(ISL_GOVERNOR_503_BODY)).toBe('service_busy_queue_full');
+  });
+
+  it('the FastAPI `detail` shape is read too — that is what PLoT\'s own 2.202 fakes serve', () => {
+    // tests/plot-2202-isl-429-retry.route.test.ts:90 and
+    // tests/plot-2202-isl-retry-after.client.test.ts:56 both answer
+    // `{"detail":"caller_concurrency_exceeded"}`. Reading only ISL's real shape
+    // would leave every in-repo harness silently unable to exercise this path.
+    expect(parseIslErrorReason('{"detail":"caller_concurrency_exceeded"}'))
+      .toBe('caller_concurrency_exceeded');
+  });
+
+  it('`reason` WINS over the coarser `code` when both are present', () => {
+    // The live body carries both. `RATE_LIMIT_EXCEEDED` would not have told the
+    // probe anything it did not already know from the status line.
+    expect(parseIslErrorReason(ISL_GOVERNOR_429_BODY)).not.toBe('RATE_LIMIT_EXCEEDED');
+    expect(parseIslErrorReason('{"code":"RATE_LIMIT_EXCEEDED"}')).toBe('RATE_LIMIT_EXCEEDED');
+    expect(parseIslErrorReason('{"error":{"code":"ISL_INVALID_DAG"}}')).toBe('ISL_INVALID_DAG');
+  });
+
+  it('absent / non-JSON / non-string causes read as MISSING, never as a fabricated reason', () => {
+    expect(parseIslErrorReason(undefined)).toBeUndefined();
+    expect(parseIslErrorReason(null)).toBeUndefined();
+    expect(parseIslErrorReason('')).toBeUndefined();
+    expect(parseIslErrorReason('   ')).toBeUndefined();
+    expect(parseIslErrorReason('Internal Server Error')).toBeUndefined(); // plain text
+    expect(parseIslErrorReason('{"message":"boom"}')).toBeUndefined(); // no cause field
+    expect(parseIslErrorReason('{"reason":123}')).toBeUndefined(); // wrong type
+    expect(parseIslErrorReason('{"reason":"   "}')).toBeUndefined(); // blank
+    expect(parseIslErrorReason('[1,2,3]')).toBeUndefined(); // array, not an object
+    expect(parseIslErrorReason('null')).toBeUndefined();
+  });
+
+  it('a hostile / oversized body cannot turn one log field into a body dump', () => {
+    const huge = 'x'.repeat(5_000);
+    const out = parseIslErrorReason(JSON.stringify({ reason: huge }))!;
+    expect(out.length).toBeLessThanOrEqual(ISL_ERROR_REASON_MAX_LEN + 1); // + the ellipsis
+    // Newlines stripped so one field cannot forge additional NDJSON log lines.
+    expect(parseIslErrorReason(JSON.stringify({ reason: 'a\nb\r{"event":"forged"}' })))
+      .toBe('a b {"event":"forged"}');
+  });
+});
+
+describe('2.202 ①b — ISLHttpError.getReason() is the reader that closes the write-only field', () => {
+  it('⭐ reads the body captured at construction', () => {
+    const err = new ISLHttpError(
+      429, ISL_GOVERNOR_429_BODY, '/api/v1/robustness/analyze/v2', undefined, 5_000,
+    );
+    expect(err.getReason()).toBe('caller_concurrency_exceeded');
+    // The rest of the class is unchanged.
+    expect(err.status).toBe(429);
+    expect(err.isRetryable()).toBe(true);
+    expect(err.retryAfterMs).toBe(5_000);
+  });
+
+  it('CONTROL — an error whose body carries no cause returns undefined', () => {
+    // Without this the assertion above could pass against a parser that returns
+    // a constant, and the "absence" half of the telemetry would be unproven.
+    const err = new ISLHttpError(500, 'boom', '/api/v1/robustness/analyze/v2');
+    expect(err.getReason()).toBeUndefined();
+    expect(err.isRetryable()).toBe(true);
+  });
+});

--- a/tests/plot-2202b-rescue-clamp.client.test.ts
+++ b/tests/plot-2202b-rescue-clamp.client.test.ts
@@ -1,0 +1,241 @@
+/**
+ * ROADMAP 2.202 fix ①b — WALL-CLOCK proof that the REAL `ISLClient` actually RUNS
+ * the rescue attempt at the CLAMPED width, and that the FIRST attempt is not.
+ *
+ * A decision function that returns a narrower timeout proves nothing on its own:
+ * if the client kept using `this.config.timeoutMs` for the retry (as it did
+ * before ①b), the clamp would be advisory — a guarantee that never executes, the
+ * defect class this programme names as dominant. So these arms drive the client
+ * against a real socket and read the clock.
+ *
+ * The discriminating signal is `ISLTimeoutError.timeoutMs`: it reports the
+ * timeout the attempt ACTUALLY ran with. A rescue attempt that reports the full
+ * configured width has not been clamped, whatever the decision said.
+ *
+ *   PROBE OF RECORD: PHASE0-EVIDENCE-2026-07-28/probe-2202-retry-under-contention.md
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { createServer as createHttpServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { ISLClient } from '../src/integrations/isl/client.js';
+import { ISLHttpError, ISLTimeoutError } from '../src/integrations/isl/errors.js';
+
+const ENDPOINT = '/api/v1/robustness/analyze/v2';
+
+describe('2.202 ①b — the rescue attempt RUNS, and it runs narrow', () => {
+  let server: Server;
+  let port: number;
+  let hits = 0;
+  /** 429s to serve before switching to the `afterRejections` behaviour. */
+  let rejectionsRemaining = 0;
+  /** After the 429s: 'hang' (never respond) or 'ok' (200). */
+  let afterRejections: 'hang' | 'ok' = 'hang';
+
+  beforeAll(async () => {
+    server = createHttpServer((req, res) => {
+      req.resume();
+      req.on('end', () => {
+        hits++;
+        if (rejectionsRemaining > 0) {
+          rejectionsRemaining--;
+          res.writeHead(429, { 'Content-Type': 'application/json' });
+          // ISL's real governor shape (reason carries the token) — no
+          // Retry-After header here, so the BUDGET alone drives the decision.
+          res.end(JSON.stringify({
+            code: 'RATE_LIMIT_EXCEEDED',
+            message: 'Too many concurrent analyses from this caller. Retry shortly.',
+            reason: 'caller_concurrency_exceeded',
+          }));
+          return;
+        }
+        if (afterRejections === 'hang') return; // accept and never answer
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    hits = 0;
+    rejectionsRemaining = 0;
+    afterRejections = 'hang';
+  });
+
+  function client(timeoutMs: number, maxRetries = 3) {
+    return new ISLClient({
+      baseUrl: `http://127.0.0.1:${port}`, apiKey: 'test-key', timeoutMs, maxRetries,
+    });
+  }
+
+  it('POSITIVE CONTROL — the harness can SEE a retry succeed under ample budget', async () => {
+    // Trap 13. Without this, every "2 hits" assertion below could be read as a
+    // harness that retries unconditionally, and every "1 hit" as one that never
+    // retries. Same server, same client, only the budget differs.
+    rejectionsRemaining = 1;
+    afterRejections = 'ok';
+    const res = await client(2_000).request<{ ok: boolean }>({
+      endpoint: ENDPOINT, body: {}, requestId: 'rid-2202b-control',
+      budget: { remainingMs: 60_000 },
+    });
+    expect(res.data).toEqual({ ok: true });
+    expect(hits).toBe(2);
+  }, 30_000);
+
+  it('⭐ RED-FIRST — a budget too small for a FULL retry still buys a CLAMPED one', async () => {
+    // 10s configured per-attempt timeout, 4.5s of budget. The pre-①b rule needed
+    // 1s backoff + 10s attempt + 1s margin = 12s and declined after ONE hit,
+    // which is precisely what staging did on 100% of contended requests.
+    // ①b affords `4.5s − ~0 elapsed − 1s delay − 1s margin ≈ 2.5s` and spends it.
+    rejectionsRemaining = 1;
+    afterRejections = 'hang'; // the rescue attempt must be ENDED BY ITS TIMEOUT
+    const CONFIGURED_TIMEOUT_MS = 10_000;
+    const BUDGET_MS = 4_500;
+
+    const t0 = Date.now();
+    let caught: unknown;
+    try {
+      await client(CONFIGURED_TIMEOUT_MS).request({
+        endpoint: ENDPOINT, body: {}, requestId: 'rid-2202b-clamped',
+        budget: { remainingMs: BUDGET_MS },
+      });
+    } catch (e) { caught = e; }
+    const elapsed = Date.now() - t0;
+
+    // THE MECHANISM: a second attempt reached ISL at all. PRE-①b: exactly 1.
+    expect(hits).toBe(2);
+
+    // THE CLAMP, observed rather than inferred: the attempt that timed out
+    // reports the width it actually ran with. PRE-①b there was no second
+    // attempt; had the client ignored the decision's timeout it would report
+    // 10_000 here and the call would have overrun the budget.
+    expect(caught).toBeInstanceOf(ISLTimeoutError);
+    const timedOut = caught as ISLTimeoutError;
+    expect(timedOut.timeoutMs).toBeLessThan(CONFIGURED_TIMEOUT_MS);
+    expect(timedOut.timeoutMs).toBeGreaterThanOrEqual(1_000);
+
+    // THE BOUND: the whole call still finished inside the caller's budget.
+    expect(elapsed).toBeLessThanOrEqual(BUDGET_MS);
+    expect(elapsed).toBeGreaterThan(2_500); // it really did spend the rescue attempt
+  }, 30_000);
+
+  it('⭐ THE FIRST ATTEMPT IS NOT NEWLY CLAMPED — #295\'s decline stands where it holds', async () => {
+    // ①b narrows RESCUE attempts only. A first attempt might still succeed if
+    // left alone, so truncating it would trade a slow success for a certain
+    // failure — the harm #295 refused, and still refuses.
+    //
+    // 1.5s configured timeout against a 400ms budget: if the clamp reached the
+    // first attempt it would abort at ~400ms (or be refused outright). It must
+    // run the full 1.5s and report 1.5s.
+    rejectionsRemaining = 0;
+    afterRejections = 'hang';
+    const CONFIGURED_TIMEOUT_MS = 1_500;
+
+    const t0 = Date.now();
+    let caught: unknown;
+    try {
+      await client(CONFIGURED_TIMEOUT_MS).request({
+        endpoint: ENDPOINT, body: {}, requestId: 'rid-2202b-first-attempt',
+        budget: { remainingMs: 400 },
+      });
+    } catch (e) { caught = e; }
+    const elapsed = Date.now() - t0;
+
+    expect(caught).toBeInstanceOf(ISLTimeoutError);
+    expect((caught as ISLTimeoutError).timeoutMs).toBe(CONFIGURED_TIMEOUT_MS);
+    expect(elapsed).toBeGreaterThanOrEqual(1_400);
+    // …and the exhausted budget still declines the retry, so this is bounded.
+    expect(hits).toBe(1);
+    expect(elapsed).toBeLessThan(2_500);
+  }, 30_000);
+
+  it('⭐ a genuinely-exhausted budget still declines — one attempt, no rescue, no hang', async () => {
+    // The other side of the floor. 800ms of budget cannot pay a 1s backoff, let
+    // alone an attempt, so `budget_exhausted` still terminates the call.
+    rejectionsRemaining = 99;
+    const t0 = Date.now();
+    let caught: unknown;
+    try {
+      await client(5_000).request({
+        endpoint: ENDPOINT, body: {}, requestId: 'rid-2202b-exhausted',
+        budget: { remainingMs: 800 },
+      });
+    } catch (e) { caught = e; }
+    const elapsed = Date.now() - t0;
+
+    expect(caught).toBeInstanceOf(ISLHttpError);
+    expect((caught as ISLHttpError).status).toBe(429);
+    // fix ①b's other half: the governor's own token is now readable off the
+    // error rather than sitting in a field nothing consults.
+    expect((caught as ISLHttpError).getReason()).toBe('caller_concurrency_exceeded');
+    expect(hits).toBe(1);
+    expect(elapsed).toBeLessThan(1_000);
+  }, 30_000);
+
+  /** Structured rows the client wrote to console.warn during one call. */
+  function captureRows() {
+    const rows: Record<string, unknown>[] = [];
+    vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      try { rows.push(JSON.parse(String(args[0]))); } catch { /* non-JSON: ignore */ }
+    });
+    return rows;
+  }
+
+  it('⭐ TELEMETRY — isl_retry_scheduled names the governor cause AND the clamp', async () => {
+    // ⚠ WITHOUT THIS ARM THE TELEMETRY IS UNPINNED, and the field that exists to
+    // make the NEXT diagnosis a log read could be deleted with the whole suite
+    // green — the same write-only shape ①b is repairing. So the row itself is
+    // asserted, not just the value the parser can produce in isolation.
+    rejectionsRemaining = 1;
+    afterRejections = 'hang';
+    const rows = captureRows();
+    await client(10_000).request({
+      endpoint: ENDPOINT, body: {}, requestId: 'rid-2202b-telemetry',
+      budget: { remainingMs: 4_500 },
+    }).catch(() => undefined);
+
+    const scheduled = rows.find((r) => r.event === 'isl_retry_scheduled');
+    expect(scheduled, 'isl_retry_scheduled must be emitted — it never fired once on 91bcac5').toBeDefined();
+    // The cause, off the wire, from the field that had zero readers.
+    expect(scheduled!.isl_reason).toBe('caller_concurrency_exceeded');
+    // The clamp, observable without a probe.
+    expect(scheduled!.timeout_clamped).toBe(true);
+    expect(scheduled!.per_attempt_timeout_ms).toBe(10_000);
+    expect(scheduled!.next_attempt_timeout_ms as number).toBeLessThan(10_000);
+    expect(scheduled!.affordable_timeout_ms as number).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('⭐ TELEMETRY — isl_retry_declined says WHY, with a negative affordable width', async () => {
+    rejectionsRemaining = 99;
+    const rows = captureRows();
+    await client(5_000).request({
+      endpoint: ENDPOINT, body: {}, requestId: 'rid-2202b-telemetry-declined',
+      budget: { remainingMs: 800 },
+    }).catch(() => undefined);
+
+    const declined = rows.find((r) => r.event === 'isl_retry_declined');
+    expect(declined).toBeDefined();
+    expect(declined!.reason).toBe('budget_exhausted');
+    expect(declined!.isl_reason).toBe('caller_concurrency_exceeded');
+    // The number that distinguishes "the floor bit" from "the budget is spent".
+    expect(declined!.affordable_timeout_ms as number).toBeLessThan(0);
+  }, 30_000);
+
+  it('a persistent 429 with ample budget still stops at the configured attempt cap', async () => {
+    // The clamp adds a rescue; it must not remove the hard upper bound.
+    rejectionsRemaining = 99;
+    const res = await client(2_000, 3).request({
+      endpoint: ENDPOINT, body: {}, requestId: 'rid-2202b-cap',
+      budget: { remainingMs: 60_000 },
+    }).catch((e) => e);
+    expect(res).toBeInstanceOf(ISLHttpError);
+    expect(hits).toBe(3);
+  }, 40_000);
+});

--- a/tests/plot-2202b-rescue-clamp.decision.test.ts
+++ b/tests/plot-2202b-rescue-clamp.decision.test.ts
@@ -1,0 +1,348 @@
+/**
+ * ⭐⭐ ROADMAP 2.202 fix ①b — THE RESCUE CLAMP, pinned at the DEPLOYED STAGING
+ * SHAPE that made fix ① dead by construction.
+ *
+ * THE DEFECT THIS FILE EXISTS FOR
+ * ------------------------------
+ * Fix ① (PR #295) shipped with 6,409 green tests, 11/11 green CI, three biting
+ * mutants and a purpose-built headroom guard — and then **never executed a single
+ * retry in production**. A live 3-way contention probe against build `91bcac5`
+ * measured **0 of 9 contended requests rescued** and **zero `isl_retry_scheduled`
+ * rows in the build's entire life** (`isl_retry_declined` returned 35 rows on the
+ * identical query, so the zero was a real absence — trap 13 satisfied).
+ *
+ *   PROBE OF RECORD: PHASE0-EVIDENCE-2026-07-28/probe-2202-retry-under-contention.md
+ *
+ * The cause was not the retry logic. Staging's Render dashboard sets
+ * `ISL_TIMEOUT_MS = 130_000` (repo default 60_000) and omits `REQUEST_BUDGET_MS`
+ * (→ 70_000). /v2/run's base-call clamp then takes its second arm and hands the
+ * retry decision a per-attempt timeout of `remaining − 1_000`, so the pre-①b gate
+ * `Retry-After + perAttempt + margin <= remaining` reduces to `Retry-After <= 0`.
+ * No positive `Retry-After` can ever fit. 100% of requests, arithmetically.
+ *
+ * ⚠⚠ WHY THIS FILE PINS 130_000 AS A LITERAL AND DOES **NOT** RE-DERIVE IT FROM
+ * `process.env` — READ BEFORE "FIXING" IT.
+ * Fix ①'s guard (amendment B1) did exactly that: it derived its constants from
+ * `ISL_TIMEOUT_MS` / `resolveRequestBudgetMs()` at TEST time, where those are
+ * unset, so it measured the repo default 60_000 and reported a comfortable ~8.9 s
+ * of headroom while the deployment ran 130_000. Mutant B1 proved the guard COULD
+ * fire; it never proved the guard was reading the DEPLOYED value. Deriving from
+ * the repo is still a mirror read when the source of truth is the Render
+ * dashboard (platform trap 18), and a control pinned to "whatever is current"
+ * decays into a tautology (trap 12b).
+ *
+ * So the numbers below are a **dated historical measurement**, deliberately
+ * separate from anything that tracks live:
+ *   • `ISL_TIMEOUT_MS = 130000` — read 2026-07-31 from
+ *     `GET /v1/services/srv-d4sl44s9c44c73ep4ak0/env-vars` (Render API, 49 keys),
+ *     corroborated on the wire by `base_isl_call_budget_clamped`
+ *     `{"isl_timeout_ms":130000,"remaining_budget_ms":69995}`.
+ *   • `REQUEST_BUDGET_MS` — ABSENT from all 49 keys → the repo default applies.
+ * If staging's posture changes, this file keeps testing the regime it names; the
+ * fix must survive that regime whether or not the deployment is still in it.
+ *
+ * The wall-clock proof that the real client RUNS the clamped attempt is in
+ * tests/plot-2202b-rescue-clamp.client.test.ts; the route-level proof at the
+ * staging shape is tests/plot-2202b-staging-shape-retry.route.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  decideIslRetry,
+  DEFAULT_RETRY_SAFETY_MARGIN_MS,
+} from '../src/integrations/isl/retry-budget.js';
+import {
+  islRetryBackoffMs,
+  BASE_CALL_MIN_TIMEOUT_MS,
+} from '../src/config/timeouts.js';
+
+// ── The deployed staging regime, as MEASURED 2026-07-31 (see header) ──────────
+/** Render dashboard value. NOT read from process.env, on purpose. */
+const STAGING_ISL_TIMEOUT_MS = 130_000;
+/**
+ * ABSENT from all 49 deployed keys → the repo default is what staging runs.
+ * Written as a literal, NOT `resolveRequestBudgetMs()`: this fixture must keep
+ * describing the regime it was measured in even if the repo default moves or a
+ * sibling test leaks the env var. That is the whole lesson of amendment B1.
+ */
+const STAGING_REQUEST_BUDGET_MS = 70_000;
+/** /v2/run's own base-call reserve (`baseCallSafetyMarginMs`). */
+const BASE_CALL_SAFETY_MARGIN_MS = 1_000;
+/** `remaining_budget_ms` on the live `base_isl_call_budget_clamped` row. */
+const STAGING_REMAINING_AT_CALL_MS = 69_995;
+/** Probe-measured fast-reject latency band: 349–891 ms. The brief's ~350 ms. */
+const STAGING_429_ELAPSED_MS = 350;
+/** ISL compute_governor RETRY_AFTER_SECONDS = 5. */
+const ISL_RETRY_AFTER_MS = 5_000;
+
+/**
+ * The per-attempt timeout /v2/run hands the client at the staging shape — the
+ * SAME expression as `run.ts`'s clamp, evaluated at the deployed constants.
+ * With `ISL_TIMEOUT_MS` (130 s) far above the budget, the second arm wins and the
+ * per-attempt timeout becomes essentially the whole budget. That is the trap.
+ */
+const STAGING_PER_ATTEMPT_MS = Math.min(
+  STAGING_ISL_TIMEOUT_MS,
+  Math.max(
+    BASE_CALL_MIN_TIMEOUT_MS,
+    Math.floor(STAGING_REMAINING_AT_CALL_MS - BASE_CALL_SAFETY_MARGIN_MS),
+  ),
+);
+
+/** The pre-①b gate, written out so the counterfactual is explicit, not implied. */
+function preFixWouldRetry(
+  delayMs: number,
+  perAttemptTimeoutMs: number,
+  remainingMs: number,
+  marginMs = DEFAULT_RETRY_SAFETY_MARGIN_MS,
+): boolean {
+  return delayMs + perAttemptTimeoutMs + marginMs <= remainingMs;
+}
+
+describe('⭐ 2.202 ①b — the STAGING shape: the retry that could never fire, now fires', () => {
+  it('⭐ RED-FIRST — ISL_TIMEOUT_MS=130000 / REQUEST_BUDGET_MS unset: a 350ms 429 with Retry-After: 5 IS rescued', () => {
+    const d = decideIslRetry({
+      retryable: true,
+      attempt: 1,
+      maxAttempts: 3,
+      elapsedMs: STAGING_429_ELAPSED_MS,
+      perAttemptTimeoutMs: STAGING_PER_ATTEMPT_MS,
+      retryAfterMs: ISL_RETRY_AFTER_MS,
+      budget: { remainingMs: STAGING_REMAINING_AT_CALL_MS },
+    });
+
+    // The whole point of ①b. PRE-FIX this returned `budget_exhausted`, exactly as
+    // the live telemetry recorded on every single contended request.
+    expect(d.retry).toBe(true);
+    expect(d.reason).toBe('budget_available');
+
+    // The mechanism: the attempt is NARROWER than the caller's configured
+    // timeout, which is what makes it fit at all.
+    expect(d.timeoutClamped).toBe(true);
+    expect(d.attemptTimeoutMs).toBeLessThan(STAGING_PER_ATTEMPT_MS);
+    expect(d.attemptTimeoutMs).toBeGreaterThanOrEqual(BASE_CALL_MIN_TIMEOUT_MS);
+
+    // ISL's own hint is still honoured, and still bounded by the budget.
+    expect(d.delayMs).toBe(ISL_RETRY_AFTER_MS);
+    expect(d.retryAfterHonoured).toBe(true);
+
+    // The invariant that must NEVER break: the attempt we are about to start
+    // finishes inside the caller's budget with the reserve untouched.
+    expect(d.delayMs + d.attemptTimeoutMs + DEFAULT_RETRY_SAFETY_MARGIN_MS)
+      .toBeLessThanOrEqual(d.remainingMs!);
+  });
+
+  it('…and the PRE-①b rule declined that exact case — the counterfactual, stated not implied', () => {
+    const remainingMs = STAGING_REMAINING_AT_CALL_MS - STAGING_429_ELAPSED_MS;
+    // 5_000 + 68_995 + 1_000 = 74_995 > 69_645. This is the live
+    // `isl_retry_declined` row from the probe, reproduced as arithmetic:
+    //   {"reason":"budget_exhausted","retry_after_ms":5000,
+    //    "remaining_budget_ms":69874,"projected_cost_ms":73974}
+    expect(preFixWouldRetry(ISL_RETRY_AFTER_MS, STAGING_PER_ATTEMPT_MS, remainingMs)).toBe(false);
+  });
+
+  it('⭐ THE REGIME, not just the point: once ISL_TIMEOUT_MS >= budget − margin, NO positive Retry-After fitted', () => {
+    // The general statement from the probe: the pre-①b gate fires iff
+    // `T <= R − A − m`. Once `T >= R − m` the base-call clamp's second arm takes
+    // over and the requirement collapses to `A <= 0`. Staging (130 s vs a 64 s
+    // ceiling) is deep in that regime — so this is not a near-miss that a small
+    // constant tweak would have fixed.
+    expect(STAGING_ISL_TIMEOUT_MS).toBeGreaterThan(
+      STAGING_REQUEST_BUDGET_MS - ISL_RETRY_AFTER_MS - DEFAULT_RETRY_SAFETY_MARGIN_MS,
+    );
+    for (const retryAfterMs of [1, 100, 1_000, 5_000, 30_000]) {
+      const remainingMs = STAGING_REMAINING_AT_CALL_MS - STAGING_429_ELAPSED_MS;
+      const delayMs = Math.max(retryAfterMs, islRetryBackoffMs(1));
+      expect(
+        preFixWouldRetry(delayMs, STAGING_PER_ATTEMPT_MS, remainingMs),
+        `pre-①b should have declined at Retry-After ${retryAfterMs}ms`,
+      ).toBe(false);
+
+      // …and ①b rescues every one of them.
+      const d = decideIslRetry({
+        retryable: true, attempt: 1, maxAttempts: 3,
+        elapsedMs: STAGING_429_ELAPSED_MS,
+        perAttemptTimeoutMs: STAGING_PER_ATTEMPT_MS,
+        retryAfterMs,
+        budget: { remainingMs: STAGING_REMAINING_AT_CALL_MS },
+      });
+      expect(d.retry, `①b should rescue at Retry-After ${retryAfterMs}ms`).toBe(true);
+      expect(d.timeoutClamped).toBe(true);
+    }
+  });
+});
+
+describe('2.202 ①b — the clamp is a STRICT RELAXATION (nothing that retried before now declines)', () => {
+  it('⭐ every decision the pre-①b rule granted is still granted, with an IDENTICAL timeout', () => {
+    // The property that bounds the blast radius. If it ever fails, ①b has
+    // REMOVED a retry rather than added one, and the floor is the likely culprit
+    // (it must be min(BASE_CALL_MIN_TIMEOUT_MS, perAttempt), never the constant
+    // alone — a sub-second caller must not be newly refused).
+    let grantedByBoth = 0;
+    let newlyGranted = 0;
+    for (const perAttemptTimeoutMs of [200, 400, 1_000, 5_000, 60_000, 68_995]) {
+      for (const budgetMs of [1_200, 3_000, 12_000, 70_000]) {
+        for (const elapsedMs of [0, 133, 350, 1_000, 5_000, 30_000, 69_000]) {
+          for (const retryAfterMs of [undefined, 0, 5_000]) {
+            const input = {
+              retryable: true, attempt: 1, maxAttempts: 3,
+              elapsedMs, perAttemptTimeoutMs, retryAfterMs,
+              budget: { remainingMs: budgetMs },
+            };
+            const d = decideIslRetry(input);
+            const delayMs = Math.max(retryAfterMs ?? 0, islRetryBackoffMs(1));
+            const remainingMs = budgetMs - elapsedMs;
+            if (preFixWouldRetry(delayMs, perAttemptTimeoutMs, remainingMs)) {
+              grantedByBoth++;
+              expect(d.retry, `pre-①b granted but ①b declined: ${JSON.stringify(input)}`).toBe(true);
+              // Unclamped: the pre-①b rule only granted when the FULL timeout fit,
+              // and where it fit, ①b must not narrow it.
+              expect(d.attemptTimeoutMs).toBe(perAttemptTimeoutMs);
+              expect(d.timeoutClamped).toBe(false);
+            } else if (d.retry) {
+              newlyGranted++;
+            }
+          }
+        }
+      }
+    }
+    // Both halves must be non-empty or the sweep proves nothing (trap 13).
+    expect(grantedByBoth, 'the sweep must contain cases the OLD rule granted').toBeGreaterThan(0);
+    expect(newlyGranted, 'the sweep must contain cases ①b newly rescues').toBeGreaterThan(0);
+  });
+
+  it('a granted rescue NEVER outlives the budget, across the same sweep', () => {
+    let clamped = 0;
+    for (const perAttemptTimeoutMs of [400, 5_000, 68_995]) {
+      for (const budgetMs of [3_000, 12_000, 70_000]) {
+        for (let elapsedMs = 0; elapsedMs <= budgetMs; elapsedMs += 250) {
+          const d = decideIslRetry({
+            retryable: true, attempt: 1, maxAttempts: 3,
+            elapsedMs, perAttemptTimeoutMs, retryAfterMs: undefined,
+            budget: { remainingMs: budgetMs },
+          });
+          if (!d.retry) continue;
+          if (d.timeoutClamped) clamped++;
+          expect(d.delayMs + d.attemptTimeoutMs + DEFAULT_RETRY_SAFETY_MARGIN_MS)
+            .toBeLessThanOrEqual(d.remainingMs!);
+          expect(d.projectedCostMs).toBe(d.delayMs + d.attemptTimeoutMs);
+        }
+      }
+    }
+    expect(clamped, 'the sweep must actually exercise the clamp').toBeGreaterThan(0);
+  });
+});
+
+describe('2.202 ①b — the viability floor: a genuinely-exhausted budget still declines', () => {
+  it('⭐ declines when not even a floored rescue attempt fits — no infinite retry', () => {
+    // remaining 1_800 − 1_000 backoff − 1_000 margin = −200 affordable.
+    const d = decideIslRetry({
+      retryable: true, attempt: 1, maxAttempts: 3,
+      elapsedMs: 68_200,
+      perAttemptTimeoutMs: 60_000,
+      budget: { remainingMs: 70_000 },
+    });
+    expect(d.retry).toBe(false);
+    expect(d.reason).toBe('budget_exhausted');
+    expect(d.delayMs).toBe(0);
+    expect(d.affordableTimeoutMs!).toBeLessThan(BASE_CALL_MIN_TIMEOUT_MS);
+  });
+
+  it('⭐ the floor BITES in the band where an attempt would fit but be uselessly short', () => {
+    // Sweep the boundary: affordable crosses BASE_CALL_MIN_TIMEOUT_MS somewhere,
+    // and the decision must flip there and stay flipped.
+    const perAttemptTimeoutMs = 60_000;
+    const budgetMs = 70_000;
+    const delayMs = islRetryBackoffMs(1);
+    let lastRetry = true;
+    let flips = 0;
+    for (let elapsedMs = 0; elapsedMs <= budgetMs; elapsedMs += 100) {
+      const d = decideIslRetry({
+        retryable: true, attempt: 1, maxAttempts: 3,
+        elapsedMs, perAttemptTimeoutMs, budget: { remainingMs: budgetMs },
+      });
+      const affordable = budgetMs - elapsedMs - delayMs - DEFAULT_RETRY_SAFETY_MARGIN_MS;
+      expect(d.retry).toBe(Math.min(perAttemptTimeoutMs, affordable) >= BASE_CALL_MIN_TIMEOUT_MS);
+      if (d.retry !== lastRetry) { flips++; lastRetry = d.retry; }
+    }
+    // Monotone: exactly ONE transition from retry to decline over the sweep.
+    expect(flips).toBe(1);
+    expect(lastRetry).toBe(false);
+  });
+
+  it('the floor is min(BASE_CALL_MIN_TIMEOUT_MS, perAttempt) — a sub-second caller is NOT newly refused', () => {
+    // A 400ms per-attempt caller with 500ms affordable: the pre-①b rule granted
+    // this (400 + 1_000 delay + 1_000 margin fits), so ①b must too. A bare
+    // `affordable >= 1_000` floor would silently REMOVE this retry.
+    const perAttemptTimeoutMs = 400;
+    const d = decideIslRetry({
+      retryable: true, attempt: 1, maxAttempts: 3,
+      elapsedMs: 590, // remaining 2_010 → affordable 10 … too small
+      perAttemptTimeoutMs,
+      budget: { remainingMs: 2_600 },
+    });
+    // affordable = 2_010 − 1_000 − 1_000 = 10 < 400 → decline, correctly.
+    expect(d.retry).toBe(false);
+
+    const ok = decideIslRetry({
+      retryable: true, attempt: 1, maxAttempts: 3,
+      elapsedMs: 100, // remaining 2_500 → affordable 500 >= 400
+      perAttemptTimeoutMs,
+      budget: { remainingMs: 2_600 },
+    });
+    expect(ok.retry).toBe(true);
+    expect(ok.attemptTimeoutMs).toBe(perAttemptTimeoutMs); // unclamped: 400 <= 500
+    expect(ok.timeoutClamped).toBe(false);
+    expect(BASE_CALL_MIN_TIMEOUT_MS).toBeGreaterThan(perAttemptTimeoutMs); // the floor WOULD have refused
+  });
+
+  it('a non-retryable failure and a spent attempt cap are unaffected by the clamp', () => {
+    const notRetryable = decideIslRetry({
+      retryable: false, attempt: 1, maxAttempts: 3, elapsedMs: 0,
+      perAttemptTimeoutMs: 1_000, budget: { remainingMs: 70_000 },
+    });
+    expect(notRetryable.retry).toBe(false);
+    expect(notRetryable.reason).toBe('not_retryable');
+
+    const capped = decideIslRetry({
+      retryable: true, attempt: 3, maxAttempts: 3, elapsedMs: 0,
+      perAttemptTimeoutMs: 1_000, budget: { remainingMs: 70_000 },
+    });
+    expect(capped.retry).toBe(false);
+    expect(capped.reason).toBe('attempt_cap');
+  });
+
+  it('an absurd Retry-After still self-limits — the clamp cannot rescue a 1-hour wait', () => {
+    // The delay is subtracted BEFORE the clamp, so a hint larger than the budget
+    // makes `affordable` deeply negative. No amount of narrowing helps.
+    const d = decideIslRetry({
+      retryable: true, attempt: 1, maxAttempts: 3, elapsedMs: 350,
+      perAttemptTimeoutMs: STAGING_PER_ATTEMPT_MS,
+      retryAfterMs: 3_600_000,
+      budget: { remainingMs: STAGING_REMAINING_AT_CALL_MS },
+    });
+    expect(d.retry).toBe(false);
+    expect(d.reason).toBe('budget_exhausted');
+    expect(d.affordableTimeoutMs!).toBeLessThan(0);
+  });
+});
+
+describe('2.202 ①b — the NO-BUDGET path is untouched (blast radius)', () => {
+  it('no budget → no clamp, no affordable figure, previous behaviour exactly', () => {
+    for (const perAttemptTimeoutMs of [250, 1_000, 60_000]) {
+      const d = decideIslRetry({
+        retryable: true, attempt: 1, maxAttempts: 3,
+        elapsedMs: 999_999, perAttemptTimeoutMs,
+        retryAfterMs: 3_600_000, budget: undefined,
+      });
+      expect(d.retry).toBe(true);
+      expect(d.reason).toBe('attempts_remaining');
+      // The clamp needs a budget to clamp against; with none there is nothing to
+      // derive a narrower timeout FROM, and inventing one would be a magic number.
+      expect(d.attemptTimeoutMs).toBe(perAttemptTimeoutMs);
+      expect(d.timeoutClamped).toBe(false);
+      expect(d.affordableTimeoutMs).toBeUndefined();
+      expect(d.delayMs).toBe(islRetryBackoffMs(1)); // A1: Retry-After still ignored
+    }
+  });
+});

--- a/tests/plot-2202b-staging-shape-retry.route.test.ts
+++ b/tests/plot-2202b-staging-shape-retry.route.test.ts
@@ -1,0 +1,233 @@
+/**
+ * ⭐⭐ ROADMAP 2.202 fix ①b — THE PIN AT THE DEPLOYED STAGING SHAPE.
+ *
+ * This is the test-time analogue of the live regime that fix ①'s guard could not
+ * see. Fix ① merged with 6,409 green tests and 11/11 green CI, deployed as build
+ * `91bcac5`, and then rescued **0 of 9** contended requests: `isl_retry_scheduled`
+ * never fired once in the build's whole life, while `isl_retry_declined` returned
+ * 35 rows on the identical Render query (so the zero was a real absence).
+ *
+ *   PROBE OF RECORD: PHASE0-EVIDENCE-2026-07-28/probe-2202-retry-under-contention.md
+ *
+ * WHY THE EXISTING ROUTE PINS COULD NOT CATCH IT. They run at the repo defaults —
+ * `ISL_TIMEOUT_MS = 60_000`, `REQUEST_BUDGET_MS = 70_000` — where fix ① works.
+ * Staging's Render DASHBOARD sets `ISL_TIMEOUT_MS = 130_000` and omits
+ * `REQUEST_BUDGET_MS`. At that posture /v2/run's base-call clamp takes its second
+ * arm and hands the client a per-attempt timeout of `remaining − 1_000`, so the
+ * pre-①b gate `Retry-After + perAttempt + margin <= remaining` reduces to
+ * `Retry-After <= 0` and no positive hint can ever fit. Platform trap 18: env
+ * posture comes from the Render API or a live witness, never from `render.yaml`
+ * or from `process.env` at test time.
+ *
+ * SO THIS FILE SETS THAT POSTURE EXPLICITLY, BEFORE the modules that read it are
+ * loaded (`ISL_TIMEOUT_MS` is a module-level `const` in config/timeouts.ts, so a
+ * static import would freeze the default before `beforeAll` ever runs — hence the
+ * dynamic import below). The values are a DATED MEASUREMENT, not a re-derivation:
+ * `GET /v1/services/srv-d4sl44s9c44c73ep4ak0/env-vars`, 2026-07-31, 49 keys.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createServer as createHttpServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { FastifyInstance } from 'fastify';
+
+const BASE_ROBUSTNESS_PATH = '/api/v1/robustness/analyze/v2';
+
+/** Render dashboard value, measured 2026-07-31. The repo default is 60_000. */
+const STAGING_ISL_TIMEOUT_MS = '130000';
+/** Probe-measured fast-reject latency band was 349–891 ms. */
+const REJECT_DELAY_MS = 350;
+/** ISL compute_governor `RETRY_AFTER_SECONDS = 5`. */
+const RETRY_AFTER_HEADER = '5';
+
+const ISL_OK = {
+  options: [
+    { option_id: 'opt1', outcome: { mean: 0.8, std: 0.1, p10: 0.6, p50: 0.8, p90: 0.95, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 1, win_probability: 0.7, probability_of_goal: 0.65 },
+    { option_id: 'opt2', outcome: { mean: 0.7, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 }, rank: 2, win_probability: 0.3, probability_of_goal: 0.55 },
+  ],
+  factor_sensitivity: [],
+  robustness: { score: 0.82, label: 'robust', fragile_edges: [], robust_edges: [], edge_e_values: [] },
+};
+
+/** Single factor / two options — below the flip-probe trigger, so the only ISL
+ *  traffic is the BASE call (the one the staging regime disabled). */
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'factor-a', kind: 'factor', label: 'Marketing', observed_state: { value: 0.6 } },
+  ],
+  edges: [{ from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],
+};
+const OPTIONS = [
+  { id: 'opt1', label: 'A', interventions: { 'factor-a': 0.8 } },
+  { id: 'opt2', label: 'B', interventions: { 'factor-a': 0.3 } },
+];
+
+let islServer: Server;
+let islPort: number;
+let rejectionsRemaining = 0;
+let baseHits: number[] = [];
+
+describe('⭐ 2.202 ①b — at the DEPLOYED staging shape the 429 retry finally fires', () => {
+  let app: FastifyInstance;
+  let previousIslTimeout: string | undefined;
+  let previousIslRequestTimeout: string | undefined;
+
+  beforeAll(async () => {
+    islServer = createHttpServer((req, res) => {
+      const path = (req.url ?? '').split('?')[0];
+      req.resume();
+      req.on('end', () => {
+        if (path === BASE_ROBUSTNESS_PATH) {
+          baseHits.push(Date.now());
+          if (rejectionsRemaining > 0) {
+            rejectionsRemaining--;
+            // A FAST reject after ~350 ms, carrying ISL's real governor body and
+            // its `Retry-After: 5` — the exact shape measured on the wire.
+            setTimeout(() => {
+              res.writeHead(429, {
+                'Content-Type': 'application/json',
+                'Retry-After': RETRY_AFTER_HEADER,
+              });
+              res.end(JSON.stringify({
+                code: 'RATE_LIMIT_EXCEEDED',
+                message: 'Too many concurrent analyses from this caller. Retry shortly.',
+                reason: 'caller_concurrency_exceeded',
+                retryable: true,
+                source: 'isl',
+              }));
+            }, REJECT_DELAY_MS);
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(ISL_OK));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({}));
+      });
+    });
+    await new Promise<void>((resolve) => islServer.listen(0, '127.0.0.1', () => resolve()));
+    islPort = (islServer.address() as AddressInfo).port;
+
+    previousIslTimeout = process.env.ISL_TIMEOUT_MS;
+    previousIslRequestTimeout = process.env.ISL_REQUEST_TIMEOUT_MS;
+    // ⭐ THE STAGING POSTURE. Set BEFORE the dynamic import below, because
+    // config/timeouts.ts freezes ISL_TIMEOUT_MS at module evaluation.
+    process.env.ISL_TIMEOUT_MS = STAGING_ISL_TIMEOUT_MS;
+    delete process.env.ISL_REQUEST_TIMEOUT_MS; // takes precedence if set
+    delete process.env.REQUEST_BUDGET_MS; // ABSENT on staging → repo default 70s
+    delete process.env.ISL_MAX_RETRIES; // absent on staging → default 3
+
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.ISL_ENABLE = '1';
+    process.env.ISL_BASE_URL = `http://127.0.0.1:${islPort}`;
+    process.env.ISL_API_KEY = 'test-key';
+
+    const { createServer } = await import('../src/createServer.js');
+    const { ISL_TIMEOUT_MS } = await import('../src/config/timeouts.js');
+    // Guard the harness itself: if the dynamic import did not observe the env,
+    // every assertion below would silently run at the repo default and this file
+    // would test the regime fix ① already handled. Fail loudly instead.
+    expect(
+      ISL_TIMEOUT_MS,
+      'the staging posture did not reach config/timeouts.ts — this file would be vacuous',
+    ).toBe(Number(STAGING_ISL_TIMEOUT_MS));
+
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    islServer.closeAllConnections?.();
+    await new Promise<void>((resolve) => islServer.close(() => resolve()));
+    // Restore rather than blanket-delete: ISL_TIMEOUT_MS is process-wide and
+    // other files in this worker read it at their own module load.
+    if (previousIslTimeout === undefined) delete process.env.ISL_TIMEOUT_MS;
+    else process.env.ISL_TIMEOUT_MS = previousIslTimeout;
+    if (previousIslRequestTimeout === undefined) delete process.env.ISL_REQUEST_TIMEOUT_MS;
+    else process.env.ISL_REQUEST_TIMEOUT_MS = previousIslRequestTimeout;
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    delete process.env.ISL_ENABLE;
+    delete process.env.ISL_BASE_URL;
+    delete process.env.ISL_API_KEY;
+    delete process.env.REQUEST_BUDGET_MS;
+  });
+
+  beforeEach(() => {
+    baseHits = [];
+    rejectionsRemaining = 0;
+    delete process.env.REQUEST_BUDGET_MS;
+  });
+
+  async function run() {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: 's2202b' }),
+    });
+    return { statusCode: res.statusCode, body: JSON.parse(res.body) as any };
+  }
+
+  const critiqueCodes = (body: any): string[] => (body.critiques ?? []).map((c: any) => c.code);
+
+  it('POSITIVE CONTROL — at the staging posture a clean run still succeeds in ONE hit', async () => {
+    // Trap 13: prove the harness can produce a PASS at ISL_TIMEOUT_MS=130000
+    // before any "the 429 is now rescued" claim is made against it.
+    rejectionsRemaining = 0;
+    const { statusCode, body } = await run();
+    expect(statusCode).toBe(200);
+    expect(baseHits).toHaveLength(1);
+    expect(body.analysis_status).not.toBe('failed');
+    expect(critiqueCodes(body)).not.toContain('ISL_CALL_FAILED');
+  }, 60_000);
+
+  it('⭐⭐ RED-FIRST AT THE STAGING SHAPE — a 350ms 429 with Retry-After: 5 IS rescued', async () => {
+    // THIS IS THE ARM THAT WAS DEAD ON `91bcac5`. Pre-①b the live telemetry read
+    //   {"event":"isl_retry_declined","reason":"budget_exhausted","attempt":1,
+    //    "max_retries":3,"retry_after_ms":5000,"remaining_budget_ms":69874,
+    //    "projected_cost_ms":73974}
+    // on 9 of 9 contended requests, and the tester got the 500.
+    rejectionsRemaining = 1;
+    const t0 = Date.now();
+    const { statusCode, body } = await run();
+    const elapsed = Date.now() - t0;
+
+    // What the tester feels: the analysis completes.
+    expect(statusCode).toBe(200);
+    expect(body.analysis_status).not.toBe('failed');
+    expect(critiqueCodes(body)).not.toContain('ISL_CALL_FAILED');
+    expect(JSON.stringify(body)).not.toContain('HTTP 429');
+
+    // The mechanism: a SECOND attempt reached ISL. Pre-①b this was exactly one.
+    expect(baseHits).toHaveLength(2);
+
+    // …and it waited the governor's own 5s hint, not our 1s backoff — proving
+    // the delay that made the pre-①b projection impossible was actually paid.
+    const gapMs = baseHits[1] - baseHits[0];
+    expect(gapMs).toBeGreaterThanOrEqual(4_900);
+    expect(gapMs).toBeLessThan(12_000);
+    expect(elapsed).toBeLessThan(45_000);
+  }, 90_000);
+
+  it('⭐ a genuinely-exhausted budget still declines at the staging shape — no infinite retry', async () => {
+    // The floor must still bite when the budget really is spent: 1.5s of budget
+    // cannot pay a 5s Retry-After, whatever the clamp affords afterwards.
+    process.env.REQUEST_BUDGET_MS = '1500';
+    rejectionsRemaining = 99;
+    const t0 = Date.now();
+    const { statusCode, body } = await run();
+    const elapsed = Date.now() - t0;
+
+    expect(statusCode).toBe(200); // V2 contract: a failure is a 200 envelope
+    expect(body.analysis_status).toBe('failed');
+    expect(critiqueCodes(body)).toContain('ISL_CALL_FAILED');
+    expect(String(body.status_reason ?? '')).toContain('429');
+    expect(baseHits.length).toBeLessThanOrEqual(2);
+    expect(elapsed).toBeLessThan(20_000);
+  }, 60_000);
+});


### PR DESCRIPTION
## Why

Fix ① (PR #295, deployed `91bcac5`) is **dead by construction on staging**. A live 3-way contention
probe measured **0 of 9** contended requests rescued, and **`isl_retry_scheduled` has never fired
once** in the build's entire life — while `isl_retry_declined` returned **35 rows** on the identical
Render query, so the zero is a real absence, not a broken search.

Evidence: `PHASE0-EVIDENCE-2026-07-28/probe-2202-retry-under-contention.md`.

**Cause — not the retry logic.** Staging's Render dashboard sets `ISL_TIMEOUT_MS = 130000` (repo
default 60000) and omits `REQUEST_BUDGET_MS` (→ 70000). `/v2/run`'s base-call clamp then takes its
second arm and hands the retry decision a per-attempt timeout of `remaining − 1000`, so the gate
`Retry-After + perAttempt + margin <= remaining` reduces to `Retry-After <= 0`. **No positive hint
can ever fit, at any budget.** Fix ① shipped with 6,409 green tests, 11/11 green CI and a
purpose-built headroom guard that derived its constant from `process.env` at *test* time — the repo
default — and so measured a comfortable ~8.9 s of headroom while the deployment sat 66 s the wrong
side of the line. Platform trap 18, exactly.

## What changed

- **`retry-budget.ts` — the rescue clamp.** `rescue = min(perAttempt, remaining − delay − margin)`,
  granted iff `rescue >= min(BASE_CALL_MIN_TIMEOUT_MS, perAttempt)`.
  #295 declined downward-clamping because it "would truncate slow-but-successful calls". **That is
  correct for a FIRST attempt and does not transfer to a rescue attempt**, whose alternative is not a
  slower success but a typed failure already decided. So the clamp applies to **retries only**; the
  first attempt is untouched and #295's decline is **pinned, not merely described**.
  The floor is a **viability threshold, never a `Math.max`** — flooring up would start an attempt that
  outlives the caller's budget. The rule is a **strict relaxation**, pinned over a 504-case sweep:
  every decision the old rule granted is still granted, with an identical unclamped timeout.
- **`client.ts`** — the per-attempt timeout becomes a per-attempt **variable**, so the clamp actually
  executes instead of being advisory.
- **`errors.ts` — `parseIslErrorReason()` + `ISLHttpError.getReason()`**: the **first reader**
  `public body: string` has ever had (trap 10's write-only column, in the one field naming *why* the
  governor rejected us). The probe's `caller_concurrency_exceeded` log search was **vacuous** for
  exactly this reason. Body shape derived read-only from `Talchain/Inference-Service-Layer@7c681fda`.
- **Telemetry** — `isl_reason`, `timeout_clamped`, `next_attempt_timeout_ms`, `affordable_timeout_ms`
  on both retry rows, so the next contention diagnosis is a log read rather than a three-service probe.
- **`timeouts.ts`** — `BASE_CALL_MIN_TIMEOUT_MS` de-mirrored out of `run.ts` (trap 12).

**No env var changed. ISL and CEE untouched.** The fix works under any posture where a floored rescue fits.

## Verification

- **RED-first at the deployed staging tip `91bcac50`**, throwaway worktree outside the clone root.
  The headline: `expected 'failed' not to be 'failed'`, and the pre-fix run's own
  `isl_retry_declined` row (`retry_after_ms:5000, remaining_budget_ms:69642,
  projected_cost_ms:73999`) reproduces the **live probe's row within 25 ms**.
  Also verbatim: `expected 1 to be 2` (one attempt, 4.5 s of budget unspent),
  `caught.getReason is not a function`, and
  `isl_retry_scheduled must be emitted — it never fired once on 91bcac5: expected undefined to be defined`.
- **⚠ Two arms of #295's own decision test were RE-POINTED** — they pinned the mechanism ①b replaces
  and would have gone RED against their own fix. Disclosed in-file, and the changed behaviour is now
  pinned in **both** directions. The `HEADROOM` guard's message said *"2.202 is DISABLED"*, which is
  no longer true post-①b; corrected, because a false alarm is worse than none (trap 14).
- **5 mutants**, each in its own throwaway worktree outside the clone root, all removed before the gate:
  | mutant | RED |
  |---|---|
  | A — drop the narrowing (`min`) | **23 tests / 6 files**, incl. a 20 s timeout and a 23 s run against a 4.5 s budget |
  | A2 — restore the pre-①b gate | **11 tests / 4 files**, incl. the staging-shape route pin. #295's own pins stay GREEN — clean attribution |
  | B — remove the viability floor | **2 tests / 1 file**, both in the floor block, non-overlapping with A2 |
  | C — drop the body cause from the log rows | **2 tests / 1 file** (the telemetry pins) |
  | C2 — revert `body` to write-only | **4 tests / 2 files** |
- **Gate:** `bash scripts/pre-push-validate.sh` → **6/6 PASS, 6440 passed | 28 skipped | 0 failed**
  (staging baseline 6409 → +31 net new arms).

Full lane evidence: `PHASE0-EVIDENCE-2026-07-28/fix-plot-retry-reachable-2202b.md`.

## Not done
- **Not measured live.** This pins the deployed *posture* in the suite; it does not re-run the
  contention probe. The direct confirmation is `isl_retry_scheduled > 0` on staging after deploy.
- Flip probes still run `maxRetries: 1` with no budget — untouched (probe §5, rowed separately).
- CEE still maps a residual 429 to a 500 (fix ③).

🤖 Generated with [Claude Code](https://claude.com/claude-code)