### PR TITLE
fix(2.260): make the silent skew-fallback depth cut LOUD, and derive the weight-key guard

### DIFF
--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -251,10 +251,16 @@ import type {
  * with the function body below:
  *  - every key here must be READ by estimateWeightedCostV2 (else PLoT demands a
  *    coefficient it does not use);
- *  - every key estimateWeightedCostV2 reads must appear here (else PLoT plans
- *    against a coefficient it never validated as finite).
- * `tests/isl-compute-admission-handshake.test.ts` pins both directions
- * mechanically by mutating each key and asserting the cost moves.
+ *  - every key estimateWeightedCostV2 reads must appear here — an UNDECLARED
+ *    read is never validated as finite, so it resolves to `undefined` and
+ *    yields a NaN cost while the block still classifies `ok`.
+ *
+ * `tests/isl-compute-admission-handshake.test.ts` pins the two directions with
+ * two DIFFERENT mechanisms, because one cannot see the other: DIRECTION 1
+ * perturbs each declared key and asserts the cost moves (declared ⇒ read);
+ * DIRECTION 2 prices a request through a recording Proxy and asserts no read
+ * fell outside this set (read ⇒ declared). A value-based assertion cannot
+ * detect an undeclared read, so the Proxy is not decoration.
  */
 export const V2_WEIGHTED_2026_07_WEIGHT_KEYS = [
   'base_per_sample_per_option_per_struct',

--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -244,15 +244,71 @@ import type {
 } from '../integrations/isl/types/isl-types.js';
 
 /**
- * Formula-shape versions PLoT knows how to plan against. The shape implemented
- * by {@link estimateWeightedCostV2} is `v2-weighted-2026-07`. An advertised
- * version NOT in this set is treated as skew → fail-loud conservative fallback.
- * This is a DERIVED guard, not a mirror: it lists only the SHAPES PLoT has code
- * for; the numeric coefficients still come from the live `weights`.
+ * The weight coefficients {@link estimateWeightedCostV2} consumes — i.e. the
+ * COMPLETE set of `weights` keys the `v2-weighted-2026-07` formula shape prices.
+ *
+ * ⚠ This list is load-bearing in BOTH directions and must stay exactly in step
+ * with the function body below:
+ *  - every key here must be READ by estimateWeightedCostV2 (else PLoT demands a
+ *    coefficient it does not use);
+ *  - every key estimateWeightedCostV2 reads must appear here (else PLoT plans
+ *    against a coefficient it never validated as finite).
+ * `tests/isl-compute-admission-handshake.test.ts` pins both directions
+ * mechanically by mutating each key and asserting the cost moves.
  */
-export const KNOWN_COMPLEXITY_FORMULA_VERSIONS: ReadonlySet<string> = new Set([
-  'v2-weighted-2026-07',
+export const V2_WEIGHTED_2026_07_WEIGHT_KEYS = [
+  'base_per_sample_per_option_per_struct',
+  'evpi_sample_cap',
+  'sensitivity_coef',
+  'evalue_coef',
+  'bands_coef',
+  'path_coef',
+  'max_decomposition_paths',
+] as const;
+
+/**
+ * Formula-shape version → the EXACT set of advertised `weights` keys that
+ * version's estimator consumes. This map is the SINGLE source of truth for the
+ * handshake's version guard (ROADMAP 2.260).
+ *
+ * Two properties follow mechanically from the map's shape, and both exist to
+ * kill the hand-maintained-mirror defect class (programme trap 12):
+ *
+ *  1. {@link KNOWN_COMPLEXITY_FORMULA_VERSIONS} is DERIVED from these keys, so a
+ *     version can never be admitted without also declaring which coefficients
+ *     its estimator prices — "just add the version string" is not expressible.
+ *  2. The resolver (compute-admission.ts `classify`) compares ISL's ADVERTISED
+ *     weight keys against this set and treats any UNEXPECTED key as skew
+ *     (`unknown_weight_keys`). An unrecognised coefficient is precisely the
+ *     signal that ISL's cost formula grew a term PLoT does not price, and it is
+ *     DERIVED from the live payload rather than remembered — so the drift is
+ *     caught at the seam, at the moment it happens, with nobody maintaining a
+ *     list. Without it a same-version term addition under-prices SILENTLY and
+ *     converts a safe conservative fallback into a pass-then-422.
+ */
+export const COMPLEXITY_FORMULA_WEIGHT_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ['v2-weighted-2026-07', new Set<string>(V2_WEIGHTED_2026_07_WEIGHT_KEYS)],
 ]);
+
+/**
+ * Formula-shape versions PLoT knows how to plan against — DERIVED from
+ * {@link COMPLEXITY_FORMULA_WEIGHT_KEYS}, never hand-listed. The shape
+ * implemented by {@link estimateWeightedCostV2} is `v2-weighted-2026-07`. An
+ * advertised version NOT in this set is treated as skew → fail-loud
+ * conservative fallback. This lists only the SHAPES PLoT has code for; the
+ * numeric coefficients still come from the live `weights`.
+ *
+ * ⚠ ISL staging currently advertises `v5-factor-flips-2026-08-01`, which is NOT
+ * here and deliberately so: its cost formula carries four terms PLoT does not
+ * price (full-population EVPPI, EVPC, structural influence, factor flips).
+ * Admitting it without an `estimateWeightedCostV5` would under-count the true
+ * cost by ~43% on a typical graph and turn a conservative fallback into a
+ * pass-then-422. See ROADMAP 2.260 and the PR that added this note for why the
+ * v5 estimator could not be completed from ISL's advertised contract.
+ */
+export const KNOWN_COMPLEXITY_FORMULA_VERSIONS: ReadonlySet<string> = new Set(
+  COMPLEXITY_FORMULA_WEIGHT_KEYS.keys(),
+);
 
 /**
  * PLoT-side hard upper bound on the planning ceiling, in ISL cost units.
@@ -358,6 +414,23 @@ export function estimateWeightedCostV2(
 /** Which planning mode produced a {@link DepthPlanDecision}. */
 export type DepthPlanMode = 'weighted' | 'legacy_fallback';
 
+/**
+ * WHY a planned depth ended up below the requested/defaulted depth. The two
+ * causes are genuinely different and must not be reported with one message:
+ *
+ *  - `admission_budget` — the graph's cost exceeds the admission ceiling, so the
+ *    depth was lowered to the largest value that fits. The reduction is a
+ *    property of THIS GRAPH.
+ *  - `admission_unavailable` — PLoT could not confirm ISL's live admission
+ *    capability (unreachable /health, a malformed block, an unknown formula
+ *    version or unrecognised weight keys), so it planned conservatively and
+ *    DISABLED the depth-raise. The reduction is a property of the SERVICE SEAM,
+ *    not of the graph, and the same graph would run at full depth once the
+ *    handshake is healthy. ROADMAP 2.260: this case previously produced
+ *    `kind: 'unchanged'` and was therefore invisible on the wire.
+ */
+export type DepthReductionReason = 'admission_budget' | 'admission_unavailable';
+
 /** Input to {@link planSampleDepth} — the full request shape plus caller intent. */
 export interface DepthPlanInput extends WeightedCostRequest {
   /** True when the caller supplied n_samples explicitly (never depth-capped). */
@@ -376,6 +449,11 @@ export type DepthPlanDecision =
   | {
       kind: 'reduced';
       nSamples: number;
+      /**
+       * The depth the caller asked for (explicit) or that the standard default
+       * resolved to — ALWAYS the true pre-reduction depth, never an
+       * intermediate already lowered by the conservative fallback.
+       */
       originalNSamples: number;
       /** cost at the ORIGINAL depth. */
       cost: number;
@@ -383,6 +461,8 @@ export type DepthPlanDecision =
       reducedCost: number;
       ceiling: number;
       mode: DepthPlanMode;
+      /** WHY the depth was lowered — drives the user-facing disclosure. */
+      reason: DepthReductionReason;
     }
   | {
       kind: 'refused';
@@ -482,6 +562,7 @@ function planWeighted(input: DepthPlanInput, admission: ISLComputeAdmission): De
     reducedCost: costAt(reduced),
     ceiling,
     mode: 'weighted',
+    reason: 'admission_budget',
   };
 }
 
@@ -497,12 +578,28 @@ function planWeighted(input: DepthPlanInput, admission: ISLComputeAdmission): De
  * — byte-for-byte the pre-handshake behaviour.
  */
 function planLegacyFallback(input: DepthPlanInput, conservative: boolean): DepthPlanDecision {
+  // The depth the caller actually asked for (explicit) or that the standard
+  // default resolved to. EVERY branch below reports reductions against THIS
+  // number — see the ROADMAP 2.260 note under `raiseDisabled`.
+  const requested = input.nSamples;
+
   // Disable the depth-raise for a DEFAULTED depth ONLY under a genuine skew;
   // explicit caller depths pass through to the budget check untouched (never
   // silently raised or lowered except by the reduction/refusal below).
-  const planned = conservative && !input.nSamplesExplicit
-    ? Math.min(input.nSamples, LEGACY_BASE_N_SAMPLES)
-    : input.nSamples;
+  //
+  // ⚠ ROADMAP 2.260 — THIS CAP USED TO BE INVISIBLE. It was applied BEFORE
+  // applyComplexityBudget, which then saw the already-lowered `planned`, found
+  // it fitted, and returned `kind: 'unchanged'`. The route only sets
+  // `meta.originalNSamples` on a `reduced` decision, so a defaulted 10,000 →
+  // 4,000 cut (−60% Monte Carlo depth) reached the user with NO
+  // SAMPLES_REDUCED_FOR_COMPLEXITY warning and every confidence marker green.
+  // Measured live on staging 1 Aug 2026 (PHASE0-EVIDENCE-2026-07-28/
+  // measure-2260-skew-fallback.md). The cap itself is CORRECT — planning at a
+  // depth ISL may refuse is worse — but it must be disclosed, so the depth loss
+  // is now reported against `requested` and surfaces as a first-class reduction.
+  const raiseDisabled =
+    conservative && !input.nSamplesExplicit && requested > LEGACY_BASE_N_SAMPLES;
+  const planned = raiseDisabled ? LEGACY_BASE_N_SAMPLES : requested;
 
   const budget = conservative
     ? Math.min(LEGACY_FALLBACK_SCALAR_BUDGET, resolveComplexityBudget())
@@ -512,7 +609,8 @@ function planLegacyFallback(input: DepthPlanInput, conservative: boolean): Depth
   if (scalar.kind === 'refused') {
     return {
       kind: 'refused',
-      originalNSamples: scalar.originalNSamples,
+      // The caller's depth, not the conservatively-capped intermediate.
+      originalNSamples: requested,
       costAtFloor: ADAPTIVE_N_SAMPLES_FLOOR * scalar.nodeEdgeProduct,
       ceiling: budget,
       nodeCount: input.nodeCount,
@@ -520,18 +618,35 @@ function planLegacyFallback(input: DepthPlanInput, conservative: boolean): Depth
       mode: 'legacy_fallback',
     };
   }
-  if (scalar.kind === 'reduced') {
+
+  // Single exit for BOTH ways a depth can end up below what was asked for: the
+  // raise-disable cap and/or the scalar budget. Collapsing them here is what
+  // stops the cap from hiding inside a `kind: 'unchanged'`.
+  const finalNSamples = scalar.nSamples;
+  const product = input.nodeCount * input.edgeCount;
+  if (finalNSamples < requested) {
     return {
       kind: 'reduced',
-      nSamples: scalar.nSamples,
-      originalNSamples: scalar.originalNSamples,
-      cost: scalar.complexity,
-      reducedCost: scalar.reducedComplexity,
+      nSamples: finalNSamples,
+      originalNSamples: requested,
+      cost: requested * product,
+      reducedCost: finalNSamples * product,
       ceiling: budget,
       mode: 'legacy_fallback',
+      // When the raise-disable contributed, the SEAM is the cause the user
+      // needs to hear — it is not a property of their graph, and the same graph
+      // runs at full depth once the handshake is healthy. (A budget reduction
+      // stacked on top does not change that attribution.)
+      reason: raiseDisabled ? 'admission_unavailable' : 'admission_budget',
     };
   }
-  return { kind: 'unchanged', nSamples: scalar.nSamples, cost: scalar.complexity, ceiling: budget, mode: 'legacy_fallback' };
+  return {
+    kind: 'unchanged',
+    nSamples: finalNSamples,
+    cost: scalar.complexity,
+    ceiling: budget,
+    mode: 'legacy_fallback',
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/integrations/isl/compute-admission.ts
+++ b/src/integrations/isl/compute-admission.ts
@@ -21,7 +21,10 @@
  */
 
 import { getISLClientConfig, isISLConfigured, ISLClient } from './client.js';
-import { KNOWN_COMPLEXITY_FORMULA_VERSIONS } from '../../config/sampling.js';
+import {
+  COMPLEXITY_FORMULA_WEIGHT_KEYS,
+  KNOWN_COMPLEXITY_FORMULA_VERSIONS,
+} from '../../config/sampling.js';
 import { recordIslAdmissionVersionSkew } from '../../metrics/registry.js';
 import { isFiniteNumber, allFiniteNumberFields } from '../../util/numeric.js';
 import type {
@@ -34,8 +37,20 @@ import type {
 /** Cache TTL for the /health capability read. */
 export const ADMISSION_CACHE_TTL_MS = 60_000;
 
-/** Reasons the handshake could not yield a usable, version-known capability. */
-export type AdmissionSkewReason = 'unreachable' | 'missing_block' | 'unknown_version';
+/**
+ * Reasons the handshake could not yield a usable, version-known capability.
+ *
+ * `unknown_weight_keys` (ROADMAP 2.260) is the DERIVED drift alarm: ISL
+ * advertised the SAME formula version but a `weights` object carrying a
+ * coefficient PLoT's estimator for that version does not price. That is exactly
+ * the signature of ISL growing a cost term in place — the case the version
+ * string alone cannot catch, and the one that silently under-prices.
+ */
+export type AdmissionSkewReason =
+  | 'unreachable'
+  | 'missing_block'
+  | 'unknown_version'
+  | 'unknown_weight_keys';
 
 /** Resolved capability state served to the planner. */
 export interface AdmissionResolution {
@@ -50,6 +65,12 @@ export interface AdmissionResolution {
   status: 'ok' | AdmissionSkewReason | 'disabled' | 'warming';
   /** Advertised formula version when a block was present (for logging). */
   advertisedVersion?: string;
+  /**
+   * Advertised `weights` keys PLoT's estimator for the advertised version does
+   * NOT consume — populated only on `unknown_weight_keys`. Named in the alarm so
+   * the drift is diagnosable from one log line, without a source dive.
+   */
+  unexpectedWeightKeys?: readonly string[];
 }
 
 const WARMING: AdmissionResolution = { admission: null, skew: false, status: 'warming' };
@@ -68,35 +89,25 @@ function isFresh(now: number): boolean {
   return _cache !== null && now - _cache.at < ADMISSION_CACHE_TTL_MS;
 }
 
-/** Coefficients an advertised `weights` object must carry as finite numbers. */
-const WEIGHT_KEYS = [
-  'base_per_sample_per_option_per_struct',
-  'evpi_sample_cap',
-  'sensitivity_coef',
-  'evalue_coef',
-  'bands_coef',
-  'path_coef',
-  'max_decomposition_paths',
-] as const;
-
 /** Cap fields an advertised `caps` object must carry as finite numbers. */
 const CAP_KEYS = ['max_options', 'max_nodes', 'max_edges', 'max_parameter_uncertainties'] as const;
-
-/** Validate the advertised `weights` object — every coefficient must be finite. */
-function validWeights(w: unknown): w is ISLComputeAdmissionWeights {
-  return allFiniteNumberFields(w, WEIGHT_KEYS);
-}
 
 function validCaps(c: unknown): c is ISLComputeAdmissionCaps {
   return allFiniteNumberFields(c, CAP_KEYS);
 }
 
 /**
- * Validate a `compute_admission` block: ceiling positive-finite, version a
- * non-empty string, weights + caps well-formed. A malformed block is treated as
- * a missing block (a partial/garbled advertisement must NOT be planned against).
+ * Validate the VERSION-INDEPENDENT shape of a `compute_admission` block:
+ * ceiling positive-finite, version a non-empty string, `weights` an object at
+ * all, caps well-formed. A malformed block is treated as a missing block (a
+ * partial/garbled advertisement must NOT be planned against).
+ *
+ * The `weights` CONTENT is deliberately NOT checked here — which coefficients
+ * are required depends on which formula version is advertised, so that check
+ * lives in {@link classify} after the version is resolved
+ * ({@link validWeightsForVersion}).
  */
-function validAdmission(block: unknown): block is ISLComputeAdmission {
+function validAdmissionShape(block: unknown): block is ISLComputeAdmission {
   if (!block || typeof block !== 'object') return false;
   const o = block as Record<string, unknown>;
   return (
@@ -104,9 +115,33 @@ function validAdmission(block: unknown): block is ISLComputeAdmission {
     o.max_cost_units > 0 &&
     typeof o.complexity_formula_version === 'string' &&
     o.complexity_formula_version.length > 0 &&
-    validWeights(o.weights) &&
+    !!o.weights &&
+    typeof o.weights === 'object' &&
     validCaps(o.caps)
   );
+}
+
+/** Every coefficient the named version's estimator prices is present + finite. */
+function validWeightsForVersion(
+  w: unknown,
+  expectedKeys: ReadonlySet<string>,
+): w is ISLComputeAdmissionWeights {
+  return allFiniteNumberFields(w, [...expectedKeys]);
+}
+
+/**
+ * Advertised weight keys the named version's estimator does NOT consume.
+ *
+ * DERIVED, NOT MIRRORED (programme trap 12): the expected set comes from
+ * `COMPLEXITY_FORMULA_WEIGHT_KEYS` — the same map that decides which versions
+ * are admissible at all — so a version can never be admitted without declaring
+ * the coefficients it prices, and a coefficient ISL adds in place can never be
+ * ignored. Returned sorted so the alarm text is stable/diffable.
+ */
+function unexpectedWeightKeysFor(w: object, expectedKeys: ReadonlySet<string>): string[] {
+  return Object.keys(w)
+    .filter((k) => !expectedKeys.has(k))
+    .sort();
 }
 
 /** Classify a fetched /health payload into a resolution. */
@@ -115,23 +150,40 @@ function classify(health: ISLHealthResponse | null): AdmissionResolution {
     return { admission: null, skew: true, status: 'unreachable' };
   }
   const block = health.compute_admission;
-  if (!validAdmission(block)) {
+  if (!validAdmissionShape(block)) {
     return { admission: null, skew: true, status: 'missing_block' };
   }
-  if (!KNOWN_COMPLEXITY_FORMULA_VERSIONS.has(block.complexity_formula_version)) {
+  const advertisedVersion = block.complexity_formula_version;
+
+  // The version gate, and the source of the key set the weights are judged
+  // against — one map, so the two can never disagree.
+  const expectedKeys = COMPLEXITY_FORMULA_WEIGHT_KEYS.get(advertisedVersion);
+  if (expectedKeys === undefined) {
+    return { admission: null, skew: true, status: 'unknown_version', advertisedVersion };
+  }
+
+  // A coefficient this version's estimator prices is missing or non-numeric →
+  // the advertisement is garbled, not merely drifted.
+  if (!validWeightsForVersion(block.weights, expectedKeys)) {
+    return { admission: null, skew: true, status: 'missing_block', advertisedVersion };
+  }
+
+  // ISL advertised a coefficient PLoT does not price under this version — its
+  // formula grew a term in place. Under-pricing here would convert a safe
+  // conservative fallback into a confident plan ISL then refuses with a raw 422,
+  // so the version stays UNADMITTED and the drift is named.
+  const unexpectedWeightKeys = unexpectedWeightKeysFor(block.weights, expectedKeys);
+  if (unexpectedWeightKeys.length > 0) {
     return {
       admission: null,
       skew: true,
-      status: 'unknown_version',
-      advertisedVersion: block.complexity_formula_version,
+      status: 'unknown_weight_keys',
+      advertisedVersion,
+      unexpectedWeightKeys,
     };
   }
-  return {
-    admission: block,
-    skew: false,
-    status: 'ok',
-    advertisedVersion: block.complexity_formula_version,
-  };
+
+  return { admission: block, skew: false, status: 'ok', advertisedVersion };
 }
 
 /** Emit the loud fail-loud signal (warning + metric) when a skew is detected. */
@@ -149,9 +201,12 @@ function signalSkew(resolution: AdmissionResolution): void {
       reason,
       advertised_version: resolution.advertisedVersion ?? null,
       known_versions: [...KNOWN_COMPLEXITY_FORMULA_VERSIONS],
+      // Named on `unknown_weight_keys` so the drift is diagnosable from this one
+      // line: these are the coefficients ISL prices and PLoT does not.
+      unexpected_weight_keys: resolution.unexpectedWeightKeys ?? null,
       action: 'fail_loud_conservative_fallback',
       msg:
-        'ISL /health compute-admission handshake unusable — planning against the conservative legacy scalar bound (base depth capped) until the live capability is readable and its formula version is known.',
+        'ISL /health compute-admission handshake unusable — planning against the conservative legacy scalar bound (base depth capped) until the live capability is readable and its formula version is known. Every DEFAULTED analysis is now running at the reduced fallback depth and says so in its response (SAMPLES_REDUCED_FOR_COMPLEXITY).',
     }),
   );
 }
@@ -219,5 +274,5 @@ export async function __refreshForTest(): Promise<AdmissionResolution> {
 /** Directly exercise the classifier (unit tests). */
 export const __classifyForTest = classify;
 
-/** Directly exercise the validator (unit tests). */
-export const __validAdmissionForTest = validAdmission;
+/** Directly exercise the version-independent shape validator (unit tests). */
+export const __validAdmissionForTest = validAdmissionShape;

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -326,12 +326,16 @@ export function initializeHistograms(): void {
 
   // Codex F8 handshake: fires when PLoT cannot plan against ISL's advertised
   // compute-admission model (unreachable /health, missing compute_admission
-  // block, or an unknown complexity_formula_version) and falls back to the
-  // conservative legacy scalar bound. A sustained non-zero rate = drift.
+  // block, an unknown complexity_formula_version, or advertised weight keys the
+  // known version's estimator does not price) and falls back to the
+  // conservative legacy scalar bound. A sustained non-zero rate = drift, and
+  // while it persists EVERY defaulted analysis runs at the reduced fallback
+  // depth (ROADMAP 2.260 — now disclosed in the response, not just here).
   islAdmissionVersionSkewCounter = new CounterMetric(
     'plot_engine_isl_admission_version_skew_total',
     'Total detections of ISL compute-admission handshake skew (fail-loud fallback engaged)',
-    ['reason'] // reason: unreachable|missing_block|unknown_version
+    // Label values are the AdmissionSkewReason union — see recordIslAdmissionVersionSkew below.
+    ['reason']
   );
 
   // Meta-reasoning quality metrics

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -468,7 +468,7 @@ export function observeIslLatency(operation: 'validation' | 'sensitivity' | 'fac
 
 // Codex F8 handshake: record a compute-admission version-skew detection.
 export function recordIslAdmissionVersionSkew(
-  reason: 'unreachable' | 'missing_block' | 'unknown_version',
+  reason: 'unreachable' | 'missing_block' | 'unknown_version' | 'unknown_weight_keys',
 ): void {
   islAdmissionVersionSkewCounter?.inc({ reason });
 }

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -139,7 +139,7 @@ import type { SeedSourceType } from '@talchain/schemas';
 import { factorReviewV2, type CEESchemaV2Config } from '../../cee/client.js';
 import { FLAGS } from '../../config/flags.js';
 import { getAllFeatureFlags } from '../../config/feature-flags.js';
-import { resolveStandardNSamples, ADAPTIVE_N_SAMPLES_FLOOR, planSampleDepth, checkAdmissionCaps, type DepthPlanInput, type AdmissionCapsDecision, type AdmissionCapDimension } from '../../config/sampling.js';
+import { resolveStandardNSamples, ADAPTIVE_N_SAMPLES_FLOOR, planSampleDepth, checkAdmissionCaps, type DepthPlanInput, type AdmissionCapsDecision, type AdmissionCapDimension, type DepthReductionReason } from '../../config/sampling.js';
 import { LIMITS_MAX_NODES, LIMITS_MAX_EDGES, LIMITS_MAX_OPTIONS } from '../../config/constants.js';
 import { getIslComputeAdmission } from '../../integrations/isl/compute-admission.js';
 import { generateM1Coaching } from '../../coaching/m1-coaching.js';
@@ -1419,8 +1419,20 @@ interface MetaParams {
    * reduced to fit ISL's complexity budget. Present ONLY on reduced runs —
    * its presence drives the SAMPLES_REDUCED_FOR_COMPLEXITY inference warning.
    * nSamples itself is always the TRUE depth used.
+   *
+   * ROADMAP 2.260: also present when the CONSERVATIVE fallback disabled the
+   * depth-raise because ISL's admission capability was unreadable. That cut
+   * (10,000 → 4,000 on every defaulted analysis) used to reach here as
+   * `undefined`, so the warning below never fired and a 60% loss of Monte Carlo
+   * depth was invisible on the wire.
    */
   originalNSamples?: number;
+  /**
+   * ROADMAP 2.260: WHY the depth was reduced. Set alongside originalNSamples on
+   * every reduced run; selects the disclosure wording so a seam failure is never
+   * reported to the user as a property of their graph.
+   */
+  nSamplesReducedReason?: DepthReductionReason;
   /**
    * Track S: sample depth used for flip probes (decoupled from nSamples).
    *
@@ -3230,11 +3242,23 @@ function buildResponse(
   // BOTH depths. meta.n_samples (and brief/fact lineage) already report the
   // TRUE reduced depth; this warning is what stops the reduction from being
   // a silent override, including when the caller set n_samples explicitly.
+  //
+  // ROADMAP 2.260: the same disclosure now also covers the CONSERVATIVE
+  // fallback's depth-raise cut, which previously reached the wire as silence.
+  // The CODE is deliberately reused rather than minted fresh: this family's
+  // transport to the response and into decision_brief.warning_codes is proven,
+  // and the user-facing fact ("you got fewer samples than the standard depth")
+  // is identical. Only the CAUSE differs, so only the MESSAGE branches — an
+  // admission-seam failure must never be reported as a property of the caller's
+  // graph, which would send them optimising a graph that is not the problem.
   if (meta.originalNSamples !== undefined && meta.originalNSamples !== meta.nSamples) {
+    const reducedForSeam = meta.nSamplesReducedReason === 'admission_unavailable';
     inferenceWarnings.push({
       code: INFERENCE_WARNING_CODES.SAMPLES_REDUCED_FOR_COMPLEXITY,
       // provisional_doctrine_v0 — wording surface (diagnostic disclosure)
-      message: `Monte Carlo sample depth was reduced from ${meta.originalNSamples} to ${meta.nSamples} samples so this graph fits the analysis engine's compute-admission budget. All reported results were computed at ${meta.nSamples} samples; displayed probabilities may be slightly less stable than at the standard depth.`,
+      message: reducedForSeam
+        ? `Monte Carlo sample depth was reduced from ${meta.originalNSamples} to ${meta.nSamples} samples because the analysis engine's compute-admission capability could not be confirmed, so this run was planned conservatively. All reported results were computed at ${meta.nSamples} samples; displayed probabilities may be slightly less stable than at the standard depth. This is a service condition, not a property of your decision model — the same analysis runs at full depth once the engines agree.`
+        : `Monte Carlo sample depth was reduced from ${meta.originalNSamples} to ${meta.nSamples} samples so this graph fits the analysis engine's compute-admission budget. All reported results were computed at ${meta.nSamples} samples; displayed probabilities may be slightly less stable than at the standard depth.`,
       severity: 'warning',
     });
   }
@@ -5592,6 +5616,8 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         const nSamples = complexityDecision.nSamples;
         const originalNSamples =
           complexityDecision.kind === 'reduced' ? complexityDecision.originalNSamples : undefined;
+        const nSamplesReducedReason =
+          complexityDecision.kind === 'reduced' ? complexityDecision.reason : undefined;
 
         if (complexityDecision.kind === 'reduced') {
           req.log.info({
@@ -5601,6 +5627,10 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             edge_count: causalDirectedEdgeCount,
             option_count: causalOptionCount,
             plan_mode: complexityDecision.mode,
+            // ROADMAP 2.260: distinguishes a graph-cost reduction from a
+            // conservative fallback cut. Both were previously indistinguishable
+            // in the logs; the latter did not log at all.
+            reduction_reason: complexityDecision.reason,
             original_n_samples: complexityDecision.originalNSamples,
             reduced_n_samples: complexityDecision.nSamples,
             original_cost: complexityDecision.cost,
@@ -5718,6 +5748,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
               seedSource: providedSeed !== undefined ? 'client_generated' : 'server_generated',
               nSamples,
               originalNSamples,
+              nSamplesReducedReason,
               detailLevel,
               latencyMs: totalMs,
               normalizationMs,
@@ -7811,6 +7842,7 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             seedSource: providedSeed !== undefined ? 'client_generated' : 'server_generated',
             nSamples,
             originalNSamples,
+            nSamplesReducedReason,
             // ROADMAP 2.228-F3: no probe runs on this route any more, so there
             // is no probe depth to report. Deliberately not passed as
             // `undefined` from a dead local — the local is gone with the probe.

--- a/tests/adaptive-n-samples-complexity.test.ts
+++ b/tests/adaptive-n-samples-complexity.test.ts
@@ -476,10 +476,88 @@ describe('adaptive n_samples via /v2/run (F8 handshake — weighted planning)', 
     });
 
     expect(res.statusCode).toBe(200);
-    // 3 nodes × 3 edges fits the 10M scalar bound at 4000 → unchanged at 4000.
+    // 3 nodes × 3 edges fits the 10M scalar bound at 4000 → 4000 is sent.
     expect(islCalls[0].n_samples).toBe(LEGACY_BASE_N_SAMPLES); // 4000, not 10000
     const body = JSON.parse(res.body);
     expect(body.meta?.n_samples).toBe(LEGACY_BASE_N_SAMPLES);
+  });
+
+  // ---------------------------------------------------------------------------
+  // ROADMAP 2.260 — the degradation must be LOUD, not just the cause.
+  //
+  // Measured on staging 1 Aug 2026 (PHASE0-EVIDENCE-2026-07-28/
+  // measure-2260-skew-fallback.md): with ISL advertising a formula version PLoT
+  // does not know, EVERY defaulted analysis silently ran at 4,000 samples
+  // instead of 10,000 — a 60% cut in Monte Carlo depth — while the response
+  // carried `validity_ratio: 1`, `status: computed` and no warning of any kind.
+  // The ONLY trace was a PLoT-side log line that named neither the request nor
+  // the resulting depth. These tests pin the wire, not the plan.
+  // ---------------------------------------------------------------------------
+
+  it('ROADMAP 2.260: the skew-capped depth is DISCLOSED on the wire, naming both depths', async () => {
+    __setIslComputeAdmissionForTest({ admission: null, skew: true, status: 'unknown_version' });
+    islCalls = [];
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      // n_samples DELIBERATELY omitted — this is how CEE calls PLoT on every
+      // real analysis (verified in CEE staging: the run-analysis snapshot loader
+      // has no n_samples field to populate), so it is the production shape.
+      payload: { graph: denseGraph(2), options: OPTIONS, goal_node_id: 'goal', seed: '42' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.meta?.n_samples).toBe(LEGACY_BASE_N_SAMPLES);
+
+    const warnings = findSamplesReducedWarnings(body);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].severity).toBe('warning');
+    // Both depths named — a disclosure that does not say how much was lost is
+    // not a disclosure.
+    expect(warnings[0].message).toContain('10000');
+    expect(warnings[0].message).toContain(String(LEGACY_BASE_N_SAMPLES));
+    // ...and it attributes the cause to the SEAM, not to the caller's graph.
+    expect(warnings[0].message).toContain('could not be confirmed');
+    expect(warnings[0].message).not.toContain('fits the analysis');
+  });
+
+  it('ROADMAP 2.260: a BUDGET reduction still blames the budget (the two causes do not blur)', async () => {
+    // Healthy handshake, genuinely over-costly graph → the pre-existing wording
+    // must be untouched. Guards against "fix the silence" flattening both causes
+    // into one message and telling users to shrink a graph that is fine.
+    islCalls = [];
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: { graph: denseGraph(43), options: OPTIONS, goal_node_id: 'goal', seed: '42' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const warnings = findSamplesReducedWarnings(JSON.parse(res.body));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("fits the analysis engine's compute-admission budget");
+    expect(warnings[0].message).not.toContain('could not be confirmed');
+  });
+
+  it('ROADMAP 2.260: under skew, an EXPLICIT in-budget depth is untouched and produces NO warning', async () => {
+    // The cap applies to DEFAULTED depths only. A disclosure that fires when
+    // nothing was lost trains people to ignore it — the same broken-alarm
+    // failure as the silence, in the other direction.
+    __setIslComputeAdmissionForTest({ admission: null, skew: true, status: 'unknown_version' });
+    islCalls = [];
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: { graph: denseGraph(2), options: OPTIONS, goal_node_id: 'goal', seed: '42', n_samples: 8000 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(islCalls[0].n_samples).toBe(8000);
+    expect(findSamplesReducedWarnings(JSON.parse(res.body))).toHaveLength(0);
   });
 
   it('MULTI-CONSTRAINT: prices EVPI over factor PUs UNION constraint-injected PUs — plans conservatively (no pass-then-422)', async () => {

--- a/tests/isl-compute-admission-handshake.test.ts
+++ b/tests/isl-compute-admission-handshake.test.ts
@@ -28,6 +28,9 @@ import {
   LEGACY_BASE_N_SAMPLES,
   ADAPTIVE_N_SAMPLES_FLOOR,
   ISL_COMPLEXITY_BUDGET_DEFAULT,
+  COMPLEXITY_FORMULA_WEIGHT_KEYS,
+  KNOWN_COMPLEXITY_FORMULA_VERSIONS,
+  V2_WEIGHTED_2026_07_WEIGHT_KEYS,
   type WeightedCostRequest,
   type DepthPlanInput,
 } from '../src/config/sampling.js';
@@ -207,12 +210,61 @@ describe('planSampleDepth (weighted) — reduction + refusal fit the live gate',
 // ===========================================================================
 
 describe('planSampleDepth — fail-loud conservative fallback (admission null)', () => {
-  it('DISABLES the depth-raise: a DEFAULTED 10000 plans at the legacy 4000 base', () => {
-    // Small graph: no reduction needed; the only effect is the raise being off.
+  it('DISABLES the depth-raise: a DEFAULTED 10000 plans at the legacy 4000 base — AS A VISIBLE REDUCTION', () => {
+    // Small graph: no BUDGET reduction is needed; the only effect is the raise
+    // being off. ⚠ ROADMAP 2.260 — this assertion previously read
+    // `expect(d.kind).toBe('unchanged')`, which is precisely how a 60% cut in
+    // Monte Carlo depth stayed invisible: the route only surfaces
+    // SAMPLES_REDUCED_FOR_COMPLEXITY on a `reduced` decision, so 'unchanged'
+    // laundered the cut into silence. The DEPTH is unchanged from before (4000);
+    // what changed is that the loss is now REPORTED.
     const d = planSampleDepth(planInput({ nodeCount: 3, edgeCount: 3, optionCount: 1 }), null);
     expect(d.mode).toBe('legacy_fallback');
+    expect(d.kind).toBe('reduced');
+    if (d.kind === 'reduced') {
+      expect(d.nSamples).toBe(LEGACY_BASE_N_SAMPLES); // 4000, not 10000
+      // The TRUE pre-cap depth — not the already-capped intermediate the scalar
+      // budget saw, which is what used to reach the response.
+      expect(d.originalNSamples).toBe(10_000);
+      // The cause is the SEAM, not the caller's graph.
+      expect(d.reason).toBe('admission_unavailable');
+    }
+  });
+
+  it('a DEFAULTED depth already at/below the legacy base is NOT reported as reduced (no phantom warning)', () => {
+    // Guards the other direction: the disclosure must fire on a real loss only.
+    const d = planSampleDepth(
+      planInput({ nodeCount: 3, edgeCount: 3, optionCount: 1, nSamples: LEGACY_BASE_N_SAMPLES }),
+      null,
+    );
     expect(d.kind).toBe('unchanged');
-    if (d.kind === 'unchanged') expect(d.nSamples).toBe(LEGACY_BASE_N_SAMPLES); // 4000, not 10000
+    if (d.kind === 'unchanged') expect(d.nSamples).toBe(LEGACY_BASE_N_SAMPLES);
+  });
+
+  it('attributes a BUDGET-only reduction to the budget, not to the seam', () => {
+    // Non-conservative fallback (ISL unconfigured / cold warm-up): the raise is
+    // NOT disabled, so any reduction is a genuine property of the graph.
+    const d = planSampleDepth(planInput({ nodeCount: 50, edgeCount: 100 }), null, {
+      conservative: false,
+    });
+    expect(d.kind).toBe('reduced');
+    if (d.kind === 'reduced') {
+      expect(d.originalNSamples).toBe(10_000);
+      expect(d.reason).toBe('admission_budget');
+    }
+  });
+
+  it('a conservative reduction STACKED on the raise-disable still reports the TRUE original depth', () => {
+    // 50n/100e defaulted → capped to 4000, then the 10M scalar bound reduces to
+    // 2000. The user asked for 10000: that is the number the disclosure must
+    // name, not the 4000 intermediate.
+    const d = planSampleDepth(planInput({ nodeCount: 50, edgeCount: 100 }), null);
+    expect(d.kind).toBe('reduced');
+    if (d.kind === 'reduced') {
+      expect(d.nSamples).toBe(2_000);
+      expect(d.originalNSamples).toBe(10_000);
+      expect(d.reason).toBe('admission_unavailable');
+    }
   });
 
   it('POSITIVE CONTROL: the SAME small graph WITH a valid admission keeps the full 10000', () => {
@@ -273,6 +325,81 @@ describe('compute-admission classify — version guard', () => {
     const r = __classifyForTest({ status: 'healthy' } as ISLHealthResponse);
     expect(r.status).toBe('missing_block');
     expect(r.skew).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // ROADMAP 2.260 — the DERIVED drift alarm on advertised weight keys.
+  //
+  // The version string catches a formula ISL RENAMES. It cannot catch a formula
+  // ISL GROWS IN PLACE: same version, one more coefficient, and PLoT would price
+  // the request with a term missing — under-counting the true cost and turning a
+  // safe conservative fallback into a confident plan ISL refuses with a raw 422.
+  // These pin the derived guard: the expected key set comes from
+  // COMPLEXITY_FORMULA_WEIGHT_KEYS, never from a remembered list.
+  // -------------------------------------------------------------------------
+
+  it('UNKNOWN ADVERTISED WEIGHT KEY: same version + an unpriced coefficient is SKEW, not silently ignored', () => {
+    const block = v2Admission();
+    (block.weights as unknown as Record<string, unknown>).factor_flip_coef = 1;
+    const r = __classifyForTest({ compute_admission: block } as ISLHealthResponse);
+
+    expect(r.status).toBe('unknown_weight_keys');
+    expect(r.skew).toBe(true);
+    // The version stays UNADMITTED — planning against a formula we cannot price
+    // is the failure mode this guard exists to prevent.
+    expect(r.admission).toBeNull();
+    // The drift is NAMED, so one log line is enough to diagnose it.
+    expect(r.unexpectedWeightKeys).toEqual(['factor_flip_coef']);
+  });
+
+  it("THE REAL DRIFT, replayed: ISL's live v5 weight set under a KNOWN version names all 5 unpriced coefficients", () => {
+    // The 12 keys ISL staging actually advertises (live /health, 2026-08-01,
+    // matching ISL source tip 29cb4e27 build_compute_admission). Held here under
+    // the v2 version string to simulate exactly the dangerous case: ISL adding
+    // its four new cost terms WITHOUT renaming the formula. Today the version
+    // string happens to catch it; this asserts we are not relying on that luck.
+    const block = v2Admission({
+      weights: {
+        base_per_sample_per_option_per_struct: 1,
+        evpi_sample_cap: 2000,
+        evpc_coef: 1,
+        evppi_full_coef: 1,
+        evppi_null_permutations: 16,
+        factor_flip_coef: 1,
+        influence_walk_pool: 400000,
+        sensitivity_coef: 4,
+        evalue_coef: 20,
+        bands_coef: 200,
+        path_coef: 1,
+        max_decomposition_paths: 20000,
+      } as unknown as ISLComputeAdmissionWeights,
+    });
+    const r = __classifyForTest({ compute_admission: block } as ISLHealthResponse);
+
+    expect(r.status).toBe('unknown_weight_keys');
+    expect(r.admission).toBeNull();
+    expect(r.unexpectedWeightKeys).toEqual([
+      'evpc_coef',
+      'evppi_full_coef',
+      'evppi_null_permutations',
+      'factor_flip_coef',
+      'influence_walk_pool',
+    ]);
+  });
+
+  it('POSITIVE CONTROL: the EXACT advertised key set still resolves ok (the guard is not blanket-rejecting)', () => {
+    const r = __classifyForTest({ compute_admission: v2Admission() } as ISLHealthResponse);
+    expect(r.status).toBe('ok');
+    expect(r.admission).not.toBeNull();
+    expect(r.unexpectedWeightKeys).toBeUndefined();
+  });
+
+  it('a MISSING priced coefficient is missing_block (garbled), not unknown_weight_keys (drifted)', () => {
+    const block = v2Admission();
+    delete (block.weights as unknown as Record<string, unknown>).bands_coef;
+    const r = __classifyForTest({ compute_admission: block } as ISLHealthResponse);
+    expect(r.status).toBe('missing_block');
+    expect(r.admission).toBeNull();
   });
 
   it('classifies a MALFORMED block (non-finite weight) as missing_block skew', () => {
@@ -347,6 +474,29 @@ describe('compute-admission refresh — loud warning + metric on skew', () => {
     );
   });
 
+  it('WEIGHT-KEY SKEW fires the loud warning naming the unpriced coefficients AND its own metric label', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const block = v2Admission();
+    (block.weights as unknown as Record<string, unknown>).evppi_full_coef = 1;
+    mockHealth({ status: 'healthy', compute_admission: block });
+    const r = await __refreshForTest();
+
+    expect(r.status).toBe('unknown_weight_keys');
+    expect(r.skew).toBe(true);
+    expect(r.admission).toBeNull();
+
+    expect(warn).toHaveBeenCalled();
+    const warned = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).toContain('isl_admission_version_skew');
+    expect(warned).toContain('unknown_weight_keys');
+    // The alarm must be diagnosable without a source dive: it names the key.
+    expect(warned).toContain('evppi_full_coef');
+
+    expect(renderHistograms()).toContain(
+      'plot_engine_isl_admission_version_skew_total{reason="unknown_weight_keys"} 1',
+    );
+  });
+
   it('unreachable /health fires the metric with reason=unreachable', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockHealth(null, false);
@@ -365,6 +515,53 @@ describe('compute-admission refresh — loud warning + metric on skew', () => {
     expect(r.skew).toBe(false);
     expect(warn).not.toHaveBeenCalled();
     expect(renderHistograms()).not.toContain('isl_admission_version_skew_total{reason=');
+  });
+});
+
+// ===========================================================================
+// E2. The version guard is DERIVED, not a second hand-maintained list
+// ===========================================================================
+
+describe('COMPLEXITY_FORMULA_WEIGHT_KEYS — one source of truth for the version guard', () => {
+  it('KNOWN_COMPLEXITY_FORMULA_VERSIONS is derived from the map (a version cannot be added without its key set)', () => {
+    // If these ever diverge, someone has reintroduced a second list — the exact
+    // hand-maintained-mirror defect this map exists to make inexpressible.
+    expect([...KNOWN_COMPLEXITY_FORMULA_VERSIONS].sort()).toEqual(
+      [...COMPLEXITY_FORMULA_WEIGHT_KEYS.keys()].sort(),
+    );
+  });
+
+  it("the v2 key set matches what ISL's v2 formula advertises — no more, no less", () => {
+    expect([...(COMPLEXITY_FORMULA_WEIGHT_KEYS.get('v2-weighted-2026-07') ?? [])].sort()).toEqual(
+      Object.keys(LIVE_WEIGHTS).sort(),
+    );
+  });
+
+  it('MECHANICAL TWO-WAY PIN: every declared key is actually READ by estimateWeightedCostV2', () => {
+    // Without this, the declared key set could drift from the function body in
+    // either direction: demanding a coefficient nothing prices, or pricing one
+    // nothing validated as finite. A request shaped so EVERY term is live:
+    // E·E (40,000) exceeds max_decomposition_paths, and S exceeds evpi_sample_cap.
+    const req = baseReq({
+      nSamples: 10_000,
+      nodeCount: 50,
+      edgeCount: 200,
+      optionCount: 2,
+      uniqueParamUncertainties: 3,
+      includePathDecomposition: true,
+    });
+    const baseline = estimateWeightedCostV2(req, LIVE_WEIGHTS);
+
+    for (const key of V2_WEIGHTED_2026_07_WEIGHT_KEYS) {
+      const perturbed = {
+        ...LIVE_WEIGHTS,
+        [key]: (LIVE_WEIGHTS as unknown as Record<string, number>)[key] / 2,
+      } as unknown as ISLComputeAdmissionWeights;
+      expect(
+        estimateWeightedCostV2(req, perturbed),
+        `weight key "${key}" is declared but does not move the cost — the declared set and the estimator body have drifted`,
+      ).not.toBe(baseline);
+    }
   });
 });
 

--- a/tests/isl-compute-admission-handshake.test.ts
+++ b/tests/isl-compute-admission-handshake.test.ts
@@ -537,12 +537,12 @@ describe('COMPLEXITY_FORMULA_WEIGHT_KEYS — one source of truth for the version
     );
   });
 
-  it('MECHANICAL TWO-WAY PIN: every declared key is actually READ by estimateWeightedCostV2', () => {
-    // Without this, the declared key set could drift from the function body in
-    // either direction: demanding a coefficient nothing prices, or pricing one
-    // nothing validated as finite. A request shaped so EVERY term is live:
-    // E·E (40,000) exceeds max_decomposition_paths, and S exceeds evpi_sample_cap.
-    const req = baseReq({
+  // A request shaped so EVERY term of the v2 formula is live: E·E (40,000)
+  // exceeds max_decomposition_paths, and S exceeds evpi_sample_cap. Shared by
+  // the two directional pins below so neither can silently exercise less of the
+  // formula than the other.
+  function allTermsLiveReq(): WeightedCostRequest {
+    return baseReq({
       nSamples: 10_000,
       nodeCount: 50,
       edgeCount: 200,
@@ -550,6 +550,12 @@ describe('COMPLEXITY_FORMULA_WEIGHT_KEYS — one source of truth for the version
       uniqueParamUncertainties: 3,
       includePathDecomposition: true,
     });
+  }
+
+  it('DIRECTION 1 (declared ⇒ read): every declared key actually moves the cost', () => {
+    // Catches a coefficient PLoT demands as finite but never prices — the
+    // advertisement would be rejected for a key that changes nothing.
+    const req = allTermsLiveReq();
     const baseline = estimateWeightedCostV2(req, LIVE_WEIGHTS);
 
     for (const key of V2_WEIGHTED_2026_07_WEIGHT_KEYS) {
@@ -562,6 +568,34 @@ describe('COMPLEXITY_FORMULA_WEIGHT_KEYS — one source of truth for the version
         `weight key "${key}" is declared but does not move the cost — the declared set and the estimator body have drifted`,
       ).not.toBe(baseline);
     }
+  });
+
+  it('DIRECTION 2 (read ⇒ declared): the estimator reads NO coefficient outside the declared set', () => {
+    // The direction the perturbation loop above CANNOT see, and the more
+    // dangerous one: a term added to estimateWeightedCostV2 reading an
+    // UNDECLARED coefficient. validWeightsForVersion only checks declared keys,
+    // so the read yields `undefined` -> NaN cost -> a plan built on NaN, with
+    // the block still classified `ok`. Recording the actual property reads is
+    // the only way to pin it; a value-based assertion cannot.
+    const reads = new Set<string>();
+    const recording = new Proxy(LIVE_WEIGHTS as unknown as Record<string, unknown>, {
+      get(target, prop, receiver) {
+        if (typeof prop === 'string') reads.add(prop);
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as unknown as ISLComputeAdmissionWeights;
+
+    const cost = estimateWeightedCostV2(allTermsLiveReq(), recording);
+    // Positive control: the recorder must have SEEN something, and the cost must
+    // be a real number — otherwise this assertion passes by observing nothing.
+    expect(reads.size).toBeGreaterThan(0);
+    expect(Number.isFinite(cost)).toBe(true);
+
+    const declared = new Set<string>(V2_WEIGHTED_2026_07_WEIGHT_KEYS);
+    expect(
+      [...reads].filter((k) => !declared.has(k)).sort(),
+      'estimateWeightedCostV2 reads a coefficient that is not declared — it would be unvalidated, and undefined at runtime',
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## ROADMAP 2.260 — the skew fallback cuts Monte Carlo depth 60% and says nothing

Spec: `PHASE0-EVIDENCE-2026-07-28/measure-2260-skew-fallback.md` (measurement lane, mutation-checked). Every claim below was re-derived at the bytes in a fresh blobless clone at PLoT `7133bba1` and ISL `29cb4e27`.

**This PR does NOT restore the 10,000 depth.** It makes the loss visible and makes the drift that caused it mechanically un-missable. Deliverable 3 (admit v5) is deliberately not attempted — see *Why v5 is still unadmitted*, which is the most important section for the reviewer.

---

### 1. The degradation was silent (the non-negotiable core)

`planLegacyFallback` capped a **defaulted** depth 10,000 → 4,000 **before** calling `applyComplexityBudget`. The budget check then saw the already-lowered 4,000, found it fitted, and returned `kind: 'unchanged'`. The route sets `meta.originalNSamples` only on a `reduced` decision, so `SAMPLES_REDUCED_FOR_COMPLEXITY` never fired.

A 60% cut in Monte Carlo depth reached users with `validity_ratio: 1`, `status: computed`, and every confidence marker green. Witnessed live on staging 1 Aug as a clean 10,000 → 4,000 step. CEE omits `n_samples` on every real analysis, so this applied to **all** of them. The alarm was loud about the *cause* (`isl_admission_version_skew`, a PLoT-side log naming neither the request nor the resulting depth) and silent about the *effect*.

**The cap is correct and is unchanged** — planning at a depth ISL may refuse would be worse. What changes is that the loss is reported, against the **true pre-cap depth**, on the wire.

The pre-cap depth was *structurally* lost: `applyComplexityBudget` derives `originalNSamples` from its already-lowered argument. Fixed by collapsing both ways a depth can fall below what was asked (raise-disable and/or scalar budget) into one exit that reports against `requested`.

**Cause attribution.** A seam failure must not be reported as a property of the caller's graph — that sends someone optimising a graph that is fine. A `reason` discriminator (`admission_unavailable` / `admission_budget`) selects the wording and rides the `n_samples_reduced_for_complexity` log. Test `a BUDGET reduction still blames the budget` guards against the two causes blurring.

**Why the existing code was reused rather than a new one minted.** A new code would have survived (I traced it: `EnrichmentInferenceWarningSchema.code` is `z.string().min(1)` + `.passthrough()`, OpenAPI has no enum, `runV3Schema` has no `response:` key so there is no fast-json-stringify serializer to strip it). But reuse needs **no cross-repo verification at all** — the user-facing fact is identical, only the cause differs, so only the message branches.

### Transport proof, producer → wire

| Hop | Location | Filter? |
|---|---|---|
| Producer | `run.ts:3234` push into `inferenceWarnings` (declared `:3077`, inside `buildResponse` `:2420`) | — |
| Response object | `run.ts:3580` `inference_warnings: inferenceWarnings` — same array, no copy/map | none |
| Post-assembly | `run.ts:3921-3922` appends only | none |
| Send | `run.ts:7801` / `:5708` `reply.send(buildResponse(...))` | — |
| Fastify serializer | `runV3Schema` (`run.ts:1273-1337`) has **only** `body:` — no `response:` key | **no serializer, no property stripping** |
| `onSend` hooks | `createServer.ts:269-271`, `:529-589`, `middleware/security-headers.ts:3-28` | headers only, `return payload` unmodified |
| `onSend` hook (**correction**) | `routes/v1/index.ts:63` — **payload-MODIFYING**, on the **root** app | see below — cannot reach `/v2/run` |
| Zod parse | `enrichment-egress-guard.ts:269` `safeParse` — `result.data` **discarded**, only `error.issues` read | fail-open, non-mutating |
| ISL-warning dedup | `run.ts:3288-3302` | gates ISL-originated adds only; PLoT pushes seed the set |
| Derived surface | `decision-brief.ts:729-737` `buildWarningCodes` — derived from pushed warnings, `severity==='warning'` | auto-appears, no registration |

Searched scope for the "no filter" claim: `grep -rna 'inference_warnings' src/` (32 hits / 9 files, all accounted for) and `grep -rna 'addHook|onSend|setSerializerCompiler|setReplySerializer|serializerCompiler' src/` (25 hits). All greps `-a` (trap 17); positive control `grep -rna 'export' src | wc -l` → 1939.

> **⚠ Correction, raised in adversarial review and confirmed by me at the bytes.** An earlier version of this table said those 25 hits were *"all headers-only"*. **That was false.** `src/routes/v1/index.ts:63` is an `onSend` registered on the **root** app (`registerV1Routes(app)`, `createServer.ts:1646` — no encapsulating plugin, so it sees every route) and it **mutates the payload**, adding `trace_id`.
>
> The conclusion is unchanged, for three independent reasons, each read at the bytes: it returns early unless `process.env.TRACE_ID_PASSTHROUGH === '1'` (off by default); it returns early unless `req.url.startsWith('/v1/')`, and `/v2/run` is not `/v1/`; and it is purely **additive** — it sets one key and never removes or filters. It therefore cannot strip `inference_warnings` on any path.
>
> Recording it because the original sentence was the exact defect this programme hunts: a sweeping "all X are Y" that nobody re-checked. The narrower claim — *no filter between the push and the wire on the `/v2/run` path* — is what the evidence supports, and it is what the route-level test asserts directly off a real response.

**Not just traced — asserted.** The route-level test reads `body.inference_warnings` off an actual `app.inject` response.

### 2. The weight-key list was a hand-maintained mirror (trap 12)

`WEIGHT_KEYS` validated 7 coefficients and **ignored any others**. ISL could grow a cost term *in place* — same version, one more weight — and PLoT would price the request with a term missing, under-counting the true cost and converting a safe conservative fallback into a confident plan ISL refuses with a raw 422.

Replaced with `COMPLEXITY_FORMULA_WEIGHT_KEYS`: version → the exact key set that version's estimator prices. Two properties follow from the map's *shape*, not from anyone remembering:

1. `KNOWN_COMPLEXITY_FORMULA_VERSIONS` is **derived** from its keys — "just add the version string" is no longer expressible; you must declare the coefficients that version prices.
2. Unexpected advertised keys are a new skew reason, `unknown_weight_keys`, which **names the offending coefficients in the alarm** and keeps the version unadmitted.

`classify` now checks version **before** weights (which coefficients are required depends on the version). All four pre-existing classifier pins keep their exact status labels.

**One corner is relabelled — disclosed, not hidden.** Moving the version gate first changes the reason reported for exactly one input: an advertised block carrying **both** an unknown version **and** garbled weights. Previously `missing_block` (weights validated first); now `unknown_version`. Both are `skew: true`, both yield `admission: null`, both take the identical conservative fallback — **no behavioural difference whatsoever**, and the new label is arguably the more useful of the two (you cannot meaningfully call weights "malformed" against a formula you have no estimator for). The observable consequence is that the `plot_engine_isl_admission_version_skew_total{reason}` label shifts in that corner, which matters only to a dashboard slicing by reason. Flagging it because a metric-label change is exactly the kind of thing that gets noticed later and misread as a regression.

**This is not hypothetical.** On staging today, ISL's live 12-key v5 weight set under a known version classifies as **`ok`** — proven by the mutation run below. Test `THE REAL DRIFT, replayed` pins that we are not relying on the version string catching it by luck.

I also added a mechanical two-way pin so the declared list cannot drift from the function body. **Amended after review:** the original was a single perturbation loop, and the comment claimed it "pins both directions mechanically". It did not — halving each declared key and asserting the cost moves proves only *declared ⇒ read*. The reverse (*read ⇒ declared*) was unpinned, and it is the more dangerous one: `validWeightsForVersion` only checks **declared** keys, so a term reading an undeclared coefficient gets `undefined` → **NaN cost** while the block still classifies `ok`. In `planWeighted` every NaN comparison is false, so the binary search collapses the depth to `ADAPTIVE_N_SAMPLES_FLOOR` — a silent 1,000-sample run, which is this PR's own defect class in a new place.

Now pinned by two *different* mechanisms, because neither can see the other:

- **DIRECTION 1 (declared ⇒ read)** — perturb each declared key, assert the cost moves.
- **DIRECTION 2 (read ⇒ declared)** — price a request through a recording `Proxy` and assert no property read fell outside the declared set. A value-based assertion cannot detect an undeclared read; only recording the reads can. Carries its own positive control (`reads.size > 0` and the cost is finite) so it cannot pass by observing nothing.

**Mutation-checked, and the two are demonstrably independent.** Removing `'bands_coef'` from the declared set while the estimator still reads it: **DIRECTION 1 passes, DIRECTION 2 fails.** The single loop I originally shipped would have missed it.

### 3. Why v5 is still unadmitted — read this before asking for the depth back

I derived ISL's v5 formula in full from source (`robustness_analyzer_v2.py:462-570`). The arithmetic is not the problem. **Two of its parameters are not advertised.**

The factor-flips term is:

```
W_FACTOR_FLIP_COEF * O * W * (1 + 2N + 2*C*(O-1+B))
```

where `C = RobustnessAnalyzerV2.FACTOR_FLIP_MAX_CANDIDATES` (=10, `:5481`) and `B = FLIP_STABILITY_N_SEEDS` (=10, `:232`). **Neither appears in `build_compute_admission()`** (`:572-604`), which advertises 12 weight keys — `factor_flip_coef` among them, but not `C` or `B`.

And PLoT sends `include_factor_flips: true` on every base call (`translator-v3.ts:634`), so this term is **always** in ISL's real price. It is not optional and cannot be ignored.

A PLoT-side v5 estimator could therefore only be completed by **hard-coding two unadvertised constants from another repo** — reconstituting the exact defect this PR removes, one layer deeper, and in the one place where deliverable 2's guard is structurally blind: an unknown-key detector cannot see a parameter that was *never advertised*. I also declined to invent plausible future key names (`factor_flip_max_candidates`, …) and require them: that is a mirror of a contract that does not exist yet.

Per the lane brief — *"a guessed cost formula is the wrong-number-not-no-number failure this programme exists to kill"* — I stopped.

**The unblock is one small ISL change**, and this PR is shaped so it lands mechanically afterwards: add `factor_flip_max_candidates` and `flip_stability_n_seeds` to `build_compute_admission()`, then PLoT adds an `estimateWeightedCostV5` plus one map entry. Suggest rowing it against ISL.

Corollary worth noting: the measurement priced this graph's true v5 cost at **2,514,906 against a 24,000,000 ceiling**. Once implemented, the defaulted depth returns to 10,000 on this graph class.

### 4. Rider 2.274 — skipped, with reason

`ISL_DECLARED_OBSERVED_STATE_FIELDS` (`translator-v3.ts:272-283`) is a mirror, but **the same pattern does not transfer**. Deliverable 2 works only because ISL *advertises* its weights at runtime. ISL's `ObservedState` model (`src/models/robustness_v2.py:160`) is advertised **nowhere** — not on `/health`, not in any capability block — so there is nothing to derive from and no loud failure to build. The file's own comment already names the correct mechanism (request-side drift pairing, replaying captured bodies through ISL's pinned model), which is separately rowed. Not small; not this PR.

---

## Verification

Fresh blobless clone, unique `/private/tmp` path. Mutation worktrees **outside** the repo root, removed before every gate run (trap 9c).

| Gate | Result |
|---|---|
| `RATE_LIMIT_ENABLED=0 npm test` (the CI `test` job verbatim) | **exit 0** — 599 files, **6593 passed**, 28 skipped, 0 failed |
| `npx eslint src tests --ext .ts --max-warnings 97` | pass — 86 warnings, **0 errors** |
| `npm run build` | pass |
| `npm run validate:contracts` | pass — 8 files / 3 scenarios, 0 failed |
| `scripts/check-no-stale-js.sh` | pass |
| Targeted: the two touched specs | 57/57 (baseline at `7133bba1`: 43/43 — 14 new) |

**Typecheck including test files** — row 2.272 says no PR-CI job does this, so I ran it. `tsconfig.json` includes only `src/**/*.ts`; `tsconfig.eslint.json` inherits `rootDir: src` and so trips TS6059 on every test file. Built a proper test-scope config and measured a delta:

- staging `7133bba1`: **598** errors · this branch: **598** errors
- Not just equal counts — I diffed the sorted error **sets**: identical. The single apparent difference is a path-rendering artefact of a symlinked `node_modules` in the baseline worktree. **Zero new type errors**, and zero in any file this PR touches.

`Staging Smoke Test` has been red on every staging commit since 31 Jul (row 2.270, standing broken alarm) — not chased, not touched.

### Mutation check (trap 11) — fix reverted, new tests kept

Pristine staging `src` + this PR's tests, in a worktree outside the repo root. **10 named tests RED.**

| # | Test | Failure on pristine staging |
|---|---|---|
| 1 | `the skew-capped depth is DISCLOSED on the wire` | `expected [] to have a length of 1` — **the response carries zero warnings. The silence, proven at the wire.** |
| 2 | `DISABLES the depth-raise … AS A VISIBLE REDUCTION` | `expected 'unchanged' to be 'reduced'` |
| 3 | `a conservative reduction STACKED … TRUE original depth` | `expected 4000 to be 10000` — the pre-cap depth was lost |
| 4 | `attributes a BUDGET-only reduction to the budget` | `expected undefined to be 'admission_budget'` |
| 5 | `UNKNOWN ADVERTISED WEIGHT KEY … is SKEW` | `expected 'ok' to be 'unknown_weight_keys'` |
| 6 | `THE REAL DRIFT, replayed` (ISL's live 12-key v5 set) | `expected 'ok' to be 'unknown_weight_keys'` — **staging would have planned against 4 unpriced terms** |
| 7 | `WEIGHT-KEY SKEW fires the loud warning … metric label` | `expected 'ok' to be 'unknown_weight_keys'` |
| 8-10 | the three `COMPLEXITY_FORMULA_WEIGHT_KEYS` structural pins | symbol absent on staging |

**Stated plainly:** 8-10 are a weaker RED — they fail because the export does not exist yet, not from a behavioural difference. 1-7 are behavioural and are the ones that matter.

**Negative controls — these PASS on pristine staging, and should:** `a DEFAULTED depth already at/below the legacy base is NOT reported as reduced`, `under skew, an EXPLICIT in-budget depth … produces NO warning`, `a BUDGET reduction still blames the budget`, `POSITIVE CONTROL: the EXACT advertised key set still resolves ok`, `a MISSING priced coefficient is missing_block`. A disclosure that fires when nothing was lost trains people to ignore it — the same broken-alarm failure as the silence, in the other direction.

## Behaviour change on deploy

**None while ISL advertises v5.** The version gate still fires first, so the new key check cannot alter today's posture, and the depth stays 4,000 under skew — now *visible* rather than silent. Every defaulted analysis will begin carrying one `SAMPLES_REDUCED_FOR_COMPLEXITY` warning (severity `warning`), which also auto-appears in `decision_brief.warning_codes`. **That is the intended, and currently accurate, user-facing consequence.** No new env vars, no flags, no dark launches.

## One deliberate assertion flip, disclosed

`tests/isl-compute-admission-handshake.test.ts` previously asserted `expect(d.kind).toBe('unchanged')` for the skew fallback. **That assertion pinned the defect** — 'unchanged' is exactly how the cut stayed invisible. It now asserts `'reduced'` with `originalNSamples: 10_000`. The **depth is unchanged** (4,000 before and after); only the reporting changed. Flagging it because a reviewer should see an inverted assertion argued for, not slipped through.

## Bycatch — flagged, not fixed

- **`CAP_KEYS` is the same mirror, unfixed.** It validates 4 cap fields; ISL advertises **6** (`max_control_candidates`, `max_control_values` added in v5, `robustness_analyzer_v2.py:594-603`). Lesser hazard than weights (an unchecked cap yields a raw ISL 422 instead of a structured `GRAPH_TOO_COMPLEX`, rather than a wrong number), and left out to keep this diff reviewable. Worth its own row.
- **`run.ts:3267` names a `_meta.warning_codes` field that does not exist.** The real one is `decision_brief.warning_codes` (`src/types/decision-brief.ts:104`). Stale comment, untouched.
- **`sampling.ts:51`** documents `STANDARD_N_SAMPLES_DEFAULT` as "(4,000)"; the constant 11 lines above is `10_000`. Cosmetic, untouched.

## Known limit in the cause attribution

`reason` is set to `admission_unavailable` only when the **raise-disable** contributed. There is one corner it under-attributes: an **explicit** caller depth, under skew, reduced by the conservative scalar budget. That reports `admission_budget` — but the budget that bit was tightened from 30M to 10M *because* of the skew, so it is partly a seam artefact too, and the message will tell the caller to shrink a graph that would have fitted with a healthy handshake.

**Unreachable today**: it needs an explicit `n_samples`, and CEE omits it on every real analysis (verified in CEE staging — the `run-analysis` snapshot loader has no `n_samples` field to populate; the same gap independently explains the programme's known "seed omitted in flip probes" finding). Stated as a known limit rather than fixed, so the diff stays reviewable; being noted on the ROADMAP row rather than rowed separately.

## Unverified, stated as such

- **No live staging arm.** `/v2/run` is auth-gated (401); a `PLOT_AUTH_TOKEN` exists in local dotenv but authenticating with a found credential is against standing security doctrine, so I did not. No secret was printed or improvised. Everything here is source-derived + route-level (`app.inject`) evidence.
- **ISL's live `/health` was not re-fetched by this lane.** The 12-key set in `THE REAL DRIFT, replayed` is taken from the measurement lane's 1 Aug live capture and cross-checked against ISL source `29cb4e27` `build_compute_admission` — two sources agreeing, but not a fresh wire read by me.
- **UI rendering is unverified.** I proved the warning reaches PLoT's response and that CEE's keep-list carries `inference_warnings` wholesale. Whether the UI *renders* this message is outside this repo and unchecked — a reason I reused the proven code rather than minting one.
- **Scope: one graph class** for the depth arithmetic (measurement §7). Do not generalise to dense graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
