### PR TITLE
fix(2.266,2.278): gate goal-constraint auto-synthesis on the ISL sample frame; stop claiming flips on attested-no-flip turns

### DIFF
--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -48,7 +48,7 @@ export const STANDARD_N_SAMPLES_DEFAULT = 10_000;
  *     emergency rollback / override; malformed (`1,000`, `1000abc`) or
  *     out-of-bounds values are ignored (with a one-time warning) so they cannot
  *     bypass the /v2/run schema bound or forward a garbage depth to ISL;
- *  2. otherwise `STANDARD_N_SAMPLES_DEFAULT` (4,000).
+ *  2. otherwise `STANDARD_N_SAMPLES_DEFAULT` (10,000).
  *
  * Read at call time so the override takes effect without a rebuild and is
  * trivially testable. An explicit `n_samples` in the request always wins over

--- a/src/routes/v2/robustness-display-verdict.ts
+++ b/src/routes/v2/robustness-display-verdict.ts
@@ -31,6 +31,9 @@
  *  - The reason phrases are producer-owned, claim-safe, and carry no numbers.
  */
 
+import type { DenormalisedFlipThreshold } from '../../lib/flip-threshold-denormaliser.js';
+import { classifyFlipThresholdsStatus } from '../../lib/flip-threshold-status.js';
+
 /** The four display-safe verdict values. Additive /v2/run wire enum. */
 export type RobustnessDisplayVerdict =
   | 'robust'
@@ -51,6 +54,46 @@ export const ROBUSTNESS_DISPLAY_VERDICT_REASONS: Record<
   moderate: 'this result mostly held up, but could shift under some changes',
   fragile: 'small changes could flip this result',
   not_assessed: 'robustness was not assessed for this run',
+};
+
+/**
+ * ROADMAP 2.278 — the SAME verdicts, worded for a run whose own flip evidence
+ * ATTESTS that no factor flips the leading option.
+ *
+ * WHY THIS EXISTS. The verdict above is derived purely from robustness
+ * marginals and never consulted the flip evidence sitting in the same
+ * response. Witnessed live (`witness-2267-onscreen-flip.md`): across four
+ * analysed scenarios, 19 of 19 flip-threshold rows came back
+ * `structurally_invariant` — ISL's MATHEMATICAL ATTESTATION that no value of
+ * that factor can move the argmax — and the product rendered no flip card,
+ * because there was no flip to render. On those same turns the robustness
+ * verdict shipped `fragile` + "small changes could flip this result". The run
+ * asserted a flip and denied one, in the same payload.
+ *
+ * WHAT CHANGES AND WHAT DOES NOT. Only the REASON STRING changes. The VERDICT
+ * is untouched: a run with no flippable factor can still be genuinely
+ * non-robust for other reasons this module already measures (an explicit
+ * `is_robust: false`, a low robustness level — and, on the witnessed turn,
+ * fragile EDGES with a high switch probability, which is a different
+ * measurement from factor flips and is not contradicted by them). Softening
+ * the verdict on flip evidence alone would be the mirror-image error: using
+ * one measurement to overrule another that never claimed the same thing.
+ *
+ * So these strings do two things the originals did not: they say WHAT WAS
+ * MEASURED, and they stop claiming flippability that this run's own evidence
+ * refutes.
+ *
+ * `robust` and `not_assessed` are intentionally absent — neither original
+ * carries flip language, so neither has anything to correct, and restating
+ * them here would create a second copy to drift.
+ */
+export const ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP: Partial<
+  Record<RobustnessDisplayVerdict, string>
+> = {
+  fragile:
+    'no single factor on its own changed which option leads, but this result scored low on our other robustness checks',
+  moderate:
+    'no single factor on its own changed which option leads, and this result mostly held up under the other changes we tested',
 };
 
 /**
@@ -81,12 +124,40 @@ export interface RobustnessVerdictFacts {
 export function deriveRobustnessDisplayVerdict(
   facts: RobustnessVerdictFacts | undefined,
   robustnessComputed: boolean,
+  flipThresholds?: DenormalisedFlipThreshold[] | null,
 ): { display_verdict: RobustnessDisplayVerdict; display_verdict_reason: string } {
   const display_verdict = deriveVerdict(facts, robustnessComputed);
-  return {
-    display_verdict,
-    display_verdict_reason: ROBUSTNESS_DISPLAY_VERDICT_REASONS[display_verdict],
-  };
+
+  // ROADMAP 2.278. The no-flip wording is used ONLY on `all_no_effect`, and the
+  // classification is DERIVED by the shared classifier rather than re-read from
+  // `flip_reason` strings here. That matters twice over:
+  //
+  //  · `classifyFlipThresholdsStatus` is the single source of truth for which
+  //    reasons ATTEST a no-flip (`NO_EFFECT_REASONS`) and which merely mean "we
+  //    did not finish". Restating that vocabulary here would be the
+  //    hand-maintained-mirror defect — and it would drift SILENTLY, because a
+  //    new unresolved reason misfiled as no-effect reads as a cleaner result.
+  //  · `all_no_effect` is the ONLY status that means "every factor was probed
+  //    and none can flip the winner". Every other status is left on the
+  //    original wording, deliberately and for distinct reasons:
+  //      - `unavailable`  → empty or absent array. This is the dominant LEGACY
+  //                         and degraded shape and it means "nobody computed
+  //                         this", NOT "nothing can flip". Blinding it would be
+  //                         asserting an absence from a measurement that never
+  //                         ran.
+  //      - `unresolved` / `partial_no_effect` → at least one row timed out,
+  //                         errored, or was never evaluated. An unfinished
+  //                         probe attests nothing.
+  //      - `computed`     → a real flip WAS found; flip language is earned.
+  const attestedNoFlip =
+    classifyFlipThresholdsStatus(flipThresholds).status === 'all_no_effect';
+
+  const display_verdict_reason =
+    (attestedNoFlip
+      ? ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP[display_verdict]
+      : undefined) ?? ROBUSTNESS_DISPLAY_VERDICT_REASONS[display_verdict];
+
+  return { display_verdict, display_verdict_reason };
 }
 
 function deriveVerdict(

--- a/src/routes/v2/robustness-display-verdict.ts
+++ b/src/routes/v2/robustness-display-verdict.ts
@@ -23,12 +23,21 @@
  *   6. anything else (verdict-bearing facts missing or
  *      unrecognised)                                        → 'not_assessed'
  *
+ * ⚠ THE REASON HAS A SECOND AXIS SINCE ROADMAP 2.278 — the mapping table above
+ * describes the VERDICT only. The verdict is still derived from robustness
+ * marginals alone and nothing below changes it. But the REASON is additionally
+ * a function of the same run's FLIP EVIDENCE, because the two used to
+ * contradict each other on the wire (see
+ * `ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP` for the full account).
+ * Reason = f(verdict, flip-evidence status); verdict = f(producer facts).
+ *
  * Honesty invariants:
  *  - NEVER a determinate-looking verdict ('robust'/'moderate'/'fragile') when
  *    robustness was not actually computed.
  *  - `confidence` is NEVER an input — the function signature does not accept
  *    it, so confidence alone can never upgrade (or create) a verdict.
  *  - The reason phrases are producer-owned, claim-safe, and carry no numbers.
+ *  - Flip evidence may reword a reason but must NEVER move a verdict.
  */
 
 import type { DenormalisedFlipThreshold } from '../../lib/flip-threshold-denormaliser.js';

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -5102,7 +5102,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
          * threshold carry, to keep the target itself on the wire (see there).
          * Values are the diagnostic cause, never a frame PLoT asserts.
          */
-        let autoSynthesisFrameRefusal: 'unattested' | 'level' | undefined;
+        let autoSynthesisFrameRefusal:
+          | 'unattested'
+          | 'level'
+          | 'attestation_mismatch'
+          | undefined;
         const clientConstraintCount = body.goal_constraints?.length ?? 0;
 
         // =================================================================
@@ -5259,29 +5263,82 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           // this branch, which runs only when the compiled set is empty.
           const frameIsSampleFrame = nodeGoalThresholdFrame === 'delta';
 
