### PR TITLE
DO NOT MERGE — fix(cee) row 23 step 1: stop fabricating a 'ready' readiness verdict; REFUSE to surface the CEE bias payload (it describes an invented graph)

### DIFF
--- a/src/cee/orchestrator.ts
+++ b/src/cee/orchestrator.ts
@@ -8,6 +8,7 @@ import type {
   CeeTrace,
   CeeReviewRequest,
   CeeReviewResponse,
+  CeeReviewReadiness,
   CeeReviewBlock,
   CeeErrorNormalized,
 } from './types.js';
@@ -115,6 +116,25 @@ export type BriefContext = {
   edges?: number;
 };
 
+/**
+ * Build the brief PLoT sends to CEE's /assist/v1/draft-graph.
+ *
+ * ⚠ READ BEFORE WIRING ANYTHING ELSE OUT OF THE CEE COMPOSE RESULT (ROADMAP row 23).
+ *
+ * This brief carries the user's node/edge COUNTS and nothing else — deliberately, see
+ * the "no user content exposed" comment below. CEE therefore DRAFTS A NEW GRAPH from a
+ * string like "Decision review context: Decision review for inference results
+ * (12 nodes, 18 edges)", and `runDecisionReviewVia{Sdk,V2Http}` then run /options and
+ * /bias-check against THAT drafted graph (`:172` and `:341` at 5ab93383), not against
+ * `request.graph_snapshot` — which `orchestrateCeeReview` reads for `.length` only
+ * (`:583-584`, `:622-623`).
+ *
+ * Consequence: `bias.bias_findings` and `bias.mitigation_patches` describe a graph the
+ * user never built, and any patch node ids come from it. Surfacing them to a user —
+ * e.g. via the UI's "apply to my model" action — would be a fabrication, not a fix.
+ * The graph seam must be corrected first, and doing so reverses the explicit
+ * "no user content exposed" decision, so it is an architecture call, not a patch.
+ */
 export function buildCeeBrief(shortLabel: string, context?: BriefContext): string {
   const prefix = 'Decision review context: ';
   const label = (shortLabel ?? '').trim();
@@ -429,6 +449,40 @@ export interface CeeOrchestrationResult {
  * Check if SDK supports review() method (v1.12.0+)
  * This will be updated when SDK v1.12.0 is published
  */
+const VALID_READINESS_LEVELS = ['ready', 'needs_attention', 'not_ready'] as const;
+
+/**
+ * Extract a readiness verdict from the CEE compose result, or `undefined` when CEE
+ * computed none.
+ *
+ * ROADMAP row 23. Both branches below previously discarded the CEE result and emitted
+ * `readiness: { level: 'ready', headline: 'Analysis complete', factors: [] }` on EVERY
+ * successful turn. That is a constant, not a verdict — omitting the field is the honest
+ * output, and a downstream surface that renders nothing is preferable to one that
+ * renders an unearned "ready".
+ *
+ * CEE's compose endpoints carry no readiness field today (olumi-assistants-service
+ * `src/schemas/ceeResponses.ts`, CEEDraftGraph/Options/BiasCheck response schemas), so
+ * in practice this returns `undefined`. It is written as a real extractor, not as a
+ * hardcoded `undefined`, so that a readiness CEE later starts sending is carried
+ * through without another code change — and so both directions stay testable.
+ */
+function extractCeeReadiness(review: unknown): CeeReviewReadiness | undefined {
+  const candidate = (review as { readiness?: unknown } | null | undefined)?.readiness;
+  if (!candidate || typeof candidate !== 'object') return undefined;
+
+  const { level, headline, factors } = candidate as Record<string, unknown>;
+  if (typeof level !== 'string') return undefined;
+  if (!VALID_READINESS_LEVELS.includes(level as typeof VALID_READINESS_LEVELS[number])) return undefined;
+  if (typeof headline !== 'string' || headline.length === 0) return undefined;
+
+  return {
+    level: level as CeeReviewReadiness['level'],
+    headline,
+    factors: Array.isArray(factors) ? factors.filter((f): f is string => typeof f === 'string') : [],
+  };
+}
+
 function sdkSupportsReview(client: ReturnType<typeof createCEEClient>): boolean {
   // TODO: Update when SDK v1.12.0 is published
   // return typeof (client as any).review === 'function';
@@ -594,15 +648,14 @@ export async function orchestrateCeeReview(
         throw new Error(result.error.code ?? 'CEE_V2_ERROR');
       }
 
-      // Convert compose result to M1 response shape
+      // Convert compose result to M1 response shape.
+      // ROADMAP row 23: readiness is carried from the CEE result when CEE computed one
+      // and OMITTED otherwise. It is never fabricated — see extractCeeReadiness().
+      const readiness = extractCeeReadiness(result.review);
       ceeReview = result.review ? {
         intent: request.intent,
         analysis_state: 'ran',
-        readiness: {
-          level: 'ready',
-          headline: 'Analysis complete (v2)',
-          factors: [],
-        },
+        ...(readiness ? { readiness } : {}),
         blocks: [],
         trace: {
           request_id: result.trace?.cee_returned_request_id ?? undefined,
@@ -634,15 +687,14 @@ export async function orchestrateCeeReview(
         throw new Error(result.error.code ?? 'CEE_SDK_ERROR');
       }
 
-      // Convert compose result to M1 response shape (blocks added below)
+      // Convert compose result to M1 response shape (blocks added below).
+      // ROADMAP row 23: readiness is carried from the CEE result when CEE computed one
+      // and OMITTED otherwise. It is never fabricated — see extractCeeReadiness().
+      const readiness = extractCeeReadiness(result.review);
       ceeReview = result.review ? {
         intent: request.intent,
         analysis_state: 'ran',
-        readiness: {
-          level: 'ready',
-          headline: 'Analysis complete',
-          factors: [],
-        },
+        ...(readiness ? { readiness } : {}),
         blocks: [], // Will be populated with ISL blocks below
         trace: {
           request_id: result.trace?.cee_returned_request_id ?? undefined,

--- a/src/cee/types.ts
+++ b/src/cee/types.ts
@@ -313,7 +313,19 @@ export interface CeeReviewReadiness {
 export interface CeeReviewResponse {
   intent: string;
   analysis_state: 'ran' | 'skipped' | 'failed';
-  readiness: CeeReviewReadiness;
+  /**
+   * Readiness verdict — OPTIONAL, and present only when CEE actually computed one.
+   *
+   * It used to be required, and `orchestrateCeeReview` satisfied that requirement by
+   * hardcoding `{ level: 'ready', headline: 'Analysis complete', factors: [] }` on
+   * every successful turn: a constant dressed as a computed verdict. CEE's compose
+   * endpoints (/assist/v1/draft-graph, /options, /bias-check) carry no readiness
+   * field, so on the current live path the honest value is ABSENCE, not 'ready'.
+   *
+   * Consumers must treat an absent readiness as "no verdict available" and render
+   * nothing, rather than defaulting to a positive one.
+   */
+  readiness?: CeeReviewReadiness;
   blocks: CeeReviewBlock[];
   trace: {
     request_id?: string;

--- a/tests/cee-orchestrator-readiness.test.ts
+++ b/tests/cee-orchestrator-readiness.test.ts
@@ -1,0 +1,275 @@
+/**
+ * ROADMAP row 23 (step 1) — `orchestrateCeeReview` must not fabricate a readiness verdict.
+ *
+ * Before this suite, BOTH live branches of `orchestrateCeeReview` used the CEE compose
+ * result only as a truthiness test and then emitted a hardcoded object containing
+ *   readiness: { level: 'ready', headline: 'Analysis complete[ (v2)]', factors: [] }
+ * on EVERY successful turn — a constant dressed as a computed verdict
+ * (src/cee/orchestrator.ts:598-612 and :638-652 at 5ab93383).
+ *
+ * CEE's compose endpoints (/assist/v1/draft-graph, /options, /bias-check) return no
+ * readiness field at all (olumi-assistants-service@42e0b8ec
+ * src/schemas/ceeResponses.ts:288-387), so the honest output is ABSENCE.
+ *
+ * The suite covers both branches (SDK compose = default live branch; v2 HTTP when
+ * CEE_SCHEMA_V2 ∈ {1,true}) in both directions: verdict present in the CEE payload →
+ * carried; verdict absent → field omitted, never fabricated.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { resetCeeCircuitBreaker } from '../src/cee/circuit-breaker.js';
+import type { CeeReviewRequest } from '../src/cee/types.js';
+
+// -----------------------------------------------------------------------------
+// Mocks
+//
+// Both mocks spread `importOriginal()` so that every export we do NOT override
+// keeps its real implementation. A bare factory would replace the module and
+// silently drop exports added later (see the repo's hand-maintained-mirror trap).
+// -----------------------------------------------------------------------------
+
+/** What the mocked SDK helper returns as the "CEE compose result" review payload. */
+let sdkReviewPayload: unknown = { story: {}, journey: {}, uiFlags: {} };
+/** What the mocked CEE bias-check envelope returns. */
+let biasEnvelope: Record<string, unknown> = { bias_findings: [] };
+/** When true, the mocked CEE bias-check rejects — exercises the degraded path. */
+let biasEnvelopeThrows = false;
+
+vi.mock('@olumi/assistants-sdk', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createCEEClient: () => ({
+      draftGraph: async () => ({
+        graph: { nodes: [], edges: [] },
+        archetype: null,
+        trace: { request_id: 'cee-req-sdk' },
+        model: 'test-model',
+      }),
+      options: async () => ({ options: [] }),
+      evidenceHelper: async () => ({ items: [] }),
+      biasCheck: async () => {
+        if (biasEnvelopeThrows) throw new Error('CEE_UPSTREAM_FAILURE');
+        return biasEnvelope;
+      },
+    }),
+    buildCeeDecisionReviewPayload: () => sdkReviewPayload,
+  };
+});
+
+vi.mock('../src/cee/client.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    draftGraphV2: async () => ({
+      data: {
+        graph: { nodes: [], edges: [] },
+        archetype: null,
+        trace: { request_id: 'cee-req-v2' },
+        model: 'test-model',
+      },
+      latency_ms: 1,
+    }),
+    optionsV2: async () => ({ data: { options: [] }, latency_ms: 1 }),
+    biasCheckV2: async () => {
+      if (biasEnvelopeThrows) throw new Error('CEE_UPSTREAM_FAILURE');
+      return { data: biasEnvelope, latency_ms: 1 };
+    },
+  };
+});
+
+// Imported after the mocks so the module graph picks them up.
+const { orchestrateCeeReview } = await import('../src/cee/orchestrator.js');
+
+const ENV = { baseUrl: 'http://cee.test', apiKey: 'test-key', timeoutMs: 5_000 };
+
+function makeRequest(): CeeReviewRequest {
+  return {
+    scenario_id: 'scenario-1',
+    graph_snapshot: {
+      nodes: [{ id: 'A' }, { id: 'B' }],
+      edges: [{ from: 'A', to: 'B' }],
+    },
+    graph_schema_version: '2.2',
+    inference_results: { quantiles: { p10: 0.1, p50: 0.5, p90: 0.9 } },
+    intent: 'selection',
+  };
+}
+
+describe('orchestrateCeeReview — readiness is carried, never fabricated', () => {
+  beforeEach(() => {
+    resetCeeCircuitBreaker();
+    delete process.env.CEE_SCHEMA_V2;
+    sdkReviewPayload = { story: {}, journey: {}, uiFlags: {} };
+    biasEnvelope = { bias_findings: [] };
+    biasEnvelopeThrows = false;
+  });
+
+  afterEach(() => {
+    delete process.env.CEE_SCHEMA_V2;
+    resetCeeCircuitBreaker();
+  });
+
+  // ---------------------------------------------------------------------------
+  // (d) readiness absent in CEE payload → absent in output (no 'ready' fabrication)
+  // ---------------------------------------------------------------------------
+
+  it('SDK branch: omits readiness entirely when CEE computed none', async () => {
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-1');
+
+    expect(result.ceeReview).not.toBeNull();
+    expect(result.ceeReview).not.toHaveProperty('readiness');
+    expect((result.ceeReview as Record<string, unknown>).readiness).toBeUndefined();
+    // The specific fabricated constant must be gone.
+    expect(JSON.stringify(result.ceeReview)).not.toContain('Analysis complete');
+  });
+
+  it('v2 HTTP branch: omits readiness entirely when CEE computed none', async () => {
+    process.env.CEE_SCHEMA_V2 = '1';
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-2');
+
+    expect(result.ceeReview).not.toBeNull();
+    expect(result.ceeReview).not.toHaveProperty('readiness');
+    expect(JSON.stringify(result.ceeReview)).not.toContain('Analysis complete (v2)');
+  });
+
+  // ---------------------------------------------------------------------------
+  // (d) readiness present in CEE payload → carried through byte-identical
+  // ---------------------------------------------------------------------------
+
+  it('SDK branch: carries a real CEE readiness verdict through byte-identical', async () => {
+    sdkReviewPayload = {
+      story: {},
+      journey: {},
+      uiFlags: {},
+      readiness: {
+        level: 'needs_attention',
+        headline: 'Two fragile edges dominate the outcome',
+        factors: ['Model robustness', 'Evidence coverage'],
+      },
+    };
+
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-3');
+
+    expect(result.ceeReview?.readiness).toEqual({
+      level: 'needs_attention',
+      headline: 'Two fragile edges dominate the outcome',
+      factors: ['Model robustness', 'Evidence coverage'],
+    });
+  });
+
+  it('v2 HTTP branch: carries a real CEE readiness verdict through byte-identical', async () => {
+    process.env.CEE_SCHEMA_V2 = '1';
+    sdkReviewPayload = {
+      story: {},
+      journey: {},
+      uiFlags: {},
+      readiness: {
+        level: 'not_ready',
+        headline: 'Outcome node is unidentifiable',
+        factors: ['Identifiability'],
+      },
+    };
+
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-4');
+
+    expect(result.ceeReview?.readiness).toEqual({
+      level: 'not_ready',
+      headline: 'Outcome node is unidentifiable',
+      factors: ['Identifiability'],
+    });
+  });
+
+  it('rejects a malformed readiness rather than passing it through or fabricating one', async () => {
+    sdkReviewPayload = {
+      story: {},
+      journey: {},
+      uiFlags: {},
+      readiness: { level: 'totally-fine', headline: 42, factors: 'nope' },
+    };
+
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-5');
+
+    expect(result.ceeReview).not.toBeNull();
+    expect(result.ceeReview).not.toHaveProperty('readiness');
+  });
+
+  // ---------------------------------------------------------------------------
+  // (c) existing fallback behaviour — pinned, must not change
+  // ---------------------------------------------------------------------------
+
+  it('SDK branch: ceeReview is null when CEE returns no review', async () => {
+    sdkReviewPayload = null;
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-6');
+
+    expect(result.ceeReview).toBeNull();
+    expect(result.ceeError).toBeNull();
+  });
+
+  it('v2 HTTP branch: ceeReview is null when CEE returns no review', async () => {
+    process.env.CEE_SCHEMA_V2 = '1';
+    sdkReviewPayload = null;
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-7');
+
+    expect(result.ceeReview).toBeNull();
+    expect(result.ceeError).toBeNull();
+  });
+
+  it('degrades with a normalised error and null review when the CEE call fails', async () => {
+    biasEnvelopeThrows = true;
+
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-8');
+
+    expect(result.ceeReview).toBeNull();
+    expect(result.ceeError).not.toBeNull();
+    expect(result.ceeTrace.degraded).toBe(true);
+  });
+
+  it('still carries intent, analysis_state, blocks and trace on a successful turn', async () => {
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-9');
+
+    expect(result.ceeReview?.intent).toBe('selection');
+    expect(result.ceeReview?.analysis_state).toBe('ran');
+    expect(Array.isArray(result.ceeReview?.blocks)).toBe(true);
+    expect(result.ceeReview?.trace?.request_id).toBe('cee-req-sdk');
+    expect(result.ceeTrace.degraded).toBe(false);
+  });
+
+  it('still synthesises the ISL robustness block', async () => {
+    const request = makeRequest();
+    request.isl_robustness = { overall_robustness: 'fragile' };
+
+    const result = await orchestrateCeeReview(ENV, request, 'req-10');
+
+    expect(result.ceeReview?.blocks?.some((b) => b.id === 'robustness')).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // (a)/(b) Bias payload — PINNED AS *NOT* SURFACED, deliberately.
+  //
+  // This is NOT an endorsement of the gap. `orchestrateCeeReview` asks CEE to draft
+  // a graph from a COUNT-ONLY brief ("Decision review context: ... (N nodes, E edges)",
+  // src/cee/orchestrator.ts:118-133) and then runs the bias check against THAT drafted
+  // graph (:172, :341) — the user's own graph (`request.graph_snapshot`) is read for
+  // `.length` only (:583-584, :622-623). So `bias_findings` / `mitigation_patches`
+  // describe a graph the user never built, and surfacing them would be a fabrication,
+  // not a fix. The graph seam must be corrected first — see
+  // PHASE0-EVIDENCE-2026-07-28/fix-row23-plot-carry-review.md §2.
+  //
+  // Delete this test when, and only when, that seam is fixed.
+  // ---------------------------------------------------------------------------
+
+  it('does NOT surface CEE bias findings (they describe a CEE-drafted graph, not the user\'s)', async () => {
+    biasEnvelope = {
+      bias_findings: [{ code: 'ANCHORING', severity: 'warning', message: 'anchored on X' }],
+      mitigation_patches: [{ bias_code: 'ANCHORING', patch: { adds: { nodes: [{ id: 'invented-1' }] } } }],
+    };
+
+    const result = await orchestrateCeeReview(ENV, makeRequest(), 'req-11');
+
+    expect(result.ceeReview).not.toBeNull();
+    expect(result.ceeReview).not.toHaveProperty('bias');
+    expect(JSON.stringify(result.ceeReview)).not.toContain('invented-1');
+    expect(JSON.stringify(result.ceeReview)).not.toContain('ANCHORING');
+  });
+});


### PR DESCRIPTION
**DO NOT MERGE without review.** PLoT `staging` is unprotected, so this PR + review IS the gate.

ROADMAP row 23, step 1 (PLoT). **The brief for this lane asked for two things. One is shipped. The other is refused, with byte evidence — and the refusal is the more important finding.**

---

## 1. What is fixed

Both live branches of `orchestrateCeeReview` used the CEE compose result only as a truthiness test in a ternary, then emitted a hardcoded object containing

```ts
readiness: { level: 'ready', headline: 'Analysis complete[ (v2)]', factors: [] }
```

on **every** successful turn — `src/cee/orchestrator.ts:598-612` (v2 HTTP) and `:638-652` (SDK compose, the default live branch) at `5ab93383`. A constant dressed as a computed verdict: exactly pass-condition 2's target.

CEE's compose endpoints carry no readiness field (`olumi-assistants-service@42e0b8ec` `src/schemas/ceeResponses.ts:288-387`), so the honest output is **absence**.

- `extractCeeReadiness(review)` carries a verdict through when CEE computed one — validating `level` against the enum and requiring a non-empty `headline` — and returns `undefined` otherwise.
- Both branches spread it conditionally, so the field is **omitted, not invented**.
- `CeeReviewResponse.readiness` becomes optional. This is `src/cee/types.ts`, a **PLoT-local** type — **not** `@talchain/schemas` (PLoT pins the vendored `@talchain/schemas@0.30.0`, `package.json:85` → `vendor/talchain-schemas-0.30.0.tgz`). **No shared-contract fork.** `/v1/run` has no Fastify response schema (`src/routes/v1/run.ts:299-325` declares `body` only), so nothing strips or requires the key on the wire.

It is written as a real extractor rather than a hardcoded `undefined` so a readiness CEE later starts sending is carried without another code change — and so both directions stay testable.

---

## 2. 🔴 What is deliberately NOT done, and why — the bias payload describes a graph the user never built

The brief said "carry `bias` (findings + `mitigation_patches`) through". **Doing that would convert a dead field into a live fabrication.** Two byte-verified corrections to the row-23 mechanism:

**(a) `result.review` never contained the bias payload.** `buildCeeDecisionReviewPayload` at `src/cee/orchestrator.ts:174` / `:345` is the SDK helper (`@olumi/assistants-sdk@1.11.1`), not PLoT's local `ceePort.ts` shim. Its implementation (`node_modules/@olumi/assistants-sdk/dist/ceeHelpers.js:533-566`) returns exactly `{ story, journey, uiFlags, trace? }`, and its own docblock (`ceeHelpers.d.ts:110-118`) states *"Only structured metadata … No prompts, briefs, graph labels, or LLM text."* `bias` is consumed only by `summarizeBiasForBiasStructure` (`:653-686`), which **counts** `bias_findings` and throws the array away.

**(b) The bias check runs on a CEE-invented graph.** `request.graph_snapshot` — the user's real graph — is used for **nothing but `.length`**. Complete manifest of `graph_snapshot` in `src/cee/orchestrator.ts` @ `5ab93383` (4 occurrences, all counts, plus `:488` a docstring):

```
:583  nodes: request.graph_snapshot.nodes?.length ?? 0,   (v2 branch briefContext)
:584  edges: request.graph_snapshot.edges?.length ?? 0,
:622  nodes: request.graph_snapshot.nodes?.length ?? 0,   (SDK branch briefContext)
:623  edges: request.graph_snapshot.edges?.length ?? 0,
```

Both branches then call `runDecisionReviewVia{Sdk,V2Http}(env, 'Decision review for inference results', …, briefContext, id)`, which:

1. `buildCeeBrief` (`:118-133`) → the literal string `"Decision review context: Decision review for inference results (N nodes, E edges)"`. Its own comment at `:123` reads **"Add structural hints (no user content exposed)"** — the count-only brief is a **deliberate** design choice.
2. `client.draftGraph({ brief })` (`:159`, `:316`) → **CEE LLM-drafts a brand-new graph from that string.**
3. `client.biasCheck({ graph: draft.graph })` (`:172`, `:341`) → **bias detection runs on CEE's invented graph.**

So `bias_findings` and `mitigation_patches` are findings about a graph with no relationship to the user's decision, and the patch node ids come from it. Same contamination applies to `result.review.story`: `buildDecisionStorySummary` (`ceeHelpers.js:165-225`) emits sentences such as *"N CEE options were generated for this decision."* from the invented graph's options.

**The UI blast radius is wider than the brief assumed.** Beyond `PostRunState.tsx:106` (`ceeReview?.bias?.findings`), **three** more sites read `ceeReview.bias_findings` at the *top* level — the exact key name CEE's envelope uses: `GuidancePanel.tsx:160,316`, `PreAnalysisGuidance.tsx:361`, `useUnifiedActions.ts:268`. And `BiasMitigation.tsx:57-77` writes patch nodes onto the user's canvas.

**Consequence for the 3-step train:** steps 2 (CEE wire shape + flag flip) and 3 (UI shape/source) are premised on the bias payload describing the user's graph. It does not. The prerequisite is a graph-seam fix in PLoT (`biasCheck({ graph: request.graph_snapshot })`) which **reverses the explicit "no user content exposed" decision** — an architecture call, not a lane's. `CEE_BIAS_MITIGATION_PATCHES_ENABLED` was not touched; no new flag or env var was added.

Shipped instead: a test pinning the current non-surfacing (with a "delete me when the seam is fixed" comment) and a load-bearing comment on `buildCeeBrief`, so the next lane cannot wire this without reading it.

---

## 3. Reader manifest

**Claim type:** readers of the object `orchestrateCeeReview` returns as `ceeReview`, and of the `ceeReview` key it puts on the `/v1/run` wire. Pinned SHAs: PLoT `5ab93383`, CEE `42e0b8ec`, UI `bf86f672`. Scope searched: `grep -rn ceeReview src/` in each repo (UI: 104 non-test occurrences excluding `ceeReviewV1`, all classified).

**PLoT @ 5ab93383 — 4 readers, none read `readiness`**

| # | Site | Reads |
|---|------|-------|
| 1 | `src/routes/v1/run.ts:1481-1482` | whole object → response body key `ceeReview` |
| 2 | `src/routes/v1/run.ts:1485` | `.weight_suggestions` (→ mapped into `critique[]`, `:1486-1562`) |
| 3 | `src/routes/v2/run.ts:4296` → `extractCeeResultsFromResponse` (`:4090-4144`) | `.decision_quality`, `.insights`, `.improvement_guidance`, `.rationale` |
| 4 | `src/routes/v2/run.ts:4297` → `extractRobustnessSynthesis` (`:4147+`) | `.blocks` where `id === 'robustness'` |

**CEE @ 42e0b8ec — zero readers.** `grep -rn "/v1/run" src/` → 0 hits; CEE calls PLoT `/v2/run` only (`src/orchestrator/plot-client.ts`). It consumes `/v2/run`'s CEE-derived enrichment keys (`enrichment-manifest.ts:151-156`) i.e. readers #3/#4 — never `readiness`.

**UI @ bf86f672 — one ingest path, 10 reader sites, zero of `readiness`**

Ingest: `src/adapters/plot/httpV1Adapter.ts:884,895` → `src/canvas/hooks/useResultsRun.ts:108,130,156` → `resultsComplete({ceeReview})` → `canvas/store.ts:3012,3196` and `canvas/stores/resultsStore.ts:148,164`.
The other three `resultsComplete` callers pass **no** `ceeReview` — `useV2Run.ts:991-999`, `useConversation.ts:3217-3225`, `applyV5State.ts:1064-1073` pass `ceeReviewV1` (locally synthesised by `synthesizeCeeReviewFromV2`, `responseMapper.ts:1350-1396`) or nothing. **On the V5 conversation path — the documented live analysis path — `runMeta.ceeReview` is `null`.** Whether the `useResultsRun`/httpV1 path is reachable in the deployed product is **not** established by this lane; source-reachable ≠ live.

| Reader site | Reads |
|-------------|-------|
| `pages/sandbox-guide/.../PostRunState.tsx:33,86,103,105,106,243,247` | `.story.headline`, `.trace.verification`, `.critique`, `.bias.findings`, `.story.next_actions` |
| `hooks/useResultsPanelData.ts:357,551` | `.story`, `.story.next_actions` |
| `canvas/utils/ceeDataAdapter.ts:259-260,436-437,523` | `.story.headline`, `.story.key_drivers`, `.story.next_actions` |
| `canvas/components/DecisionSummary.tsx:239` | `.story` |
| `canvas/components/GuidancePanel.tsx:160,316` | `.bias_findings` (top level) |
| `canvas/components/PreAnalysisGuidance.tsx:361` | `.bias_findings` (top level) |
| `canvas/hooks/useUnifiedActions.ts:268` | `.bias_findings` (top level) |
| `canvas/hooks/useComparisonDetection.ts:39,43` | `.uiFlags.comparison_suggested` |
| `canvas/ui/EdgeInspector.tsx:32,47-49`, `canvas/edges/StyledEdge.tsx:96-99,201-207` | `.weight_suggestions` |

The UI's readiness readers (`ceeDataAdapter.ts:311-315`, `useResultsSectionData.ts:2340-2342`) read `runMeta.ceeReviewV1`, the locally synthesised payload. The one place the two could have met — `useResultsRun.ts:113` `ceeReviewV1 = anyData.ceeReviewV1 ?? report.ceeReview ?? null` — is dead: `httpV1Adapter`'s `onDone` emits no `ceeReviewV1` (`:889-898`) and `mapV1ResultToReport` (`:133-300`) never assigns `ceeReview` onto the report.

**Verdict: PLoT's `ceeReview.readiness` has ZERO readers in all three repos. Nothing that renders today changes.**

**Overclaim I made and withdrew, recorded:** I first wrote that carrying `result.review` would fire `useComparisonDetection` via `uiFlags.comparison_suggested`. **False** — `buildCeeUiFlags` (`ceeHelpers.js:270-283`) emits only `has_high_risk_envelopes`, `has_team_disagreement`, `has_truncation_somewhere`, `is_journey_complete`.

---

## 4. RED-first evidence and mutation table

New suite `tests/cee-orchestrator-readiness.test.ts` (11 tests). Against unmodified source: **5 failed / 6 passed** — the 6 passing are deliberate pins of behaviour that must not change.

| # | Mutant | Tests killed |
|---|--------|--------------|
| M0 | control (unmutated fix) | 0 — **11/11 green** |
| M1 | v2 branch re-hardcodes `readiness:'ready'` | 2 (v2 omits-when-none; v2 carries-real) |
| M2 | SDK branch re-hardcodes `readiness:'ready'` | 3 (SDK omits-when-none; SDK carries-real; malformed-rejected) |
| M3 | `extractCeeReadiness` drops validation | 1 (malformed-rejected) |
| M4 | `extractCeeReadiness` never carries a real verdict | 2 (SDK + v2 carries-real) |
| M5 | surfaces a CEE bias payload on `ceeReview` | 1 (does-NOT-surface-bias) |
| M6 | ISL robustness block never synthesised | 1 (still-synthesises-ISL-block) |

Every mutant bites; each maps to a named test. Run in a throwaway git worktree at `/private/tmp/lane-r23p-4b881848/mut/plot` — **outside** the clone root — removed before every gate run.

---

## 5. Gate results (exact counts)

Fresh blobless clone at a unique path, branched off `origin/staging` = `5ab93383`.

| Step (from `.github/workflows/ci.yml`, job `test`) | pristine `staging` | this branch | delta |
|---|---|---|---|
| stray `src/*.js` check | pass | pass | 0 |
| `npx eslint src tests --ext .ts --max-warnings 29` | **86 warnings, 0 errors** | **86 warnings, 0 errors** | **0** |
| `npm run validate:contracts` | pass | pass (8 files / 3 scenarios, 0 failed) | 0 |
| `npm run build` | pass | pass | 0 |
| `RATE_LIMIT_ENABLED=0 CI=true npm test` | Test Files **591 passed / 4 skipped (595)**; Tests **6440 passed / 28 skipped (6479)**; exit **0** | Test Files 591 passed / **1 failed** / 4 skipped (596); Tests **6450 passed** / 1 failed / 28 skipped (6490); exit 1 | +1 file, +11 tests (both mine) |

**The single branch failure is environmental, not mine:** `tests/intervene-openapi.test.ts` → `TypeError: fetch failed … ECONNREFUSED 127.0.0.1:26885` — an ephemeral-port race in that spec's own server harness. **Re-run in isolation on this branch: 2/2 pass** (together with the new suite: `Test Files 2 passed, Tests 13 passed`). This change touches no route, server or port.

**Honest note on the lint step:** locally it reports 86 warnings against `--max-warnings 29` on **both** pristine staging and this branch, i.e. it would fail identically either way, yet recent PR runs of `CI` are green. Something in the CI environment resolves fewer warnings than my macOS run. I did not chase it; the delta attributable to this change is **0** (my new test file contributes 0 warnings; `orchestrator.ts`'s 6 are all pre-existing `no-console` / unused-var hits at `:325`, `:341`, `:345`, `:485`, `:554`, `:633`).

`contracts/openapi.yaml` is untouched, so the path-filtered `validate-structure` job will not run.

---

## 6. Evidence-integrity disclosure

My **first** baseline run was **void and is not used**. The blobless clone's `HEAD` was the repo default branch (`main`, `f19ed87a`), not `staging`; `npm ci` + `npm run build` + the full suite all ran on `main`, and `git checkout -b … origin/staging` then moved the tree under the finished run. Symptom that caught it: the next build failed with `TS2305 … '@talchain/schemas' has no exported member 'DEFAULT_EXISTS_PROBABILITY'` and `TS2307 … '@talchain/schemas/boundary'` — `main` pins registry `@talchain/schemas@0.1.0` while `staging` pins the vendored `0.30.0` tarball. Fixed by `rm -rf node_modules && npm ci` on the staging tree; **all numbers above are from that state.** (Voided numbers, for the record: 411 test files, 7 failed. Staging has 596.)

Second confounder, also disclosed: `npm run build` emits compiled `.js` into `src/`, and vitest resolves `../src/cee/orchestrator.js` to it — so an un-rebuilt tree silently tests **stale** code, and my first "RED" was against `main`'s compiled copy. `scripts/check-no-stale-js.sh --clean` (part of `npm run build` on staging) removes them. Every RED/GREEN above was taken after a successful build on staging deps.

---

## 7. Residuals a reviewer must know

1. **The bias/story seam is unfixed and now documented, not repaired.** ROADMAP row 23's remaining value depends on an architecture decision (send the real graph to CEE's bias check vs keep the count-only brief). Rowing that is the follow-up.
2. **`analysis_state: 'ran'` is still a constant** in both branches. It is *true* when CEE returned, so I left it — but it is the same shape of claim and deserves a look.
3. **The `/v1/run` `ceeReview` OpenAPI schema is stale**, describing the legacy `cee.decision-review.v1` shape (`contracts/openapi.yaml:4949+`), not the M1 `CeeReviewResponse` this code emits. Untouched here to avoid the path-filtered `validate-structure` job; worth rowing.
4. **`readiness` liveness is a source claim, not a runtime one.** I proved zero readers by reading three repos at pinned SHAs. I did not probe staging.
5. The `does NOT surface CEE bias findings` test **pins a gap on purpose**. It is labelled and must be deleted when the graph seam is fixed — it is not an endorsement.

Evidence file: `PHASE0-EVIDENCE-2026-07-28/fix-row23-plot-carry-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
