### PR TITLE
fix(2.239): carry the goal target to ISL so probability_of_goal is computed

### DIFF
--- a/src/integrations/isl/translator-v3.ts
+++ b/src/integrations/isl/translator-v3.ts
@@ -125,8 +125,21 @@ export interface ISLRobustnessRequestV3 {
   /**
    * Multiple success constraints for joint evaluation.
    * When provided, ISL evaluates joint satisfaction across all constraints.
-   * Takes precedence over goal_threshold if both are provided.
    * Uses ISL's canonical "value" field (same as PLoT's GoalConstraint.value).
+   *
+   * ⚠ This used to say "Takes precedence over goal_threshold if both are
+   * provided". FALSE, corrected under ROADMAP 2.239 by reading ISL at
+   * `35149dd1`: `probability_of_goal` (robustness_analyzer_v2.py:3073-3077)
+   * and `constraint_analysis` (:3079-3083) are computed in the same option
+   * loop from independent gates, neither suppressing the other, and
+   * `RobustnessRequestV2` declares no mutual-exclusion validator
+   * (models/robustness_v2.py:856, :895). ISL is built for the pair —
+   * `_align_goal_constraint_samples` (:3005-3035) exists so a goal-node
+   * constraint and `probability_of_goal` answer from IDENTICAL samples.
+   *
+   * The false comment mattered: it made "send both" look pointless, and
+   * sending both is exactly what makes the goal probability computable when
+   * the only constraint is the auto-synthesised goal target.
    */
   goal_constraints?: ISLGoalConstraint[];
 

--- a/src/normalisation/constraint-filter.ts
+++ b/src/normalisation/constraint-filter.ts
@@ -6,7 +6,16 @@
  * Temporal constraints (e.g., "achieve goal within 6 months") cannot be evaluated
  * because time is not a modelled dimension — the graph is a point-in-time snapshot.
  *
- * Pipeline order: constraint compilation → auto-fallback → TEMPORAL FILTER → validation → ISL
+ * Pipeline order: constraint compilation → TEMPORAL FILTER → auto-fallback → validation → ISL
+ *
+ * ⚠ The filter runs BEFORE the auto-fallback (changed under ROADMAP 2.239). The
+ * fallback asks "did any constraint survive to the ISL boundary?", so it must
+ * see the POST-filter set: a deadline constraint that this filter is about to
+ * delete used to suppress the fallback that would have replaced it, and the
+ * request reached ISL with no constraints AND no goal threshold. The fallback
+ * re-enters this function with its own synthesised constraint (it can never be
+ * dropped — no deadline_metadata, no unit) so the out-of-domain safety gate
+ * still applies to it.
  *
  * Drop rules (any match → remove):
  *   1. deadline_metadata is present (reliable CEE temporal signal)

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -6050,6 +6050,57 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           effectiveGoalThreshold = sentAutoConstraint?.value ?? autoThreshold;
         }
 
+        // === 2.239-G: refuse a DEGENERATE threshold rather than ask for a
+        // === fabricated certainty ==========================================
+        // ISL computes `probability_of_goal = P(goal_samples >= threshold)` on
+        // the NORMALISED [0,1] goal scale. A threshold sitting on either bound
+        // of that scale answers nothing about the decision:
+        //
+        //   <= 0  → P(goal >= 0) is satisfied by essentially every sample, so
+        //           every option returns ~1.0. That is a confident "100% chance
+        //           of hitting your target" which is really a statement about
+        //           the normalisation FLOOR. Measured on this branch before the
+        //           guard: an input of 0 or -0.2 shipped exactly this.
+        //   >= 1  → P(goal >= max-of-scale): the ceiling-pinned target. CEE's
+        //           own doctrine (`goal-threshold-cap.ts`) names `cap === target`
+        //           forbidden precisely because it "would force
+        //           goal_threshold = 1.0 and kill probability spread"; measured
+        //           live at 0.021 / 0.0 on a decision whose leader wins 95% of
+        //           scenarios.
+        //
+        // Both are degenerate BY CONSTRUCTION — meaningless whenever produced,
+        // not merely when some upstream bug produces them. So this guard does
+        // not depend on any reachability argument, and does not expire when the
+        // CEE cap defect is fixed.
+        //
+        // The honest output is a GAP, not a number: omit the field, and let the
+        // (re-gated) `goal_threshold_no_probability` alarm fire — `goalTargetStated`
+        // is still true, because the user did state a target. An honest "not
+        // available" plus a loud log beats a fabricated certainty; "0%"/"100%"
+        // read as findings, "not available" reads as the gap it is.
+        //
+        // Scope: this guards the field THIS change introduced. The synthesised
+        // `auto_goal_threshold` constraint is still sent, exactly as it was at
+        // base — its degenerate `prob_satisfied` is pre-existing behaviour with
+        // zero UI readers, and narrowing the guard keeps the diff off untested
+        // ground. Rowed, not silently ignored.
+        if (
+          effectiveGoalThreshold !== undefined &&
+          (effectiveGoalThreshold <= 0 || effectiveGoalThreshold >= 1)
+        ) {
+          req.log.warn({
+            event: 'goal_threshold_degenerate_refused',
+            goal_threshold: effectiveGoalThreshold,
+            bound: effectiveGoalThreshold <= 0 ? 'floor' : 'ceiling',
+            goal_target: goalThreshold ?? nodeGoalThreshold ?? nodeGoalThresholdRaw ?? null,
+            reason:
+              effectiveGoalThreshold <= 0
+                ? 'P(goal >= scale floor) is ~1.0 for every option — a fabricated certainty, not a finding'
+                : 'P(goal >= scale ceiling) is degenerate — the target is pinned to the top of its own normalisation range',
+          });
+          effectiveGoalThreshold = undefined;
+        }
+
         // Build ISL request (using normalised options and constraints)
         // CIL Phase 1: ALWAYS forward seed to ISL for deterministic Monte Carlo runs.
         // Derived seeds must be forwarded to ensure end-to-end determinism: if only computed

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -4984,93 +4984,44 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         }
 
         // =================================================================
-        // Phase 1c+: Auto-constraint fallback from goal_threshold
+        // ROADMAP 2.239: goal-target inputs, resolved ONCE, before the filter
         // =================================================================
-        // When no constraints were extracted (neither explicit goal_constraints
-        // nor graph constraint nodes), but a goal_threshold exists, synthesise
-        // a single constraint so ISL produces constraint_analysis output.
-        // This is a deterministic computation — no LLM call (F.6: PLoT = compute).
-        let autoSynthesisFired = false;
-        if (constraintCompilation.constraints.length === 0) {
-          // Resolve threshold: prefer request-level goal_threshold (already parsed),
-          // fall back to goal_threshold on the raw upstream goal node (CEE may set
-          // it on the node even if the request root field is absent).
-          const nodeGoalThreshold = (() => {
-            const rawGoalNode = (body.graph?.nodes as any[])?.find(
-              (n: any) => n.id === body.goal_node_id
-            );
-            const v = rawGoalNode?.goal_threshold;
-            return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
-          })();
-          const autoThreshold = goalThreshold ?? nodeGoalThreshold;
-
-          if (autoThreshold !== undefined && Number.isFinite(autoThreshold)) {
-            // Synthesise a single >= constraint from goal_threshold.
-            // The _internal namespace carries PLoT metadata through the pipeline
-            // (filter, validation, merge) and is stripped at wire boundaries
-            // (ISL translator). For UI consumers, the canonical provenance signal
-            // is _meta.constraint_sources.
-            const autoConstraint: GoalConstraint & { _internal: InternalMetadata } = {
-              constraint_id: 'auto_goal_threshold',
-              node_id: body.goal_node_id,
-              operator: '>=',
-              value: autoThreshold,
-              label: 'Goal target',
-              _internal: { source: 'auto_from_goal_threshold' },
-            };
-            constraintCompilation.constraints.push(autoConstraint as GoalConstraint);
-            autoSynthesisFired = true;
-            repairs.push({
-              field: 'goal_constraints',
-              action: 'derived',
-              from_value: `goal_threshold=${autoThreshold}`,
-              to_value: 'auto_goal_threshold',
-              reason: 'No goal_constraints provided; auto-generated single constraint from goal_threshold',
-            });
-            req.log.info({
-              event: 'plot.auto_constraint_from_threshold',
-              goal_node_id: body.goal_node_id,
-              threshold: autoThreshold,
-              threshold_source: goalThreshold !== undefined ? 'request' : 'goal_node',
-              action: 'synthesised',
-            });
-          } else {
-            req.log.info({
-              event: 'plot.auto_constraint_from_threshold',
-              goal_node_id: body.goal_node_id,
-              action: 'skipped',
-              reason: 'no_goal_threshold',
-            });
-          }
-        } else {
-          req.log.info({
-            event: 'plot.auto_constraint_from_threshold',
-            goal_node_id: body.goal_node_id,
-            action: 'skipped',
-            reason: 'constraints_present',
-            constraint_count: constraintCompilation.constraints.length,
-          });
-        }
-
-        const clientConstraintCount = body.goal_constraints?.length ?? 0;
-        const compiledSource = autoSynthesisFired
-          ? 'auto_synthesis'
-          : clientConstraintCount > 0
-            ? 'client'
-            : constraintCompilation.constraints.length > 0
-              ? 'graph_node'
-              : 'none';
-        req.log.info(
-          {
-            event: 'constraint-trace.compiled',
-            source: compiledSource,
-            compiled_count: constraintCompilation.constraints.length,
-            client_supplied_count: clientConstraintCount,
-            constraint_ids: constraintCompilation.constraints.map((c) => c.constraint_id),
-            auto_synthesis_fired: autoSynthesisFired,
-          },
-          'Constraint trace: compilation complete',
+        // A goal target can arrive three ways: the request root field, or the
+        // raw upstream goal node's normalised `goal_threshold` / raw
+        // `goal_threshold_raw` (CEE stamps both on the node; the canonical
+        // EngineNodeV3 drops them, which is why they are read off `body.graph`).
+        // Resolved here because two later consumers need them:
+        //   - the auto-synthesis fallback (Phase 1c+, now AFTER the filter)
+        //   - the goal_threshold_no_probability alarm (Phase 3)
+        // Unlike `effectiveGoalThreshold`, these are INPUT facts: nothing
+        // downstream clears them.
+        const rawGoalNode = (body.graph?.nodes as any[])?.find(
+          (n: any) => n.id === body.goal_node_id
         );
+        const asFiniteNumber = (v: unknown): number | undefined =>
+          typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+        const nodeGoalThreshold = asFiniteNumber(rawGoalNode?.goal_threshold);
+        const nodeGoalThresholdRaw = asFiniteNumber(rawGoalNode?.goal_threshold_raw);
+        /**
+         * "The user stated a success target somewhere in this request."
+         *
+         * This is the alarm's gate (Phase 3). The alarm used to be gated on
+         * `effectiveGoalThreshold`, which precedence routing clears — so in
+         * every case the alarm exists to catch, it was silent BY CONSTRUCTION.
+         * That is why the goal-probability gap survived to a live walk under
+         * green CI. Gate on the input, which nothing downstream can clear.
+         */
+        const goalTargetStated =
+          goalThreshold !== undefined ||
+          nodeGoalThreshold !== undefined ||
+          nodeGoalThresholdRaw !== undefined;
+
+        // Auto-synthesis state — populated by Phase 1c+ below (AFTER the
+        // temporal filter). Declared here so the precedence routing and the
+        // ISL request build can read it.
+        let autoSynthesisFired = false;
+        let autoThreshold: number | undefined;
+        const clientConstraintCount = body.goal_constraints?.length ?? 0;
 
         // =================================================================
         // P0-C1: capture producer-declared constraint scales BEFORE they
@@ -5136,6 +5087,118 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         }
 
         // =================================================================
