### PR TITLE
fix(flip): ship flip_thresholds[] in user units with a row-level value_scale (2.228 F2) [DO NOT MERGE]

### DIFF
--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -191,10 +191,26 @@ export function denormaliseFlipThresholds(
     // A2: clean the float tail off anything this module MULTIPLIED. An accepted
     // `raw_value` is passed through untouched — it is the user's own exact
     // number and carries no tail to remove.
+    const cleanedCurrent = currentFinite ? cleanDenormalised(denormCurrent, range) : undefined;
+    const cleanedFlip = flipFinite ? cleanDenormalised(denormFlip, range) : undefined;
+
+    // R1: if cleaning cannot produce a faithful number for a value this row
+    // would present as user-scale, the row is NOT display-safe. Fall back to the
+    // honest normalised row — precisely what shipped before 2.228, and precisely
+    // what CEE's cage refuses. Refusing costs a card; a fabricated zero would
+    // OPEN the cage and reach the what_would_flip chip, which executes the value
+    // into the user's graph.
+    const cleaningUnfaithful =
+      (rawCurrent === undefined && currentFinite && cleanedCurrent === undefined) ||
+      (flipFinite && cleanedFlip === undefined);
+    if (displayScale && cleaningUnfaithful) {
+      return enrichWithLabels(flip, options, node);
+    }
+
     const currentValue =
       rawCurrent ??
-      (currentFinite ? cleanDenormalised(denormCurrent, range) : flip.current_value);
-    const flipValue = flipFinite ? cleanDenormalised(denormFlip, range) : null;
+      (currentFinite ? (cleanedCurrent ?? denormCurrent) : flip.current_value);
+    const flipValue = flipFinite ? (cleanedFlip ?? denormFlip) : null;
 
     // Display strings are authored only for a display-scale row, and only when
     // they can be written LOSSLESSLY: CEE's agreement rung compares
@@ -345,7 +361,8 @@ function cleaningDecimals(range: NormalisationRange): number {
 
 /**
  * Remove the float tail a denormalisation leaves behind, so the number PLoT
- * ships and the string describing it agree by construction.
+ * ships and the string describing it agree by construction — or return
+ * `undefined` when that cannot be done faithfully.
  *
  * `0.29 × 100` is `28.999999999999996` in IEEE double arithmetic. CEE's
  * agreement rung is an EXACT equality (`Number(token) === rawValue`), so an LLM
@@ -354,14 +371,48 @@ function cleaningDecimals(range: NormalisationRange): number {
  * display-scale value to the precision the model can actually resolve is more
  * honest than shipping that tail, not less**: the tail is an artefact of the
  * multiplication, and no digit it adds was ever measured.
+ *
+ * ⚠ **It must never FABRICATE, though, and the zero case is the sharp one.**
+ * `flip.current_value` is the node's own normalised number
+ * (`getFactorCurrentValue`), which is NOT on the flip search's `roundTo4` grid,
+ * so a legitimately tiny value can round to nothing: `1e-5 × 16000` is exactly
+ * `0.16`, and cleaning to whole units yielded `current_value: 0` presented as
+ * `"0 £"` at `value_scale: 'display'`. That is worse than dust and worse than
+ * doing nothing — it INVERTS the safety direction. Before 2.228 that row shipped
+ * `0.00001` unlabelled and CEE's cage CLOSED; a confident zero OPENS it, and
+ * `'display'` is also the token that un-suppresses the `what_would_flip` chip
+ * whose value is executed straight into the user's graph.
+ *
+ * So the refusal, fail-closed (the caller drops the row back to its honest
+ * normalised form): a **non-zero** measurement that would clean to exactly `0`.
+ *
+ * GUARANTEE (absolute, not relative): a returned value differs from the exact
+ * product by at most `0.5 × 10^-decimals`, and since `10^-decimals ≤ width ×
+ * 1e-4`, by at most **half the model's own grid step**. A *relative* bound does
+ * NOT hold and is not claimed — cleaning `1.6 → 2` is a 25% relative move and is
+ * entirely correct at a grid step of 1.6.
+ *
+ * ⚠ **That guarantee is enforced by the SWEEP TEST, deliberately not by a
+ * runtime check.** A general "refuse anything further than half a rounding unit"
+ * branch was written here and then REMOVED: `toFixed` is correctly rounded, so
+ * the error cannot exceed half a rounding unit by construction, and the branch
+ * was unreachable — proven by its mutant turning nothing red, and by a direct
+ * probe (0 firings in 3,199,928 cases spanning widths 1e-6 … 1e20, worst ratio
+ * exactly 1.000000). A guard that cannot fire reads as a guarantee and provides
+ * none, so the invariant is asserted where it can actually fail: over the full
+ * 4dp grid in `tests/lib/flip-threshold-display-scale.test.ts`.
  */
-function cleanDenormalised(value: number, range: NormalisationRange): number {
-  if (!Number.isFinite(value)) return value;
+function cleanDenormalised(value: number, range: NormalisationRange): number | undefined {
+  if (!Number.isFinite(value)) return undefined;
   const decimals = cleaningDecimals(range);
   // toFixed is exact for |v| < 1e21 and decimals ≤ 100; beyond that it returns
   // exponential text, and Number() of that is the unchanged value — which
   // formatUserScale then refuses to describe. Either way, never a wrong number.
-  return Number(value.toFixed(decimals));
+  const cleaned = Number(value.toFixed(decimals));
+  if (!Number.isFinite(cleaned)) return undefined;
+  // Never manufacture a zero out of a real measurement.
+  if (cleaned === 0 && value !== 0) return undefined;
+  return cleaned;
 }
 
 /**
@@ -446,14 +497,18 @@ function denormaliseMarginSensitivity(
   // `probeIsFinite` pre-check is redundant and has been removed with it: one guard,
   // in the primitive, instead of a cast plus a caller-side mirror of the same test.
   const denormProbe = denormaliseValue(margin.strongest_probe_value, range);
-  const denormProbeFinite = isFiniteNumber(denormProbe);
+  // A2/R1: same cleaning, and the same refusal. A probe value that cannot be
+  // cleaned faithfully is withheld rather than fabricated — which is exactly
+  // what `display_value_available: false` already means.
+  const cleanedProbe = isFiniteNumber(denormProbe)
+    ? cleanDenormalised(denormProbe, range)
+    : undefined;
+  const probeUsable = cleanedProbe !== undefined;
   return {
     ...margin,
-    // A2: same float-tail cleaning as the row's own values — this is the other
-    // number this module denormalises, and dust is no more correct here.
-    strongest_probe_value: denormProbeFinite ? cleanDenormalised(denormProbe, range) : null,
+    strongest_probe_value: probeUsable ? cleanedProbe : null,
     value_scale: 'display',
-    display_value_available: denormProbeFinite,
+    display_value_available: probeUsable,
   };
 }
 

--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -387,20 +387,40 @@ function cleaningDecimals(range: NormalisationRange): number {
  * normalised form): a **non-zero** measurement that would clean to exactly `0`.
  *
  * GUARANTEE (absolute, not relative): a returned value differs from the exact
- * product by at most `0.5 × 10^-decimals`, and since `10^-decimals ≤ width ×
- * 1e-4`, by at most **half the model's own grid step**. A *relative* bound does
- * NOT hold and is not claimed — cleaning `1.6 → 2` is a 25% relative move and is
- * entirely correct at a grid step of 1.6.
+ * product by at most `0.5 × 10^-decimals`, plus up to half a ULP from the
+ * decimal→double re-parse below. **Where the {@link MAX_CLEAN_DECIMALS} clamp
+ * does not bind (range width ≥ 1e-8) `10^-decimals ≤ width × 1e-4`, so that is
+ * also at most half the model's own grid step; where the clamp DOES bind the
+ * grid-step corollary fails** (ratio 10 at width 1e-9, 100 at 1e-10 — legal
+ * widths per `isFiniteRange`, behaviourally out of reach but not proven absent).
+ * A *relative* bound does NOT hold and is not claimed — cleaning `1.6 → 2` is a
+ * 25% relative move and is entirely correct at a grid step of 1.6.
  *
- * ⚠ **That guarantee is enforced by the SWEEP TEST, deliberately not by a
- * runtime check.** A general "refuse anything further than half a rounding unit"
- * branch was written here and then REMOVED: `toFixed` is correctly rounded, so
- * the error cannot exceed half a rounding unit by construction, and the branch
- * was unreachable — proven by its mutant turning nothing red, and by a direct
- * probe (0 firings in 3,199,928 cases spanning widths 1e-6 … 1e20, worst ratio
- * exactly 1.000000). A guard that cannot fire reads as a guarantee and provides
- * none, so the invariant is asserted where it can actually fail: over the full
- * 4dp grid in `tests/lib/flip-threshold-display-scale.test.ts`.
+ * ⚠ **The guarantee is asserted by the SWEEP TEST, deliberately not by a runtime
+ * check — and the reason recorded here in an earlier revision was WRONG.**
+ * That revision said a general "refuse anything beyond half a rounding unit"
+ * branch had been removed because it was *unreachable*, citing 0 firings in
+ * 3,199,928 sampled cases. **That claim is false and is withdrawn.** `toFixed`
+ * is correctly rounded in DECIMAL, but `Number()` then re-parses that text to
+ * the nearest double, up to half a ULP away, so the round trip CAN exceed
+ * `0.5 × 10^-decimals`: `(0.75).toFixed(1)` is `"0.8"` and
+ * `Number("0.8") − 0.75 = 0.050000000000000044 > 0.05`. Measured on exact
+ * rounding ties: **2,048 of 43,999 exceed the bare bound.** The earlier probe
+ * sampled `(i/200000) × width`, which lands on an exact tie essentially never —
+ * it could not have observed the phenomenon it was cited as ruling out.
+ *
+ * **The real reason the branch is gone is stronger than "it cannot fire":**
+ *  1. every one of those firings is a case where the cleaning is CORRECT
+ *     (`0.75 → 0.8` is the right answer), so the branch would refuse GOOD rows —
+ *     when it fires, it is wrong;
+ *  2. the version actually written here carried an epsilon slack
+ *     (`|value| × EPSILON × 8`) that absorbs the re-parse error ~16× over, and
+ *     fires on **0** of those same 43,999 ties — so with the slack it was inert.
+ *
+ * A branch that is WRONG without a fudge factor and INERT with one — where the
+ * fudge was never derived from anything — is not a guard. Hence: no runtime
+ * check, and the invariant lives in
+ * `tests/lib/flip-threshold-display-scale.test.ts` where it can actually fail.
  */
 function cleanDenormalised(value: number, range: NormalisationRange): number | undefined {
   if (!Number.isFinite(value)) return undefined;

--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -10,9 +10,34 @@
 
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
 import type { NormalisationContext, NormalisationRange } from './intervention-normaliser.js';
-import { denormaliseValue } from './intervention-normaliser.js';
+import { denormaliseValue, deriveRange } from './intervention-normaliser.js';
 import { isFiniteNumber } from '../util/numeric.js';
 import type { MarginSensitivity } from '../analysis/margin-sensitivity.js';
+// Type-only (erased at runtime): engine-v3.ts imports DenormalisedFlipThreshold
+// from this module, so a VALUE import here would close a runtime cycle.
+import type { EngineGraphV3, EngineNodeV3 } from '../types/engine-v3.js';
+
+/**
+ * Scale of a flip row's `current_value` / `flip_value`, at ROW level.
+ *
+ * CEE's flip-threshold cage reads this key FIRST and only then falls back to
+ * `margin_sensitivity.value_scale`
+ * (olumi-assistants-service `src/orchestrator-v5/context/analysis-signals.ts`
+ * `readRowValueScale`/`flipRowScaleIsDisplaySafe`, CEE staging `b8a38de7`):
+ * `'display'` licenses the row, any other non-empty token closes it, and an
+ * absent token falls through to a value-magnitude heuristic that cannot license
+ * a factor whose honest user units are themselves ≤ 1.
+ *
+ * - `'display'`    — user units. Set ONLY when this module actually denormalised
+ *                    the pair against an `explicit_cap` range.
+ * - `'normalised'` — still in [0,1]. Set only when the node positively attests
+ *                    normalisation (it carries `raw_value` and/or `cap`) but no
+ *                    usable cap was available to lift it.
+ * - absent         — scale not established. A caller may legitimately post a
+ *                    graph in user units with no cap; claiming either token
+ *                    there would be an unattested assertion.
+ */
+export type FlipValueScale = 'display' | 'normalised';
 
 // =============================================================================
 // Types
@@ -56,6 +81,22 @@ export interface DenormalisedFlipThreshold {
    * `'normalised'` and the value is preserved as emitted by the helper.
    */
   margin_sensitivity?: MarginSensitivity;
+  /**
+   * ROADMAP 2.228 F2 — the scale of `current_value`/`flip_value` on THIS row.
+   * See {@link FlipValueScale}. Absent when the scale is not established.
+   */
+  value_scale?: FlipValueScale;
+  /**
+   * `current_value` rendered in user units with the unit appended
+   * (e.g. `"275000 £"`). Present only alongside `value_scale: 'display'`, and
+   * only when the value can be written losslessly — see {@link formatUserScale}.
+   */
+  current_display?: string;
+  /**
+   * `flip_value` rendered in user units with the unit appended. Present only
+   * alongside `value_scale: 'display'` AND a non-null, finite `flip_value`.
+   */
+  flip_display?: string;
 }
 
 // =============================================================================
@@ -65,35 +106,56 @@ export interface DenormalisedFlipThreshold {
 /**
  * Denormalise flip thresholds from [0,1] to user units.
  *
+ * ROADMAP 2.228 F2: `context` is `undefined` for the entire V5 request — Phase 4a
+ * only runs when some option intervention value falls outside [0,1]
+ * (`intervention-normaliser.ts` `needsNormalisation`), and CEE's V5 graph already
+ * carries normalised interventions. That gate is correct for its own job and is
+ * deliberately NOT widened here. Instead the factor's scale is taken from the
+ * NODE, whose `observed_state.cap` is the same `explicit_cap` tier `deriveRange`
+ * already ranks first — so a row can reach user units on the V5 path without
+ * re-scaling anything else in the request.
+ *
  * @param flipData Flip threshold data in normalised [0,1] space
  * @param context Normalisation context with per-factor ranges (undefined if no normalisation happened)
  * @param options Options array for alternative_winner_label lookup
+ * @param graph Graph the flip candidates were drawn from, for the per-factor
+ *   `explicit_cap` scale. Optional — omit and the pre-2.228 behaviour is exact.
  * @returns Denormalised flip thresholds in user units
  */
 export function denormaliseFlipThresholds(
   flipData: FlipThresholdInputData[],
   context: NormalisationContext | undefined,
-  options: Array<{ id: string; label: string }>
+  options: Array<{ id: string; label: string }>,
+  graph?: EngineGraphV3
 ): DenormalisedFlipThreshold[] {
-  return flipData.map((flip) => {
-    const factorContext = context?.factors.get(flip.factor_id);
+  const nodesById = indexNodes(graph);
 
-    // If no normalisation context for this factor, values are already in user units
-    if (!factorContext) {
-      return enrichWithLabels(flip, options);
+  return flipData.map((flip) => {
+    const node = nodesById?.get(flip.factor_id);
+    // Phase 4a's range when it exists (unchanged), else the node's own
+    // authoritative cap. Only the `explicit_cap` tier is accepted from the node:
+    // deriveRange's chain ends at `default` [0,1], and denormalising by [0,1] is
+    // the identity — stamping 'display' off it would assert user-scale about a
+    // number that never moved.
+    const factorContext = context?.factors.get(flip.factor_id);
+    const range = factorContext?.range ?? explicitCapRange(node);
+
+    // If no range is available for this factor, values are left as they arrived.
+    if (!range) {
+      return enrichWithLabels(flip, options, node);
     }
 
     // Denormalise current_value and flip_value using the factor's range.
     // ROADMAP 1.277: denormaliseValue is absence-in ⇒ absence-out, so both of
     // these are `number | undefined` and the finite checks below narrow them.
-    const denormCurrent = denormaliseValue(flip.current_value, factorContext.range);
+    const denormCurrent = denormaliseValue(flip.current_value, range);
     // `flip_value === null` means "no flip achievable" — a genuine, already-modelled
     // absence, NOT a failed denormalisation. The primitive would now reject null on
     // its own, but the explicit branch stays: it is what keeps that absence out of
     // the `nonFiniteDenorm` disclosure below, which must fire only for a real
     // mapping failure.
     const denormFlip = flip.flip_value !== null
-      ? denormaliseValue(flip.flip_value, factorContext.range)
+      ? denormaliseValue(flip.flip_value, range)
       : null;
 
     // F14 (defense-in-depth): the range-source finite guard (deriveRange) makes
@@ -109,13 +171,42 @@ export function denormaliseFlipThresholds(
     const flipFinite = isFiniteNumber(denormFlip);
     const nonFiniteDenorm = !currentFinite || (denormFlip !== null && !flipFinite);
 
+    // F2: the row is user-scale only when the range that mapped it IS a user
+    // scale. `explicit_cap` is the authoritative CEE-set cap; every other tier
+    // either infers a range or falls back to [0,1], and neither earns the claim.
+    const displayScale = range.source === 'explicit_cap';
+
+    // Prefer the node's own `raw_value` — the number the USER gave — over the
+    // round-trip of an already-ROUNDED normalised value. The live a7 factor
+    // carries value 0.86 with raw_value 275000 and cap 320000: round-tripping
+    // 0.86 yields 275200, so the card would show £275,200 for a £275,000 input.
+    // Accepted only when it agrees with `value × cap` to the precision `value`
+    // is written at (see reconcileRawValue) — a raw_value that disagrees by more
+    // than its own rounding error would put current_value and flip_value on
+    // different footings, which is the "two numbers, one factor" hazard itself.
+    const rawCurrent = displayScale
+      ? reconcileRawValue(node?.observed_state?.raw_value, flip.current_value, range)
+      : undefined;
+
+    const currentValue = rawCurrent ?? (currentFinite ? denormCurrent : flip.current_value);
+    const flipValue = flipFinite ? denormFlip : null;
+
+    // Display strings are authored only for a display-scale row, and only when
+    // they can be written LOSSLESSLY: CEE's agreement rung compares
+    // `Number(token) === rawValue` exactly, so a string we cannot guarantee is
+    // not written at all. `value_scale` is independent — the row can be honestly
+    // display-scale while its digits are unwritable (see formatUserScale).
+    const currentDisplay = displayScale ? formatUserScale(currentValue, flip.unit) : undefined;
+    const flipDisplay =
+      displayScale && flipValue !== null ? formatUserScale(flipValue, flip.unit) : undefined;
+
     return {
       factor_id: flip.factor_id,
       factor_label: flip.factor_label,
       // Never emit a non-finite current_value — fall back to the pre-denorm
       // (normalised) value, which the disclosed flip_reason flags as unmapped.
-      current_value: currentFinite ? denormCurrent : flip.current_value,
-      flip_value: flipFinite ? denormFlip : null,
+      current_value: currentValue,
+      flip_value: flipValue,
       direction: flip.direction,
       unit: flip.unit,
       alternative_winner_id: flip.alternative_winner_id ?? null,
@@ -124,8 +215,11 @@ export function denormaliseFlipThresholds(
       iterations_used: flip.iterations_used,
       probes_used: flip.probes_used,
       ...(flip.margin_sensitivity
-        ? { margin_sensitivity: denormaliseMarginSensitivity(flip.margin_sensitivity, factorContext.range) }
+        ? { margin_sensitivity: denormaliseMarginSensitivity(flip.margin_sensitivity, range) }
         : {}),
+      ...(displayScale ? { value_scale: 'display' as const } : {}),
+      ...(currentDisplay !== undefined ? { current_display: currentDisplay } : {}),
+      ...(flipDisplay !== undefined ? { flip_display: flipDisplay } : {}),
     };
   });
 }
@@ -136,11 +230,12 @@ export function denormaliseFlipThresholds(
 
 /**
  * Enrich flip threshold with labels (no denormalisation).
- * Used when no normalisation context is available for a factor.
+ * Used when no usable range is available for a factor.
  */
 function enrichWithLabels(
   flip: FlipThresholdInputData,
-  options: Array<{ id: string; label: string }>
+  options: Array<{ id: string; label: string }>,
+  node?: EngineNodeV3
 ): DenormalisedFlipThreshold {
   return {
     factor_id: flip.factor_id,
@@ -157,7 +252,103 @@ function enrichWithLabels(
     // No factor context for denormalisation. Pass margin_sensitivity through
     // untouched: `value_scale` stays `'normalised'` for honesty.
     ...(flip.margin_sensitivity ? { margin_sensitivity: flip.margin_sensitivity } : {}),
+    // F2 fail-closed, ATTESTED: say 'normalised' only where the node itself
+    // proves normalisation happened (it carries raw_value and/or cap) yet no
+    // usable cap range could be derived. Where the node bears neither mark the
+    // scale is genuinely unknown and the key stays ABSENT — a direct /v2/run
+    // caller may legitimately post user-scale values with no cap, and stamping
+    // 'normalised' there would close a door that is correctly open.
+    ...(normalisationAttested(node) ? { value_scale: 'normalised' as const } : {}),
   };
+}
+
+/** Index a graph's nodes by id. `undefined` graph ⇒ `undefined` index (pre-2.228 path). */
+function indexNodes(graph: EngineGraphV3 | undefined): Map<string, EngineNodeV3> | undefined {
+  if (!graph || !Array.isArray(graph.nodes)) return undefined;
+  return new Map(graph.nodes.map((n) => [n.id, n]));
+}
+
+/**
+ * The node's `explicit_cap` range, or null.
+ *
+ * DERIVED, not mirrored: `deriveRange` is called and only its priority-0 verdict
+ * is accepted, so this inherits that tier's own guards (`cap > 0`, finite width)
+ * instead of re-implementing them next door. Every other tier — including the
+ * `default` [0,1] fallback that a capless node lands on — is refused.
+ */
+function explicitCapRange(node: EngineNodeV3 | undefined): NormalisationRange | null {
+  if (!node) return null;
+  const range = deriveRange(node);
+  return range.source === 'explicit_cap' ? range : null;
+}
+
+/** True when the node carries the marks of having been normalised. */
+function normalisationAttested(node: EngineNodeV3 | undefined): boolean {
+  const observed = node?.observed_state;
+  if (!observed) return false;
+  return observed.raw_value !== undefined || observed.cap !== undefined;
+}
+
+/**
+ * Decimal places in a number's canonical JS decimal text; `-1` when that text is
+ * exponential, so the caller can refuse rather than guess a precision.
+ */
+function decimalPlaces(value: number): number {
+  const text = String(value);
+  if (text.includes('e') || text.includes('E')) return -1;
+  const dot = text.indexOf('.');
+  return dot === -1 ? 0 : text.length - dot - 1;
+}
+
+/**
+ * Accept `raw_value` as the authoritative user-scale current value iff it agrees
+ * with `normalised × range` to within the rounding error the normalised value's
+ * OWN precision implies.
+ *
+ * The tolerance is derived from the data, never a magic constant: a `value`
+ * written with `d` decimals carries an implied error of half a unit in its last
+ * place, which is `0.5 × 10^-d` of the range width in user units. For the live
+ * a7 factor (value 0.86, cap 320000) that is ±1600, and |275000 − 275200| = 200
+ * sits well inside it. A raw_value further out than its own rounding error is a
+ * stale or mismatched field, and is refused so the row falls back to the
+ * round-trip — consistent with `flip_value`, which has no raw counterpart.
+ */
+function reconcileRawValue(
+  rawValue: unknown,
+  normalisedValue: number,
+  range: NormalisationRange
+): number | undefined {
+  if (!isFiniteNumber(rawValue)) return undefined;
+  const places = decimalPlaces(normalisedValue);
+  if (places < 0) return undefined;
+  const roundTripped = denormaliseValue(normalisedValue, range);
+  if (!isFiniteNumber(roundTripped)) return undefined;
+
+  const tolerance = 0.5 * Math.pow(10, -places) * Math.abs(range.max - range.min);
+  // Float slack so a value exactly on the boundary is not rejected by noise.
+  const slack = Math.abs(roundTripped) * Number.EPSILON * 8;
+  return Math.abs(rawValue - roundTripped) <= tolerance + slack ? rawValue : undefined;
+}
+
+/**
+ * `<value> <unit>` — the form CEE's decision_review prompt specifies for
+ * `current_display`/`flip_display` ("16000 GBP", "800 customers").
+ *
+ * Returns `undefined` rather than a string it cannot guarantee. CEE's agreement
+ * rung (`licenceAgreesWithRawValue`) tokenises with `/-?\d+(?:\.\d+)?/g` and
+ * requires `Number(token) === rawValue` EXACTLY, so:
+ *   - no `toLocaleString()` — it rounds to 3 fraction digits by default, turning
+ *     1234.56789 into "1,234.568", which fails the equality it is meant to prove;
+ *   - no thousands separators and no abbreviation ("£275k" fails);
+ *   - exponential text is refused outright — String(1e21) is "1e+21", which
+ *     tokenises to [1, 21] and would silently disagree with the value it names.
+ */
+function formatUserScale(value: number, unit: string | undefined): string | undefined {
+  if (!Number.isFinite(value)) return undefined;
+  const text = String(value);
+  if (text.includes('e') || text.includes('E')) return undefined;
+  const trimmedUnit = typeof unit === 'string' ? unit.trim() : '';
+  return trimmedUnit.length > 0 ? `${text} ${trimmedUnit}` : text;
 }
 
 /**

--- a/src/lib/flip-threshold-denormaliser.ts
+++ b/src/lib/flip-threshold-denormaliser.ts
@@ -188,8 +188,13 @@ export function denormaliseFlipThresholds(
       ? reconcileRawValue(node?.observed_state?.raw_value, flip.current_value, range)
       : undefined;
 
-    const currentValue = rawCurrent ?? (currentFinite ? denormCurrent : flip.current_value);
-    const flipValue = flipFinite ? denormFlip : null;
+    // A2: clean the float tail off anything this module MULTIPLIED. An accepted
+    // `raw_value` is passed through untouched — it is the user's own exact
+    // number and carries no tail to remove.
+    const currentValue =
+      rawCurrent ??
+      (currentFinite ? cleanDenormalised(denormCurrent, range) : flip.current_value);
+    const flipValue = flipFinite ? cleanDenormalised(denormFlip, range) : null;
 
     // Display strings are authored only for a display-scale row, and only when
     // they can be written LOSSLESSLY: CEE's agreement rung compares
@@ -301,17 +306,84 @@ function decimalPlaces(value: number): number {
 }
 
 /**
+ * Absolute ceiling on how far `raw_value` may sit from the model's own baseline,
+ * as a fraction of the range width, REGARDLESS of how few decimals the producer
+ * wrote.
+ *
+ * The implied-precision term alone (`0.5 × 10^-decimals × width`) widens as the
+ * producer writes fewer decimals — 2dp is 0.5% of range, 1dp is 5%, 0dp is 50% —
+ * so the guard would be loosest at exactly the values most likely to be written
+ * exactly (`0`, `1`, `x.5`). Reproduced before this ceiling existed: a node with
+ * `value: 0` and `raw_value: 100000` shipped `100000` as a display-scale number
+ * while `flip_value` was computed from a baseline of `0`.
+ *
+ * This is a SAFETY CEILING, not a measurement: exceeding it costs nothing but a
+ * fallback to `value × range`, which is by construction consistent with
+ * `flip_value`. The error direction is therefore always fail-closed.
+ */
+const MAX_RAW_VALUE_DIVERGENCE_FRACTION = 0.02;
+
+/**
+ * Decimal places to which a denormalised value is cleaned.
+ *
+ * The flip search resolves normalised values on a 1e-4 grid
+ * (`roundTo4`, `src/analysis/flip-thresholds.ts:768`), so the finest step that
+ * carries meaning in user units is `width × 1e-4`; anything below it is IEEE
+ * noise from the multiplication, not measurement. Rounding there is unit-
+ * appropriate by construction — a £320,000 range cleans to whole pounds, a
+ * [0,1] ratio keeps 4 decimals.
+ */
+const NORMALISED_GRID_STEP = 1e-4;
+const MAX_CLEAN_DECIMALS = 12;
+
+function cleaningDecimals(range: NormalisationRange): number {
+  const step = Math.abs(range.max - range.min) * NORMALISED_GRID_STEP;
+  if (!Number.isFinite(step) || step <= 0) return 0;
+  const places = Math.ceil(-Math.log10(step));
+  return Math.min(MAX_CLEAN_DECIMALS, Math.max(0, places));
+}
+
+/**
+ * Remove the float tail a denormalisation leaves behind, so the number PLoT
+ * ships and the string describing it agree by construction.
+ *
+ * `0.29 × 100` is `28.999999999999996` in IEEE double arithmetic. CEE's
+ * agreement rung is an EXACT equality (`Number(token) === rawValue`), so an LLM
+ * writing the obvious "29" would be DENIED — and once a consumer echoes the
+ * producer string, the user is shown sixteen digits of noise. **Rounding a
+ * display-scale value to the precision the model can actually resolve is more
+ * honest than shipping that tail, not less**: the tail is an artefact of the
+ * multiplication, and no digit it adds was ever measured.
+ */
+function cleanDenormalised(value: number, range: NormalisationRange): number {
+  if (!Number.isFinite(value)) return value;
+  const decimals = cleaningDecimals(range);
+  // toFixed is exact for |v| < 1e21 and decimals ≤ 100; beyond that it returns
+  // exponential text, and Number() of that is the unchanged value — which
+  // formatUserScale then refuses to describe. Either way, never a wrong number.
+  return Number(value.toFixed(decimals));
+}
+
+/**
  * Accept `raw_value` as the authoritative user-scale current value iff it agrees
  * with `normalised × range` to within the rounding error the normalised value's
  * OWN precision implies.
  *
- * The tolerance is derived from the data, never a magic constant: a `value`
- * written with `d` decimals carries an implied error of half a unit in its last
- * place, which is `0.5 × 10^-d` of the range width in user units. For the live
- * a7 factor (value 0.86, cap 320000) that is ±1600, and |275000 − 275200| = 200
- * sits well inside it. A raw_value further out than its own rounding error is a
- * stale or mismatched field, and is refused so the row falls back to the
- * round-trip — consistent with `flip_value`, which has no raw counterpart.
+ * The tolerance has TWO terms and takes the tighter of them:
+ *
+ *  1. **implied precision** — a `value` written with `d` decimals carries an
+ *     implied error of half a unit in its last place, i.e. `0.5 × 10^-d` of the
+ *     range width in user units. For the live a7 factor (value 0.86, cap 320000)
+ *     that is ±1600, and |275000 − 275200| = 200 sits well inside it.
+ *  2. **an absolute ceiling** ({@link MAX_RAW_VALUE_DIVERGENCE_FRACTION}) —
+ *     because term 1 alone runs off a cliff as decimals shrink (1dp = 5% of
+ *     range, 0dp = 50%), and the widest cases are precisely the values most
+ *     likely to be written exactly. Without it, `value: 0` + `raw_value: 100000`
+ *     shipped 100000 against a model baseline of 0.
+ *
+ * A raw_value outside the tighter bound is stale or mismatched and is refused,
+ * so the row falls back to `value × range` — which is by construction consistent
+ * with `flip_value`, the sibling that has no raw counterpart.
  */
 function reconcileRawValue(
   rawValue: unknown,
@@ -324,7 +396,10 @@ function reconcileRawValue(
   const roundTripped = denormaliseValue(normalisedValue, range);
   if (!isFiniteNumber(roundTripped)) return undefined;
 
-  const tolerance = 0.5 * Math.pow(10, -places) * Math.abs(range.max - range.min);
+  const width = Math.abs(range.max - range.min);
+  const impliedPrecision = 0.5 * Math.pow(10, -places) * width;
+  const ceiling = MAX_RAW_VALUE_DIVERGENCE_FRACTION * width;
+  const tolerance = Math.min(impliedPrecision, ceiling);
   // Float slack so a value exactly on the boundary is not rejected by noise.
   const slack = Math.abs(roundTripped) * Number.EPSILON * 8;
   return Math.abs(rawValue - roundTripped) <= tolerance + slack ? rawValue : undefined;
@@ -374,7 +449,9 @@ function denormaliseMarginSensitivity(
   const denormProbeFinite = isFiniteNumber(denormProbe);
   return {
     ...margin,
-    strongest_probe_value: denormProbeFinite ? denormProbe : null,
+    // A2: same float-tail cleaning as the row's own values — this is the other
+    // number this module denormalises, and dust is no more correct here.
+    strongest_probe_value: denormProbeFinite ? cleanDenormalised(denormProbe, range) : null,
     value_scale: 'display',
     display_value_available: denormProbeFinite,
   };

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -7125,11 +7125,19 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
                 resolvedFlipData = flipCandidates;
               }
 
-              // Step 3: Denormalise to user units
+              // Step 3: Denormalise to user units.
+              // ROADMAP 2.228 F2: `normalisationContext` is undefined for the
+              // whole V5 request (Phase 4a only fires on out-of-[0,1] option
+              // intervention values), so `filteredGraph` is passed as the
+              // per-factor scale source — the same graph the candidates were
+              // drawn from at :7038, whose nodes carry observed_state.cap /
+              // raw_value. Without it every row ships a normalised [0,1] number
+              // wearing a currency unit.
               flipThresholds = denormaliseFlipThresholds(
                 resolvedFlipData,
                 normalisationContext,
-                normalizedOptions
+                normalizedOptions,
+                filteredGraph
               );
             }
           } catch (err) {

--- a/tests/lib/flip-threshold-display-scale.test.ts
+++ b/tests/lib/flip-threshold-display-scale.test.ts
@@ -163,18 +163,19 @@ describe('F2 POSITIVE: a node carrying raw_value + cap yields a display-scale ro
       makeFlip({ flip_value: 241500 / 320000, flip_reason: 'found', alternative_winner_id: 'opt_locum' }),
       makeGraph([makeNode()]),
     );
-    expect(row.flip_value).toBeCloseTo(241500, 6);
-    expect(row.flip_display).toBeDefined();
-    expect(ceeLicenceAgreesWithRawValue(row.flip_display!, row.flip_value!)).toBe(true);
+    // Literal expectations, not `agrees(ourString, ourValue)` — that comparison
+    // is self-referential and can only fail via the exponential guard.
+    expect(row.flip_value).toBe(241500);
+    expect(row.flip_display).toBe('241500 £');
   });
 
   it('falls back to value x cap when the node carries a cap but no raw_value', () => {
     const node = makeNode();
     delete (node.observed_state as Record<string, unknown>).raw_value;
     const row = denormOne(makeFlip(), makeGraph([node]));
-    expect(row.current_value).toBeCloseTo(275200, 6);
+    expect(row.current_value).toBe(275200);
     expect(row.value_scale).toBe('display');
-    expect(ceeLicenceAgreesWithRawValue(row.current_display!, row.current_value)).toBe(true);
+    expect(row.current_display).toBe('275200 £');
   });
 });
 
@@ -202,8 +203,15 @@ describe('F2 POSITIVE: the row satisfies CEE #776 cage rungs P4 and P7', () => {
 
   it('P7 both display strings DESCRIBE the raw values the row ships', () => {
     const row = denormOne(flip, makeGraph([makeNode()]));
-    expect(ceeLicenceAgreesWithRawValue(row.current_display!, row.current_value)).toBe(true);
-    expect(ceeLicenceAgreesWithRawValue(row.flip_display!, row.flip_value!)).toBe(true);
+    // Independently-written expectations. `agrees(row.current_display,
+    // row.current_value)` would be self-referential: the string is built from
+    // String(value), and Number(String(x)) === x for every finite
+    // non-exponential double, so it could only ever fail via the exponential
+    // guard — it would pass even if both were the wrong number together.
+    expect(row.current_display).toBe('275000 £');
+    expect(row.flip_display).toBe('241500 £');
+    expect(ceeLicenceAgreesWithRawValue('275000 £', row.current_value)).toBe(true);
+    expect(ceeLicenceAgreesWithRawValue('241500 £', row.flip_value!)).toBe(true);
   });
 
   it('P7 CONTROL: the pre-fix pair (0.86 + "£") would FAIL agreement', () => {
@@ -256,6 +264,150 @@ describe('F2 fail-closed: rows we cannot lift stay honest', () => {
     const row = denormOne(makeFlip(), makeGraph([makeNode({ raw_value: 225000 })]));
     expect(row.current_value).toBeCloseTo(275200, 6);
     expect(row.value_scale).toBe('display');
+  });
+
+  // ===========================================================================
+  // A1 (review #298) — the precision-implied tolerance must not run off a cliff
+  // ===========================================================================
+  //
+  // The implied-precision term is `0.5 x 10^-decimals x width`, which widens as
+  // the producer writes FEWER decimals: 2dp = 0.5% of range, 1dp = 5%, 0dp = 50%.
+  // The widest cases are exactly the values most likely to be written exactly
+  // (0, 1, x.5), so without an absolute ceiling the guard is loosest where it
+  // most needs to bite — and a divergent raw_value ships as `display` while
+  // `flip_value` was computed from a different baseline. That is the "two
+  // numbers, one factor" hazard the function exists to prevent.
+
+  it('A1 0dp: value=0 does NOT license a raw_value of 100000 (model baseline is 0)', () => {
+    const row = denormOne(
+      makeFlip({ current_value: 0 }),
+      makeGraph([makeNode({ value: 0, raw_value: 100000 })]),
+    );
+    expect(row.current_value).toBe(0);
+  });
+
+  it('A1 0dp: value=1 does NOT license a raw_value of 200000 (model baseline is 320000)', () => {
+    const row = denormOne(
+      makeFlip({ current_value: 1 }),
+      makeGraph([makeNode({ value: 1, raw_value: 200000 })]),
+    );
+    expect(row.current_value).toBe(320000);
+  });
+
+  it('A1 1dp: value=0.9 does NOT license a raw_value 8000 off the 288000 baseline', () => {
+    const row = denormOne(
+      makeFlip({ current_value: 0.9 }),
+      makeGraph([makeNode({ value: 0.9, raw_value: 280000 })]),
+    );
+    expect(row.current_value).toBe(288000);
+  });
+
+  it('A1 x.5: value=0.5 does NOT license a raw_value of 50000 (baseline 160000)', () => {
+    const row = denormOne(
+      makeFlip({ current_value: 0.5 }),
+      makeGraph([makeNode({ value: 0.5, raw_value: 50000 })]),
+    );
+    expect(row.current_value).toBe(160000);
+  });
+
+  it('A1 CONTROL: the ceiling still admits the genuine live case (0.86 / 275000 / 320000)', () => {
+    // Without this, "reject everything" would pass every A1 pin above while
+    // silently removing the feature.
+    const row = denormOne(makeFlip(), makeGraph([makeNode()]));
+    expect(row.current_value).toBe(275000);
+    expect(row.value_scale).toBe('display');
+  });
+});
+
+// =============================================================================
+// A2 (review #298) — no float tail may reach current_value / flip_value
+// =============================================================================
+//
+// `flip_value` is roundTo4'd and then multiplied by the cap, so the product
+// carries IEEE dust: 0.29 x 100 = 28.999999999999996. CEE's agreement rung is an
+// EXACT equality, so an LLM writing the obvious "29" is DENIED — and once F1
+// reads the producer string, the user is shown the tail itself. Rounding a
+// display-scale value to the precision the model can actually resolve is MORE
+// honest than shipping sixteen digits of float noise, not less.
+
+describe('F2/A2 emitted values carry no float tail', () => {
+  function capNode(value: number, cap: number, unit = '%'): EngineNodeV3 {
+    return {
+      id: 'fac_annual_staffing_cost',
+      kind: 'factor',
+      label: 'Annual Staffing Cost',
+      observed_state: { value, unit, cap },
+    } as EngineNodeV3;
+  }
+
+  it('0.29 of a cap of 100 is 29, not 28.999999999999996', () => {
+    const row = denormOne(
+      makeFlip({ current_value: 0.29, unit: '%' }),
+      makeGraph([capNode(0.29, 100)]),
+    );
+    expect(row.current_value).toBe(29);
+    expect(row.current_display).toBe('29 %');
+  });
+
+  it('0.29 of a cap of 3000 is 870, not 869.9999999999999', () => {
+    const row = denormOne(
+      makeFlip({ current_value: 0.29, unit: '%' }),
+      makeGraph([capNode(0.29, 3000)]),
+    );
+    expect(row.current_value).toBe(870);
+    expect(row.current_display).toBe('870 %');
+  });
+
+  it('a flip_value is cleaned on the same grid as current_value', () => {
+    const row = denormOne(
+      makeFlip({ current_value: 0.29, flip_value: 0.83, unit: '%', flip_reason: 'found' }),
+      makeGraph([capNode(0.29, 100)]),
+    );
+    expect(row.flip_value).toBe(83);
+    expect(row.flip_display).toBe('83 %');
+  });
+
+  it('⭐ P7 against an INDEPENDENTLY-written string — the non-self-referential check', () => {
+    // Comparing our own string to our own value can only fail via the
+    // exponential guard, because Number(String(x)) === x for every finite
+    // non-exponential double. The real question is whether a string written by
+    // SOMEONE ELSE — CEE's decision_review LLM, told to emit the value "as-is"
+    // with its unit — agrees with the number we ship. That is what P7 actually
+    // evaluates, and it is what the float tail breaks.
+    const row = denormOne(
+      makeFlip({ current_value: 0.29, flip_value: 0.83, unit: '%', flip_reason: 'found' }),
+      makeGraph([capNode(0.29, 100)]),
+    );
+    expect(ceeLicenceAgreesWithRawValue('29 %', row.current_value)).toBe(true);
+    expect(ceeLicenceAgreesWithRawValue('83 %', row.flip_value!)).toBe(true);
+    // And the separator-bearing form an LLM might write for a large number.
+    const big = denormOne(makeFlip(), makeGraph([makeNode()]));
+    expect(ceeLicenceAgreesWithRawValue('275,000 GBP', big.current_value)).toBe(true);
+  });
+
+  it('SWEEP: no emitted value carries dust, and every one stays faithful to value x cap', () => {
+    const caps = [100, 500, 1000, 3000, 12000, 16000, 320000];
+    let checked = 0;
+    for (const cap of caps) {
+      for (let i = 1; i <= 99; i++) {
+        const value = i / 100;
+        const row = denormOne(
+          makeFlip({ current_value: value, unit: '%' }),
+          makeGraph([capNode(value, cap)]),
+        );
+        const decimals = (String(row.current_value).split('.')[1] ?? '').length;
+        // Dust shows up as 12-17 decimals; a legitimately fractional user value
+        // needs at most the 4 the normalised grid can resolve.
+        expect(decimals, `cap=${cap} value=${value} -> ${row.current_value}`).toBeLessThanOrEqual(4);
+        // Cleaning must not move the number meaningfully.
+        expect(Math.abs(row.current_value - value * cap)).toBeLessThanOrEqual(
+          Math.abs(value * cap) * 1e-6 + 1e-9,
+        );
+        checked++;
+      }
+    }
+    // Anti-vacuity: the loop really ran.
+    expect(checked).toBe(caps.length * 99);
   });
 
   it('a null flip_value keeps flip_display absent while current is still lifted', () => {
@@ -312,10 +464,13 @@ describe('F2 display strings are lossless — P7 is an EXACT equality test', () 
     expect(row.current_display).toBeUndefined();
   });
 
-  it('never rounds — a fractional user value round-trips through the agreement check', () => {
-    const node = makeNode({ cap: 3, raw_value: undefined, value: 1 / 3 });
-    const row = denormOne(makeFlip({ current_value: 1 / 3 }), makeGraph([node]));
-    expect(row.current_display).toBeDefined();
-    expect(ceeLicenceAgreesWithRawValue(row.current_display!, row.current_value)).toBe(true);
+  it('keeps genuine fractional precision on a small-range factor', () => {
+    // Range width 2 ⇒ the normalised grid resolves 2e-4 ⇒ 4 decimals are kept.
+    // Cleaning must remove float noise WITHOUT flattening a real fraction.
+    const node = makeNode({ cap: 2, raw_value: undefined, value: 0.1235 });
+    const row = denormOne(makeFlip({ current_value: 0.1235 }), makeGraph([node]));
+    expect(row.current_value).toBe(0.247);
+    expect(row.current_display).toBe('0.247 £');
+    expect(ceeLicenceAgreesWithRawValue('0.247 £', row.current_value)).toBe(true);
   });
 });

--- a/tests/lib/flip-threshold-display-scale.test.ts
+++ b/tests/lib/flip-threshold-display-scale.test.ts
@@ -385,29 +385,191 @@ describe('F2/A2 emitted values carry no float tail', () => {
     expect(ceeLicenceAgreesWithRawValue('275,000 GBP', big.current_value)).toBe(true);
   });
 
-  it('SWEEP: no emitted value carries dust, and every one stays faithful to value x cap', () => {
-    const caps = [100, 500, 1000, 3000, 12000, 16000, 320000];
+  // ===========================================================================
+  // R1 (review round 3) — cleaning must never FABRICATE a value
+  // ===========================================================================
+  //
+  // `flip.current_value` is the node's own normalised number
+  // (`getFactorCurrentValue`), which is NOT on the flip search's roundTo4 grid.
+  // So a legitimately tiny value can round to zero: value 1e-5 at cap 16000 is
+  // exactly 0.16, and cleaning to whole units produced `current_value: 0`,
+  // `current_display: "0 £"`, `value_scale: "display"`.
+  //
+  // That inverts the safety direction. BEFORE 2.228 such a row shipped 0.00001
+  // with no row-level scale and CEE's cage CLOSED; with a fabricated zero the
+  // cage OPENS — and `value_scale: 'display'` is also what un-suppresses the
+  // `what_would_flip` CHIP, whose params.value.value is executed straight into
+  // the user's graph. A fabricated zero must never get that far.
+
+  it('R1: a non-zero value that would clean to zero is REFUSED, not shipped as 0', () => {
+    // 1e-5 x 16000 = 0.16 exactly; the grid for this range is whole units.
+    const row = denormOne(
+      makeFlip({ current_value: 1e-5, unit: '£' }),
+      makeGraph([capNode(1e-5, 16000, '£')]),
+    );
+    expect(row.current_value).toBe(1e-5);
+    expect(row.value_scale).toBe('normalised');
+    expect(row.current_display).toBeUndefined();
+  });
+
+  it('R1: a flip_value that would clean to zero refuses the WHOLE row', () => {
+    const row = denormOne(
+      makeFlip({ current_value: 0.5, flip_value: 1e-5, unit: '£', flip_reason: 'found' }),
+      makeGraph([capNode(0.5, 16000, '£')]),
+    );
+    expect(row.value_scale).toBe('normalised');
+    expect(row.current_display).toBeUndefined();
+    expect(row.flip_display).toBeUndefined();
+  });
+
+  it('R1 CONTROL: a GENUINELY zero value is still display-scale', () => {
+    // Without this, "refuse every zero" would pass both pins above while
+    // removing a legitimate case.
+    const row = denormOne(
+      makeFlip({ current_value: 0, unit: '£' }),
+      makeGraph([capNode(0, 16000, '£')]),
+    );
+    expect(row.current_value).toBe(0);
+    expect(row.value_scale).toBe('display');
+    expect(row.current_display).toBe('0 £');
+  });
+
+  // ===========================================================================
+  // R2 (review round 3) — the cleaning guarantee is ABSOLUTE, not relative
+  // ===========================================================================
+  //
+  // The previous sweep asserted a 1e-6 RELATIVE bound over 693 cases (2dp
+  // only). That bound does NOT generalise: over the full 4dp grid, 16,000 of
+  // 109,989 cases exceed it, worst 25% (cap 16000, value 1e-4: exact 1.6 →
+  // shipped 2). Nothing is wrong with those values — they are within half a
+  // rounding unit — but the relative bound was the wrong KIND of guarantee to
+  // state. The invariant that actually holds is absolute: the cleaned value is
+  // never more than half a rounding unit from the exact product, hence never
+  // more than half the model's own 1e-4 grid step.
+
+  it('SWEEP over the FULL 4dp grid: cleaning is faithful within half a grid step', () => {
+    const caps = [1, 10, 100, 500, 1000, 3000, 12000, 16000, 320000, 1e6, 1e7];
     let checked = 0;
+    let displayed = 0;
+    let refused = 0;
+    let worstRatio = 0;
     for (const cap of caps) {
-      for (let i = 1; i <= 99; i++) {
-        const value = i / 100;
-        const row = denormOne(
-          makeFlip({ current_value: value, unit: '%' }),
-          makeGraph([capNode(value, cap)]),
-        );
-        const decimals = (String(row.current_value).split('.')[1] ?? '').length;
-        // Dust shows up as 12-17 decimals; a legitimately fractional user value
-        // needs at most the 4 the normalised grid can resolve.
-        expect(decimals, `cap=${cap} value=${value} -> ${row.current_value}`).toBeLessThanOrEqual(4);
-        // Cleaning must not move the number meaningfully.
-        expect(Math.abs(row.current_value - value * cap)).toBeLessThanOrEqual(
-          Math.abs(value * cap) * 1e-6 + 1e-9,
-        );
+      const node = capNode(0, cap, '£');
+      for (let i = 1; i <= 9999; i++) {
+        const value = i / 10000;
+        (node.observed_state as { value: number }).value = value;
+        const row = denormOne(makeFlip({ current_value: value, unit: '£' }), makeGraph([node]));
         checked++;
+        if (row.value_scale !== 'display') {
+          // R1 refusal: the value is passed through untouched and unclaimed.
+          refused++;
+          expect(row.current_value).toBe(value);
+          expect(row.current_display).toBeUndefined();
+          continue;
+        }
+        displayed++;
+        const exact = value * cap;
+        const halfGridStep = 0.5 * cap * 1e-4;
+        const err = Math.abs(row.current_value - exact);
+        worstRatio = Math.max(worstRatio, halfGridStep > 0 ? err / halfGridStep : 0);
+        expect(
+          err,
+          `cap=${cap} value=${value} exact=${exact} shipped=${row.current_value}`,
+        ).toBeLessThanOrEqual(halfGridStep + Math.abs(exact) * Number.EPSILON * 8);
+        // No float tail on anything emitted.
+        const decimals = (String(row.current_value).split('.')[1] ?? '').length;
+        expect(decimals).toBeLessThanOrEqual(4);
       }
     }
-    // Anti-vacuity: the loop really ran.
-    expect(checked).toBe(caps.length * 99);
+    expect(checked).toBe(caps.length * 9999);
+    // Anti-vacuity: the display path really ran, for every case.
+    expect(displayed).toBe(checked);
+    // ON the 4dp grid nothing is ever refused: the smallest exact product is a
+    // full grid step, which is never below half a rounding unit. R1's refusals
+    // live strictly BELOW this grid — see the next test.
+    expect(refused).toBe(0);
+    // The measured worst error, as a fraction of half a grid step (< 1).
+    expect(worstRatio).toBeLessThan(1);
+  });
+
+  it('R1: a sub-resolution strongest_probe_value is WITHHELD, not zeroed', () => {
+    // `strongest_probe_value` is a normalised probe value; the baseline probe is
+    // the node's own `current_value`, which is not on the roundTo4 grid. So it
+    // can be sub-resolution too, and must be withheld through the
+    // `display_value_available: false` flag that already exists for it — never
+    // published as a confident 0.
+    const margin = {
+      movement: 'weakened',
+      threshold: 0.05,
+      baseline_margin: 0.4,
+      min_probe_margin: 0.3,
+      max_probe_margin: 0.4,
+      min_probe_delta: -0.1,
+      max_probe_delta: 0,
+      strongest_direction: 'towards_min',
+      strongest_probe_value: 1e-5,
+      value_scale: 'normalised',
+      strongest_delta: -0.1,
+      strongest_delta_abs: 0.1,
+      strongest_delta_percentage_points: -10,
+      display_value_available: false,
+    } as never;
+    const row = denormOne(
+      makeFlip({ current_value: 0.5, unit: '£', margin_sensitivity: margin }),
+      makeGraph([capNode(0.5, 16000, '£')]),
+    );
+    expect(row.margin_sensitivity).toBeDefined();
+    expect(row.margin_sensitivity!.strongest_probe_value).toBeNull();
+    expect(row.margin_sensitivity!.display_value_available).toBe(false);
+  });
+
+  it('R1 CONTROL: a resolvable strongest_probe_value IS published', () => {
+    const margin = {
+      movement: 'weakened',
+      threshold: 0.05,
+      baseline_margin: 0.4,
+      min_probe_margin: 0.3,
+      max_probe_margin: 0.4,
+      min_probe_delta: -0.1,
+      max_probe_delta: 0,
+      strongest_direction: 'towards_min',
+      strongest_probe_value: 0.25,
+      value_scale: 'normalised',
+      strongest_delta: -0.1,
+      strongest_delta_abs: 0.1,
+      strongest_delta_percentage_points: -10,
+      display_value_available: false,
+    } as never;
+    const row = denormOne(
+      makeFlip({ current_value: 0.5, unit: '£', margin_sensitivity: margin }),
+      makeGraph([capNode(0.5, 16000, '£')]),
+    );
+    expect(row.margin_sensitivity!.strongest_probe_value).toBe(4000);
+    expect(row.margin_sensitivity!.display_value_available).toBe(true);
+  });
+
+  it('SWEEP below the grid: every sub-resolution value is REFUSED, never zeroed', () => {
+    // `current_value` comes from the node, not from the roundTo4 grid, so values
+    // finer than the model's resolution do arrive. Each must be refused rather
+    // than collapsed to a confident 0.
+    const caps = [1, 10, 100, 500, 1000, 3000, 12000, 16000, 320000, 1e6, 1e7];
+    let refused = 0;
+    for (const cap of caps) {
+      const step = cap * 1e-4;
+      const decimals = Math.min(12, Math.max(0, Math.ceil(-Math.log10(step))));
+      // Exact product sits at 0.4 of a rounding unit ⇒ rounds to zero.
+      const value = (0.4 * Math.pow(10, -decimals)) / cap;
+      expect(value).toBeGreaterThan(0);
+      const row = denormOne(
+        makeFlip({ current_value: value, unit: '£' }),
+        makeGraph([capNode(value, cap, '£')]),
+      );
+      expect(row.current_value, `cap=${cap} value=${value}`).toBe(value);
+      expect(row.value_scale).toBe('normalised');
+      expect(row.current_display).toBeUndefined();
+      refused++;
+    }
+    expect(refused).toBe(caps.length);
   });
 
   it('a null flip_value keeps flip_display absent while current is still lifted', () => {

--- a/tests/lib/flip-threshold-display-scale.test.ts
+++ b/tests/lib/flip-threshold-display-scale.test.ts
@@ -1,0 +1,321 @@
+/**
+ * ROADMAP 2.228 F2 — display-safe flip-threshold rows.
+ *
+ * The defect (diagnosis-2228-enrichment-values.md §2.1/§2.2, re-verified at PLoT
+ * staging 11a03b4d): `enrichment.flip_thresholds[]` ships `current_value` as the
+ * node's NORMALISED [0,1] number while `unit` comes from `observed_state.unit`,
+ * producing the `0.86` + `'£'` pair on the live wire. The node already carries
+ * `raw_value: 275000` and `cap: 320000`; the flip path simply never asks for them,
+ * because `denormaliseFlipThresholds` only denormalises when Phase 4a happened to
+ * build a `normalisationContext` — and on the V5 path it never does.
+ *
+ * This suite pins the producer half of CEE's flip-threshold card chain: the row
+ * must arrive in user units, must SAY so at row level, and its display strings
+ * must DESCRIBE the raw values it ships.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  denormaliseFlipThresholds,
+  type DenormalisedFlipThreshold,
+} from '../../src/lib/flip-threshold-denormaliser.js';
+import type { FlipThresholdInputData } from '../../src/cee/validation/m1-review-types.js';
+import type { NormalisationContext } from '../../src/lib/intervention-normaliser.js';
+import type { EngineGraphV3, EngineNodeV3 } from '../../src/types/engine-v3.js';
+
+// =============================================================================
+// CEE CAGE ORACLES — pinned copies of the predicates this output must satisfy
+// =============================================================================
+
+/**
+ * ⚠ CROSS-REPO MIRROR, PINNED AND DECLARED.
+ *
+ * These two functions are copied VERBATIM from CEE
+ * `src/orchestrator-v5/context/analysis-signals.ts` at CEE staging
+ * `b8a38de79cdaa0995d31ce45a52c1f763112ad0e` (the merged PR #776 cages) —
+ * `readRowValueScale`/`flipRowScaleIsDisplaySafe` at :323-349 and
+ * `licenceAgreesWithRawValue` at :361-365.
+ *
+ * A copy is a hand-maintained mirror (CLAUDE.md trap 12) and cannot be derived
+ * from here — the predicate lives in another repo and cannot be imported. The
+ * mitigation is that it is DECLARED as a mirror, pinned to a SHA, and confined
+ * to this oracle: nothing in `src/` copies it. **If CEE's predicate changes,
+ * this oracle must be re-derived from the new bytes, not trusted.**
+ *
+ * Its purpose: prove PLoT's row satisfies P4 and P7 as an executable check
+ * rather than by reading the target JSON and believing it.
+ */
+const MODEL_SCALE_SUSPECT_ABS = 1;
+
+function ceeReadRowValueScale(row: Record<string, unknown>): string | null {
+  if (typeof row.value_scale === 'string') return row.value_scale;
+  const ms = row.margin_sensitivity;
+  if (ms !== null && typeof ms === 'object' && !Array.isArray(ms)) {
+    const nested = (ms as Record<string, unknown>).value_scale;
+    if (typeof nested === 'string') return nested;
+  }
+  return null;
+}
+
+/** CEE rung P4. */
+function ceeFlipRowScaleIsDisplaySafe(
+  row: Record<string, unknown>,
+  currentValue: number,
+  flipValue: number,
+): boolean {
+  const raw = ceeReadRowValueScale(row);
+  const scale = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  if (scale === 'display') return true;
+  if (scale.length > 0) return false;
+  return Math.abs(currentValue) > MODEL_SCALE_SUSPECT_ABS &&
+    Math.abs(flipValue) > MODEL_SCALE_SUSPECT_ABS;
+}
+
+/** CEE rung P7. */
+function ceeLicenceAgreesWithRawValue(display: string, rawValue: number): boolean {
+  const tokens = display.replace(/(?<=\d),(?=\d{3}\b)/g, '').match(/-?\d+(?:\.\d+)?/g);
+  if (tokens === null) return false;
+  return tokens.some((t) => Number(t) === rawValue);
+}
+
+// =============================================================================
+// Fixtures — the live a7 factor from the 2026-07-31 wire capture
+// =============================================================================
+
+const OPTIONS = [
+  { id: 'opt_status_quo', label: 'Status quo' },
+  { id: 'opt_locum', label: 'Locum cover' },
+];
+
+/** The real node shape from the GRAPH_READY frame of attempt a7 (diagnosis §2.1). */
+function makeNode(overrides: Partial<EngineNodeV3['observed_state']> = {}): EngineNodeV3 {
+  return {
+    id: 'fac_annual_staffing_cost',
+    kind: 'factor',
+    label: 'Annual Staffing Cost',
+    observed_state: {
+      value: 0.86,
+      unit: '£',
+      raw_value: 275000,
+      cap: 320000,
+      ...overrides,
+    },
+  } as EngineNodeV3;
+}
+
+function makeGraph(nodes: EngineNodeV3[]): EngineGraphV3 {
+  return { nodes, edges: [] };
+}
+
+function makeFlip(overrides: Partial<FlipThresholdInputData> = {}): FlipThresholdInputData {
+  return {
+    factor_id: 'fac_annual_staffing_cost',
+    factor_label: 'Annual Staffing Cost',
+    current_value: 0.86,
+    flip_value: null,
+    direction: 'increase',
+    flip_reason: 'no_effect_within_bounds',
+    iterations_used: 0,
+    probes_used: 3,
+    alternative_winner_id: null,
+    unit: '£',
+    ...overrides,
+  };
+}
+
+/** Convenience: run the denormaliser over one row with a graph and return it. */
+function denormOne(
+  flip: FlipThresholdInputData,
+  graph: EngineGraphV3 | undefined,
+  context?: NormalisationContext,
+): DenormalisedFlipThreshold {
+  const rows = denormaliseFlipThresholds([flip], context, OPTIONS, graph);
+  expect(rows).toHaveLength(1);
+  return rows[0];
+}
+
+// =============================================================================
+// POSITIVES — RED before the fix
+// =============================================================================
+
+describe('F2 POSITIVE: a node carrying raw_value + cap yields a display-scale row', () => {
+  it('lifts current_value out of [0,1] into user units using observed_state.raw_value', () => {
+    const row = denormOne(makeFlip(), makeGraph([makeNode()]));
+    // 275000 is the number the USER gave; 0.86 x 320000 = 275200 is the
+    // round-trip of the already-rounded normalised value. The authoritative
+    // raw_value wins, so the card never shows £275,200 for a £275,000 input.
+    expect(row.current_value).toBe(275000);
+  });
+
+  it('stamps row-level value_scale "display" — the token CEE reads FIRST', () => {
+    const row = denormOne(makeFlip(), makeGraph([makeNode()]));
+    expect(row.value_scale).toBe('display');
+  });
+
+  it('emits current_display describing the raw value with its unit', () => {
+    const row = denormOne(makeFlip(), makeGraph([makeNode()]));
+    expect(row.current_display).toBe('275000 £');
+  });
+
+  it('denormalises a real flip_value against the cap and emits flip_display', () => {
+    // A flip found at normalised 0.7546875 == 241500 / 320000.
+    const row = denormOne(
+      makeFlip({ flip_value: 241500 / 320000, flip_reason: 'found', alternative_winner_id: 'opt_locum' }),
+      makeGraph([makeNode()]),
+    );
+    expect(row.flip_value).toBeCloseTo(241500, 6);
+    expect(row.flip_display).toBeDefined();
+    expect(ceeLicenceAgreesWithRawValue(row.flip_display!, row.flip_value!)).toBe(true);
+  });
+
+  it('falls back to value x cap when the node carries a cap but no raw_value', () => {
+    const node = makeNode();
+    delete (node.observed_state as Record<string, unknown>).raw_value;
+    const row = denormOne(makeFlip(), makeGraph([node]));
+    expect(row.current_value).toBeCloseTo(275200, 6);
+    expect(row.value_scale).toBe('display');
+    expect(ceeLicenceAgreesWithRawValue(row.current_display!, row.current_value)).toBe(true);
+  });
+});
+
+describe('F2 POSITIVE: the row satisfies CEE #776 cage rungs P4 and P7', () => {
+  const flip = makeFlip({ flip_value: 241500 / 320000, flip_reason: 'found', alternative_winner_id: 'opt_locum' });
+
+  it('P4 flipRowScaleIsDisplaySafe accepts the row', () => {
+    const row = denormOne(flip, makeGraph([makeNode()]));
+    expect(
+      ceeFlipRowScaleIsDisplaySafe(
+        row as unknown as Record<string, unknown>,
+        row.current_value,
+        row.flip_value!,
+      ),
+    ).toBe(true);
+  });
+
+  it('P4 is satisfied by the ROW-LEVEL token, overriding a nested normalised one', () => {
+    // The live wire's margin_sensitivity says 'normalised'. Row level is read
+    // first, so the row-level stamp must be what decides.
+    const withMargin = { ...flip, margin_sensitivity: { value_scale: 'normalised' } as never };
+    const row = denormOne(withMargin, makeGraph([makeNode()]));
+    expect(ceeReadRowValueScale(row as unknown as Record<string, unknown>)).toBe('display');
+  });
+
+  it('P7 both display strings DESCRIBE the raw values the row ships', () => {
+    const row = denormOne(flip, makeGraph([makeNode()]));
+    expect(ceeLicenceAgreesWithRawValue(row.current_display!, row.current_value)).toBe(true);
+    expect(ceeLicenceAgreesWithRawValue(row.flip_display!, row.flip_value!)).toBe(true);
+  });
+
+  it('P7 CONTROL: the pre-fix pair (0.86 + "£") would FAIL agreement', () => {
+    // Proves the oracle can see a failure — an agreement assertion that cannot
+    // fail proves nothing (trap 13).
+    expect(ceeLicenceAgreesWithRawValue('275000 £', 0.86)).toBe(false);
+  });
+});
+
+// =============================================================================
+// NEGATIVES / FAIL-CLOSED PINS
+// =============================================================================
+
+describe('F2 fail-closed: rows we cannot lift stay honest', () => {
+  it('no cap and no raw_value → values untouched, no display strings, no display stamp', () => {
+    const node = makeNode();
+    node.observed_state = { value: 0.86, unit: '£' };
+    const row = denormOne(makeFlip(), makeGraph([node]));
+    expect(row.current_value).toBe(0.86);
+    expect(row.current_display).toBeUndefined();
+    expect(row.flip_display).toBeUndefined();
+    expect(row.value_scale).not.toBe('display');
+  });
+
+  it('a cap of 0 is not a scale → fail closed, never a 1:1 "display" claim', () => {
+    const row = denormOne(makeFlip(), makeGraph([makeNode({ cap: 0, raw_value: undefined })]));
+    expect(row.current_value).toBe(0.86);
+    expect(row.value_scale).not.toBe('display');
+    expect(row.current_display).toBeUndefined();
+  });
+
+  it('the factor is absent from the graph → row untouched', () => {
+    const row = denormOne(makeFlip(), makeGraph([]));
+    expect(row.current_value).toBe(0.86);
+    expect(row.value_scale).not.toBe('display');
+    expect(row.current_display).toBeUndefined();
+  });
+
+  it('no graph supplied at all → pre-fix behaviour preserved exactly', () => {
+    const row = denormOne(makeFlip(), undefined);
+    expect(row.current_value).toBe(0.86);
+    expect(row.value_scale).toBeUndefined();
+    expect(row.current_display).toBeUndefined();
+  });
+
+  it('a raw_value inconsistent with value x cap beyond its own rounding error is REFUSED', () => {
+    // value 0.86 has 2 dp ⇒ implied rounding error 0.005 ⇒ 1600 in user units.
+    // A raw_value 50000 away cannot be this node's number; taking it would put
+    // current_value and flip_value on different footings.
+    const row = denormOne(makeFlip(), makeGraph([makeNode({ raw_value: 225000 })]));
+    expect(row.current_value).toBeCloseTo(275200, 6);
+    expect(row.value_scale).toBe('display');
+  });
+
+  it('a null flip_value keeps flip_display absent while current is still lifted', () => {
+    const row = denormOne(makeFlip({ flip_value: null }), makeGraph([makeNode()]));
+    expect(row.flip_value).toBeNull();
+    expect(row.flip_display).toBeUndefined();
+    expect(row.current_value).toBe(275000);
+    expect(row.value_scale).toBe('display');
+  });
+
+  it('attested-normalised: raw_value present but the cap is unusable → value_scale "normalised"', () => {
+    // The node bears the marks of normalisation (raw_value) but we cannot lift
+    // it. Saying so beats leaving the scale absent for a magnitude heuristic.
+    const row = denormOne(makeFlip(), makeGraph([makeNode({ cap: undefined })]));
+    expect(row.current_value).toBe(0.86);
+    expect(row.value_scale).toBe('normalised');
+    expect(row.current_display).toBeUndefined();
+  });
+});
+
+describe('F2 does not disturb the pre-existing Phase 4a path', () => {
+  const ctx = (source: 'explicit' | 'explicit_cap'): NormalisationContext => ({
+    factors: new Map([
+      [
+        'fac_annual_staffing_cost',
+        { factor_id: 'fac_annual_staffing_cost', range: { min: 0, max: 320000, source }, baseline: 0 },
+      ],
+    ]),
+    goal_node_id: 'goal',
+  });
+
+  it('an explicit (state_space) range still denormalises and gains no row-level stamp', () => {
+    const row = denormOne(makeFlip({ flip_value: 0.5 }), undefined, ctx('explicit'));
+    expect(row.current_value).toBeCloseTo(275200, 6);
+    expect(row.flip_value).toBeCloseTo(160000, 6);
+    expect(row.value_scale).toBeUndefined();
+  });
+
+  it('an explicit_cap context range DOES stamp display', () => {
+    const row = denormOne(makeFlip({ flip_value: 0.5 }), makeGraph([makeNode()]), ctx('explicit_cap'));
+    expect(row.value_scale).toBe('display');
+    expect(row.flip_display).toBeDefined();
+  });
+});
+
+describe('F2 display strings are lossless — P7 is an EXACT equality test', () => {
+  it('never uses exponential notation; a value JS would render as 1e+21 gets no string', () => {
+    // String(1e21) === '1e+21' tokenises to [1, 21]; Number('1') !== 1e21, so a
+    // string we cannot guarantee is not authored at all.
+    const row = denormOne(
+      makeFlip({ current_value: 1 }),
+      makeGraph([makeNode({ cap: 1e21, raw_value: undefined, value: 1 })]),
+    );
+    expect(row.current_display).toBeUndefined();
+  });
+
+  it('never rounds — a fractional user value round-trips through the agreement check', () => {
+    const node = makeNode({ cap: 3, raw_value: undefined, value: 1 / 3 });
+    const row = denormOne(makeFlip({ current_value: 1 / 3 }), makeGraph([node]));
+    expect(row.current_display).toBeDefined();
+    expect(ceeLicenceAgreesWithRawValue(row.current_display!, row.current_value)).toBe(true);
+  });
+});

--- a/tests/lib/flip-threshold-display-scale.test.ts
+++ b/tests/lib/flip-threshold-display-scale.test.ts
@@ -448,39 +448,58 @@ describe('F2/A2 emitted values carry no float tail', () => {
   // more than half the model's own 1e-4 grid step.
 
   it('SWEEP over the FULL 4dp grid: cleaning is faithful within half a grid step', () => {
+    // Batched deliberately: one denormaliser call per cap rather than 9,999, and
+    // violations accumulated for a single assertion instead of ~110,000 expect()
+    // calls. The per-case version measured 15.4-26.8s locally against the
+    // global `testTimeout: 15000` (vitest.config.ts:35) and 9.95s in CI — about
+    // 5s of headroom, i.e. one slow runner away from redding CI on the test that
+    // carries this PR's headline guarantee.
     const caps = [1, 10, 100, 500, 1000, 3000, 12000, 16000, 320000, 1e6, 1e7];
+    const violations: string[] = [];
     let checked = 0;
     let displayed = 0;
     let refused = 0;
     let worstRatio = 0;
+
     for (const cap of caps) {
-      const node = capNode(0, cap, '£');
+      const graph = makeGraph([capNode(0.5, cap, '£')]);
+      const flips: FlipThresholdInputData[] = [];
       for (let i = 1; i <= 9999; i++) {
-        const value = i / 10000;
-        (node.observed_state as { value: number }).value = value;
-        const row = denormOne(makeFlip({ current_value: value, unit: '£' }), makeGraph([node]));
+        flips.push(makeFlip({ current_value: i / 10000, unit: '£' }));
+      }
+      const rows = denormaliseFlipThresholds(flips, undefined, OPTIONS, graph);
+      if (rows.length !== flips.length) {
+        violations.push(`cap=${cap}: got ${rows.length} rows for ${flips.length} inputs`);
+        continue;
+      }
+      const halfGridStep = 0.5 * cap * 1e-4;
+      for (let i = 0; i < rows.length; i++) {
+        const value = (i + 1) / 10000;
+        const row = rows[i];
         checked++;
         if (row.value_scale !== 'display') {
-          // R1 refusal: the value is passed through untouched and unclaimed.
           refused++;
-          expect(row.current_value).toBe(value);
-          expect(row.current_display).toBeUndefined();
+          if (row.current_value !== value || row.current_display !== undefined) {
+            violations.push(`cap=${cap} value=${value}: refused row not passed through cleanly`);
+          }
           continue;
         }
         displayed++;
         const exact = value * cap;
-        const halfGridStep = 0.5 * cap * 1e-4;
         const err = Math.abs(row.current_value - exact);
-        worstRatio = Math.max(worstRatio, halfGridStep > 0 ? err / halfGridStep : 0);
-        expect(
-          err,
-          `cap=${cap} value=${value} exact=${exact} shipped=${row.current_value}`,
-        ).toBeLessThanOrEqual(halfGridStep + Math.abs(exact) * Number.EPSILON * 8);
+        const ratio = halfGridStep > 0 ? err / halfGridStep : 0;
+        if (ratio > worstRatio) worstRatio = ratio;
+        if (err > halfGridStep + Math.abs(exact) * Number.EPSILON * 8) {
+          violations.push(`cap=${cap} value=${value} exact=${exact} shipped=${row.current_value}`);
+        }
         // No float tail on anything emitted.
-        const decimals = (String(row.current_value).split('.')[1] ?? '').length;
-        expect(decimals).toBeLessThanOrEqual(4);
+        if ((String(row.current_value).split('.')[1] ?? '').length > 4) {
+          violations.push(`cap=${cap} value=${value}: float tail ${row.current_value}`);
+        }
       }
     }
+
+    expect(violations.slice(0, 5)).toEqual([]);
     expect(checked).toBe(caps.length * 9999);
     // Anti-vacuity: the display path really ran, for every case.
     expect(displayed).toBe(checked);
@@ -490,7 +509,7 @@ describe('F2/A2 emitted values carry no float tail', () => {
     expect(refused).toBe(0);
     // The measured worst error, as a fraction of half a grid step (< 1).
     expect(worstRatio).toBeLessThan(1);
-  });
+  }, 60_000);
 
   it('R1: a sub-resolution strongest_probe_value is WITHHELD, not zeroed', () => {
     // `strongest_probe_value` is a normalised probe value; the baseline probe is

--- a/tests/v2-run.flip-display-scale.contract.test.ts
+++ b/tests/v2-run.flip-display-scale.contract.test.ts
@@ -1,0 +1,233 @@
+/**
+ * /v2/run route-level contract for ROADMAP 2.228 F2 — display-scale flip rows.
+ *
+ * The unit suite (`tests/lib/flip-threshold-display-scale.test.ts`) proves the
+ * denormaliser lifts a row when it is HANDED the graph. This file proves the
+ * route actually hands it over: without the `filteredGraph` argument at
+ * `src/routes/v2/run.ts` the whole fix is inert on the live path and every unit
+ * test still passes. Closing that gap is the only reason this file exists.
+ *
+ * The request is deliberately shaped like CEE's V5 payload — intervention values
+ * INSIDE [0,1], so `needsNormalisation` is false and Phase 4a never builds a
+ * `normalisationContext` (diagnosis §2.1 step 7) — with the scale carried on the
+ * node as `observed_state.cap` / `raw_value`, exactly as the live `GRAPH_READY`
+ * frame of attempt a7 carries it.
+ *
+ * ISL is mocked (the module-level pattern used by
+ * `tests/enrichment-emission-contract.test.ts`): a real ISL is unreachable in
+ * CI, and without one `analysis_status` is `'failed'` and `flip_thresholds` is
+ * `[]`, which would make every display assertion below vacuous.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const OPTION_IDS = ['opt_status_quo', 'opt_locum'];
+
+/** Two options with a clear, stable winner so a flip candidate set is produced. */
+function mockOptions(options: Array<{ id: string }>): unknown[] {
+  return options.map((opt, idx) => ({
+    option_id: opt.id,
+    label: opt.id,
+    win_probability: idx === 0 ? 0.72 : 0.28,
+    outcome: {
+      mean: 0.7 - idx * 0.2,
+      std: 0.1,
+      p10: 0.5,
+      p50: 0.7,
+      p90: 0.9,
+      n_samples: 1000,
+      n_valid_samples: 1000,
+      validity_ratio: 1.0,
+    },
+    rank: idx + 1,
+  }));
+}
+
+/** Non-zero elasticity on the two CAPPED factors so both become candidates. */
+const MOCK_FACTOR_SENSITIVITY = [
+  { node_id: 'fac_annual_staffing_cost', factor_id: 'fac_annual_staffing_cost', sensitivity_score: 0.62, elasticity: -0.62, direction: 'negative', value_of_information: 0.1 },
+  { node_id: 'fac_demand', factor_id: 'fac_demand', sensitivity_score: 0.41, elasticity: 0.41, direction: 'positive', value_of_information: 0.1 },
+];
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable' as const,
+      confidence: 'high' as const,
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' },
+      source: 'isl' as const,
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' as const };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      options: mockOptions(options),
+      edges: [],
+      edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factor_sensitivity: MOCK_FACTOR_SENSITIVITY,
+      factors: [], value_of_information: [],
+      factors_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      factor_sensitivity_status: 'available' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.8,
+      fragile_edges: [], robust_edges: [], latency_ms: 10, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    const options = body.options || [];
+    return {
+      data: {
+        options: mockOptions(options),
+        edges: [],
+        factor_sensitivity: MOCK_FACTOR_SENSITIVITY,
+        conditional_winners: [],
+        overall_robustness: 'robust', robustness_score: 0.8,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+const REQUEST_BODY = {
+  graph: {
+    nodes: [
+      {
+        id: 'fac_annual_staffing_cost',
+        kind: 'factor',
+        label: 'Annual Staffing Cost',
+        // The live a7 shape: normalised value + authoritative cap + the user's
+        // own raw number.
+        observed_state: { value: 0.86, baseline: 0.86, unit: 'GBP', raw_value: 275000, cap: 320000 },
+      },
+      {
+        id: 'fac_demand',
+        kind: 'factor',
+        label: 'Demand',
+        observed_state: { value: 0.4, baseline: 0.4, unit: 'GBP', raw_value: 40, cap: 100 },
+      },
+      {
+        id: 'fac_lever',
+        kind: 'factor',
+        label: 'Service Model',
+        // Deliberately CAPLESS — the fail-closed control on the same response.
+        observed_state: { value: 0.5, baseline: 0.5 },
+      },
+      { id: 'outcome', kind: 'goal', label: 'Net Position' },
+    ],
+    edges: [
+      { from: 'fac_annual_staffing_cost', to: 'outcome', exists_probability: 0.95, strength: { mean: -0.7, std: 0.1 } },
+      { from: 'fac_demand', to: 'outcome', exists_probability: 0.9, strength: { mean: 0.6, std: 0.1 } },
+      { from: 'fac_lever', to: 'outcome', exists_probability: 0.9, strength: { mean: 0.5, std: 0.1 } },
+    ],
+  },
+  options: [
+    // Both intervention values sit inside [0,1] ⇒ needsNormalisation is false ⇒
+    // normalisationContext stays undefined for the whole request.
+    { id: OPTION_IDS[0], label: 'Status quo', interventions: { fac_lever: { value: 0.2, source: 'user_specified' } } },
+    { id: OPTION_IDS[1], label: 'Locum cover', interventions: { fac_lever: { value: 0.8, source: 'user_specified' } } },
+  ],
+  goal_node_id: 'outcome',
+};
+
+/** CEE rung P7, pinned copy — see the unit suite's oracle note. */
+function ceeLicenceAgreesWithRawValue(display: string, rawValue: number): boolean {
+  const tokens = display.replace(/(?<=\d),(?=\d{3}\b)/g, '').match(/-?\d+(?:\.\d+)?/g);
+  if (tokens === null) return false;
+  return tokens.some((t) => Number(t) === rawValue);
+}
+
+describe('V2 Run · flip-threshold display scale (2.228 F2)', () => {
+  let app: FastifyInstance;
+  let rows: Array<Record<string, unknown>>;
+
+  beforeAll(async () => {
+    // Rate limiting OFF for this suite, and restored afterwards — the same
+    // convention `tests/enrichment-emission-contract.test.ts:162,188` uses.
+    // Rate-limit slots are a GLOBAL, time-windowed resource shared across
+    // parallel workers, so a route test that leaves limiting on spends real
+    // slots and makes the rate-limit suites flaky. Omitting this cost two runs
+    // to diagnose; see the evidence file §7.7.
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+
+    app = await createServer();
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'content-type': 'application/json' },
+      payload: REQUEST_BODY,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as Record<string, unknown>;
+    rows = (body.flip_thresholds as Array<Record<string, unknown>>) ?? [];
+  }, 120_000);
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  it('produces flip rows at all — the anti-vacuity guard for everything below', () => {
+    // Without this, an empty array would let every display assertion pass by
+    // testing nothing (trap 13).
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some((r) => r.factor_id === 'fac_annual_staffing_cost' || r.factor_id === 'fac_demand')).toBe(true);
+  });
+
+  it('THE WIRING: capped factors arrive in user units with a row-level display stamp', () => {
+    const capped = rows.filter(
+      (r) => r.factor_id === 'fac_annual_staffing_cost' || r.factor_id === 'fac_demand',
+    );
+    expect(capped.length).toBeGreaterThan(0);
+
+    for (const row of capped) {
+      expect(row.value_scale).toBe('display');
+      expect(typeof row.current_display).toBe('string');
+
+      const current = row.current_value as number;
+      expect(Number.isFinite(current)).toBe(true);
+      // Both capped factors have cap >= 100, so a still-normalised value would
+      // sit inside [0,1] — the band CEE's cage treats as model-scale.
+      expect(Math.abs(current)).toBeGreaterThan(1);
+
+      // The string must DESCRIBE the value the row ships (CEE rung P7).
+      expect(ceeLicenceAgreesWithRawValue(row.current_display as string, current)).toBe(true);
+    }
+  });
+
+  it('the authoritative raw_value wins over the round-trip of the rounded value', () => {
+    const staffing = rows.find((r) => r.factor_id === 'fac_annual_staffing_cost');
+    expect(staffing).toBeDefined();
+    // 0.86 x 320000 = 275200; the user's own number is 275000.
+    expect(staffing!.current_value).toBe(275000);
+    expect(staffing!.current_display).toBe('275000 GBP');
+  });
+
+  it('FAIL-CLOSED CONTROL on the same response: a capless factor claims nothing', () => {
+    const lever = rows.find((r) => r.factor_id === 'fac_lever');
+    if (lever !== undefined) {
+      expect(lever.value_scale).not.toBe('display');
+      expect(lever.current_display).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
**ROADMAP 2.228 F2.** Makes `enrichment.flip_thresholds[]` rows display-safe, so CEE's
flip-threshold card chain (#776's cages) can admit them. **DO NOT MERGE** — review first.

Base: `staging` `11a03b4dc143b2673a74f84f6db1f4ea9e839338` (identical to the diagnosis pin,
so every `file:line` in `PHASE0-EVIDENCE-2026-07-28/diagnosis-2228-enrichment-values.md` is
citable unchanged). Branch protection derived, not assumed: `staging` returns HTTP 404
"Branch not protected".

Full evidence: `PHASE0-EVIDENCE-2026-07-28/fix-2228-f2-plot-display-values.md`.

---

## The defect, in one row

The live wire (attempt a7, 2026-07-31 capture) ships:

```json
{ "factor_id": "fac_annual_staffing_cost", "factor_label": "Annual Staffing Cost",
  "current_value": 0.86, "flip_value": null, "direction": "increase", "unit": "£",
  "flip_reason": "no_effect_within_bounds", "iterations_used": 0, "probes_used": 3,
  "margin_sensitivity": { "…": "…", "value_scale": "normalised" } }
```

`0.86` is a **normalised [0,1] number wearing a currency symbol**. CEE's cage refuses it,
correctly: `flipRowScaleIsDisplaySafe` reads row-level `value_scale` first, finds none,
falls back to `margin_sensitivity.value_scale` = `'normalised'`, and closes (P4 fails).

The node has carried the fix all along — `raw_value: 275000`, `cap: 320000` — and
`deriveRange` already ranks `observed_state.cap` as priority-0 `explicit_cap`. The flip path
never asked, because `denormaliseFlipThresholds` only denormalises when Phase 4a built a
`normalisationContext`, and `needsNormalisation` gates Phase 4a on option intervention
values outside [0,1] — never true on the V5 path.

**After** — the **same node** (`unit: "£"`, `raw_value: 275000`, `cap: 320000`, `value: 0.86`),
run through the amended code:

```json
{ "factor_id": "fac_annual_staffing_cost", "factor_label": "Annual Staffing Cost",
  "current_value": 275000, "flip_value": null, "direction": "increase", "unit": "£",
  "alternative_winner_id": null, "alternative_winner_label": null,
  "flip_reason": "no_effect_within_bounds", "iterations_used": 0, "probes_used": 3,
  "margin_sensitivity": { "movement": "none", "…": "…", "value_scale": "display",
                          "strongest_probe_value": null, "display_value_available": false },
  "value_scale": "display", "current_display": "275000 £" }
```

⚠ **CORRECTION (review A3).** An earlier version of this table showed `unit: "£"` → `unit:
"GBP"` as an effect of this PR. **That was wrong and is withdrawn.** No `£`→`GBP` mapping
exists anywhere in PLoT — `unit: flip.unit` is a verbatim passthrough — and the apparent
change was an artefact of pairing the live a7 capture (`"£"`) as "before" with the route
test's fixture (`unit: 'GBP'`) as "after". Two different fixtures, presented as one
transition. The table above is now same-node throughout, and `"£"` in → `"275000 £"` out is
pinned by a test. **Unit normalisation is NOT in scope for this PR** and no code here
touches it; if `£`/`GBP` should be normalised somewhere, that is a separate change and needs
its own row.

⚠ **Two further behaviour changes to disclose:**

1. On a row that now denormalises, `margin_sensitivity.value_scale` flips
   `'normalised' → 'display'` and `strongest_probe_value` is cleaned on the same grid,
   because `denormaliseMarginSensitivity` is now reached with a cap range. Correct — that
   probe value is genuinely denormalised now. Rows with no usable cap are untouched.
2. **CORRECTION (review):** an earlier version cited `normaliseReport`
   (`canonical-json.ts:102-110`) as the reason `margin_sensitivity` is outside
   `response_hash`. **Wrong mechanism** — `normaliseReport` serves `/v1/self-check`. On
   `/v2/run` the hash is `hashRequest(...)` (`canonicalise.ts:399-423`), computed from the
   canonicalised **request**, so *no* response field is in it. Conclusion unchanged, citation
   corrected.

## Target-JSON conformance (diagnosis §5(A))

| §5(A) requires | This PR | Note |
|---|---|---|
| `current_value: 275000` (user units, not 0.86) | ✅ | prefers the node's `raw_value`; `0.86 × 320000` = 275,200 would show £275,200 for a £275,000 input |
| `value_scale: "display"` at ROW level | ✅ | CEE reads row level before `margin_sensitivity` |
| `unit` preserved | ✅ | unchanged |
| `flip_value` finite | ❌ **requires F3** | out of scope |
| `flip_reason: "found"` | ❌ **requires F3** | out of scope |

## Cage-predicate cross-check (CEE `analysis-signals.ts` @ `b8a38de7`; #776 is now MERGED)

| Rung | Predicate | Verdict |
|---|---|---|
| **P4** `flipRowScaleIsDisplaySafe` | row-level `value_scale === 'display'` → true | ✅ **satisfied**, pinned by an executable oracle copied from CEE's bytes |
| **P7** `licenceAgreesWithRawValue` | `Number(token) === rawValue` exactly, after stripping thousands separators | ✅ **satisfiable** — display strings lossless by construction; asserted with the same oracle |
| **P6** `hasFlipPair` | finite `current_value` AND finite `flip_value` | ❌ **NOT satisfied — needs F3.** An attested `no_effect_within_bounds` is deliberately unlicensable |
| **P1** `deriveFlipDisplayLicences` | `decision_review.flip_thresholds[]` non-empty | ❌ **needs F1** (CEE-side, separate lane) |

**This PR ships no flip-threshold CARD on its own.** It removes the P4/P7 blockers; P6 needs
F3 and P1 needs F1. All three must land for a flip *card* to reach a user.

---

## ⭐ BUT IT DOES ACTIVATE A CHIP THAT WRITES INTO THE USER'S GRAPH — read this first

⚠ **CORRECTION (review round 3).** An earlier version of this body said *"This PR ships no
card on its own, and does not claim to"* without qualification. **True of the card, FALSE of
the `what_would_flip` chip**, and that chip is the largest live behaviour change in the PR.

A second, independent consumer reads the same `value_scale` token — verified at the bytes at
CEE `b8a38de7`:

- `compose/flip-proposal.ts` `readValueScale` → `classifyValueScale` (`:171-186`): today
  PLoT's `'normalised'` is a **present-but-unrecognised** token → `'ambiguous'`. After this PR
  the row-level `'display'` routes to `buildFromDisplayScale` (`:243`).
  ⚠ *Precision:* `'ambiguous'` is a **per-entry** skip (`{ok:false, reason:'ambiguous_scale'}`),
  and `selectFlipProposal` (`:498-507`) **iterates every entry and returns the first that
  succeeds** — so today the chip dies only when *every* row fails, not because one does. In
  practice all live rows carry `'normalised'`, so the emit is suppressed; but the mechanism is
  "no row qualified", not "the array was rejected".
- It reads **`enrichment.flip_thresholds[]` DIRECTLY** — no `decision_review`, so **no F1**;
  no card chain, so **no F3 beyond a finite `flip_value`**.
- The call site (`turn-executor.ts:8152-8160`) is gated **only** on
  `proposedHandlerId === 'what_would_flip' && currentAnalysisGraphHashForTurn !== null`.
  **There is no feature flag.**
- The emitted chip is a `set_factor_value` proposal — *"Test {label} at {N}"* — whose
  `params.value.value` is **the exact `flip_value`**, executed into the user's graph
  (`set_factor_value` normalises `rawInput / cap`).

So: on a `what_would_flip` turn with a finite `flip_value` and a capped factor, this PR turns
a suppressed chip into a live one that writes a value onto the canvas. Activating it is
consistent with the no-dark-launches doctrine, and the value path is correct (no
double-multiply; `buildFromDisplayScale` rejects `flip > cap` before emitting) — **but it
must be reviewed as an activation, not as groundwork.**

**This is also the real reason R1 below is a FIX and not a footnote:** a fabricated zero
would have carried `value_scale: 'display'` into exactly this path and produced
*"Test {factor} at 0"*, applied to the user's graph.

⚠ **CEE's P7 reads the display strings from `decision_review.flip_thresholds[]`
(LLM-authored), not from PLoT's row.** The `current_display`/`flip_display` added here are
therefore *additive and forward-looking* — they give F1 an authoritative producer string so
the cross-array agreement #776's amendment A2 flagged ("they come from different arrays …
agreement was never established, only assumed") can be made structural instead of hoped for.

⚠ **CORRECTION (review) — BLAST RADIUS IS LARGER THAN I FIRST STATED.** I wrote that these
fields "change nothing CEE reads today". That is true of `current_display`/`flip_display`
only. It is **false for `value_scale` and for the denormalised AND CLEANED
`current_value`/`flip_value`**: `deriveTippingPointsFromTopLevel` has a **LIVE caller** at CEE
`src/orchestrator-v5/context/analysis-fallback.ts:459` (verified at CEE `b8a38de7`), which
projects those very fields into the ContextPack on the prior-run fallback path — and
`compose/flip-proposal.ts` reads them for the chip (see the activation section above).
**This PR is therefore not purely forward-looking**: it changes numbers two live CEE
consumers already read — from normalised `[0,1]` values to user-scale ones, *and* by the
cleaning rounding (`28.999999999999996 → 29`). That is the intended correction (the
projection was carrying `0.86` beside `unit: "£"`), but it is a live change on both counts
and should be reviewed as one.

## Design decisions (each fail-closed, each mutant-checked)

- **Denormalisation stays at step 3, not `getFactorCurrentValue`.** The diagnosis's fix
  point (a) as literally written would break the probe: `resolveFlipValues` consumes
  `current_value` as its **normalised** baseline and probes bounds `0`/`1`
  (`src/analysis/flip-thresholds.ts:462-465`).
- **Only the `explicit_cap` tier earns `'display'`.** `explicitCapRange` CALLS `deriveRange`
  and accepts only its priority-0 verdict, so the cap guards are inherited, not mirrored
  (trap 12). Every other tier is refused — critically the `default` [0,1] fallback a capless
  node lands on, where denormalising is the identity and a `'display'` stamp would assert
  user-scale about a number that never moved.
- **`raw_value` is reconciled before use** — accepted only when it agrees with `value × cap`
  within the **tighter of** (a) the precision `value` is written at
  (`0.5 × 10^-decimals × width`) and (b) an absolute ceiling of **2% of range**. A stale
  `raw_value` would put `current_value` and `flip_value` on different footings — the "two
  numbers, one factor" hazard itself. See A1 below for why (a) alone was not enough.
- **Denormalised values are cleaned to the model's own resolution** (A2 below), so the
  number shipped and the string describing it agree by construction.
- **`'normalised'` only where ATTESTED.** Stamping it on every unlifted row would be an
  unattested claim *and a regression*: a direct `/v2/run` caller may legitimately post
  user-scale values with no cap, and CEE's absent-scale branch correctly licenses those via
  `|v| > MODEL_SCALE_SUSPECT_ABS`. So it is written only where the node itself proves
  normalisation (`raw_value` and/or `cap` present) yet no usable cap range exists.
- **Display strings lossless or absent** — no `toLocaleString` (rounds to 3 fraction digits,
  so `1234.56789 → "1,234.568"` would fail the exact equality P7 performs), no
  abbreviation, exponential text refused outright.

## The 2% ceiling, quantified — it is a JUDGEMENT, not a measurement

This sentence previously lived only in the source docstring; it belongs here. The ceiling is
a **safety bound chosen by this lane**, not a figure derived from data. What it admits, by
the producer's decimal precision, on a `cap: 320000` factor:

| decimals in `value` | implied precision | effective tolerance | on a £320,000 range |
|---|---|---|---|
| 0dp (`0`, `1`) | 50% of range | **2% (ceiling binds)** | up to **£6,400** |
| 1dp (`0.9`) | 5% of range | **2% (ceiling binds)** | up to **£6,400** |
| x.5 (`0.5`) | 50% of range | **2% (ceiling binds)** | up to **£6,400** |
| 2dp (`0.86`) | **0.5%** (precision binds) | 0.5% | up to £1,600 |
| 3dp | 0.05% | 0.05% | up to £160 |
| 4dp | 0.005% | 0.005% | up to £16 |

So a coarsely-written `value` still admits a `raw_value` up to **£6,400** away from the
model's own baseline before refusal. That is deliberate — it is far tighter than the 50% the
unbounded formula allowed — but it is a **judgement about acceptable divergence, and it has
not been calibrated against live data.** Named here so it can be re-tuned rather than
rediscovered. The error direction is fail-closed either way: refusal falls back to
`value × range`, which is consistent with `flip_value` by construction.

## Explicitly NOT done

`needsNormalisation` untouched (widening it re-scales the whole request; it is correct for
its own job) · flip-probe candidate selection untouched (F3, founder doctrine, unruled) ·
`evpi_percentage_points` / VOI untouched (F4/F5).

## ⚠ The gap I almost shipped

The unit suite passes the graph to the denormaliser directly — **all 20 of its cases stay
green if the route never passes `filteredGraph`**, i.e. if the fix is completely inert in
production. `tests/v2-run.flip-display-scale.contract.test.ts` exists solely to close that:
a real `/v2/run` POST shaped like CEE's V5 payload. Mutant M7 (delete the argument) turns it
RED and nothing else.

Its first version was itself **vacuous** and its own anti-vacuity guard caught it: without a
reachable ISL the route returns `analysis_status: 'failed'` and `flip_thresholds: []`, so
every display assertion passed over an empty array. Fixed by mocking ISL at module level.
**Side finding for the reviewer:** the pre-existing
`tests/v2-run.margin-sensitivity.contract.test.ts` is largely vacuous offline for the same
reason — it guards its per-entry assertions behind `if (ft && ft.length > 0)`. Not fixed
here; flagged because it is the same defect class.

## Review amendments (round 2)

### A1 — the tolerance ran off a cliff, and it was NOT fail-closed

The implied-precision term widens as the producer writes **fewer** decimals: 2dp = 0.5% of
range, 1dp = 5%, **0dp = 50%** — so the guard was loosest at exactly the values most likely
to be written exactly (`0`, `1`, `x.5`), and my only test exercised the well-behaved 2dp
case. Reproduced against the real module **before** fixing:

| node | shipped | model's own baseline |
|---|---|---|
| `value: 0`, `raw_value: 100000`, `cap: 320000` | **100000** as `display` | `0` |
| `value: 1`, `raw_value: 200000`, `cap: 320000` | **200000** as `display` | `320000` |
| `value: 0.9`, `raw_value: 280000`, `cap: 320000` | **280000** as `display` | `288000` |

That emits a user-scale number while `flip_value` was computed from a different baseline —
the exact hazard the function's docstring claims to prevent.

**Fix:** tolerance is now `min(impliedPrecision, 2% of range)`. Refusal is free — the row
falls back to `value × range`, which is consistent with `flip_value` by construction, so the
error direction is always fail-closed. All four divergent cases above now refuse; the
genuine live case (`0.86` / `275000`) still accepts, **pinned by a control** so that
"refuse everything" cannot pass the A1 tests. Pins at 0dp, 1dp and `value ∈ {0, 1, 0.5}`.

### A2 — a float tail kept the cage SHUT, and my P7 assertions were self-referential

`flip_value` is `roundTo4`'d then multiplied by the cap, so the product carries IEEE dust —
reachable **today** on the cap-present/`raw_value`-absent path: `value: 0.29`, `cap: 100` →
`current_value: 28.999999999999996`, `current_display: "28.999999999999996 %"`. CEE's
agreement rung is an exact equality, so an LLM writing the obvious `"29"` is **denied**, and
once F1 echoes the producer string the user sees the tail.

**Fix:** denormalised values are cleaned to the precision the model can actually resolve.
The flip search works on a **1e-4 normalised grid** (`roundTo4`), so the finest meaningful
step in user units is `width × 1e-4`; anything below it is an artefact of the
multiplication, never a measurement. Rounding there is unit-appropriate by construction —
a 320000 range cleans to whole units, a `[0,1]` ratio keeps 4 decimals. **Rounding a
display-scale value to the model's own resolution is more honest than shipping sixteen
digits of float noise, not less.** An accepted `raw_value` is passed through untouched (the
user's exact number, no tail to remove). `margin_sensitivity.strongest_probe_value` is
cleaned by the same function.

Measured over the **full 4dp normalised grid × 7 caps (69,993 cases)**: **0 dust**, against
8–12% before.

### R1 — cleaning could fabricate a ZERO, turning a fail-CLOSED row fail-OPEN

`flip.current_value` is the node's own normalised number (`getFactorCurrentValue`), which is
**not** on the flip search's `roundTo4` grid — so a legitimately tiny value could round to
nothing. Reproduced before the fix:

| node | exact product | shipped |
|---|---|---|
| `value: 1e-5`, `cap: 16000` | `0.16` | **`current_value: 0`**, `current_display: "0 £"`, `value_scale: "display"` |
| `value: 2e-5`, `cap: 1000` | `0.02` | **`current_value: 0`**, `"0 £"`, `"display"` |

**Before 2.228 that row shipped `0.00001` unlabelled and CEE's cage CLOSED. With a confident
zero the cage OPENS** — fail-OPEN where it was fail-CLOSED — and the same token releases the
chip above, so *"Test {factor} at 0"* could have been written to the canvas.

**Fix:** `cleanDenormalised` returns `undefined` rather than a number when it cannot be
faithful — specifically when a **non-zero** measurement would clean to exactly `0`. The
caller then drops the whole row back to its honest normalised form: exactly what shipped
before 2.228, exactly what the cage refuses, exactly what keeps the chip suppressed. A
**genuinely** zero value is still display-scale, pinned by a control so "refuse every zero"
cannot pass. `margin_sensitivity.strongest_probe_value` takes the same refusal, surfaced
through its existing `display_value_available: false`. After:

```
value=1e-5 cap=16000 -> current_value=1e-5  display=undefined  scale="normalised"
value=0    cap=16000 -> current_value=0     display="0 £"      scale="display"
```

### R2 — the stated guarantee was the wrong KIND, and is now absolute

The committed sweep asserted a **1e-6 relative** bound over 693 cases (2dp only). That does
not generalise: over the full 4dp grid × 11 caps (**109,989 cases**) **16,000 exceed it**,
worst **25%** (`cap 16000`, `value 1e-4`: exact `1.6` → `2`). Those values are *correct* —
within half a rounding unit — the relative bound was simply never the invariant.

**The invariant that holds is ABSOLUTE:** a cleaned value differs from the exact product by
at most `0.5 × 10^-decimals`, hence at most **half the model's own 1e-4 grid step**.
Independently re-measured over 109,989 cases: worst error **0.6667 × half a grid step** —
matching the reviewer's figure exactly. The sweep now asserts *that*, over the **full** grid,
and a second sweep pins that every sub-resolution value is refused rather than zeroed.

### ⚠ WITHDRAWN: my "unreachable" justification was FALSE — corrected in source

An earlier revision of this PR (and of the source docstring) said the general faithfulness
branch was removed because it was **unreachable**, citing *"0 firings in 3,199,928 cases …
worst ratio exactly 1.000000"*. **That claim does not survive and is withdrawn.**

`toFixed` is correctly rounded in **decimal**, but `Number()` then re-parses that text to the
nearest **double**, up to half a ULP away. So the round trip *can* exceed `0.5 × 10^-decimals`:

```
(0.75).toFixed(1) === "0.8"      Number("0.8") − 0.75 = 0.050000000000000044  >  0.05
```

Re-measured on **exact rounding ties**: **2,048 of 43,999 exceed the bare bound.** My original
probe walked `(i/200000) × width`, which lands on an exact tie essentially never — **it could
not have observed the phenomenon it was cited as ruling out.** Unverified absence, written
into source where the next session would have trusted it. The reviewer is right, and the
inference — not the arithmetic — was the error: a non-biting mutant meant *my suite contained
no tie case*, not that the branch could not fire.

**The correct reason the branch is gone is stronger than "it cannot fire":**

1. **When it fires, it is WRONG.** Every one of those 2,048 cases is a *correct* cleaning —
   `0.75 → 0.8` is the right answer — so the branch would refuse **good** rows.
2. **With the slack it was inert.** ⚠ One precision on the review's wording: the version I
   actually wrote carried an epsilon term (`|value| × EPSILON × 8`) that absorbs the re-parse
   error ~16× over. Re-added *as written*, it fires on **0** of those same 43,999 ties, and the
   three named rows (`0.75`, `1.05`, `8.25`) ship correctly as `0.8`, `1.1`, `8.3` — I verified
   this through the real module. The "refuses three legitimate rows" result holds against a
   **slack-free** re-add. Both formulations are damning, for different reasons.

**A branch that is WRONG without a fudge factor and INERT with one — where the fudge was never
derived from anything — is not a guard.** Removed; the invariant is asserted where it can
actually fail (the sweep). Only the zero-collapse refusal is reachable and correct; it is kept
and mutant-checked (M10, M11, M13, M14 all bite).

### ⚠ Guarantee wording corrected (clamp caveat)

The docstring said the bound is *"at most `0.5 × 10^-decimals`, and since `10^-decimals ≤
width × 1e-4`, at most half the model's grid step"*. **The grid-step corollary fails when the
`MAX_CLEAN_DECIMALS = 12` clamp binds** — width < 1e-8, legal per `isFiniteRange` — giving a
ratio of 10 at width 1e-9 and 100 at 1e-10. Both sweeps use caps ≥ 1 and cannot see it.
Behaviourally out of reach, but not proven absent, so the guarantee is now stated as
`0.5 × 10^-decimals` with the grid-step corollary explicitly conditioned on the clamp not
binding. (The *test* was already honest — it carries epsilon slack; only the prose overstated.)

**And the self-referential assertions are gone.** `agrees(row.current_display,
row.current_value)` compares PLoT's own string to PLoT's own value; since the string is
built from `String(value)` and `Number(String(x)) === x` for every finite non-exponential
double, it could only ever fail via the exponential guard — it would pass even if both were
the *same wrong number*. Replaced with literal expectations (`current_display === '29 %'`)
plus agreement against **independently-written** strings (`'29 %'`, `'275,000 GBP'`) — what
CEE's LLM would actually emit, which is what P7 evaluates and what the tail broke.

## RED-first

Round 1: both new files written and run **before** any source edit at `11a03b4d` —
`Tests 13 failed | 7 passed (20)`.
Round 2: the A1 and A2 pins written and run **before** either fix —
**`Tests 7 failed | 23 passed (30)`**, failing exactly the three A1 pins and the four A2
pins. After both fixes, across both files: **`Tests 34 passed (34)`**.

## Mutants — 13/13 bite at the final head, controls green both sides

Throwaway worktree **outside the clone root** (trap 9c), `--detach` at the fix commit so
`git checkout --` restores the mutated-from state; removed before every gate run. The
harness now **VOIDs any run whose test total ≠ 34** — the guard that would have caught round
1's zsh failure immediately. Every run below reported `total 34 ✓`.

| # | Mutation | RED |
|---|---|---|
| M1 | `explicitCapRange` accepts ANY `deriveRange` tier | 3 fail-closed pins |
| M2 | `reconcileRawValue` always accepts `raw_value` | 5 (the original pin + all four A1 pins) |
| M3 | stamp `value_scale: 'display'` unconditionally | the Phase 4a non-cap pin |
| M4 | `formatUserScale` drops the exponential guard | the lossless-string pin |
| M5 | drop the `raw_value` preference | 7, incl. the route test **and the A1 control** (NOT the R1 zero-control — `capNode` carries no `raw_value`, so M5 is a no-op there; M14 is that control's guard) |
| M6 | drop the attested-`normalised` stamp | the attested pin |
| M7 | **drop `filteredGraph` at the run.ts call site** | **2 route-level (the wiring)** |
| **M8** | **[A1] remove the absolute tolerance ceiling** | **the 3 cliff pins (0dp ×2, 1dp)** |
| **M9** | **[A2] `cleanDenormalised` returns the raw product** | **8, incl. both sweeps and the independent-string P7 check** |
| **M10** | **[R1] remove the fabricated-zero refusal** | **4, incl. the below-grid sweep** |
| **M11** | **[R1] remove the caller's fail-closed branch** | **3 R1 pins** |
| **M13** | **[R1] `margin_sensitivity` probe refusal removed** | **the sub-resolution probe pin** |
| **M14** | **[R1] refuse EVERY zero, not just fabricated ones** | **`R1 CONTROL: a GENUINELY zero value is still display-scale`** |

*(M12 — the general faithfulness net — is absent because the code is absent. Note it was
NOT removed for the reason first given: see the withdrawn-unreachability section above.
M13 was found non-biting and FIXED by adding the two `margin_sensitivity` tests, not reported
as a pass. **M14 was missing from the register entirely** — the R1 zero-control was
non-vacuous but nothing in the set demonstrated it, because M5 cannot: `capNode` carries no
`raw_value`, so dropping the raw-value preference is a no-op on that test. M14 supplied by
the reviewer, verified here, and it REDs exactly that one control.)*

M1, M3, M4, M8 and M9 each manufacture a **false claim about a number** — a still-normalised
value stamped `'display'`, a divergent `raw_value` shipped as user-scale, or a string that
does not describe its value — which is exactly the output this change must never produce.
M5 REDs the A1 control, which is what proves that control is not vacuous.

⚠ **Round 1's first two mutation runs were VOID and are recorded, not quietly redone.** Under
zsh, `npx vitest run $FILES` does not word-split, so both test paths were passed as one
argument and vitest matched **no test files at all** — all seven mutants would have "passed"
while proving nothing. Only the control caught it; the count-check above now catches it
automatically. Detail in the evidence file §6.1.

## Hash / idempotency derivation

- **`response_hash` — UNMOVED.** `canonicalise.ts:399-423` hashes the canonicalised
  **request**. It is the hash the UI actually compares (`applyV5State.ts:1062`,
  `useConversation.ts:3191`, `useCoachingReview.ts`).
- **`response_content_hash` (`_meta`, `rch_v2`) — MOVES, zero external consumers.** It
  hashes the response body, which is its declared purpose. Full-tree `rg -a -uu` at pinned
  SHAs: **0 hits** for `response_content_hash` / `responseContentHash` / `rch_v2` in CEE
  `b8a38de7`, UI `bf86f672`, olumi-schemas `f5815a34` (that repo has **no** `staging`
  branch; `main` searched). Disclosed rather than silent.
- **PLoT's review cache key** = `SHA256(version + response_hash + brief_hash)` —
  request-derived, unchanged; in-process `Map` + TTL, cleared by deploy.
- **Contract:** `AnalysisEnrichmentSchema` flip rows are `additionalProperties: true` at the
  pinned `@talchain/schemas@0.30.0`, so the new keys are legal with **no schemas change** —
  no version-skew risk added.