+          // =============================================================
+          // 2.266 AMENDMENT — THE ATTESTATION MUST BE ABOUT THE NUMBER WE
+          // ARE ACTUALLY SENDING (adversarial review of #304, probe-proven)
+          // =============================================================
+          // `autoThreshold` resolves REQUEST-ROOT first (`goalThreshold ??
+          // nodeGoalThreshold`), but the frame is read off the NODE. So a
+          // producer that sends root `goal_threshold: 0.9` while the node
+          // carries `{goal_threshold: 0.8, goal_threshold_frame: 'delta'}`
+          // would ship `value: 0.9` under an attestation made about 0.8 —
+          // the gate satisfied by a stamp describing a different number.
+          //
+          // Reachability, stated honestly: this needs a producer-inconsistent
+          // caller, and CEE stamps node-only today, so it is not the live
+          // shape. It is closed anyway because the whole point of this row is
+          // that an attestation is only worth what it is attached to.
+          //
+          // ⚠ WHY REFUSE RATHER THAN SYNTHESISE THE NODE'S OWN VALUE (the
+          // other option the review offered). Precedence routing leaves
+          // `effectiveGoalThreshold` at the ROOT value, and the 2.239 carry
+          // below only re-derives it from the constraint when synthesis
+          // fired. Synthesising 0.8 while the root ships 0.9 would put BOTH
+          // numbers on one wire and make ISL answer "P(goal >= 0.9)" and
+          // "P(constraint goal >= 0.8)" in the same response — precisely the
+          // divergence the "derive, never mirror" carry exists to prevent.
+          // Refusing keeps the invariant that the target and the constraint
+          // describe the same number, or there is no constraint.
+          //
+          // A node frame WITHOUT a node threshold is NOT a mismatch: the
+          // frame describes what this goal node's samples mean, so it
+          // legitimately covers a root-supplied target. Only two PRESENT and
+          // UNEQUAL numbers are refused.
+          const targetAttestationMismatch =
+            goalThreshold !== undefined &&
+            nodeGoalThreshold !== undefined &&
+            goalThreshold !== nodeGoalThreshold;
+
+          const synthesisRefusal: 'unattested' | 'level' | 'attestation_mismatch' | undefined =
+            !frameIsSampleFrame
+              ? nodeGoalThresholdFrame === undefined
+                ? 'unattested'
+                : 'level'
+              : targetAttestationMismatch
+                ? 'attestation_mismatch'
+                : undefined;
+
           if (
             autoThreshold !== undefined &&
             Number.isFinite(autoThreshold) &&
-            !frameIsSampleFrame
+            synthesisRefusal !== undefined
           ) {
-            autoSynthesisFrameRefusal =
-              nodeGoalThresholdFrame === undefined ? 'unattested' : 'level';
+            autoSynthesisFrameRefusal = synthesisRefusal;
             req.log.warn({
               event: 'plot.auto_constraint_from_threshold',
               goal_node_id: body.goal_node_id,
               threshold: autoThreshold,
               action: 'refused',
               goal_threshold_frame: nodeGoalThresholdFrame ?? null,
+              refusal: synthesisRefusal,
+              ...(synthesisRefusal === 'attestation_mismatch'
+                ? { root_goal_threshold: goalThreshold, node_goal_threshold: nodeGoalThreshold }
+                : {}),
               reason:
-                autoSynthesisFrameRefusal === 'unattested'
+                synthesisRefusal === 'unattested'
                   ? 'goal_threshold carries no goal_threshold_frame, so the frame it is stated in is unknown. ' +
                     'ISL evaluates goal_constraints against change-from-baseline samples; synthesising an ' +
                     'unattested target would compare a possibly-absolute level against a change. ' +
                     'No constraint synthesised — the joint-goal figure is omitted rather than guessed.'
-                  : 'goal_threshold is attested as a LEVEL, but ISL evaluates goal_constraints against ' +
-                    'change-from-baseline samples and goal_constraints carry no frame field. PLoT cannot ' +
-                    'convert it (no goal-node baseline; ROADMAP 2.281 pending) and will not guess. ' +
-                    'No constraint synthesised — the joint-goal figure is omitted rather than mis-framed.',
+                  : synthesisRefusal === 'level'
+                    ? 'goal_threshold is attested as a LEVEL, but ISL evaluates goal_constraints against ' +
+                      'change-from-baseline samples and goal_constraints carry no frame field. PLoT cannot ' +
+                      'convert it (no goal-node baseline; ROADMAP 2.281 pending) and will not guess. ' +
+                      'No constraint synthesised — the joint-goal figure is omitted rather than mis-framed.'
+                    : 'the request root and the goal node state DIFFERENT goal targets, and the frame is ' +
+                      'stamped on the node. The attestation therefore describes a different number from the ' +
+                      'one auto-synthesis would send. No constraint synthesised — an attestation is only ' +
+                      'worth what it is attached to.',
             });
           } else if (autoThreshold !== undefined && Number.isFinite(autoThreshold)) {
             // Synthesise a single >= constraint from goal_threshold.

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -3077,6 +3077,11 @@ function buildResponse(
   const displayVerdictFields = deriveRobustnessDisplayVerdict(
     { is_robust: robustness.is_robust, level: robustness.level },
     robustnessStatus === 'computed',
+    // ROADMAP 2.278: the SAME run's flip evidence. `flipThresholds` is a
+    // parameter of this function, so this is the array that ships on the wire
+    // at `flip_thresholds` below — the verdict and the evidence it cites can
+    // never be taken from two different runs.
+    flipThresholds,
   );
   robustness.display_verdict = displayVerdictFields.display_verdict;
   robustness.display_verdict_reason = displayVerdictFields.display_verdict_reason;
@@ -3288,7 +3293,11 @@ function buildResponse(
   // unflippable/input-null cause and the overflow cause separately, never
   // claiming an overflow for the common benign input-null case. Severity: info
   // (ISL routinely emits null e_value for unflippable edges — expected
-  // non-representability, not an alarm; still on the wire + _meta warning_codes).
+  // non-representability, not an alarm; still on the wire in inference_warnings).
+  // NB: it is deliberately NOT in decision_brief.warning_codes — buildWarningCodes
+  // (assembly/decision-brief.ts:729-737) echoes severity 'warning' only. The
+  // earlier text here named `_meta.warning_codes`, a field that does not exist
+  // anywhere in this repo.
   if (meta.edgeEValuesDropped) {
     const disclosure = describeEdgeEValueDrop(
       meta.edgeEValuesDropped.inputNull,
@@ -5086,6 +5095,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // ISL request build can read it.
         let autoSynthesisFired = false;
         let autoThreshold: number | undefined;
+        /**
+         * ROADMAP 2.266 — set when a goal target WAS resolved but the
+         * auto-synthesis was refused because the target's frame does not match
+         * the frame ISL evaluates constraints in. Read once, at the 2.239
+         * threshold carry, to keep the target itself on the wire (see there).
+         * Values are the diagnostic cause, never a frame PLoT asserts.
+         */
+        let autoSynthesisFrameRefusal: 'unattested' | 'level' | undefined;
         const clientConstraintCount = body.goal_constraints?.length ?? 0;
 
         // =================================================================
@@ -5181,7 +5198,92 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           // it on the node even if the request root field is absent).
           autoThreshold = goalThreshold ?? nodeGoalThreshold;
 
-          if (autoThreshold !== undefined && Number.isFinite(autoThreshold)) {
+          // =============================================================
+          // ROADMAP 2.266 — SYNTHESISE ONLY IN THE FRAME ISL EVALUATES IN
+          // =============================================================
+          // ISL evaluates a goal_constraint by comparing its `value` against
+          // the goal node's Monte-Carlo samples, and those samples are a
+          // CHANGE FROM BASELINE (an uplift), not an absolute level. So the
+          // synthesised constraint is only meaningful when the goal target is
+          // itself stated as a change — i.e. frame `'delta'`.
+          //
+          // WITNESSED CONSEQUENCE OF NOT CHECKING (evidence
+          // `witness-2258-goal-probability-live.md`, three live runs): a target
+          // of 0.8 meaning "£6,000,000 of a £7,500,000 cap" — a LEVEL — was
+          // synthesised verbatim and compared against uplift samples whose
+          // median was ~£2,200,000. ISL answered the question actually asked,
+          // "is the UPLIFT >= £6,000,000?", and returned 0.0054. The question
+          // the user asked, "is £4,000,000 + uplift >= £6,000,000?", answers
+          // ~0.55. The surface showed "< 1%" — a ~100x understatement biased
+          // toward "hopeless".
+          //
+          // ⚠ WHY THE GATE IS `=== 'delta'` AND NOT MERELY "a frame is
+          // present". The witnessed runs carried NO frame, so gating on mere
+          // presence would fix today's live surface — and would REINTRODUCE
+          // the exact ~100x error the moment the producer starts stamping,
+          // because the frame it will stamp for that decision is `'level'`.
+          // A gate that passes today and breaks on the next upstream landing
+          // is not a fix. Only `'delta'` is provably in the sample frame.
+          //
+          // ⚠ WHY `'level'` IS NOT CONVERTED HERE INSTEAD. The decisive reason
+          // is structural, not circumstantial: `ISLGoalConstraint` carries NO
+          // frame field at all (`integrations/isl/translator-v3.ts:124-132`).
+          // ISL therefore reads every constraint `value` in one fixed frame and
+          // cannot be told otherwise, so a converted value would have to be
+          // PLoT unilaterally reproducing ISL's own normalisation arithmetic
+          // and hoping the two stay in step — with no field on the wire for
+          // either side to declare what it did, and so no way for a test here
+          // to prove the two agree. Constraint-frame attestation is a schemas
+          // train, deliberately out of scope for this row.
+          //
+          // The missing baseline is a second, weaker obstacle and is stated
+          // narrowly on purpose: a graph CAN carry `observed_state.baseline` on
+          // the goal node (test fixtures do). What the WITNESS establishes is
+          // that the live producer did not write one on any of the three
+          // captured runs, which is also why ISL's own main-path converter
+          // never executed there. ROADMAP 2.281 is the row that changes that.
+          // Minting the arithmetic here anyway would replace a wrong number
+          // with a differently-wrong number — the defect class this row
+          // exists to close. So `'level'` is REFUSED, not guessed.
+          //
+          // The refusal is honest absence, not a silent zero: with no
+          // constraint sent, `buildResponse` omits the whole constraint block
+          // (`run.ts:2095-2098`), so `constraint_probabilities`,
+          // `probability_of_joint_goal`, `goal_fit` and `goal_fit_basis` are
+          // all ABSENT from the wire rather than shipping 0. The user's target
+          // still reaches ISL's main path (see the 2.239 carry below), which
+          // discloses its own refusal by name.
+          //
+          // SCOPE: this gate governs ONLY the auto-synthesised constraint.
+          // User-authored `goal_constraints` are untouched — they never reach
+          // this branch, which runs only when the compiled set is empty.
+          const frameIsSampleFrame = nodeGoalThresholdFrame === 'delta';
+
+          if (
+            autoThreshold !== undefined &&
+            Number.isFinite(autoThreshold) &&
+            !frameIsSampleFrame
+          ) {
+            autoSynthesisFrameRefusal =
+              nodeGoalThresholdFrame === undefined ? 'unattested' : 'level';
+            req.log.warn({
+              event: 'plot.auto_constraint_from_threshold',
+              goal_node_id: body.goal_node_id,
+              threshold: autoThreshold,
+              action: 'refused',
+              goal_threshold_frame: nodeGoalThresholdFrame ?? null,
+              reason:
+                autoSynthesisFrameRefusal === 'unattested'
+                  ? 'goal_threshold carries no goal_threshold_frame, so the frame it is stated in is unknown. ' +
+                    'ISL evaluates goal_constraints against change-from-baseline samples; synthesising an ' +
+                    'unattested target would compare a possibly-absolute level against a change. ' +
+                    'No constraint synthesised — the joint-goal figure is omitted rather than guessed.'
+                  : 'goal_threshold is attested as a LEVEL, but ISL evaluates goal_constraints against ' +
+                    'change-from-baseline samples and goal_constraints carry no frame field. PLoT cannot ' +
+                    'convert it (no goal-node baseline; ROADMAP 2.281 pending) and will not guess. ' +
+                    'No constraint synthesised — the joint-goal figure is omitted rather than mis-framed.',
+            });
+          } else if (autoThreshold !== undefined && Number.isFinite(autoThreshold)) {
             // Synthesise a single >= constraint from goal_threshold.
             // The _internal namespace carries PLoT metadata through the pipeline
             // (filter, validation, merge) and is stripped at wire boundaries
@@ -6133,6 +6235,22 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             (c) => c.constraint_id === 'auto_goal_threshold'
           );
           effectiveGoalThreshold = sentAutoConstraint?.value ?? autoThreshold;
+        }
+
+        // === 2.266 carry: refusing the CONSTRAINT must not withdraw the TARGET
+        // When the synthesis is refused on frame grounds the compiled set stays
+        // empty, so the precedence branch above never runs and never clears
+        // `effectiveGoalThreshold`. That is correct for a target supplied at the
+        // request root — but a target read off the GOAL NODE
+        // (`nodeGoalThreshold`) was never in `effectiveGoalThreshold` in the
+        // first place; only the now-refused synthesis put it back, via the
+        // carry above. Without this line, refusing the constraint would ALSO
+        // stop the target reaching ISL, and ISL would return `(None, None)` —
+        // "nothing to disclose" — converting a DISCLOSED gap into a SILENT one.
+        // That is exactly the trade the 2.258 block below refuses to make, so
+        // it must not be made here by omission either.
+        if (autoSynthesisFrameRefusal !== undefined) {
+          effectiveGoalThreshold = effectiveGoalThreshold ?? autoThreshold;
         }
 
         // === 2.239-G: refuse a DEGENERATE threshold rather than ask for a

--- a/tests/auto-constraint-fallback.test.ts
+++ b/tests/auto-constraint-fallback.test.ts
@@ -394,7 +394,12 @@ describe('T6: Auto-constraint fallback via /v2/run', () => {
         state_space: { range: { min: 0, max: 50000 } },
       },
       { id: 'churn_factor', kind: 'factor', label: 'Churn Rate', observed_state: { value: 0.05 } },
-      { id: 'goal', kind: 'goal', label: 'Business Goal' },
+      // ROADMAP 2.266: auto-synthesis is gated on `goal_threshold_frame ===
+      // 'delta'` — the frame ISL evaluates constraints in. This suite tests the
+      // FALLBACK mechanism, not framing, so the frame is stamped to keep it
+      // engaged. `tests/goal-threshold-frame-synthesis-gate.test.ts` owns the
+      // frame-absent / 'level' refusal cases.
+      { id: 'goal', kind: 'goal', label: 'Business Goal', goal_threshold_frame: 'delta' },
     ],
     edges: [
       { from: 'mrr_factor', to: 'goal', exists_probability: 1, strength: { mean: 0.6, std: 0.1 } },
@@ -585,6 +590,9 @@ describe('T6: Auto-constraint fallback via /v2/run', () => {
           // Node-level goal_threshold — not in EngineNodeV3 type but
           // accessible on the raw upstream node before normalisation strips it
           goal_threshold: 0.65,
+          // ROADMAP 2.266: frame stamped so the synthesis this test is about
+          // still engages (the gate is exercised in its own suite).
+          goal_threshold_frame: 'delta',
         },
       ],
       edges: [
@@ -854,7 +862,8 @@ describe('T7: Log assertions for auto-constraint events', () => {
 
   const GRAPH = {
     nodes: [
-      { id: 'goal', kind: 'goal', label: 'Revenue' },
+      // ROADMAP 2.266: frame stamped so auto-synthesis engages (see gate suite).
+      { id: 'goal', kind: 'goal', label: 'Revenue', goal_threshold_frame: 'delta' },
       { id: 'factor-a', kind: 'factor', label: 'Market Size', observed_state: { value: 0.5 } },
       { id: 'factor-b', kind: 'factor', label: 'Retention', observed_state: { value: 0.3 } },
     ],

--- a/tests/constraint-direction-suspect-top-level-gating.fixture.test.ts
+++ b/tests/constraint-direction-suspect-top-level-gating.fixture.test.ts
@@ -141,7 +141,11 @@ import { createServer } from '../src/createServer.js';
 
 const GRAPH = {
   nodes: [
-    { id: 'goal_growth', kind: 'goal', label: 'Net revenue change', observed_state: { value: 50 } },
+    // ROADMAP 2.266: auto-synthesis is gated on `goal_threshold_frame ===
+    // 'delta'`. This suite is about direction-suspicion gating, not framing, so
+    // the frame is stamped to keep the synthesis engaged — and 'delta' is the
+    // honest frame for a node labelled "Net revenue CHANGE".
+    { id: 'goal_growth', kind: 'goal', label: 'Net revenue change', observed_state: { value: 50 }, goal_threshold_frame: 'delta' },
     { id: 'fac_spend', kind: 'factor', label: 'Marketing spend', observed_state: { value: 40 } },
   ],
   edges: [

--- a/tests/goal-fit-direction-defense.fixture.test.ts
+++ b/tests/goal-fit-direction-defense.fixture.test.ts
@@ -126,7 +126,15 @@ const GRAPH = {
   nodes: [
     // The goal node is the auto-constraint's implicit target (Phase 1c+
     // synthesises node_id: goal_node_id).
-    { id: 'goal_cost_reduction', kind: 'goal', label: 'Net cost change' },
+    //
+    // ROADMAP 2.266: the auto-synthesis is now gated on
+    // `goal_threshold_frame === 'delta'` — the only frame provably matching the
+    // change-from-baseline samples ISL evaluates constraints against. This
+    // suite is about the SIGN defence, not about framing, so the frame is
+    // stamped here to keep the synthesis engaged and the subject under test
+    // reachable. (A 'delta' frame is also the honest reading of this fixture:
+    // the goal node is literally labelled "Net cost change".)
+    { id: 'goal_cost_reduction', kind: 'goal', label: 'Net cost change', goal_threshold_frame: 'delta' },
     { id: 'fac_spend', kind: 'factor', label: 'Marketing spend', observed_state: { value: 0.5 } },
   ],
   edges: [

--- a/tests/goal-threshold-frame-synthesis-gate.test.ts
+++ b/tests/goal-threshold-frame-synthesis-gate.test.ts
@@ -1,0 +1,330 @@
+/**
+ * ROADMAP 2.266 — the AUTO-SYNTHESISED goal constraint must not be evaluated in
+ * the wrong frame.
+ *
+ * WHY THIS FILE EXISTS. 2.258 taught ISL's MAIN path to refuse a goal threshold
+ * whose frame is unknown: `probability_of_goal` is omitted and
+ * GOAL_THRESHOLD_FRAME_UNSPECIFIED rides back. But the same threshold is ALSO
+ * auto-materialised as a constraint (`auto_goal_threshold`, run.ts Phase 1c+),
+ * and ISL evaluates constraints against the goal node's change-from-baseline
+ * samples WITHOUT consulting any frame. One path refused; the parallel path
+ * shipped the very comparison the first one declined.
+ *
+ * WITNESSED (`PHASE0-EVIDENCE-2026-07-28/witness-2258-goal-probability-live.md`,
+ * three live runs, 2026-08-01): a target of 0.8 — a LEVEL, £6,000,000 against a
+ * £7,500,000 cap — was synthesised verbatim and compared against uplift samples
+ * with mean 0.2915. ISL answered "is the UPLIFT >= £6,000,000?" and returned
+ * `constraint_probabilities.auto_goal_threshold = 0.0054`, mirrored to
+ * `probability_of_joint_goal` and `analysis_summary.goal_fit`. The question the
+ * user asked answers ~0.55. The screen said "< 1%" — a ~100x understatement.
+ *
+ * THE ASSERTION SURFACE. Every test reads the OUTBOUND ISL REQUEST BODY, and
+ * the wire tests below read the RESPONSE. A 200 proves a response, not a
+ * computation.
+ *
+ * SCOPE. USER-authored `goal_constraints` are untouched — T5 pins that.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// ISL mock — captures the outbound request body verbatim, and returns a
+// constraint_analysis whenever constraints were sent, so the RESPONSE-side
+// assertions below exercise the real assembly path rather than a stub.
+// ---------------------------------------------------------------------------
+
+let capturedISLRequestBody: any = null;
+
+function mockOptionRows(body: any) {
+  const options = body.options || [];
+  const constraints = body.goal_constraints || [];
+  return options.map((opt: any, idx: number) => ({
+    option_id: opt.id,
+    outcome: {
+      mean: 0.2915, std: 0.2048, p10: 0.05, p50: 0.294, p90: 0.555,
+      n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0,
+    },
+    rank: idx + 1,
+    // The witnessed shape: ISL evaluates whatever constraints it is sent and
+    // returns a near-zero probability for a level-vs-delta comparison.
+    ...(constraints.length > 0
+      ? {
+          constraint_analysis: {
+            constraints: constraints.map((c: any) => ({
+              constraint_id: c.constraint_id,
+              prob_satisfied: 0.0054,
+              satisfied: false,
+            })),
+            joint_probability: 0.0054,
+          },
+        }
+      : {}),
+  }));
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      options: options.map((opt: any, idx: number) => ({
+        option_id: opt.id,
+        outcome: {
+          mean: 0.2915, std: 0.2048, p10: 0.05, p50: 0.294, p90: 0.555,
+          n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0,
+        },
+        rank: idx + 1,
+      })),
+      edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [], value_of_information: [],
+      factors_provenance: 'unavailable' as const,
+      factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.8,
+      fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    capturedISLRequestBody = body;
+    return {
+      data: {
+        options: mockOptionRows(body),
+        edges: [], factors: [], value_of_information: [],
+        overall_robustness: 'robust', robustness_score: 0.8,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+const { createServer } = await import('../src/createServer.js');
+
+// ---------------------------------------------------------------------------
+// Fixtures — the witnessed Run-1 shape, reduced.
+// ---------------------------------------------------------------------------
+
+const OPTIONS = [
+  { id: 'opt1', label: 'Expand Leeds', interventions: { lever: 0.9 } },
+  { id: 'opt2', label: 'Expand Bristol', interventions: { lever: 0.2 } },
+];
+
+function graphWithGoal(goalOverrides: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      {
+        id: 'goal_arr',
+        kind: 'goal',
+        label: 'Reach 6M ARR',
+        observed_state: { value: 0.4, baseline: 0.35, unit: '£' },
+        ...goalOverrides,
+      },
+      { id: 'lever', kind: 'factor', label: 'Sales headcount', observed_state: { value: 0.5 } },
+      { id: 'other', kind: 'factor', label: 'Market', observed_state: { value: 0.3 } },
+    ],
+    edges: [
+      { from: 'lever', to: 'goal_arr', strength: { mean: 0.6, std: 0.1 } },
+      { from: 'other', to: 'goal_arr', strength: { mean: 0.3, std: 0.1 } },
+    ],
+  };
+}
+
+/** The witnessed live shape: a target, and NO frame stamped. */
+const GOAL_TARGET_UNSTAMPED = {
+  goal_threshold: 0.8,
+  goal_threshold_raw: 6000000,
+  goal_threshold_unit: '£',
+  goal_threshold_cap: 7500000,
+};
+
+describe('ROADMAP 2.266 — auto-synthesis is gated on the ISL sample frame', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    capturedISLRequestBody = null;
+  });
+
+  async function run(payload: Record<string, unknown>) {
+    capturedISLRequestBody = null;
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload });
+    return { res, isl: capturedISLRequestBody };
+  }
+
+  function basePayload(goalNodeExtras: Record<string, unknown>, extra: Record<string, unknown> = {}) {
+    return {
+      graph: graphWithGoal(goalNodeExtras),
+      options: OPTIONS,
+      goal_node_id: 'goal_arr',
+      seed: 'frame-gate-2266',
+      ...extra,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // T1 — THE WITNESSED RUN-1 SHAPE. Threshold present, frame ABSENT.
+  // Before this row: one synthesised constraint reached ISL. After: none.
+  // -------------------------------------------------------------------------
+  it('T1: frame ABSENT — no auto constraint is synthesised', async () => {
+    const { res, isl } = await run(basePayload(GOAL_TARGET_UNSTAMPED));
+
+    expect(res.statusCode).toBe(200);
+    expect(isl).not.toBeNull();
+
+    const sent = (isl.goal_constraints ?? []) as any[];
+    expect(sent.find((c) => c.constraint_id === 'auto_goal_threshold')).toBeUndefined();
+    expect(sent).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // T2 — THE WIRE. A guard that only changes an internal plan is theatre, so
+  // this asserts what CEE actually receives: the joint-goal figure is ABSENT,
+  // not zero. (`buildResponse` omits the whole constraint block when no
+  // constraints were sent — run.ts:2095-2098.)
+  // -------------------------------------------------------------------------
+  it('T2: frame ABSENT — the response carries NO goal_fit derived from the synthesis', async () => {
+    const { res } = await run(basePayload(GOAL_TARGET_UNSTAMPED));
+    const body = res.json() as any;
+
+    for (const opt of body.option_comparison ?? []) {
+      expect(opt.constraint_probabilities, opt.option_id).toBeUndefined();
+      expect(opt.probability_of_joint_goal, opt.option_id).toBeUndefined();
+      expect(opt.goal_fit_basis, opt.option_id).toBeUndefined();
+    }
+
+    // And nothing re-introduces it downstream in the brief.
+    expect(body.decision_brief?.analysis_summary?.goal_fit).toBeUndefined();
+
+    // The near-zero witnessed value must appear NOWHERE on the wire.
+    expect(JSON.stringify(body)).not.toContain('0.0054');
+  });
+
+  // -------------------------------------------------------------------------
+  // T3 — REFUSING THE CONSTRAINT MUST NOT WITHDRAW THE TARGET.
+  // The disclosure is the whole point: ISL still receives goal_threshold, so it
+  // still returns GOAL_THRESHOLD_FRAME_UNSPECIFIED. Clearing it would turn a
+  // DISCLOSED gap into a SILENT one.
+  // -------------------------------------------------------------------------
+  it('T3: frame ABSENT — goal_threshold still reaches ISL (request-root target)', async () => {
+    const { isl } = await run(basePayload(GOAL_TARGET_UNSTAMPED, { goal_threshold: 0.8 }));
+    expect(isl.goal_threshold).toBe(0.8);
+    expect(isl.goal_threshold_frame).toBeUndefined();
+  });
+
+  it('T3b: frame ABSENT — a NODE-sourced target also still reaches ISL', async () => {
+    // No request-root goal_threshold at all: the target exists only on the goal
+    // node. This is the case the 2.266 carry exists for — without it, refusing
+    // the synthesis would also delete the target, and ISL would return
+    // "(None, None)" with nothing to disclose.
+    const { isl } = await run(basePayload(GOAL_TARGET_UNSTAMPED));
+    expect(isl.goal_threshold).toBe(0.8);
+    expect(isl.goal_threshold_frame).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // T4 — THE 'level' CASE. This is the one that matters most for the future:
+  // the witnessed target IS a level, so a gate on mere frame-PRESENCE would
+  // reintroduce the ~100x error the moment CEE starts stamping.
+  // -------------------------------------------------------------------------
+  it("T4: frame attested 'level' — still no auto constraint (level != sample frame)", async () => {
+    const { isl } = await run(
+      basePayload({ ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'level' }),
+    );
+
+    const sent = (isl.goal_constraints ?? []) as any[];
+    expect(sent.find((c) => c.constraint_id === 'auto_goal_threshold')).toBeUndefined();
+
+    // The target and its attestation still go, so ISL's own main-path
+    // converter can do the job PLoT declines to guess at.
+    expect(isl.goal_threshold).toBe(0.8);
+    expect(isl.goal_threshold_frame).toBe('level');
+  });
+
+  // -------------------------------------------------------------------------
+  // T5 — POSITIVE CONTROL. Attested 'delta' IS the frame ISL evaluates
+  // constraints in, so synthesis proceeds exactly as before. Without this the
+  // gate could be satisfied by never synthesising anything at all.
+  // -------------------------------------------------------------------------
+  it("T5: frame attested 'delta' — synthesis PROCEEDS, unchanged", async () => {
+    const { isl } = await run(
+      basePayload({ ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'delta' }),
+    );
+
+    const sent = (isl.goal_constraints ?? []) as any[];
+    const auto = sent.find((c) => c.constraint_id === 'auto_goal_threshold');
+    expect(auto).toBeDefined();
+    expect(auto.node_id).toBe('goal_arr');
+    expect(auto.operator).toBe('>=');
+    expect(auto.value).toBe(0.8);
+    expect(isl.goal_threshold_frame).toBe('delta');
+  });
+
+  it("T5b: frame attested 'delta' — the joint-goal figure DOES reach the wire", async () => {
+    const { res } = await run(
+      basePayload({ ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'delta' }),
+    );
+    const body = res.json() as any;
+    const withJoint = (body.option_comparison ?? []).filter(
+      (o: any) => o.probability_of_joint_goal !== undefined,
+    );
+    expect(withJoint.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // T6 — SCOPE PIN. A USER-authored goal constraint is never touched by this
+  // gate, frame or no frame: it does not come from the goal target and PLoT has
+  // no standing to second-guess the frame the user stated it in.
+  // -------------------------------------------------------------------------
+  it('T6: a USER-authored goal_constraint survives with the frame ABSENT', async () => {
+    const { isl } = await run(
+      basePayload(GOAL_TARGET_UNSTAMPED, {
+        goal_constraints: [
+          { constraint_id: 'user_target', node_id: 'goal_arr', operator: '>=', value: 0.5 },
+        ],
+      }),
+    );
+
+    const sent = (isl.goal_constraints ?? []) as any[];
+    expect(sent.map((c) => c.constraint_id)).toContain('user_target');
+    expect(sent.find((c) => c.constraint_id === 'auto_goal_threshold')).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // T7 — no target at all: unchanged behaviour, and no accidental synthesis
+  // just because a frame happens to be stamped.
+  // -------------------------------------------------------------------------
+  it('T7: a frame with NO target synthesises nothing', async () => {
+    const { isl } = await run(basePayload({ goal_threshold_frame: 'delta' }));
+    const sent = (isl.goal_constraints ?? []) as any[];
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/tests/goal-threshold-frame-synthesis-gate.test.ts
+++ b/tests/goal-threshold-frame-synthesis-gate.test.ts
@@ -319,6 +319,60 @@ describe('ROADMAP 2.266 — auto-synthesis is gated on the ISL sample frame', ()
   });
 
   // -------------------------------------------------------------------------
+  // T8 — THE ATTESTATION MUST DESCRIBE THE NUMBER BEING SENT.
+  // (Adversarial review of #304, probe-proven on the real route.)
+  // `autoThreshold` resolves request-root FIRST, but the frame is read off the
+  // NODE — so an inconsistent producer could satisfy the gate with a stamp made
+  // about a different number.
+  // -------------------------------------------------------------------------
+  it('T8: root target != node target (frame on the node) — synthesis is REFUSED', async () => {
+    const { isl } = await run(
+      basePayload(
+        { ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'delta' }, // node target 0.8
+        { goal_threshold: 0.9 },                                    // root target 0.9
+      ),
+    );
+
+    const sent = (isl.goal_constraints ?? []) as any[];
+    expect(sent.find((c) => c.constraint_id === 'auto_goal_threshold')).toBeUndefined();
+
+    // The target still reaches ISL — refusing the constraint never withdraws it.
+    expect(isl.goal_threshold).toBe(0.9);
+  });
+
+  it('T8b: CONTROL — root target EQUAL to node target still synthesises', async () => {
+    // The attestation and the value agree, so there is nothing to refuse. This
+    // is what stops T8 passing merely because a root threshold is present.
+    const { isl } = await run(
+      basePayload(
+        { ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'delta' },
+        { goal_threshold: 0.8 },
+      ),
+    );
+
+    const auto = ((isl.goal_constraints ?? []) as any[]).find(
+      (c) => c.constraint_id === 'auto_goal_threshold',
+    );
+    expect(auto).toBeDefined();
+    expect(auto.value).toBe(0.8);
+  });
+
+  it('T8c: CONTROL — a node frame with NO node target covers a root target', async () => {
+    // Not a mismatch: the frame describes what this goal node's samples MEAN,
+    // so it legitimately covers a target supplied at the request root. Only two
+    // PRESENT and UNEQUAL numbers are refused.
+    const { isl } = await run(
+      basePayload({ goal_threshold_frame: 'delta' }, { goal_threshold: 0.8 }),
+    );
+
+    const auto = ((isl.goal_constraints ?? []) as any[]).find(
+      (c) => c.constraint_id === 'auto_goal_threshold',
+    );
+    expect(auto).toBeDefined();
+    expect(auto.value).toBe(0.8);
+  });
+
+  // -------------------------------------------------------------------------
   // T7 — no target at all: unchanged behaviour, and no accidental synthesis
   // just because a frame happens to be stamped.
   // -------------------------------------------------------------------------

--- a/tests/goal-threshold-frame.test.ts
+++ b/tests/goal-threshold-frame.test.ts
@@ -310,7 +310,16 @@ describe('ROADMAP 2.258 — goal_threshold_frame reaches the ISL request', () =>
     // the filter, auto-synthesis fires here — and 2.258 requires the frame to
     // ride with the threshold it recovers.
     const { status, isl, body } = await run({
-      graph: graphWithGoal({ ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'level' }),
+      // ROADMAP 2.266: was 'level'. Auto-synthesis is now gated on
+      // `goal_threshold_frame === 'delta'` (the frame ISL evaluates constraints
+      // in), and a LEVEL target is refused rather than compared against
+      // change-from-baseline samples. The SUBJECT of this test is the
+      // temporal-filter residual path — that the recovery fires at all and that
+      // the frame rides with the threshold it recovers — so the fixture is
+      // stamped with the frame that keeps that subject reachable. The 'level'
+      // refusal on this same path is pinned in
+      // tests/goal-threshold-frame-synthesis-gate.test.ts (T4).
+      graph: graphWithGoal({ ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'delta' }),
       options: OPTIONS,
       goal_node_id: 'goal_arr',
       seed: '42',
@@ -321,7 +330,7 @@ describe('ROADMAP 2.258 — goal_threshold_frame reaches the ISL request', () =>
     expect(isl.goal_threshold).toBe(0.65);
     // THE part-5 pin. An unstamped threshold on this path would make ISL omit
     // probability_of_goal — the fix would look landed and compute nothing.
-    expect(isl.goal_threshold_frame).toBe('level');
+    expect(isl.goal_threshold_frame).toBe('delta');
 
     // The recovery really did run through auto-synthesis...
     const sent = (isl.goal_constraints ?? []) as any[];
@@ -365,7 +374,16 @@ describe('ROADMAP 2.258 — goal_threshold_frame reaches the ISL request', () =>
     // run, and the goal probability would vanish again — silently. Pin the
     // claim rather than trusting the comment.
     const { status, isl, body } = await run({
-      graph: graphWithGoal({ ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'level' }),
+      // ROADMAP 2.266: was 'level'. Auto-synthesis is now gated on
+      // `goal_threshold_frame === 'delta'` (the frame ISL evaluates constraints
+      // in), and a LEVEL target is refused rather than compared against
+      // change-from-baseline samples. The SUBJECT of this test is the
+      // temporal-filter residual path — that the recovery fires at all and that
+      // the frame rides with the threshold it recovers — so the fixture is
+      // stamped with the frame that keeps that subject reachable. The 'level'
+      // refusal on this same path is pinned in
+      // tests/goal-threshold-frame-synthesis-gate.test.ts (T4).
+      graph: graphWithGoal({ ...GOAL_TARGET_UNSTAMPED, goal_threshold_frame: 'delta' }),
       options: OPTIONS,
       goal_node_id: 'goal_arr',
       seed: '42',

--- a/tests/goal-threshold-ordering.test.ts
+++ b/tests/goal-threshold-ordering.test.ts
@@ -114,11 +114,26 @@ const OPTIONS = [
   { id: 'opt2', label: 'Ship slow', interventions: { 'lever': 0.2 } },
 ];
 
-/** Graph whose goal node carries whatever CEE stamped on it. */
+/**
+ * Graph whose goal node carries whatever CEE stamped on it.
+ *
+ * ROADMAP 2.266: `goal_threshold_frame: 'delta'` is stamped BY DEFAULT (still
+ * overridable via `goalOverrides`). Auto-synthesis is now gated on that frame —
+ * it is the only one provably matching the change-from-baseline samples ISL
+ * evaluates constraints against — and every test in this file is about ORDERING
+ * and threshold CARRY, not about framing. Without the default they would all be
+ * testing the refusal path instead of their own subject. The frame-absent and
+ * 'level' refusals are pinned in
+ * tests/goal-threshold-frame-synthesis-gate.test.ts.
+ */
 function graphWithGoal(goalOverrides: Record<string, unknown> = {}) {
   return {
     nodes: [
-      { id: 'goal_arr', kind: 'goal', label: 'Reach 6M ARR Within 12 Months', ...goalOverrides },
+      {
+        id: 'goal_arr', kind: 'goal', label: 'Reach 6M ARR Within 12 Months',
+        goal_threshold_frame: 'delta',
+        ...goalOverrides,
+      },
       { id: 'lever', kind: 'factor', label: 'Sales headcount', observed_state: { value: 0.5 } },
       { id: 'other', kind: 'factor', label: 'Market', observed_state: { value: 0.3 } },
     ],
@@ -300,7 +315,8 @@ describe('ROADMAP 2.239 — goal target reaches the ISL request', () => {
     const { status, isl } = await run({
       graph: {
         nodes: [
-          { id: 'goal_arr', kind: 'goal', label: 'ARR', goal_threshold_cap: 50000 },
+          // ROADMAP 2.266: frame stamped so auto-synthesis engages (see builder note).
+          { id: 'goal_arr', kind: 'goal', label: 'ARR', goal_threshold_cap: 50000, goal_threshold_frame: 'delta' },
           {
             id: 'lever', kind: 'factor', label: 'MRR',
             observed_state: { value: 15000 },

--- a/tests/multi-constraint.test.ts
+++ b/tests/multi-constraint.test.ts
@@ -1090,7 +1090,11 @@ describe('Integration: Precedence Routing via /v2/run', () => {
         state_space: { range: { min: 0, max: 50000 } },
       },
       { id: 'churn_factor', kind: 'factor', label: 'Churn Rate', observed_state: { value: 0.05 } },
-      { id: 'goal', kind: 'goal', label: 'Business Goal' },
+      // ROADMAP 2.266: the auto-synthesis fallback is gated on
+      // `goal_threshold_frame === 'delta'` (the frame ISL evaluates constraints
+      // in). These tests are about PRECEDENCE ROUTING, not framing, so the
+      // frame is stamped to keep the fallback engaged.
+      { id: 'goal', kind: 'goal', label: 'Business Goal', goal_threshold_frame: 'delta' },
     ],
     edges: [
       { from: 'mrr_factor', to: 'goal', exists_probability: 1, strength: { mean: 0.6, std: 0.1 } },

--- a/tests/robustness-display-verdict.flip-evidence.test.ts
+++ b/tests/robustness-display-verdict.flip-evidence.test.ts
@@ -1,0 +1,389 @@
+/**
+ * ROADMAP 2.278 — the fragility verdict must not use FLIP language on turns
+ * whose own flip evidence attests there is no flip.
+ *
+ * WITNESSED (`PHASE0-EVIDENCE-2026-07-28/witness-2267-onscreen-flip.md`):
+ * across four analysed guest scenarios, 19 of 19 `flip_thresholds` rows came
+ * back `structurally_invariant` — ISL's MATHEMATICAL ATTESTATION that no value
+ * of that factor can move the argmax — and the product rendered no flip card,
+ * because there was nothing to render. On those same turns the payload shipped
+ * `display_verdict: "fragile"` with
+ * `display_verdict_reason: "small changes could flip this result"`.
+ * One response both asserted a flip and denied one.
+ *
+ * WHAT IS PINNED HERE:
+ *  - the VERDICT is unchanged in every case (2.278 corrects the copy, not the
+ *    assessment — a run can be genuinely non-robust with no flippable factor);
+ *  - only `all_no_effect` — every row an ATTESTED no-effect, none unresolved —
+ *    earns the reworded reason;
+ *  - `computed` (a real flip), `unresolved`/`partial_no_effect` (an unfinished
+ *    probe) and `unavailable` (legacy/empty) all keep the original wording.
+ *
+ * The route-level block proves the change survives to the CEE-visible wire —
+ * a guard that only changes an internal value is theatre.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  deriveRobustnessDisplayVerdict,
+  ROBUSTNESS_DISPLAY_VERDICT_REASONS,
+  ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP,
+} from '../src/routes/v2/robustness-display-verdict.js';
+import type { DenormalisedFlipThreshold } from '../src/lib/flip-threshold-denormaliser.js';
+
+// ---------------------------------------------------------------------------
+// Row builders — the witnessed shapes.
+// ---------------------------------------------------------------------------
+
+function noFlipRow(
+  factor_id: string,
+  flip_reason: 'structurally_invariant' | 'no_effect_within_bounds' = 'structurally_invariant',
+): DenormalisedFlipThreshold {
+  return {
+    factor_id,
+    factor_label: factor_id,
+    current_value: 0,
+    flip_value: null,
+    alternative_winner_id: null,
+    alternative_winner_label: null,
+    flip_reason,
+    no_flip_in_range: true,
+  } as DenormalisedFlipThreshold;
+}
+
+function realFlipRow(factor_id: string): DenormalisedFlipThreshold {
+  return {
+    factor_id,
+    factor_label: factor_id,
+    current_value: 0,
+    flip_value: 0.65,
+    direction: 'increase',
+    alternative_winner_id: 'opt_build',
+    alternative_winner_label: 'Build In-House',
+    flip_reason: 'found',
+  } as DenormalisedFlipThreshold;
+}
+
+function unresolvedRow(
+  factor_id: string,
+  flip_reason: string = 'timeout',
+): DenormalisedFlipThreshold {
+  return {
+    factor_id,
+    factor_label: factor_id,
+    current_value: 0,
+    flip_value: null,
+    alternative_winner_id: null,
+    alternative_winner_label: null,
+    flip_reason,
+  } as DenormalisedFlipThreshold;
+}
+
+const FRAGILE_FACTS = { is_robust: false, level: 'low' };
+const MODERATE_FACTS = { is_robust: true, level: 'medium' };
+const ROBUST_FACTS = { is_robust: true, level: 'high' };
+
+const FLIP_PHRASE = 'small changes could flip this result';
+
+describe('ROADMAP 2.278 — flip evidence informs the verdict REASON', () => {
+  // -------------------------------------------------------------------------
+  // THE WITNESSED CASE. 19/19 structurally_invariant + fragile.
+  // -------------------------------------------------------------------------
+  it('W1: attested no-flip + fragile — the reason no longer claims flippability', () => {
+    const rows = Array.from({ length: 4 }, (_, i) => noFlipRow(`fac_${i}`));
+    const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, rows);
+
+    // The verdict is deliberately UNCHANGED — this row corrects copy, not
+    // assessment.
+    expect(out.display_verdict).toBe('fragile');
+
+    expect(out.display_verdict_reason).not.toBe(FLIP_PHRASE);
+    expect(out.display_verdict_reason).not.toMatch(/flip/i);
+    expect(out.display_verdict_reason).toBe(
+      ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP.fragile,
+    );
+  });
+
+  it('W1b: the reworded reason says what WAS measured', () => {
+    const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, [noFlipRow('f')]);
+    // It must describe the flip measurement that actually ran...
+    expect(out.display_verdict_reason).toMatch(/no single factor/i);
+    expect(out.display_verdict_reason).toMatch(/which option leads/i);
+    // ...and still disclose that the run scored badly on the OTHER checks,
+    // so the corrected copy cannot read as an all-clear.
+    expect(out.display_verdict_reason).toMatch(/robustness checks/i);
+  });
+
+  it('W2: `no_effect_within_bounds` is equally an attestation', () => {
+    const rows = [noFlipRow('a', 'no_effect_within_bounds'), noFlipRow('b')];
+    const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, rows);
+    expect(out.display_verdict_reason).not.toMatch(/flip/i);
+  });
+
+  it('W3: attested no-flip + moderate — reason reworded, verdict unchanged', () => {
+    const out = deriveRobustnessDisplayVerdict(MODERATE_FACTS, true, [noFlipRow('f')]);
+    expect(out.display_verdict).toBe('moderate');
+    expect(out.display_verdict_reason).toBe(
+      ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP.moderate,
+    );
+    expect(out.display_verdict_reason).not.toMatch(/flip/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // POSITIVE CONTROL — a REAL flip. Flip language is earned; nothing changes.
+  // Shape taken from witness-2265-raw/runC (flip_reason 'found',
+  // flip_value 0.65).
+  // -------------------------------------------------------------------------
+  it('C1: a real flip keeps the original flip wording', () => {
+    const rows = [realFlipRow('fac_buy_indicator'), noFlipRow('fac_build_indicator')];
+    const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, rows);
+    expect(out.display_verdict).toBe('fragile');
+    expect(out.display_verdict_reason).toBe(FLIP_PHRASE);
+  });
+
+  // -------------------------------------------------------------------------
+  // FAIL-CLOSED CONTROLS — an unfinished probe attests nothing, and an absent
+  // array is not evidence of absence.
+  // -------------------------------------------------------------------------
+  it('C2: one unresolved row blocks the no-flip wording (a timeout attests nothing)', () => {
+    const rows = [noFlipRow('a'), noFlipRow('b'), unresolvedRow('c', 'timeout')];
+    const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, rows);
+    expect(out.display_verdict_reason).toBe(FLIP_PHRASE);
+  });
+
+  it('C2b: an UNKNOWN flip_reason is treated as unresolved, never as an attestation', () => {
+    const rows = [noFlipRow('a'), unresolvedRow('b', 'some_future_isl_token')];
+    const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, rows);
+    expect(out.display_verdict_reason).toBe(FLIP_PHRASE);
+  });
+
+  it('C3: an EMPTY array is "nobody measured", not "nothing can flip"', () => {
+    expect(deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, []).display_verdict_reason)
+      .toBe(FLIP_PHRASE);
+  });
+
+  it('C4: legacy payloads are not blinded — omitted/undefined/null keep current copy', () => {
+    expect(deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true).display_verdict_reason)
+      .toBe(FLIP_PHRASE);
+    expect(deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, undefined).display_verdict_reason)
+      .toBe(FLIP_PHRASE);
+    expect(deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, null).display_verdict_reason)
+      .toBe(FLIP_PHRASE);
+  });
+
+  // -------------------------------------------------------------------------
+  // The verdicts that never carried flip language keep their single reason.
+  // -------------------------------------------------------------------------
+  it('C5: robust / not_assessed are unaffected by flip evidence', () => {
+    expect(
+      deriveRobustnessDisplayVerdict(ROBUST_FACTS, true, [noFlipRow('f')]).display_verdict_reason,
+    ).toBe(ROBUSTNESS_DISPLAY_VERDICT_REASONS.robust);
+
+    expect(
+      deriveRobustnessDisplayVerdict(undefined, false, [noFlipRow('f')]).display_verdict_reason,
+    ).toBe(ROBUSTNESS_DISPLAY_VERDICT_REASONS.not_assessed);
+  });
+
+  it('C6: no reworded reason is ever emitted for a verdict that has none', () => {
+    expect(ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP.robust).toBeUndefined();
+    expect(ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP.not_assessed).toBeUndefined();
+  });
+
+  it('C7: every reworded reason is claim-safe (non-empty, no digits)', () => {
+    for (const [verdict, reason] of Object.entries(
+      ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP,
+    )) {
+      expect(reason, verdict).toBeTruthy();
+      expect(reason!.length, verdict).toBeGreaterThan(0);
+      expect(reason!, verdict).not.toMatch(/\d/);
+    }
+  });
+});
+
+// ===========================================================================
+// ROUTE LEVEL — does the corrected copy actually reach the wire CEE reads?
+// ===========================================================================
+
+const FIXTURES_ROOT = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+const capture = JSON.parse(
+  readFileSync(join(FIXTURES_ROOT, 'isl-v2-live-20260707', 'isl-staging-capture.json'), 'utf8'),
+);
+const request = JSON.parse(
+  readFileSync(join(FIXTURES_ROOT, 'isl-v2-live-20260707', 'isl-v2-request.json'), 'utf8'),
+);
+
+let currentIslPayload: any = null;
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(): Promise<{ data: T | null; error: string | null }> {
+    return { data: JSON.parse(JSON.stringify(currentIslPayload)) as T, error: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+const { createServer } = await import('../src/createServer.js');
+
+function buildPlotBody(islRequest: any) {
+  return {
+    graph: {
+      nodes: islRequest.graph.nodes.map((n: any) => ({
+        id: n.id,
+        kind: n.kind,
+        label: n.label,
+        ...(n.observed_state?.value !== undefined && n.observed_state?.value !== null
+          ? { observed_state: { value: n.observed_state.value } }
+          : {}),
+      })),
+      edges: islRequest.graph.edges.map((e: any) => ({
+        from: e.from,
+        to: e.to,
+        exists_probability: e.exists_probability,
+        strength: { mean: e.strength.mean, std: e.strength.std },
+      })),
+    },
+    options: islRequest.options.map((o: any) => ({
+      id: o.id,
+      label: o.label,
+      interventions: Object.fromEntries(
+        Object.entries(o.interventions).map(([nodeId, value]) => [
+          nodeId,
+          { value, source: 'user_specified' },
+        ]),
+      ),
+    })),
+    goal_node_id: islRequest.goal_node_id,
+    seed: String(islRequest.seed),
+  };
+}
+
+/** Factor ids from the captured request, so mapping finds real nodes. */
+function factorIds(limit: number): string[] {
+  return (request.graph.nodes as any[])
+    .filter((n) => n.kind === 'factor' && Number.isFinite(n.observed_state?.value))
+    .slice(0, limit)
+    .map((n) => n.id);
+}
+
+describe('ROADMAP 2.278 — the corrected reason reaches the CEE-visible wire', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+  });
+
+  async function runWithFlips(flipValues: any[] | undefined) {
+    currentIslPayload = JSON.parse(JSON.stringify(capture));
+    if (flipValues !== undefined) {
+      currentIslPayload.factor_flip_values = flipValues;
+    }
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: buildPlotBody(request),
+    });
+    expect(res.statusCode).toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  it('R1: baseline — this capture ships the FRAGILE verdict (control for R2)', async () => {
+    const body = await runWithFlips(undefined);
+    expect(body.robustness.display_verdict).toBe('fragile');
+    // No flip block from ISL → 'unavailable' → original wording preserved.
+    expect(body.robustness.display_verdict_reason).toBe(FLIP_PHRASE);
+  });
+
+  it('R2: all rows structurally_invariant — the WIRE no longer claims a flip', async () => {
+    const ids = factorIds(3);
+    expect(ids.length).toBeGreaterThan(0);
+
+    const body = await runWithFlips(
+      ids.map((id) => ({
+        factor_id: id,
+        current_value: 0,
+        flip_value: null,
+        flip_reason: 'structurally_invariant',
+      })),
+    );
+
+    // The evidence really did land as an attestation...
+    expect(body.flip_thresholds.length).toBe(ids.length);
+    expect(body.flip_thresholds.every((r: any) => r.no_flip_in_range === true)).toBe(true);
+    expect(body.flip_thresholds_status).toBe('all_no_effect');
+
+    // ...and the verdict copy on the same payload agrees with it.
+    expect(body.robustness.display_verdict).toBe('fragile');
+    expect(body.robustness.display_verdict_reason).not.toMatch(/flip/i);
+    expect(body.robustness.display_verdict_reason).toBe(
+      ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP.fragile,
+    );
+
+    // The contradiction the witness caught must be gone from the whole payload
+    // surface CEE transports.
+    expect(JSON.stringify(body.robustness)).not.toContain(FLIP_PHRASE);
+  });
+
+  it('R3: a real flip on the wire keeps the flip wording', async () => {
+    const ids = factorIds(2);
+    const body = await runWithFlips([
+      {
+        factor_id: ids[0],
+        current_value: 0,
+        flip_value: 0.65,
+        direction: 'increase',
+        flip_reason: 'found',
+        alternative_winner_id: 'opt_x',
+      },
+      { factor_id: ids[1], current_value: 0, flip_value: null, flip_reason: 'structurally_invariant' },
+    ]);
+
+    expect(body.flip_thresholds_status).not.toBe('all_no_effect');
+    expect(body.robustness.display_verdict_reason).toBe(FLIP_PHRASE);
+  });
+
+  it('R4: an unresolved row on the wire keeps the flip wording (fail-closed)', async () => {
+    const ids = factorIds(2);
+    const body = await runWithFlips([
+      { factor_id: ids[0], current_value: 0, flip_value: null, flip_reason: 'structurally_invariant' },
+      { factor_id: ids[1], current_value: 0, flip_value: null, flip_reason: 'timeout' },
+    ]);
+
+    expect(body.flip_thresholds_status).not.toBe('all_no_effect');
+    expect(body.robustness.display_verdict_reason).toBe(FLIP_PHRASE);
+  });
+});


### PR DESCRIPTION
## What this is

Two honesty fixes in the same family: a computation shipped in the wrong frame, and a copy string that claimed something the same payload refuted. Build-only — **do not merge**, adversarial review follows.

Base: `staging` @ `c0e4dc7`.

---

# Part A — ROADMAP 2.266: the auto-synthesised goal constraint was evaluated in the wrong frame

## The derived chain (at the bytes, this tip)

| step | site |
|---|---|
| frame parsed off the raw goal node | `src/routes/v2/run.ts:5067-5069` (`parseGoalThresholdFrame`) |
| **auto-synthesis fires** | `src/routes/v2/run.ts:5178-5245` (Phase 1c+, post temporal filter) |
| constraint pushed | `run.ts:5211` → `constraintCompilation.constraints` |
| becomes `activeGoalConstraints` | `run.ts:5334` |
| forwarded to ISL as `goal_constraints` | `src/integrations/isl/translator-v3.ts:711-719` |
| ISL evaluates → `constraint_analysis` | (ISL side) |
| `constraint_probabilities[id] = prob01(c.prob_satisfied)` | `run.ts:2658-2661`, written `:2771-2774` |
| `probability_of_joint_goal = prob01(constraint_analysis.joint_probability)` | `run.ts:2633`, written `:2768-2770` |
| `decision_brief.analysis_summary.goal_fit` = leader's `probability_of_joint_goal` | `src/assembly/decision-brief.ts:351-357` |

`probability_of_joint_goal` is **not** derived from `constraint_probabilities` — it is an independent copy of ISL's `joint_probability`. Both ride on the same synthesised constraint.

## The defect, witnessed

`witness-2258-goal-probability-live.md`, three live runs. The raw `goal_threshold` is an unattested **LEVEL** (`0.8` = £6,000,000 against a £7,500,000 cap). ISL evaluates goal constraints against the goal node's **change-from-baseline** samples. So the shipped number answered *"is the UPLIFT ≥ £6,000,000?"* → `0.0054`, where the question asked (*"is £4M + uplift ≥ £6M?"*) answers **≈0.55**. The screen said `< 1%`.

This is the side door around 2.258: ISL's main path refuses this exact comparison (`GOAL_THRESHOLD_FRAME_UNSPECIFIED`), while the parallel constraint path performed it.

## The fix shape chosen, and why

**Synthesis is gated on `goal_threshold_frame === 'delta'`** — the only frame provably matching ISL's constraint samples. `run.ts:5178-5245`.

Two judgements worth reviewing explicitly:

1. **The gate is `=== 'delta'`, not "a frame is present".** The witnessed runs carried *no* frame, so gating on mere presence would fix today's surface **and reintroduce the identical ~100× error the moment CEE starts stamping** — because the frame it will stamp for that decision is `'level'`. A gate that passes today and breaks on the next upstream landing is not a fix. This is the single most important design call in Part A.

2. **`'level'` is refused, not converted.** The decisive reason is structural: `ISLGoalConstraint` carries **no frame field** (`translator-v3.ts:124-132`), so ISL reads every constraint value in one fixed frame and cannot be told otherwise. A PLoT-side conversion would mean reproducing ISL's normalisation arithmetic with no wire field for either side to declare what it did — and therefore no test here could prove the two agree. Constraint-frame attestation is a schemas train, out of scope. (The missing goal baseline is a second, *weaker* obstacle, stated narrowly in the code: a graph *can* carry `observed_state.baseline`; what the witness establishes is that the live producer wrote none on any of the three runs. ROADMAP 2.281.)

**Honest absence, not a silent zero.** With no constraint sent, `buildResponse` omits the entire constraint block (`run.ts:2095-2098`): `constraint_probabilities`, `probability_of_joint_goal`, `goal_fit` and `goal_fit_basis` are all **absent** from the wire.

**The carry (`run.ts` 2.266 block).** Refusing the *constraint* must not withdraw the *target*. A target read off the goal node was never in `effectiveGoalThreshold`; only the now-refused synthesis put it back. Without the carry, refusing would stop the target reaching ISL at all, and ISL would return `(None, None)` — converting a **disclosed** gap into a **silent** one. Mutant A2 below proves this hunk is not revertible unnoticed.

**Scope:** USER-authored `goal_constraints` are untouched — they never reach this branch (it runs only when the compiled set is empty). Pinned by T6.

## Evidence

`tests/goal-threshold-frame-synthesis-gate.test.ts` — 9 tests, all reading the **outbound ISL request** or the **response wire**.

| mutant | result |
|---|---|
| **A** — `frameIsSampleFrame = true` (unconditional synthesis) | **RED: T1, T2, T4** |
| **A2** — 2.266 carry hunk removed | **RED: T3b, T4** |

- **Wire trace (T2):** every `option_comparison` row carries no `constraint_probabilities`, no `probability_of_joint_goal`, no `goal_fit_basis`; `decision_brief.analysis_summary.goal_fit` absent; and the witnessed `0.0054` appears nowhere in the serialised body.
- **Positive control (T5/T5b):** `'delta'`-attested → synthesis proceeds unchanged **and** the joint-goal figure does reach the wire. Without this the gate could be satisfied by never synthesising anything.
- **T3/T3b:** the threshold still reaches ISL for both request-root and node-sourced targets, unstamped, so the disclosure survives.

---

# Part B — ROADMAP 2.278: the fragility verdict must not use flip language on attested-no-flip turns

Witnessed (`witness-2267-onscreen-flip.md`): 19/19 flip rows `structurally_invariant`, no flip card rendered — and the same payload shipped `display_verdict: "fragile"` + `"small changes could flip this result"`. One response asserted a flip and denied one.

## The mapping table

Flip state is **derived** by the existing `classifyFlipThresholdsStatus` (`src/lib/flip-threshold-status.ts:131`), not re-read from `flip_reason` strings — that vocabulary has a single source of truth (`NO_EFFECT_REASONS`) and mirroring it here would drift silently, in the direction that reads as a cleaner result.

**Only the REASON changes. The VERDICT is never altered.**

| flip-evidence status | robustness verdict | verdict emitted | reason emitted |
|---|---|---|---|
| `all_no_effect` | `fragile` | `fragile` *(unchanged)* | **new** — "no single factor on its own changed which option leads, but this result scored low on our other robustness checks" |
| `all_no_effect` | `moderate` | `moderate` *(unchanged)* | **new** — "no single factor on its own changed which option leads, and this result mostly held up under the other changes we tested" |
| `all_no_effect` | `robust` | `robust` | unchanged (never carried flip language) |
| `all_no_effect` | `not_assessed` | `not_assessed` | unchanged |
| `computed` (a real flip) | any | unchanged | unchanged — flip language is **earned** |
| `partial_no_effect` | any | unchanged | unchanged — some row never resolved |
| `unresolved` (timeout/error/unknown token) | any | unchanged | unchanged — an unfinished probe attests nothing |
| `unavailable` (empty/absent — **legacy**) | any | unchanged | unchanged — "nobody measured", not "nothing can flip" |

**Why the verdict stays.** A run with no flippable factor can still be genuinely non-robust: an explicit `is_robust: false`, a low level — and on the witnessed turn, `fragile_edges` with ~0.49 switch probability, which is a *different* measurement from factor flips and is not contradicted by them. Softening the verdict on flip evidence alone would be the mirror-image error. The new strings therefore still disclose that the run scored badly on the other checks, so the corrected copy cannot read as an all-clear.

## Keep-list survival (traced, not assumed)

`display_verdict` / `display_verdict_reason` are **not individually keep-listed and do not need to be** — they ride inside `robustness`, which *is* on `CEE_UI_ENRICHMENT_KEEP_LIST` (`@talchain/schemas` `dist/boundary/enrichment.js:939`). The egress guard is **fail-open and never mutates** (`src/routes/v2/enrichment-egress-guard.ts:14-16`), and the schema types both fields as bare `z.string().optional()` with `.passthrough()` (`enrichment.js:457-458`) — no enum, no length, no regex. **A reworded reason cannot be stripped or rejected.** Verified end-to-end by R2, which asserts on the actual HTTP response body.

## Evidence

`tests/robustness-display-verdict.flip-evidence.test.ts` — 16 tests (12 unit + 4 route-level).

| mutant | result |
|---|---|
| **B** — flip consultation unhooked (`attestedNoFlip = false`) | **RED: W1, W1b, W2, W3, and route-level R2** |
| **B2** — `flipThresholds` arg removed from the `run.ts` call site | **RED: R2 only** — all 15 unit tests stay green |

B2 is the discriminating one: it proves R2 is a genuine wire test rather than a duplicate of the unit tests.

Controls: **C1** real flip (`flip_reason: 'found'`, shape from `witness-2265-raw/runC`) keeps the old wording; **C2/C2b** one `timeout` — or an unknown future ISL token — blocks the rewording; **C3/C4** empty/absent/null keep current copy (legacy not blinded).

**The golden fixture needed no regeneration**: `plot-v2-run.golden.json` carries `flip_thresholds: []` → `unavailable` → original wording preserved. That is a useful independent check that the change is correctly scoped, and R1 pins it as a route-level control.

---

# Riders

- **`_meta.warning_codes`** — the reference is at **`run.ts:3291`**, not `:3267` (brief's line number was stale; re-derived). It was wrong **twice**: `_meta.warning_codes` exists nowhere in the repo, *and* the real `decision_brief.warning_codes` would not carry this disclosure either — `buildWarningCodes` (`assembly/decision-brief.ts:729-737`) echoes `severity === 'warning'` only, and this one is `'info'` (`run.ts:495`). Comment corrected to name both facts.
- **`src/config/sampling.ts:51`** — stale "(4,000)"; the constant is `10_000` (`:40`). Fixed.

---

# Gates

| gate | result |
|---|---|
| `RATE_LIMIT_ENABLED=0 npm test` (CI's command) | **EXIT 0** — 603 files passed / 4 skipped; **6663 passed** / 28 skipped |
| baseline on pristine `c0e4dc7` | 601 files / **6638 passed** — delta is exactly **+2 files, +25 tests**, all mine |
| `npm run typecheck` | clean |
| **test typecheck** (no CI job does this) | **223 → 223 unique errors, zero new, zero fixed** — *with a positive control*: an injected error surfaced, then was reverted |
| `eslint src tests --max-warnings 97` | 0 errors, 86 warnings — under cap |
| `npm run validate:contracts` | all passed |
| `check-no-stale-js.sh` | OK |

Harness derived from `.github/workflows/ci.yml` + `tools/run-all-tests.js`: build → `tools/test-server.js` (`NODE_ENV=test`, `TEST_ROUTES=1`, port 4313) → `vitest run` with `TEST_BASE_URL`. Mutation worktree lived **outside** the repo root and was removed before every gate run.

## Test-suite updates — read this before reviewing the diff

20 tests across 6 files asserted that auto-synthesis **fires with no frame stamped** — precisely the behaviour 2.266 stops. Each was about something else entirely (precedence routing, temporal-filter survival, Phase 4b re-scaling, direction-suspicion gating, log payloads), so each fixture now stamps `goal_threshold_frame: 'delta'` to keep **its own subject reachable** instead of silently re-pointing it at the refusal path. **No assertion was deleted or relaxed.** In `goal-threshold-frame.test.ts` T7/T9 the fixture moved `'level'` → `'delta'` for the same reason; the `'level'` refusal on that same temporal-residual path is now pinned explicitly by T4 of the new suite.

# Amendment after adversarial review (non-blocking, closed anyway)

**Root-value / node-frame attestation mismatch.** `autoThreshold` resolves REQUEST-ROOT first (`goalThreshold ?? nodeGoalThreshold`) while the frame is read off the NODE. So root `goal_threshold: 0.9` + node `{goal_threshold: 0.8, goal_threshold_frame: 'delta'}` would have shipped `value: 0.9` under an attestation made about `0.8` — the gate satisfied by a stamp describing a different number.

**Ruling: REFUSE**, not "synthesise the node's own value". Precedence routing leaves `effectiveGoalThreshold` at the ROOT value and the 2.239 carry only re-derives it when synthesis fired, so synthesising `0.8` beside a root `0.9` would put **both numbers on one wire** and make ISL answer *"P(goal ≥ 0.9)"* and *"P(constraint goal ≥ 0.8)"* in one response — the exact divergence the "derive, never mirror" carry exists to prevent. Refusing keeps the invariant that the target and the constraint describe the same number, or there is no constraint.

A node frame with **no** node threshold is deliberately *not* a mismatch: the frame describes what this goal node's samples mean, so it legitimately covers a root-supplied target. Only two **present and unequal** numbers are refused.

Reachability, stated plainly: needs a producer-inconsistent caller, and CEE stamps node-only today — hence non-blocking. Closed because an attestation is only worth what it is attached to.

**Evidence:** T8 pins the refusal (and that the target still reaches ISL). T8b (equal values → synthesises) and T8c (node frame, no node target → synthesises) are the controls that stop T8 passing for the wrong reason. **Mutant C** (`targetAttestationMismatch = false`) → **RED: T8 only**, controls stay green.

---

# ⚠ MERGE COMMS — expect a visible DISAPPEARANCE on staging, and it is the fix working

On deploy, **every live run is currently unattested** (CEE stamps no `goal_threshold_frame` until #789 / ROADMAP 2.281 deploys). So on staging, immediately after merge:

- the **whole goal-fit block disappears** — `constraint_probabilities`, `probability_of_joint_goal`, `decision_brief.analysis_summary.goal_fit`, `goal_fit_basis` all become **absent**;
- the **"< 1% likely to reach target" badge disappears** with it.

**This is honest absence replacing a ~100× understatement, not a regression.** The number that vanishes is the one the 2258 witness proved was answering the wrong question (*"is the uplift ≥ £6M?"* → `0.0054`) where the honest answer was ≈`0.55`. The figures return, correct, once CEE #789 lands the frame stamp. Anyone triaging staging should read a missing goal-fit as **this change working as designed**.

# Bycatch — flagged, NOT fixed

1. **A stale scope note that this row falsifies.** `run.ts:6285-6289` (at head; the `:6167-6171` in the first revision of this body was itself stale — corrected in review) justifies narrowing the 2.239-G degenerate guard on the grounds that the synthesised constraint's `prob_satisfied` has **"zero UI readers"**. The 2258 witness proves it has readers all the way to the screen (`goal_fit` / "Hits target"). Left in place — rewriting it is a separate claim needing its own derivation.
2. **`constraint_probabilities: {}`** can ship as an empty-but-present object when ISL returns constraints whose `prob_satisfied` are all invalid (`run.ts:2649` + `:2771`). Not on the 2.266 path; not touched.
3. **`prob01` accepts `0`** (`numeric-egress-guards.ts:27-29`), so an ISL `joint_probability: 0` ships verbatim as a real `0`. Correct as designed, but it is the one remaining route to a bare `0` on this seam.
4. **`goal_fit_basis` can attach with no delivered probability** — its condition accepts `constraintProbs !== undefined`, true even for `{}` (`run.ts:2813-2826`).
5. **`decision_brief.analysis_summary.goal_fit` sits behind `BRIEF_DECISION_RECORD_SUMMARY_ENABLE`, default OFF** (`config/flags.ts:135-138`), yet the witness observed `goal_fit` live — so staging runs with it on. Worth confirming deliberately; not a code change.
6. **Doc sites quoting the old fragile string** will now be incomplete rather than wrong: `docs/lanes/LANE18-...md:48-51`, `src/contracts/isl-to-ui.contract.ts:284`, `openapi/openapi-plot-lite-v1.yaml:954`, `contracts/openapi.yaml:6430`. None is a runtime gate.

# Stated as unverified

- **No live staging call was made.** All wire claims are from the local route under the CI harness with a mocked ISL. The ~100× figure is the witness's, re-derived here only as arithmetic, not re-measured.
- **ISL-side behaviour** (that constraint samples are change-from-baseline; that `_resolve_goal_threshold` returns `(None, warning)`) is taken from the witness and from this repo's existing comments citing ISL line numbers — **not** read at ISL's bytes in this lane.
- The `'delta'` frame stamped in the six updated suites asserts what those fixtures *mean*, which for nodes labelled "Net cost change" / "Net revenue change" is defensible, but for the generic ones (`'Business Goal'`, `'Revenue'`) it is a **test-harness choice to keep the subject reachable**, not a claim about a real producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