+        // Phase 1c+: Auto-constraint fallback from goal_threshold
+        // =================================================================
+        // When no constraints SURVIVE to the ISL boundary (neither explicit
+        // goal_constraints nor graph constraint nodes), but a goal_threshold
+        // exists, synthesise a single constraint so ISL produces
+        // constraint_analysis output.
+        // This is a deterministic computation — no LLM call (F.6: PLoT = compute).
+        //
+        // ⚠ ROADMAP 2.239 — THIS BLOCK USED TO RUN *BEFORE* THE TEMPORAL FILTER,
+        // and that ordering was the defect. It asked "are there any constraints?"
+        // before the filter had removed the ones ISL cannot evaluate, so a
+        // deadline-bearing constraint that was about to be DELETED still
+        // suppressed the fallback that would have replaced it. Measured live
+        // (2026-08-01 walk, S1): a user who stated "£6M ARR within 12 months"
+        // reached ISL with ZERO constraints AND no threshold — strictly worse
+        // than a user who stated the target with no deadline. The two suites
+        // either side of the hole (tests/auto-constraint-fallback.test.ts,
+        // tests/golden/temporal-filter-e2e.test.ts) never crossed it, which is
+        // how it reached production under green CI.
+        //
+        // Reading the POST-filter set fires in a strict superset of the previous
+        // cases (post-filter-empty ⊇ pre-filter-empty): the only new case is
+        // "non-empty before the filter, empty after" — exactly the defect.
+        if (constraintCompilation.constraints.length === 0) {
+          // Resolve threshold: prefer request-level goal_threshold (already parsed),
+          // fall back to goal_threshold on the raw upstream goal node (CEE may set
+          // it on the node even if the request root field is absent).
+          autoThreshold = goalThreshold ?? nodeGoalThreshold;
+
+          if (autoThreshold !== undefined && Number.isFinite(autoThreshold)) {
+            // Synthesise a single >= constraint from goal_threshold.
+            // The _internal namespace carries PLoT metadata through the pipeline
+            // (filter, validation, merge) and is stripped at wire boundaries
+            // (ISL translator). For UI consumers, the canonical provenance signal
+            // is _meta.constraint_sources.
+            const autoConstraint: GoalConstraint & { _internal: InternalMetadata } = {
+              constraint_id: 'auto_goal_threshold',
+              node_id: body.goal_node_id,
+              operator: '>=',
+              value: autoThreshold,
+              label: 'Goal target',
+              _internal: { source: 'auto_from_goal_threshold' },
+            };
+            // Run the synthesised constraint through the SAME temporal filter the
+            // compiled set went through, so moving this block does not silently
+            // drop the filter's out-of-domain safety gate for it (a synthesised
+            // threshold outside [0,1] must still raise plot.constraint_out_of_domain
+            // and reach `warnings`, exactly as it did when the block ran first).
+            // It can never be DROPPED here: it carries no deadline_metadata and no
+            // unit, so neither drop rule can match.
+            const autoFilterResult = filterTemporalConstraints(
+              [autoConstraint as RawGoalConstraint],
+              filteredGraph.nodes,
+              req.log,
+              goalThresholdMetaByNodeId
+            );
+            constraintCompilation.constraints.push(...autoFilterResult.passed);
+            temporalFilterResult.warnings.push(...autoFilterResult.warnings);
+            autoSynthesisFired = true;
+            repairs.push({
+              field: 'goal_constraints',
+              action: 'derived',
+              from_value: `goal_threshold=${autoThreshold}`,
+              to_value: 'auto_goal_threshold',
+              reason: 'No goal_constraints provided; auto-generated single constraint from goal_threshold',
+            });
+            req.log.info({
+              event: 'plot.auto_constraint_from_threshold',
+              goal_node_id: body.goal_node_id,
+              threshold: autoThreshold,
+              threshold_source: goalThreshold !== undefined ? 'request' : 'goal_node',
+              action: 'synthesised',
+            });
+          } else {
+            autoThreshold = undefined;
+            req.log.info({
+              event: 'plot.auto_constraint_from_threshold',
+              goal_node_id: body.goal_node_id,
+              action: 'skipped',
+              reason: 'no_goal_threshold',
+            });
+          }
+        } else {
+          req.log.info({
+            event: 'plot.auto_constraint_from_threshold',
+            goal_node_id: body.goal_node_id,
+            action: 'skipped',
+            reason: 'constraints_present',
+            constraint_count: constraintCompilation.constraints.length,
+          });
+        }
+
+        const compiledSource = autoSynthesisFired
+          ? 'auto_synthesis'
+          : clientConstraintCount > 0
+            ? 'client'
+            : constraintCompilation.constraints.length > 0
+              ? 'graph_node'
+              : 'none';
+        req.log.info(
+          {
+            event: 'constraint-trace.compiled',
+            source: compiledSource,
+            compiled_count: constraintCompilation.constraints.length,
+            client_supplied_count: clientConstraintCount,
+            constraint_ids: constraintCompilation.constraints.map((c) => c.constraint_id),
+            auto_synthesis_fired: autoSynthesisFired,
+          },
+          'Constraint trace: compilation complete',
+        );
+
+        // =================================================================
         // Phase 1d: Constraint Validation
         // =================================================================
         // Validate compiled + explicit constraints against the filtered graph
@@ -5165,12 +5228,48 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         let activeGoalConstraints: GoalConstraint[] | undefined;
         let effectiveGoalThreshold: number | undefined = goalThreshold;
 
+        /**
+         * ROADMAP 2.239 (hole B). The auto-synthesised constraint is DERIVED FROM
+         * the goal target — it is not a competing user constraint, so it must not
+         * trigger the precedence branch that discards the target.
+         *
+         * Before this fix the fallback destroyed the very threshold it recovered:
+         * one synthesised constraint tripped `constraints.length > 0`, which set
+         * `effectiveGoalThreshold = undefined`, which made the translator omit
+         * `goal_threshold` (translator-v3.ts:534-536), which made ISL skip
+         * `probability_of_goal` (it is gated SOLELY on `request.goal_threshold is
+         * not None` — robustness_analyzer_v2.py:3073-3077 @35149dd1). Net effect,
+         * measured at the outbound request on pristine `2f6e997`: NO request
+         * routed through auto-synthesis has ever produced a goal probability,
+         * deadline or no deadline — including one carrying an explicit
+         * root-level `goal_threshold`.
+         *
+         * Sending both is legal and independently computed by ISL:
+         * `probability_of_goal` (:3073-3077) and `constraint_analysis`
+         * (:3079-3083) sit in the same option loop, neither suppressing the
+         * other, and `RobustnessRequestV2` declares no mutual-exclusion
+         * validator (models/robustness_v2.py:856, :895, :931-938, :994-1002).
+         * ISL is in fact built for the pair: `_align_goal_constraint_samples`
+         * (:3005-3035) exists so a constraint on the goal node and
+         * `probability_of_goal` are computed from IDENTICAL samples.
+         *
+         * `_internal.source` is the unspoofable witness — client-supplied
+         * `_internal` is deleted at ingress (see Phase 1c above), so a
+         * user-supplied constraint that happens to reuse the id
+         * `auto_goal_threshold` (pinned by T9) cannot reach this branch.
+         */
+        const autoSynthesisOnly =
+          autoSynthesisFired &&
+          constraintCompilation.constraints.length === 1 &&
+          (constraintCompilation.constraints[0] as { _internal?: InternalMetadata })
+            ?._internal?.source === 'auto_from_goal_threshold';
+
         if (constraintCompilation.constraints.length > 0) {
           // Multi-constraint path activated
           activeGoalConstraints = constraintCompilation.constraints;
 
           // Check for conflict with goal_threshold
-          if (goalThreshold !== undefined) {
+          if (goalThreshold !== undefined && !autoSynthesisOnly) {
             const goalNodeConstraint = activeGoalConstraints.find(
               c => c.node_id === body.goal_node_id
             );
@@ -5203,13 +5302,20 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             }
           }
 
-          // Clear goal_threshold when using multi-constraint path
+          // Clear goal_threshold when using multi-constraint path.
+          // 2.239: this stays UNCONDITIONAL on purpose. When the only constraint
+          // IS the goal target the threshold is re-established exactly once,
+          // just before the ISL request is built, from the POST-normalisation
+          // constraint value (see "2.239 threshold carry" below). Re-establishing
+          // it here too would create a second, always-overwritten authority — a
+          // hunk that could be reverted without a single test noticing.
           effectiveGoalThreshold = undefined;
 
           req.log.info({
             event: 'multi_constraint_path_activated',
             constraint_count: activeGoalConstraints.length,
             constraint_ids: activeGoalConstraints.map(c => c.constraint_id),
+            goal_threshold_carried: autoSynthesisOnly,
           });
         }
 
@@ -5928,6 +6034,22 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           }
         }
 
+        // === 2.239 threshold carry: derive, never mirror ===============
+        // When the only active constraint is the auto-synthesised goal target,
+        // `goal_threshold` and that constraint's value describe the SAME number
+        // and must be identical on the wire. Phase 4b can re-scale the
+        // constraint value (intervention-scale unification), so take the
+        // threshold FROM the constraint that is actually being sent rather than
+        // from the pre-normalisation copy — otherwise ISL would answer
+        // "P(goal >= T)" and "P(constraint goal >= X)" with two different
+        // numbers in one response.
+        if (autoSynthesisOnly) {
+          const sentAutoConstraint = constraintsForISL?.find(
+            (c) => c.constraint_id === 'auto_goal_threshold'
+          );
+          effectiveGoalThreshold = sentAutoConstraint?.value ?? autoThreshold;
+        }
+
         // Build ISL request (using normalised options and constraints)
         // CIL Phase 1: ALWAYS forward seed to ISL for deterministic Monte Carlo runs.
         // Derived seeds must be forwarded to ensure end-to-end determinism: if only computed
@@ -6163,10 +6285,25 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               });
             }
 
-            // Warn if goal_threshold is active but ISL didn't return probability_of_goal.
-            // Gate on effectiveGoalThreshold (not original goalThreshold) because
-            // multi-constraint precedence routing intentionally clears the threshold.
-            if (effectiveGoalThreshold !== undefined) {
+            // Warn when the user STATED a success target but ISL returned no
+            // probability_of_goal for some option.
+            //
+            // ⚠ ROADMAP 2.239: this used to be gated on `effectiveGoalThreshold`,
+            // with a comment defending that choice ("multi-constraint precedence
+            // routing intentionally clears the threshold"). That gating made the
+            // alarm SILENT BY CONSTRUCTION in every case it exists to catch —
+            // precedence routing clears `effectiveGoalThreshold` precisely when
+            // the threshold fails to reach ISL, so the one scenario that should
+            // ring is the one scenario that could not. Guarantee theatre: it is
+            // why the 2026-08-01 walk's goal-probability gap reached a live user
+            // under green CI with the alarm already in the code.
+            //
+            // Gate on the INPUT instead — a target stated anywhere in the request
+            // (root field, node `goal_threshold`, or node `goal_threshold_raw`).
+            // Nothing downstream can clear that, so the alarm now fires whenever
+            // a target was stated and no probability came back, whatever the
+            // routing did in between.
+            if (goalTargetStated) {
               const optionData = islResult?.options ?? islResult?.results;
               const optionsWithoutProbGoal = optionData?.filter(
                 (opt: any) => opt.probability_of_goal === undefined || opt.probability_of_goal === null
@@ -6174,7 +6311,17 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               if (optionsWithoutProbGoal && optionsWithoutProbGoal.length > 0) {
                 req.log.warn({
                   event: 'goal_threshold_no_probability',
-                  goal_threshold: effectiveGoalThreshold,
+                  // The threshold actually sent to ISL — null when routing dropped
+                  // it, which is itself the most common cause of this alarm.
+                  goal_threshold: effectiveGoalThreshold ?? null,
+                  // The target the USER stated, which is what makes this a defect.
+                  goal_target: goalThreshold ?? nodeGoalThreshold ?? nodeGoalThresholdRaw ?? null,
+                  goal_target_source:
+                    goalThreshold !== undefined
+                      ? 'request'
+                      : nodeGoalThreshold !== undefined
+                        ? 'goal_node'
+                        : 'goal_node_raw',
                   options_missing_probability: optionsWithoutProbGoal.length,
                 });
               }

--- a/tests/auto-constraint-fallback.test.ts
+++ b/tests/auto-constraint-fallback.test.ts
@@ -990,10 +990,25 @@ describe('T7: Log assertions for auto-constraint events', () => {
     vi.restoreAllMocks();
   });
 
-  it('T10: no goal_threshold_no_probability warning when multi-constraint path clears effectiveGoalThreshold', async () => {
-    // When explicit goal_constraints are present AND goal_threshold is set,
-    // precedence routing clears effectiveGoalThreshold. The warning check
-    // should NOT fire because the threshold path was intentionally disabled.
+  it('T10: goal_threshold_no_probability WARNS when precedence routing clears a stated target (2.239)', async () => {
+    // ⚠ THIS TEST WAS INVERTED BY ROADMAP 2.239, DELIBERATELY. It used to assert
+    // the opposite — "no warning when multi-constraint path clears
+    // effectiveGoalThreshold" — on the reasoning that "the threshold path was
+    // intentionally disabled". That reasoning codified the defect: the alarm was
+    // gated on `effectiveGoalThreshold`, precedence routing clears
+    // `effectiveGoalThreshold` in exactly the cases where the target fails to
+    // reach ISL, and so the alarm was silent by construction in the one scenario
+    // it exists to catch. This test was the lock on that door — it would have
+    // failed anyone who tried to fix it.
+    //
+    // The user DID state a target (goal_threshold: 0.7). PLoT routed it away and
+    // ISL returned no probability_of_goal. That is a defect, and a warn-level log
+    // is the right place to say so. Routing away a stated target is precisely
+    // what the operator needs told.
+    //
+    // The structural half of the original assertion is KEPT: precedence routing
+    // still activates and still clears the threshold for a genuine user
+    // constraint. Only the silence is gone.
     const logCalls: any[] = [];
     const warnCalls: any[] = [];
     const originalChildLogger = app.log.child.bind(app.log);
@@ -1029,18 +1044,24 @@ describe('T7: Log assertions for auto-constraint events', () => {
 
     expect(res.statusCode).toBe(200);
 
-    // Verify multi-constraint path activated (threshold was cleared)
+    // Unchanged: a genuine user constraint still activates the multi-constraint
+    // path and still clears the threshold. The 2.239 carry-through applies ONLY
+    // to the auto-synthesised constraint, which is derived from the target.
     const multiLog = logCalls.find(
       (c: any) => c?.event === 'multi_constraint_path_activated'
     );
     expect(multiLog).toBeDefined();
+    expect(multiLog.goal_threshold_carried).toBe(false);
 
-    // Critical: goal_threshold_no_probability warning must NOT appear
-    // because effectiveGoalThreshold was cleared by precedence routing
+    // Inverted (2.239): the warning MUST appear. A target was stated, nothing
+    // was sent to ISL, and no probability came back.
     const thresholdWarning = warnCalls.find(
       (c: any) => c?.event === 'goal_threshold_no_probability'
     );
-    expect(thresholdWarning).toBeUndefined();
+    expect(thresholdWarning).toBeDefined();
+    expect(thresholdWarning.goal_threshold).toBeNull();  // nothing reached ISL
+    expect(thresholdWarning.goal_target).toBe(0.7);      // but the user asked for 0.7
+    expect(thresholdWarning.goal_target_source).toBe('request');
 
     vi.restoreAllMocks();
   });

--- a/tests/goal-threshold-ordering.test.ts
+++ b/tests/goal-threshold-ordering.test.ts
@@ -1,0 +1,472 @@
+/**
+ * ROADMAP 2.239 — the goal target must survive to the ISL request.
+ *
+ * This file exists in the gap the 2026-08-01 live walk fell through. Two
+ * well-tested, individually correct blocks sat either side of it and never
+ * crossed:
+ *
+ *   tests/auto-constraint-fallback.test.ts   — 0 occurrences of deadline_metadata
+ *   tests/golden/temporal-filter-e2e.test.ts — 0 occurrences of goal_threshold
+ *
+ * So the fallback was tested with no deadline, the filter was tested with no
+ * threshold, and the defect lived in their untested intersection.
+ *
+ * The two holes pinned here:
+ *
+ *  A. ORDERING. The auto-synthesis fallback used to be gated on the PRE-filter
+ *     constraint set (run.ts:4994) while the temporal filter that deletes
+ *     unevaluable constraints ran later (run.ts:5102). A deadline constraint
+ *     that was about to be DELETED still suppressed the fallback — so a user
+ *     who stated "£6M ARR within 12 months" got a strictly worse analysis than
+ *     one who stated the target alone.
+ *
+ *  B. THE FALLBACK DESTROYED THE THRESHOLD IT RECOVERED. Auto-synthesis emits a
+ *     CONSTRAINT; one constraint tripped precedence routing, which cleared
+ *     `effectiveGoalThreshold`, so the translator omitted `goal_threshold` and
+ *     ISL — whose `probability_of_goal` is gated SOLELY on
+ *     `request.goal_threshold is not None` — computed nothing. Measured on
+ *     pristine 2f6e997: NO auto-synthesis request has ever carried a
+ *     `goal_threshold`, deadline or not.
+ *
+ * Every assertion below is on the OUTBOUND ISL REQUEST BODY, which is the only
+ * place either hole is visible. A 200 proves a response, not a computation.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// ISL mock — captures the outbound request body.
+//
+// NOTE the mock deliberately returns options with NO `probability_of_goal`.
+// That is what makes it a usable control for the alarm assertions: real ISL
+// would return one whenever goal_threshold is sent, so "target stated + no
+// probability back" is exactly the state the alarm exists to name.
+// ---------------------------------------------------------------------------
+
+let capturedISLRequestBody: any = null;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      options: options.map((opt: any, idx: number) => ({
+        option_id: opt.id,
+        outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+        rank: idx + 1,
+      })),
+      edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [], value_of_information: [],
+      factors_provenance: 'unavailable' as const,
+      factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.8,
+      fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    capturedISLRequestBody = body;
+    const options = body.options || [];
+    return {
+      data: {
+        options: options.map((opt: any, idx: number) => ({
+          option_id: opt.id,
+          outcome: { mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9, n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0 },
+          rank: idx + 1,
+        })),
+        edges: [], factors: [], value_of_information: [],
+        overall_robustness: 'robust', robustness_score: 0.8,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+const { createServer } = await import('../src/createServer.js');
+
+// ---------------------------------------------------------------------------
+// Fixtures — the 2026-08-01 walk's S1 shape, reduced.
+// ---------------------------------------------------------------------------
+
+const OPTIONS = [
+  { id: 'opt1', label: 'Ship fast', interventions: { 'lever': 0.9 } },
+  { id: 'opt2', label: 'Ship slow', interventions: { 'lever': 0.2 } },
+];
+
+/** Graph whose goal node carries whatever CEE stamped on it. */
+function graphWithGoal(goalOverrides: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      { id: 'goal_arr', kind: 'goal', label: 'Reach 6M ARR Within 12 Months', ...goalOverrides },
+      { id: 'lever', kind: 'factor', label: 'Sales headcount', observed_state: { value: 0.5 } },
+      { id: 'other', kind: 'factor', label: 'Market', observed_state: { value: 0.3 } },
+    ],
+    edges: [
+      { from: 'lever', to: 'goal_arr', strength: { mean: 0.6, std: 0.1 } },
+      { from: 'other', to: 'goal_arr', strength: { mean: 0.3, std: 0.1 } },
+    ],
+  };
+}
+
+/** CEE's goal node for a target that was stated with a deadline (the walk's S1). */
+const GOAL_NODE_WITH_TARGET = {
+  goal_threshold: 0.65,
+  goal_threshold_raw: 6000000,
+  goal_threshold_unit: '£',
+  goal_threshold_cap: 9000000,
+  provenance: 'ai_inferred',
+};
+
+/** The exact constraint CEE attached on the walk — verbatim shape from the wire. */
+const DEADLINE_CONSTRAINT = {
+  constraint_id: 'constraint_goal_arr_max',
+  node_id: 'goal_arr',
+  operator: '<=' as const,
+  value: 12,
+  label: 'Delivery deadline',
+  unit: 'months',
+  source_quote: 'within 12 months',
+  confidence: 0.95,
+  provenance: 'inferred',
+  deadline_metadata: {
+    deadline_date: '2027-08-01',
+    reference_date: '2026-08-01',
+    assumed_reference_date: true,
+  },
+};
+
+describe('ROADMAP 2.239 — goal target reaches the ISL request', () => {
+  let app: FastifyInstance;
+  const logCalls: any[] = [];
+  const warnCalls: any[] = [];
+
+  beforeAll(async () => {
+    // Set BEFORE createServer(): the rate limiter reads env at plugin
+    // registration, and a missed flag here leaks 429s into sibling files.
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    capturedISLRequestBody = null;
+  });
+
+  /** POST /v2/run, capturing the outbound ISL body and the structured logs. */
+  async function run(payload: Record<string, unknown>) {
+    capturedISLRequestBody = null;
+    logCalls.length = 0;
+    warnCalls.length = 0;
+
+    const originalChildLogger = app.log.child.bind(app.log);
+    const spy = vi.spyOn(app.log, 'child').mockImplementation((...args: any[]) => {
+      const child = originalChildLogger(...args);
+      const originalInfo = child.info.bind(child);
+      const originalWarn = child.warn.bind(child);
+      child.info = (...infoArgs: any[]) => { logCalls.push(infoArgs[0]); return originalInfo(...infoArgs); };
+      child.warn = (...warnArgs: any[]) => { warnCalls.push(warnArgs[0]); return originalWarn(...warnArgs); };
+      return child;
+    });
+
+    try {
+      const res = await app.inject({ method: 'POST', url: '/v2/run', payload });
+      return { status: res.statusCode, isl: capturedISLRequestBody, body: res.json() as any };
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  const warned = () => warnCalls.find((c: any) => c?.event === 'goal_threshold_no_probability');
+
+  // =========================================================================
+  // THE CRITICAL PIN — the assertion no existing test makes.
+  // =========================================================================
+
+  it('HOLE A+B: a deadline-bearing constraint PLUS a goal-node threshold still sends goal_threshold to ISL', async () => {
+    const { status, isl, body } = await run({
+      graph: graphWithGoal(GOAL_NODE_WITH_TARGET),
+      options: OPTIONS,
+      goal_node_id: 'goal_arr',
+      seed: '42',
+      goal_constraints: [DEADLINE_CONSTRAINT],
+    });
+
+    expect(status).toBe(200);
+    expect(isl).not.toBeNull();
+
+    // THE pin. Pre-fix this is `undefined`: the deadline suppressed the
+    // fallback (hole A), was then deleted, and nothing replaced it.
+    expect(isl.goal_threshold).toBe(0.65);
+
+    // The fallback fired despite a constraint having been present on arrival.
+    const sent = (isl.goal_constraints ?? []) as any[];
+    const auto = sent.find((c) => c.constraint_id === 'auto_goal_threshold');
+    expect(auto).toBeDefined();
+    expect(auto.operator).toBe('>=');
+
+    // The threshold and the constraint describe the same number — derived from
+    // the constraint actually being sent, not from a parallel copy, so
+    // downstream re-scaling cannot make them disagree.
+    expect(isl.goal_threshold).toBe(auto.value);
+
+    // The deadline itself is STILL filtered — this fix must not smuggle an
+    // unevaluable temporal constraint into ISL.
+    expect(sent.find((c) => c.constraint_id === 'constraint_goal_arr_max')).toBeUndefined();
+    expect(body._meta?.filtered_constraints).toEqual([
+      { constraint_id: 'constraint_goal_arr_max', node_id: 'goal_arr', reason: 'temporal_deadline' },
+    ]);
+
+    // And the log says the fallback ran, not that it was skipped.
+    const autoLog = logCalls.find((c: any) => c?.event === 'plot.auto_constraint_from_threshold');
+    expect(autoLog?.action).toBe('synthesised');
+    expect(autoLog?.threshold_source).toBe('goal_node');
+  });
+
+  // =========================================================================
+  // The shapes the diagnosis believed were already healthy. They were not.
+  // =========================================================================
+
+  it('HOLE B: target stated on the goal node, no deadline → goal_threshold still reaches ISL', async () => {
+    const { status, isl } = await run({
+      graph: graphWithGoal(GOAL_NODE_WITH_TARGET),
+      options: OPTIONS,
+      goal_node_id: 'goal_arr',
+      seed: '42',
+    });
+
+    expect(status).toBe(200);
+    expect(isl.goal_threshold).toBe(0.65);
+    const auto = ((isl.goal_constraints ?? []) as any[]).find((c) => c.constraint_id === 'auto_goal_threshold');
+    expect(auto).toBeDefined();
+    expect(isl.goal_threshold).toBe(auto.value);
+  });
+
+  it('HOLE B: an EXPLICIT root-level goal_threshold is no longer discarded by the fallback derived from it', async () => {
+    const { status, isl, body } = await run({
+      graph: graphWithGoal(),
+      options: OPTIONS,
+      goal_node_id: 'goal_arr',
+      seed: '42',
+      goal_threshold: 0.7,
+    });
+
+    expect(status).toBe(200);
+    expect(isl.goal_threshold).toBe(0.7);
+    const auto = ((isl.goal_constraints ?? []) as any[]).find((c) => c.constraint_id === 'auto_goal_threshold');
+    expect(auto.value).toBe(0.7);
+    expect(isl.goal_threshold).toBe(auto.value);
+
+    // No "goal_threshold ignored" repair: nothing overrode it. Pre-fix the
+    // response carried exactly that repair while silently dropping the field.
+    const repairs = (body._meta?.repairs_applied ?? []) as Array<Record<string, unknown>>;
+    const ignored = repairs.find(
+      (r) => r.field === 'goal_threshold' && r.to_value === 'ignored'
+    );
+    expect(ignored).toBeUndefined();
+  });
+
+  it('DERIVE-NOT-MIRROR: when Phase 4b re-scales the synthesised constraint, goal_threshold follows it', async () => {
+    // The threshold and the constraint are the SAME number stated twice. Phase 4b
+    // re-normalises constraint values onto the intervention scale, so a threshold
+    // carried from the pre-normalisation copy would put two different numbers on
+    // one wire: ISL would be asked P(goal >= 20000) and P(constraint goal >= 0.4)
+    // in the same response. Here the raw £20k target normalises to 0.4 against the
+    // node's declared 50k cap — the assertion is that BOTH land on 0.4.
+    const { status, isl } = await run({
+      graph: {
+        nodes: [
+          { id: 'goal_arr', kind: 'goal', label: 'ARR', goal_threshold_cap: 50000 },
+          {
+            id: 'lever', kind: 'factor', label: 'MRR',
+            observed_state: { value: 15000 },
+            state_space: { range: { min: 0, max: 50000 } },
+          },
+          { id: 'other', kind: 'factor', label: 'Market', observed_state: { value: 0.3 } },
+        ],
+        edges: [
+          { from: 'lever', to: 'goal_arr', strength: { mean: 0.6, std: 0.1 } },
+          { from: 'other', to: 'goal_arr', strength: { mean: 0.3, std: 0.1 } },
+        ],
+      },
+      options: [
+        { id: 'opt1', label: 'A', interventions: { lever: { value: 25000, source: 'user_specified' } } },
+        { id: 'opt2', label: 'B', interventions: { lever: { value: 10000, source: 'user_specified' } } },
+      ],
+      goal_node_id: 'goal_arr',
+      seed: '42',
+      goal_threshold: 20000,
+    });
+
+    expect(status).toBe(200);
+    const auto = ((isl.goal_constraints ?? []) as any[]).find((c) => c.constraint_id === 'auto_goal_threshold');
+    expect(auto.value).toBe(0.4);          // re-scaled by Phase 4b
+    expect(isl.goal_threshold).toBe(0.4);  // and the threshold followed it, not 20000
+  });
+
+  // =========================================================================
+  // NARROWNESS GUARD — a genuine user constraint must still take precedence.
+  // Without this, the hole-B fix could be widened into "always send both",
+  // which would silently override a user's explicit multi-constraint intent.
+  // =========================================================================
+
+  it('a real user constraint still clears goal_threshold (precedence routing unchanged)', async () => {
+    const { status, isl, body } = await run({
+      graph: graphWithGoal(),
+      options: OPTIONS,
+      goal_node_id: 'goal_arr',
+      seed: '42',
+      goal_threshold: 0.7,
+      goal_constraints: [
+        { constraint_id: 'lever_floor', node_id: 'lever', operator: '>=', value: 0.6 },
+      ],
+    });
+
+    expect(status).toBe(200);
+    expect(isl.goal_threshold).toBeUndefined();
+    const sent = (isl.goal_constraints ?? []) as any[];
+    expect(sent.map((c) => c.constraint_id)).toEqual(['lever_floor']);
+
+    const repairs = (body._meta?.repairs_applied ?? []) as Array<Record<string, unknown>>;
+    expect(
+      repairs.find((r) => r.field === 'goal_threshold' && r.to_value === 'ignored')
+    ).toBeDefined();
+
+    const multiLog = logCalls.find((c: any) => c?.event === 'multi_constraint_path_activated');
+    expect(multiLog?.goal_threshold_carried).toBe(false);
+  });
+
+  it('the synthesised constraint still goes through the temporal filter safety gate', async () => {
+    // Moving the fallback to AFTER the filter must not exempt the constraint it
+    // synthesises. A threshold outside [0,1] on a probability-domain node is a
+    // data issue the filter is supposed to flag (it warns, it does not drop).
+    // Before the move that gate applied for free; it now applies because the
+    // fallback re-enters filterTemporalConstraints with its own constraint.
+    const { status, body } = await run({
+      graph: graphWithGoal(),
+      options: OPTIONS,
+      goal_node_id: 'goal_arr',
+      seed: '42',
+      goal_threshold: 1.5,   // out of [0,1], no declared cap to scale it into range
+    });
+
+    expect(status).toBe(200);
+    const outOfDomain = ((body.critiques ?? []) as Array<Record<string, unknown>>)
+      .filter((c) => c.code === 'CONSTRAINT_OUT_OF_DOMAIN');
+    expect(outOfDomain).toHaveLength(1);
+    expect(outOfDomain[0].affected_node_ids).toEqual(['goal_arr']);
+
+    const w = warnCalls.find((c: any) => c?.event === 'plot.constraint_out_of_domain');
+    expect(w?.constraint_id).toBe('auto_goal_threshold');
+  });
+
+  it('no target stated anywhere → no synthesis, no goal_threshold, no constraints', async () => {
+    const { status, isl } = await run({
+      graph: graphWithGoal(),
+      options: OPTIONS,
+      goal_node_id: 'goal_arr',
+      seed: '42',
+    });
+
+    expect(status).toBe(200);
+    expect(isl.goal_threshold).toBeUndefined();
+    expect(isl.goal_constraints).toBeUndefined();
+  });
+
+  // =========================================================================
+  // THE ALARM — it was gated on the variable that is cleared in every failing
+  // case, so it was silent by construction. These are its first real controls.
+  // =========================================================================
+
+  describe('goal_threshold_no_probability alarm', () => {
+    it('FIRES when a target was stated on the goal node and no probability came back', async () => {
+      await run({
+        graph: graphWithGoal(GOAL_NODE_WITH_TARGET),
+        options: OPTIONS,
+        goal_node_id: 'goal_arr',
+        seed: '42',
+        goal_constraints: [DEADLINE_CONSTRAINT],
+      });
+
+      const w = warned();
+      expect(w).toBeDefined();
+      expect(w.options_missing_probability).toBe(2);
+      expect(w.goal_target).toBe(0.65);
+      expect(w.goal_target_source).toBe('goal_node');
+    });
+
+    it('FIRES when precedence routing cleared the threshold — the case it was blind to', async () => {
+      // The old gate (`effectiveGoalThreshold !== undefined`) made this exact
+      // scenario impossible to observe: a stated target, routed away, no
+      // probability back, and total silence. This assertion is the inversion of
+      // the old T10 in tests/auto-constraint-fallback.test.ts.
+      await run({
+        graph: graphWithGoal(),
+        options: OPTIONS,
+        goal_node_id: 'goal_arr',
+        seed: '42',
+        goal_threshold: 0.7,
+        goal_constraints: [
+          { constraint_id: 'lever_floor', node_id: 'lever', operator: '>=', value: 0.6 },
+        ],
+      });
+
+      const w = warned();
+      expect(w).toBeDefined();
+      expect(w.goal_threshold).toBeNull();   // nothing was sent to ISL
+      expect(w.goal_target).toBe(0.7);       // but the user did state a target
+      expect(w.goal_target_source).toBe('request');
+    });
+
+    it('FIRES on a raw-only target (goal_threshold_raw with no normalised twin)', async () => {
+      await run({
+        graph: graphWithGoal({ goal_threshold_raw: 6000000, goal_threshold_unit: '£' }),
+        options: OPTIONS,
+        goal_node_id: 'goal_arr',
+        seed: '42',
+      });
+
+      const w = warned();
+      expect(w).toBeDefined();
+      expect(w.goal_target_source).toBe('goal_node_raw');
+      expect(w.goal_target).toBe(6000000);
+    });
+
+    it('does NOT fire when no target was stated (the alarm can be silent)', async () => {
+      // Trap 13 in the other direction: an alarm that fires on everything is as
+      // useless as one that never fires. This proves it discriminates.
+      await run({
+        graph: graphWithGoal(),
+        options: OPTIONS,
+        goal_node_id: 'goal_arr',
+        seed: '42',
+      });
+
+      expect(warned()).toBeUndefined();
+    });
+  });
+});

--- a/tests/goal-threshold-ordering.test.ts
+++ b/tests/goal-threshold-ordering.test.ts
@@ -398,6 +398,103 @@ describe('ROADMAP 2.239 — goal target reaches the ISL request', () => {
   });
 
   // =========================================================================
+  // 2.239-G — a degenerate threshold is REFUSED, not asked for.
+  //
+  // Carrying the threshold to ISL (hole B) created a new way to be wrong: a
+  // threshold on either bound of the normalised [0,1] goal scale produces a
+  // confident number that is about the SCALE, not about the decision. At base
+  // these shapes sent nothing; without this guard they would ship
+  // "100% chance of hitting your target" (floor) or a degenerate ~0% (ceiling).
+  //
+  // These are degenerate BY CONSTRUCTION, so the guard is justified without any
+  // reachability argument — but note the floor case IS structurally reachable:
+  // `goal_threshold` is the field CEE stamps on the goal node, and a target
+  // normalising to exactly 0 lands here.
+  // =========================================================================
+
+  describe('degenerate threshold refusal', () => {
+    const refused = () => warnCalls.find((c: any) => c?.event === 'goal_threshold_degenerate_refused');
+
+    it('FLOOR: a goal-node threshold of 0 is refused — no fabricated "100%"', async () => {
+      const { status, isl } = await run({
+        graph: graphWithGoal({ goal_threshold: 0, goal_threshold_raw: 0 }),
+        options: OPTIONS,
+        goal_node_id: 'goal_arr',
+        seed: '42',
+      });
+
+      expect(status).toBe(200);
+      // The whole point: P(goal >= 0) = 1.0 is never asked for.
+      expect(isl.goal_threshold).toBeUndefined();
+
+      const r = refused();
+      expect(r).toBeDefined();
+      expect(r.bound).toBe('floor');
+      expect(r.goal_threshold).toBe(0);
+
+      // And the failure is LOUD, not silent — the re-gated alarm still fires,
+      // because the user did state a target.
+      expect(warned()).toBeDefined();
+
+      // SCOPE PIN: the synthesised constraint is still sent, exactly as at base.
+      // This guard narrows to the field this change introduced; it does not
+      // quietly start altering the pre-existing constraint payload.
+      const sent = (isl.goal_constraints ?? []) as any[];
+      expect(sent.map((c) => c.constraint_id)).toEqual(['auto_goal_threshold']);
+    });
+
+    it('CEILING: a goal-node threshold of 1 is refused — no ceiling-pinned ~0%', async () => {
+      // This is the shape CEE's cap defect mints (cap === raw ⇒ threshold 1.0).
+      // Guarding it here means the worst case is an honest gap plus a loud log,
+      // rather than "0% chance" on a decision whose leader wins 95% of runs —
+      // so this PR no longer depends on the CEE fix to be safe.
+      const { status, isl } = await run({
+        graph: graphWithGoal({ goal_threshold: 1, goal_threshold_raw: 6000000, goal_threshold_cap: 6000000 }),
+        options: OPTIONS,
+        goal_node_id: 'goal_arr',
+        seed: '42',
+      });
+
+      expect(status).toBe(200);
+      expect(isl.goal_threshold).toBeUndefined();
+
+      const r = refused();
+      expect(r).toBeDefined();
+      expect(r.bound).toBe('ceiling');
+      expect(r.goal_threshold).toBe(1);
+      expect(warned()).toBeDefined();
+    });
+
+    it('CONTROL (lower): 0.01 is small but MEANINGFUL — still sent, not refused', async () => {
+      // Without this, the guard could pass by refusing everything. It must
+      // discriminate "on the bound" from "near the bound".
+      const { status, isl } = await run({
+        graph: graphWithGoal({ goal_threshold: 0.01 }),
+        options: OPTIONS,
+        goal_node_id: 'goal_arr',
+        seed: '42',
+      });
+
+      expect(status).toBe(200);
+      expect(isl.goal_threshold).toBe(0.01);
+      expect(refused()).toBeUndefined();
+    });
+
+    it('CONTROL (upper): 0.99 is demanding but MEANINGFUL — still sent, not refused', async () => {
+      const { status, isl } = await run({
+        graph: graphWithGoal({ goal_threshold: 0.99 }),
+        options: OPTIONS,
+        goal_node_id: 'goal_arr',
+        seed: '42',
+      });
+
+      expect(status).toBe(200);
+      expect(isl.goal_threshold).toBe(0.99);
+      expect(refused()).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
   // THE ALARM — it was gated on the variable that is cleared in every failing
   // case, so it was silent by construction. These are its first real controls.
   // =========================================================================


### PR DESCRIPTION
## What a tester will see that they could not before

**On the live path** (UI → CEE → PLoT → ISL): set a success target on a decision — with or without a
deadline — run the analysis, and the **per-option goal probability is now computed and returned**.
Before this change it was never computed on any CEE-originated run, because PLoT never asked for it.
Question A ("will this option hit my target?") had no data on the live path, on any input shape CEE
can produce.

**⚠ That scoping is deliberate and was corrected in review — the repo-level claim is FALSE.** At
base, one shape *did* already work: a **root-level** `goal_threshold` plus a constraint set entirely
deleted by the temporal filter. Synthesis never fires (the pre-filter set was non-empty), so
precedence routing never activates, and the root threshold survives. Measured, both tips:

```
root goal_threshold: 0.8 + one deadline-bearing constraint
  base 2f6e997 → goal_threshold = 0.8 , goal_constraints = ABSENT   ← already computed a probability
  head bd837e5 → goal_threshold = 0.8 , goal_constraints = [auto_goal_threshold >= 0.8]
```

That shape is **unreachable from CEE** — `run-analysis.ts`'s `plotPayload` never sets
`goal_threshold` (diagnosis §1 step 1; independently re-verified at CEE's bytes in review) — so the
live claim stands. But "no data on any run, on any input shape" was an overclaim, and it is exactly
the shape that becomes next month's stale trap note. Withdrawn.

### Three caveats. None is a blocker; all three must be read before this reaches a user.

**(a) The number can still be degenerate — from CEE.** CEE can mint
`goal_threshold_cap === goal_threshold_raw`, forcing `goal_threshold: 1.0` and "0% chance" on a
decision whose leader wins 95% of scenarios. That is the CEE half of 2.239
(`resolveGoalThresholdCap`'s `>=` vs `>`). **This PR makes the plumbing honest; it does not make the
number honest.**

**(b) NO LIVE STAGING PROBE WAS RUN.** Everything here is measured against an in-process ISL mock at
the outbound-request boundary, plus ISL's source read at `35149dd1`. The claim *the request now
carries `goal_threshold`* is **measured**. The claim *live staging now returns a populated
`probability_of_goal`* is **inferred** from ISL's gate — it requires deploying this branch and must
be measured after merge. The section above states live behaviour; it is an inference, not an
observation.

**(c) PLoT could mint a degenerate number itself — found in review, and GUARDED IN THIS PR.**
Carrying the threshold created a new way to be wrong. Measured at both tips, before the guard:

| input | base `2f6e997` | head, pre-guard | what ISL would compute |
|---|---|---|---|
| `goal_threshold: 1.5` | absent | `1.0` (clamped by Phase 4b) | `P(goal ≥ 1.0)` — degenerate ~0% |
| `goal_threshold: -0.2` | absent | `0` (clamped) | `P(goal ≥ 0)` = **1.0 — a fabricated "100%"** |
| `goal_threshold: 0` | absent | `0` (no error raised) | `P(goal ≥ 0)` = **1.0 — a fabricated "100%"** |

**It was worse than review recorded**, which is why it is now guarded rather than rowed. Review
scoped this to the ROOT field and called it CEE-unreachable. That holds for `1.5` / `-0.2`. It does
**not** hold for `0`: the same fabricated 100% is produced from a **node-level**
`goal_threshold: 0` — the field CEE actually stamps. Measured:
`graph.nodes[goal].goal_threshold = 0` → pre-guard head sent `goal_threshold: 0`; base sent nothing.
`prob01` (`run.ts:2583`) cannot catch it — `1.0` is inside `[0,1]`, so the fabricated value passes
the response guard cleanly.

**See "The degenerate-threshold guard" below.** The guard refuses both bounds and the failure is now
loud instead of certain. **I still did not sweep CEE for whether a target can normalise to exactly
zero** — the guard makes that sweep unnecessary, it does not answer it. Recorded so nobody later
reads "guarded" as "proven unreachable".

---

## The trace, re-derived at THIS tip

Base `2f6e997757ae5aba59d28c060f6f8d8bf88ac30e` (the diagnosis pinned `11a03b4d`, so every line was
re-derived). ISL read at `35149dd148e0192ee1c44ec05336818371e30f81` (diagnosis pinned `7c681fda`).
`gh api .../branches/staging/protection` → **404 Branch not protected**: the PR checks are the only
gate.

### Hole A — the ordering hole (the diagnosis's finding, confirmed)

| # | step | file:line | what happens |
|---|---|---|---|
| 1 | fallback gate | `run.ts:4994` | `constraints.length === 0` — reads the **pre-filter** set |
| 2 | temporal filter | `run.ts:5102` → `constraint-filter.ts:96-110` | DROP RULE 1: `deadline_metadata !== undefined` → deleted |
| 3 | consequence | — | a constraint **about to be deleted** suppresses the fallback that would replace it |

A user who states a deadline alongside a target gets a strictly worse analysis than one who states
the target alone.

### Hole B — the fallback destroys the threshold it recovers (NOT in the diagnosis)

The diagnosis states (§8 row 1) *"Alone, this fixes S1 end-to-end via the node-level `goal_threshold`
fallback"*. **False**, established by measuring the outbound ISL request before writing any fix.

| # | step | file:line | what happens |
|---|---|---|---|
| 1 | fallback emits a **constraint**, not a threshold | `run.ts:5013-5021` | `auto_goal_threshold >= T` |
| 2 | one constraint trips precedence routing | `run.ts:5168` | `constraints.length > 0` |
| 3 | routing discards the target | `run.ts:5207` | `effectiveGoalThreshold = undefined` |
| 4 | translator omits the field | `translator-v3.ts:534-536` | `if (goalThreshold !== undefined)` |
| 5 | ISL cannot compute what was not asked for | `robustness_analyzer_v2.py:3073-3077` @`35149dd1` | `if request.goal_threshold is not None:` — that field, full stop |

Baseline on pristine `2f6e997`, outbound ISL request body captured via the
`temporal-filter-e2e.test.ts` mock harness:

```
P1  root goal_threshold: 0.7, no constraints
    → goal_threshold = undefined ; goal_constraints = [auto_goal_threshold >= 0.7]
P2  node-level goal_threshold: 0.65, no root field, no constraints
    → goal_threshold = undefined ; goal_constraints = [auto_goal_threshold >= 0.65]
P3  S1 shape: node goal_threshold 0.65 + one deadline-bearing goal_constraint
    → goal_threshold = undefined ; goal_constraints = undefined
    → _meta.filtered_constraints = [{constraint_id:"constraint_goal_arr_max", reason:"temporal_deadline"}]
```

P3 reproduces the live failure. **P1/P2 are the finding**: even the shape the diagnosis called
healthy sends no `goal_threshold`. An explicit root-level `goal_threshold` is discarded by the
fallback derived from it, and the response documents the discard (`run.ts:5196-5202`).

Fixing hole A alone would have shipped the constraint and still no threshold — and the UI discards
per-option `constraint_analysis` on both mapper paths, so the screen would not have changed.

### Is sending BOTH legal? — verified at ISL's bytes

`translator-v3.ts:128` claimed `goal_constraints` *"takes precedence over goal_threshold"*.
**Wrong.** At ISL `35149dd1`:

- `robustness_analyzer_v2.py:3073-3077` — `probability_of_goal`, gated only on `goal_threshold`
- `:3079-3083` — `constraint_analysis`, gated only on `goal_constraints`
- both assigned onto the same `OptionResult` in the same option loop (`:3114-3128`); neither
  suppresses the other
- `models/robustness_v2.py`: independent optional fields (`:856`, `:895`); only validators are
  finiteness (`:931-938`) and node existence (`:994-1002`). **No mutual-exclusion validator.**
- ISL is *built* for the pair: `_align_goal_constraint_samples` (`:3005-3035`, called at `:1776`)
  exists so a goal-node constraint and `probability_of_goal` answer from **identical samples**.

Review independently confirmed additivity by **whole-response diff**, not by reading: no sample /
seed / RNG change, no `win_probability`, robustness, EVPI or ranking change, no double-counting.

---

## ⚠ A SECOND WIRE CHANGE, disclosed

Raised in review; I had not disclosed it. On the **hole-A shapes only** — where the pre-filter
constraint set was non-empty and the filter emptied it — base sent **neither** goal field and head
sends **both**. Adding `goal_constraints` where there was none flips ISL's
`p_win_sensitivity[].metric_type`:

```python
# robustness_analyzer_v2.py:6104-6106 @35149dd1
"metric_type": "p_joint_goal" if request.goal_constraints else "p_win_recommended",
```

…and correspondingly changes `current_metric`, `perfect_metric` and `p_win_delta`, since the
sensitivity is now measured against a different baseline metric.

**Scope, precisely:** target-only shapes (P1/P2) are **unaffected** — base already sent the auto
constraint, so `metric_type` was already `p_joint_goal`. Only the deadline/hole-A shapes flip.

**Not a blocker:** the UI transports `p_win_sensitivity` as opaque `unknown[]` with **zero readers**,
and `metric_type` appears in four fixtures and no source file repo-wide. But it is a real wire
change on a field a future reader might adopt, and it belongs in the record.

---

## The change

1. **Hole A** — the fallback moved to **after** the temporal filter, so it reads the set that
   survives to the ISL boundary. Fires in a strict superset of the previous cases
   (post-filter-empty ⊇ pre-filter-empty). The synthesised constraint **re-enters
   `filterTemporalConstraints`** so the out-of-domain safety gate still applies (it can never be
   dropped there — no `deadline_metadata`, no unit).
2. **Hole B** — when the only active constraint carries `_internal.source ===
   'auto_from_goal_threshold'`, precedence routing does not discard the target. The carried value is
   **derived from the post-normalisation constraint value** (`constraintsForISL`), never a parallel
   copy, so ISL cannot be asked `P(goal ≥ T)` and `P(constraint goal ≥ X)` in one response.
   `_internal` is deleted at ingress, so a user constraint reusing the id `auto_goal_threshold`
   (pinned by T9) cannot reach this branch.
3. **The alarm** — `goal_threshold_no_probability` re-gated from `effectiveGoalThreshold` (cleared in
   every failing case → silent by construction) to any goal target present in the **input**.
   Log-only.

Plus `constraint-filter.ts`'s pipeline-order doc comment, and commit `bd837e5` correcting
`translator-v3.ts:128`'s proven-false precedence claim (comment-only).

### The degenerate-threshold guard (2.239-G) — added after review

`probability_of_goal` is `P(goal_samples >= threshold)` on the **normalised [0,1]** goal scale. A
threshold sitting on either bound of that scale answers nothing about the decision:

- **`<= 0`** → satisfied by essentially every sample, so every option returns ~1.0. A confident
  **"100% chance of hitting your target"** that is really a statement about the normalisation floor.
- **`>= 1`** → `P(goal >= max-of-scale)`: the ceiling-pinned target. CEE's own doctrine
  (`goal-threshold-cap.ts`) names `cap === target` forbidden because it *"would force
  goal_threshold = 1.0 and kill probability spread"*; measured live at 0.021 / 0.0 on a decision
  whose leader wins 95% of scenarios.

**Both bounds are guarded, and the reasoning is symmetric**: at the floor the answer is always yes,
at the ceiling always no; neither is about the decision, both are artefacts of where the target sits
on its own normalisation range. They are degenerate **by construction** — meaningless *whenever*
produced, not merely when some upstream bug produces them. **So the guard does not rest on a
reachability argument, and does not expire when the CEE cap defect is fixed.**

The refusal omits `goal_threshold` and emits `goal_threshold_degenerate_refused` (with the value and
which `bound`); `goalTargetStated` is still true, so the re-gated
`goal_threshold_no_probability` alarm fires too. **An honest gap plus a loud log beats a fabricated
certainty** — "0%" and "100%" read as findings, "not available" reads as the gap it is.

**A consequence worth stating: this removes caveat (a)'s dependency.** `goal_threshold: 1.0` is
exactly what CEE's `cap === raw` defect mints, and it is now refused here. The worst case if the CEE
fix has not landed is an honest "not available" plus an alarm — **not** "0% chance" on a strong
decision. This PR is now safe to ship independently of the CEE half.

**Scope, deliberately narrow.** The guard covers the `goal_threshold` field *this change
introduced*. The synthesised `auto_goal_threshold` constraint is still sent, byte-identical to base
— its `prob_satisfied` is equally degenerate at the bounds, but that is **pre-existing behaviour
with zero UI readers** (per-option `constraint_analysis` is discarded on both mapper paths), and
widening the guard would push the diff onto untested ground. Rowed below, not silently ignored.

**Layering note:** `goal_threshold: 0` remains a *valid request value* — accepted at ingress and
included in the response hash, as `v2-goal-threshold.test.ts` and `v2-contract.smoke.test.ts:463`
pin. It is refused at the **ISL boundary** only. No existing test changed.

### The flow-through to the screen — citation corrected

My original body cited `selectGoalProbability.ts` as the reader. **Wrong hop.** The chain is:

`run.ts:2583-2585` (`prob01(r.probability_of_goal)` → `result.probability_of_goal`) → UI
`mapV5AnalysisToReport.ts:797-799`, which reads `enriched.probability_of_goal` and **renames it to
`goal_probability`** → the hero model. `selectGoalProbability.ts` declares `probability_of_goal` in
its `rawFields` list, but that arm is **dormant on the V5 path** because the mapper has already
renamed the field. The conclusion (no UI change needed) is unchanged; the citation was wrong, and a
wrong citation is how a true claim becomes unverifiable later.

*Provenance note:* the UI hops are cited from the 2.239 diagnosis (pinned UI `900dbd6c`) and the
review, both independently agreeing. **I did not re-derive them in this lane — no UI clone.** Also:
review cited `run.ts:3321` as a second PLoT emission site; **that does not check out at my tip** —
`:3321` is `assembleBrief`, and `grep -an probability_of_goal src/routes/v2/run.ts` gives
`2583`/`2585` as the only emission lines. Recorded rather than propagated.

---

## RED-first

`tests/goal-threshold-ordering.test.ts` copied unmodified into a throwaway worktree at pristine
`2f6e997`, **outside** the clone root. **7 of its first 9 cases failed:**

| test | pristine result |
|---|---|
| HOLE A+B: deadline constraint + goal-node threshold still sends `goal_threshold` | **FAIL** `expected undefined to be 0.65` |
| HOLE B: target on the goal node, no deadline | **FAIL** `expected undefined to be 0.65` |
| HOLE B: explicit root-level `goal_threshold` not discarded | **FAIL** `expected undefined to be 0.7` |
| narrowness guard: a real user constraint still clears the threshold | **FAIL** — *only* on the new `goal_threshold_carried` log field. **This is a REGRESSION GUARD, not a bug pin**; its substantive half already held on pristine. |
| alarm FIRES on a goal-node target | **FAIL** `expected undefined to be defined` |
| alarm FIRES when routing cleared the threshold | **FAIL** `expected undefined to be defined` |
| alarm FIRES on a raw-only target | **FAIL** `expected undefined to be defined` |
| no target stated → no synthesis, no threshold | **PASS** (negative control) |
| alarm does NOT fire when no target stated | **PASS** (negative control) |

The two passes are what stop this being a set of assertions that fire on everything.

**The guard's own RED-first**, run against the pre-guard head `bd837e5` (the correct baseline — the
guard is new relative to the merged fix), in a throwaway worktree outside the clone root:

| test | pre-guard result |
|---|---|
| FLOOR: goal-node threshold of 0 is refused | **FAIL** — `expected +0 to be undefined` (i.e. it really did send `0`) |
| CEILING: goal-node threshold of 1 is refused | **FAIL** — `expected 1 to be undefined` |
| CONTROL (lower): 0.01 still sent | **PASS** both sides — it must, or the guard could pass by refusing everything |
| CONTROL (upper): 0.99 still sent | **PASS** both sides |


---

## Mutation table — throwaway worktree OUTSIDE the clone root, removed before gates

Harness asserts each anchor occurs exactly once and that the write landed (missing anchor →
HARNESS-BROKEN, never "no bite"), and records failing test **names**, not counts. Control run before
mutating: 15/15 + the T10 case green. **Review reproduced the original eight name-for-name, plus its
own positive control**; the five `G*` rows are new with the guard. **All 13 bite.**

**One interaction surprised me and is worth naming:** M4 (restore the old alarm gate) now also bites
the two guard tests. That is the guard and the re-gated alarm proving they are load-bearing
*together* — refusing to send a threshold is only honest **because** the alarm still fires. Under the
old gate the refusal would have been silent, which is the exact failure this PR exists to remove.
Likewise M2 (delete the carry) now bites both CONTROLs: with nothing sent, "0.01 is still sent"
fails. Both are correct couplings, not leakage.

| # | mutant | verdict | failing tests |
|---|---|---|---|
| M1 | hole A: fallback reads the PRE-filter set again | **BITES (1)** | `HOLE A+B: a deadline-bearing constraint PLUS a goal-node threshold still sends goal_threshold to ISL` |
| M2 | hole B: delete the 2.239 threshold carry | **BITES (4)** | `HOLE A+B…` · `HOLE B: target stated on the goal node…` · `HOLE B: an EXPLICIT root-level goal_threshold…` · `DERIVE-NOT-MIRROR…` |
| M2b | hole B: clear the threshold again after the carry | **BITES (4)** | same four |
| M3 | derive-not-mirror: carry the PRE-normalisation copy | **BITES (1)** | `DERIVE-NOT-MIRROR: when Phase 4b re-scales the synthesised constraint, goal_threshold follows it` |
| M4 | alarm: restore the `effectiveGoalThreshold` gate | **BITES (3)** | `alarm > FIRES when precedence routing cleared the threshold…` · `alarm > FIRES on a raw-only target…` · `T10: goal_threshold_no_probability WARNS when precedence routing clears a stated target (2.239)` |
| M5 | alarm: fire unconditionally | **BITES (1)** | `alarm > does NOT fire when no target was stated (the alarm can be silent)` |
| M6 | narrowness: treat ANY single constraint as the auto one | **BITES (2)** | `a real user constraint still clears goal_threshold (precedence routing unchanged)` · `T10 …` |
| M7 | safety gate: push the synthesised constraint without re-filtering it | **BITES (1)** | `the synthesised constraint still goes through the temporal filter safety gate` |
| G1 | guard: remove the degenerate refusal entirely | **BITES (2)** | `degenerate threshold refusal > FLOOR…` · `… > CEILING…` |
| G2 | guard: floor only (stop refusing the ceiling) | **BITES (1)** | `degenerate threshold refusal > CEILING…` |
| G3 | guard: ceiling only (stop refusing the floor) | **BITES (1)** | `degenerate threshold refusal > FLOOR…` |
| G4 | guard: refuse EVERYTHING | **BITES (6)** | both CONTROLs + `HOLE A+B…` · `HOLE B ×2` · `DERIVE-NOT-MIRROR…` |
| G5 | guard: strict `<`/`>` — the bounds themselves stop being refused | **BITES (2)** | `… > FLOOR…` · `… > CEILING…` |

**Two mutants SURVIVED a first pass and the CODE was changed, not the table:**

- The first M2 (flip the precedence-block ternary back to an unconditional clear) survived because a
  later unconditional re-establishment overwrote it — the precedence-block assignment was **dead**
  for the auto-only case. Two authorities for one value, one revertible with nothing noticing. The
  ternary was deleted; the carry now has exactly one authority, which M2/M2b kill.
- The first M7 survived because nothing asserted the synthesised constraint still meets the filter's
  out-of-domain gate. A test was added (raw `goal_threshold: 1.5` → one `CONSTRAINT_OUT_OF_DOMAIN`
  critique on `goal_arr` + `plot.constraint_out_of_domain` naming `auto_goal_threshold`).

---

## An existing test was INVERTED, deliberately

`tests/auto-constraint-fallback.test.ts` **T10** asserted *"no `goal_threshold_no_probability`
warning when multi-constraint path clears effectiveGoalThreshold"*, justified in its own comment as
*"the threshold path was intentionally disabled"*. **That test was the lock on the broken alarm** —
it would have failed anyone who fixed it. It now asserts the warning DOES fire, with the reasoning
in the test body. Its structural half is kept: a genuine user constraint still activates precedence
routing and still clears the threshold (`goal_threshold_carried: false`).

**No other existing test was modified.**

---

## Gates, run at this head

| step | result |
|---|---|
| `bash scripts/check-no-stale-js.sh` | **PASS** |
| `npx eslint src tests --ext .ts --max-warnings 97` | **PASS** — 86 problems, **0 errors** (ratchet 97). Touched files: 2 warnings, both **pre-existing** unused imports at `run.ts:82`/`:103`. **0 new.** |
| `npm run validate:contracts` | **PASS** — 8 files / 3 scenarios, 0 failed |
| `npm run build` | **PASS** |
| `npm run typecheck` | **PASS** |
| `RATE_LIMIT_ENABLED=0 CI=true npm test` | **PASS, exit 0** — Test Files **595 passed / 4 skipped (599)**; Tests **6506 passed / 28 skipped (6545)**; **0 failed**. Exactly **+4** from the pre-guard head (6502), which is the four new guard cases and nothing else. |

CI: **11/11 green** at both heads. Standing-reds register **re-derived, not restated**: with the full
suite at zero failures there is nothing to attribute. `Staging Smoke Test` does not run on PRs;
`validate-structure` is path-filtered on `contracts/openapi.yaml`, untouched here; `audit` is green.

---

## Known residual gaps — rowed, not fixed here

1. **A goal node carrying only `goal_threshold_raw` fires `goal_threshold_no_probability` on every
   request, forever.** Synthesis reads `goalThreshold ?? nodeGoalThreshold` and never `_raw`, while
   the alarm's gate does include `_raw`. Measured: raw-only input → outbound `goal_threshold`
   absent, `goal_constraints` absent, alarm fires. Standing log noise if CEE can emit raw-only. The
   alarm is still correct in kind — a target was stated and no probability came back — but it is
   unactionable in that shape.
2. **The residual discard is broader than "a competing constraint".** The threshold is discarded even
   when the surviving user constraint targets a **different node**, where ISL would compute both
   happily. Measured: node `goal_threshold: 0.65` + a surviving constraint on `lever` → outbound
   `goal_threshold` absent. Deliberately left alone here to keep the hole-B fix narrow (M6 pins that
   narrowness), but it is a real remaining gap, not a design choice.
3. **The degenerate-threshold guard covers `goal_threshold`, not the synthesised constraint.** At the
   bounds, `auto_goal_threshold >= 0` also yields a certain `prob_satisfied`. That is unchanged from
   base and has zero UI readers (per-option `constraint_analysis` is discarded on both mapper
   paths), so it is deliberately out of this diff — but it is the same class of degeneracy on a
   neighbouring field, and belongs in the same follow-up as the CEE cap fix.
4. **Whether CEE can normalise a target to exactly `0` was never swept.** The guard makes the sweep
   unnecessary for safety; it does not answer the question.

## Explicitly out of scope (per the lane brief)

- CEE's payload allowlist (`run-analysis.ts`) — **do not add `goal_threshold` there without reading
  this diff first**: with this fix in place, a root-level `goal_threshold` plus a surviving *user*
  goal-node constraint still hits the precedence branch and is discarded.
- CEE's `resolveGoalThresholdCap` `>=` vs `>` — still the right fix, but **no longer a gating
  dependency for this PR**: the 2.239-G guard refuses the `goal_threshold: 1.0` that defect mints,
  so the worst case here is an honest gap plus an alarm rather than a fabricated "0%".
- Routing via `goal_constraints` instead (rejected: UI discards per-option `constraint_analysis` on
  both mapper paths).
- ISL resolution labelling on `probability_of_goal`.

Evidence file: `PHASE0-EVIDENCE-2026-07-28/fix-2239-plot-goal-threshold.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
