### PR TITLE
fix(2.289,2.292): honest admission-unknown planning (warm+retain+disclose); scope the no-flip verdict reason

### DIFF
--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -109,12 +109,14 @@ export const ISL_COMPLEXITY_BUDGET_DEFAULT = 30_000_000;
  *
  * The fallback is therefore a DAMAGE LIMITER, not a guarantee, and the real
  * protections sit upstream (all ROADMAP 2.289): the admission cache is warmed
- * before the server accepts traffic (main.ts → warmIslComputeAdmission), a
- * skewed refresh retains the last-known-good advertisement so weighted pricing
- * survives /health outages, and any residual admission-unknown plan is
- * conservative AND disclosed on the wire (`admission_unavailable`). Never widen
- * this value on the fallback path — planning tighter when we cannot confirm
- * ISL's real gate is the one lever this path still has.
+ * before the server accepts traffic (main.ts → warmIslComputeAdmission), an
+ * OUTAGE-class skew (unreadable /health — no advertised version) retains the
+ * last-known-good advertisement so weighted pricing survives /health outages
+ * (drift-class skews never retain, by the #305 review ruling), and any
+ * residual admission-unknown plan is conservative AND disclosed on the wire
+ * (`admission_unavailable`). Never widen this value on the fallback path —
+ * planning tighter when we cannot confirm ISL's real gate is the one lever
+ * this path still has.
  */
 export const LEGACY_FALLBACK_SCALAR_BUDGET = 10_000_000;
 

--- a/src/config/sampling.ts
+++ b/src/config/sampling.ts
@@ -90,13 +90,31 @@ export const ISL_COMPLEXITY_BUDGET_DEFAULT = 30_000_000;
 
 /**
  * Conservative scalar budget for the fail-loud FALLBACK path (unknown/unreachable
- * ISL capability). This is ISL's historical pre-F8 scalar default (10M) — the
- * value that is safe against BOTH a pre-F8 ISL (which enforced exactly this
- * scalar gate) AND a live weighted-F8 ISL (the scalar `n×N×E` over-prices
- * relative to the weighted `n×O×(N+E)+…` shape, so it never under-reduces below
- * what the weighted gate would accept). Never widen this on the fallback path —
- * the whole point of failing loud is to plan conservatively when we cannot
- * confirm ISL's real gate.
+ * ISL capability). This is ISL's historical pre-F8 scalar default (10M) — safe
+ * against a pre-F8 ISL, which enforced exactly this scalar gate.
+ *
+ * ⚠ ROADMAP 2.289 — THE CLAIM THAT USED TO SIT HERE WAS FALSE. This comment
+ * asserted the scalar `n×N×E` "over-prices relative to the weighted shape, so
+ * it never under-reduces below what the weighted gate would accept". For v5
+ * that is arithmetically wrong: the scalar carries no option factor and none of
+ * v5's EVPI/EVPPI/flip terms, so an option- or uncertainty-heavy graph prices
+ * FAR below its true cost. Worked example (pinned in
+ * tests/isl-admission-unknown-honest-fallback.test.ts): N=20, E=40, O=10, U=19
+ * at S=10,000 → scalar 8.0M (inside BOTH the 10M fallback and 30M historical
+ * budgets) while the exact v5 cost is 34,930,600 against ISL's live 24M
+ * ceiling — the request passes every scalar gate and ISL refuses it with a raw
+ * 422. Even the capped fallback depth (4,000) still prices at 29.4M on that
+ * graph: NO scalar arithmetic can promise admission against a weighted gate it
+ * cannot see.
+ *
+ * The fallback is therefore a DAMAGE LIMITER, not a guarantee, and the real
+ * protections sit upstream (all ROADMAP 2.289): the admission cache is warmed
+ * before the server accepts traffic (main.ts → warmIslComputeAdmission), a
+ * skewed refresh retains the last-known-good advertisement so weighted pricing
+ * survives /health outages, and any residual admission-unknown plan is
+ * conservative AND disclosed on the wire (`admission_unavailable`). Never widen
+ * this value on the fallback path — planning tighter when we cannot confirm
+ * ISL's real gate is the one lever this path still has.
  */
 export const LEGACY_FALLBACK_SCALAR_BUDGET = 10_000_000;
 
@@ -796,13 +814,20 @@ export type DepthPlanDecision =
 /** Options controlling the fallback posture when there is no usable admission. */
 export interface PlanSampleDepthOptions {
   /**
-   * True for a GENUINE skew (ISL configured but its capability is unreadable or
-   * its formula version unknown) — the fail-loud posture: DISABLE the
-   * depth-raise (cap a defaulted depth to {@link LEGACY_BASE_N_SAMPLES}) and use
-   * the conservative {@link LEGACY_FALLBACK_SCALAR_BUDGET}. False (default:
-   * true when omitted) for a benign no-gate state (ISL not configured, or the
-   * cold warm-up before the first /health read) — keep the standard depth and
-   * the historical scalar budget, exactly as before the handshake existed.
+   * True whenever ISL is configured but no version-validated admission is in
+   * hand — a genuine skew with nothing retained, or the cold `warming` window —
+   * the fail-loud posture: DISABLE the depth-raise (cap a defaulted depth to
+   * {@link LEGACY_BASE_N_SAMPLES}) and use the conservative
+   * {@link LEGACY_FALLBACK_SCALAR_BUDGET}. False (default: true when omitted)
+   * ONLY for the truly benign no-gate state (ISL not configured — nothing
+   * downstream to refuse the request): standard depth, historical scalar
+   * budget, exactly as before the handshake existed.
+   *
+   * ⚠ ROADMAP 2.289 — the cold warm-up used to be listed here as benign. That
+   * was the hole: a cold cache planned full depth against the 30M scalar,
+   * which UNDER-prices v5 (see LEGACY_FALLBACK_SCALAR_BUDGET), and ISL
+   * refused the forwarded request with a raw 422. The route now derives this
+   * flag via compute-admission.ts `shouldPlanConservatively`.
    */
   conservative?: boolean;
 }
@@ -960,12 +985,15 @@ function planWeighted(
  * Legacy scalar fallback (no usable weighted admission). Maps
  * {@link applyComplexityBudget} into the generic decision shape.
  *
- * `conservative` (genuine skew): scalar gate at
+ * `conservative` (admission unknown while ISL is configured — skew with nothing
+ * retained, or the cold warming window): scalar gate at
  * `min(LEGACY_FALLBACK_SCALAR_BUDGET, env clamp)` AND a DEFAULTED depth capped to
  * {@link LEGACY_BASE_N_SAMPLES} (depth-raise disabled) — the fail-loud posture.
- * Otherwise (ISL absent / cold warm-up, no gate to skew against): the historical
- * scalar budget (`resolveComplexityBudget()`, 30M default) at the standard depth
- * — byte-for-byte the pre-handshake behaviour.
+ * Otherwise (ISL absent, no gate to plan against): the historical scalar budget
+ * (`resolveComplexityBudget()`, 30M default) at the standard depth — byte-for-byte
+ * the pre-handshake behaviour. Either way this path is a DAMAGE LIMITER: scalar
+ * arithmetic cannot promise admission against a weighted gate it cannot see
+ * (ROADMAP 2.289 — see LEGACY_FALLBACK_SCALAR_BUDGET).
  */
 function planLegacyFallback(input: DepthPlanInput, conservative: boolean): DepthPlanDecision {
   // The depth the caller actually asked for (explicit) or that the standard
@@ -1104,10 +1132,13 @@ export type AdmissionCapsDecision =
  *
  * Applies ONLY when caps are advertised-and-valid (`admission` non-null; the
  * resolver has already version-checked the block and validated `caps`). When
- * `admission` is null (genuine skew, ISL unconfigured, or the cold warm-up
- * before the first /health read) this returns `{ kind: 'ok' }` — NO spurious
- * caps refusal; the conservative cost-gate fallback governs exactly as before,
- * mirroring planSampleDepth's skew posture so the two halves stay consistent.
+ * `admission` is null (skew with nothing retained, ISL unconfigured, or the
+ * cold warm-up before the first /health read) this returns `{ kind: 'ok' }` —
+ * NO spurious caps refusal; the conservative cost-gate fallback governs exactly
+ * as before, mirroring planSampleDepth's posture so the two halves stay
+ * consistent. ROADMAP 2.289 note: last-known-good RETENTION (compute-admission
+ * .ts) keeps `admission` non-null through a transient /health outage, so this
+ * gate now stays live in exactly the window that used to disable it.
  *
  * First breach wins; parameter_uncertainties is checked FIRST because it is the
  * dimension PLoT has no other means to catch.

--- a/src/integrations/isl/client.ts
+++ b/src/integrations/isl/client.ts
@@ -499,24 +499,37 @@ export class ISLClient {
   }
 
   /**
-   * GET `/health` with the shared auth header + short AbortController timeout.
-   * The common boilerplate behind {@link healthCheck} and {@link fetchHealth};
-   * each caller reads only the tail it needs (`response.ok` vs the parsed body).
-   * The timeout is always cleared (finally), even when `fetch` rejects.
+   * Run one bounded /health interaction: the timeout signal covers EVERYTHING
+   * the callback does — connection, headers, AND any body read.
+   *
+   * ⚠ #305 review amendment 2 — the predecessor (`getHealthResponse`) cleared
+   * the abort timer the moment `fetch` resolved, i.e. when HEADERS arrived;
+   * `fetchHealth` then awaited `response.json()` with NO live timer, so a
+   * pathologically trickling /health body could extend the read toward
+   * undici's ~300 s idle default — and, since the boot warm awaits one
+   * refresh, extend server boot with it. The timer now lives until the
+   * callback settles, so the advertised health bound is the bound on the
+   * WHOLE read. Pinned by the trickling-body test in
+   * tests/isl-admission-unknown-honest-fallback.test.ts.
    */
-  private async getHealthResponse(): Promise<Response> {
+  private async withHealthTimeout<T>(read: (signal: AbortSignal) => Promise<T>): Promise<T> {
     const controller = new AbortController();
     const healthCheckTimeout = this.config.healthCheckTimeoutMs ?? ISL_HEALTH_CHECK_TIMEOUT_MS;
     const timeoutId = setTimeout(() => controller.abort(), healthCheckTimeout);
     try {
-      return await fetch(`${this.config.baseUrl}/health`, {
-        method: 'GET',
-        headers: { 'X-API-Key': this.config.apiKey },
-        signal: controller.signal,
-      });
+      return await read(controller.signal);
     } finally {
       clearTimeout(timeoutId);
     }
+  }
+
+  /** The bare authenticated /health GET; the caller owns the timeout signal. */
+  private healthFetch(signal: AbortSignal): Promise<Response> {
+    return fetch(`${this.config.baseUrl}/health`, {
+      method: 'GET',
+      headers: { 'X-API-Key': this.config.apiKey },
+      signal,
+    });
   }
 
   /**
@@ -526,7 +539,7 @@ export class ISLClient {
    */
   async healthCheck(): Promise<boolean> {
     try {
-      const response = await this.getHealthResponse();
+      const response = await this.withHealthTimeout((signal) => this.healthFetch(signal));
       return response.ok;
     } catch {
       return false;
@@ -537,16 +550,20 @@ export class ISLClient {
    * Fetch and parse the ISL `/health` payload (Codex F8 handshake).
    *
    * Returns the parsed body (so the caller can read `compute_admission`), or
-   * `null` on ANY failure — unreachable, timeout, non-2xx, or unparseable JSON.
-   * A `null` return is the caller's "unreachable" signal; a non-null body that
-   * simply LACKS `compute_admission` is the caller's "missing block" signal.
-   * Uses the same auth + short health timeout as {@link healthCheck}.
+   * `null` on ANY failure — unreachable, timeout (headers OR body — the health
+   * timeout bounds the entire read, see {@link withHealthTimeout}), non-2xx,
+   * or unparseable JSON. A `null` return is the caller's "unreachable" signal;
+   * a non-null body that simply LACKS `compute_admission` is the caller's
+   * "missing block" signal. Uses the same auth + short health timeout as
+   * {@link healthCheck}.
    */
   async fetchHealth(): Promise<ISLHealthResponse | null> {
     try {
-      const response = await this.getHealthResponse();
-      if (!response.ok) return null;
-      const body = (await response.json()) as ISLHealthResponse;
+      const body = await this.withHealthTimeout(async (signal) => {
+        const response = await this.healthFetch(signal);
+        if (!response.ok) return null;
+        return (await response.json()) as ISLHealthResponse;
+      });
       return body && typeof body === 'object' ? body : null;
     } catch {
       return null;

--- a/src/integrations/isl/compute-admission.ts
+++ b/src/integrations/isl/compute-admission.ts
@@ -9,15 +9,28 @@
  * This module owns:
  *  - the CACHE (TTL 60 s; stale-while-revalidate background refresh, so a live
  *    analysis request NEVER blocks on a per-request /health fetch);
+ *  - the BOOT WARM (ROADMAP 2.289 fix a): {@link warmIslComputeAdmission} runs
+ *    ONE awaited refresh so main.ts can populate the cache BEFORE `listen` —
+ *    production requests are planned against ISL's real advertised cost model,
+ *    not the cold-cache fallback. Bounded by the ISL health-check timeout; it
+ *    never throws and never blocks a live request;
  *  - the VERSION GUARD (a validated block whose complexity_formula_version is
  *    in KNOWN_COMPLEXITY_FORMULA_VERSIONS resolves 'ok'; anything else — an
  *    unreachable /health, a missing/malformed compute_admission block, or an
- *    unknown formula version — resolves to a SKEW state that the planner turns
- *    into the conservative legacy fallback);
+ *    unknown formula version — resolves to a SKEW state);
+ *  - LAST-KNOWN-GOOD RETENTION (ROADMAP 2.289 fix b): a skewed refresh serves
+ *    the most recent 'ok' admission (`retainedAdmissionVersion` set, skew still
+ *    true and still alarmed) so weighted pricing AND the structural caps gate
+ *    survive a transient /health outage instead of dropping to the blind legacy
+ *    scalar — which can UNDER-price v5 (see LEGACY_FALLBACK_SCALAR_BUDGET in
+ *    sampling.ts for the worked example). Only when NOTHING was ever retained
+ *    does planning fall back to the conservative, wire-disclosed legacy mode
+ *    ({@link shouldPlanConservatively});
  *  - the FAIL-LOUD signal on skew: a structured warning + a metric, emitted on
  *    each refresh that detects skew (≈ once per TTL — loud enough to alert on,
  *    quiet enough not to flood per request). Drift is VISIBLE, never silent
- *    (programme memory-trap #12).
+ *    (programme memory-trap #12) — retention changes what is SERVED, never
+ *    whether the alarm fires.
  */
 
 import { getISLClientConfig, isISLConfigured, ISLClient } from './client.js';
@@ -98,6 +111,38 @@ export interface AdmissionResolution {
    * advisory warning + metric. See `foreignFormulaParameterGroupsFor`.
    */
   foreignFormulaParameterGroups?: readonly string[];
+  /**
+   * ROADMAP 2.289 fix (b) — set ONLY when a skewed live read is being served
+   * with the LAST KNOWN GOOD admission: `admission` is that retained block and
+   * this names its formula version (while `advertisedVersion`, when present,
+   * names what the UNUSABLE live read claimed). `status`/`skew` still describe
+   * the live read truthfully — retention changes what planning USES, never what
+   * the alarm SAYS.
+   */
+  retainedAdmissionVersion?: string;
+}
+
+/**
+ * Should the depth planner take the CONSERVATIVE, wire-disclosed fallback
+ * posture for this resolution? (ROADMAP 2.289 fix c.)
+ *
+ * True whenever ISL is configured but no version-validated admission is in hand
+ * — a genuine skew with nothing retained, or the cold 'warming' window — plus
+ * the fail-safe case of a skew WITH a retained admission (irrelevant on the
+ * weighted path, but if weighted planning ever declines the retained block the
+ * legacy fallback must still be the conservative one).
+ *
+ * ⚠ THIS PREDICATE EXISTS BECAUSE `skew` ALONE WAS THE 2.289 DEFECT. The route
+ * used `conservative: resolution.skew`, so the cold cache (`warming`,
+ * skew=false) took the BENIGN legacy path: full defaulted depth against the
+ * historical 30M scalar budget, which UNDER-prices ISL's v5 gate (worked
+ * example: scalar 8.0M vs exact v5 34.9M against the live 24M ceiling) —
+ * forwarded, then refused by ISL as a raw 422. Only `disabled` (no ISL to
+ * refuse anything) keeps the benign posture.
+ */
+export function shouldPlanConservatively(resolution: AdmissionResolution): boolean {
+  if (resolution.status === 'disabled') return false;
+  return resolution.admission === null || resolution.skew;
 }
 
 const WARMING: AdmissionResolution = { admission: null, skew: false, status: 'warming' };
@@ -110,6 +155,15 @@ interface CacheEntry {
 
 let _cache: CacheEntry | null = null;
 let _inflight: Promise<void> | null = null;
+/**
+ * The most recent 'ok' resolution (ROADMAP 2.289 fix b). Written ONLY by a
+ * healthy refresh; served (with the skew reason and alarm intact) when a later
+ * refresh is unusable. Deliberately unbounded within the process lifetime:
+ * pricing against the most recently VERIFIED real gate is strictly more
+ * accurate than the blind legacy scalar, refreshes keep retrying every TTL, and
+ * every skewed refresh re-fires the alarm — the staleness is loud, never silent.
+ */
+let _lastKnownGood: AdmissionResolution | null = null;
 
 /** Is a value present and within TTL? */
 function isFresh(now: number): boolean {
@@ -391,6 +445,12 @@ function signalSkew(resolution: AdmissionResolution): void {
   if (!resolution.skew) return;
   const reason = resolution.status as AdmissionSkewReason;
   recordIslAdmissionVersionSkew(reason);
+  // ROADMAP 2.289 fix (b): when a last-known-good admission is being served,
+  // the alarm still fires (the live read IS unusable) but must describe the
+  // action truthfully — planning is weighted against the retained block, not
+  // the conservative scalar fallback. An alarm that misdescribes its own
+  // mitigation teaches responders the wrong recovery (trap 7b).
+  const retained = resolution.admission !== null;
   // Structured, matches the ISL client's console logging style. Loud on purpose:
   // this is the VISIBLE drift alarm that makes derive-not-mirror safe.
   console.warn(
@@ -400,6 +460,7 @@ function signalSkew(resolution: AdmissionResolution): void {
       event: 'isl_admission_version_skew',
       reason,
       advertised_version: resolution.advertisedVersion ?? null,
+      retained_admission_version: resolution.retainedAdmissionVersion ?? null,
       known_versions: [...KNOWN_COMPLEXITY_FORMULA_VERSIONS],
       // Named on the corresponding reason so the drift is diagnosable from this
       // one line, without a source dive: exactly what ISL advertises and PLoT
@@ -408,9 +469,10 @@ function signalSkew(resolution: AdmissionResolution): void {
       unexpected_cap_keys: resolution.unexpectedCapKeys ?? null,
       missing_formula_parameters: resolution.missingFormulaParameters ?? null,
       unexpected_formula_parameters: resolution.unexpectedFormulaParameters ?? null,
-      action: 'fail_loud_conservative_fallback',
-      msg:
-        'ISL /health compute-admission handshake unusable — planning against the conservative legacy scalar bound (base depth capped) until the live capability is readable and its formula version is known. Every DEFAULTED analysis is now running at the reduced fallback depth and says so in its response (SAMPLES_REDUCED_FOR_COMPLEXITY).',
+      action: retained ? 'retained_last_known_good_admission' : 'fail_loud_conservative_fallback',
+      msg: retained
+        ? 'ISL /health compute-admission read unusable — planning continues against the LAST KNOWN GOOD advertisement (weighted pricing and structural caps stay live) while refreshes retry every TTL. If ISL genuinely changed its cost model, the retained pricing may drift from the live gate until the named reason is resolved.'
+        : 'ISL /health compute-admission handshake unusable and nothing retained — planning against the conservative legacy scalar bound (base depth capped) until the live capability is readable and its formula version is known. Every DEFAULTED analysis is now running at the reduced fallback depth and says so in its response (SAMPLES_REDUCED_FOR_COMPLEXITY).',
     }),
   );
 }
@@ -450,22 +512,28 @@ async function refresh(): Promise<void> {
     const client = new ISLClient(getISLClientConfig());
     const health = await client.fetchHealth();
     resolution = classify(health);
+    if (resolution.status === 'ok') {
+      _lastKnownGood = resolution;
+    } else if (resolution.skew && _lastKnownGood?.admission) {
+      // ROADMAP 2.289 fix (b): the live read is unusable but a verified
+      // advertisement exists — serve it. `status`/`skew` keep describing the
+      // live read; `admission` carries the retained block so weighted pricing
+      // and the caps gate stay live. The alarm below names both.
+      resolution = {
+        ...resolution,
+        admission: _lastKnownGood.admission,
+        retainedAdmissionVersion: _lastKnownGood.advertisedVersion,
+      };
+    }
     signalSkew(resolution);
     signalForeignFormulaParameterGroups(resolution);
   }
   _cache = { at: Date.now(), value: resolution };
 }
 
-/**
- * Resolve the ISL compute-admission capability for planning — SYNCHRONOUS and
- * NON-BLOCKING. Serves the cached value immediately; when the cache is cold or
- * stale it kicks off a background refresh (deduped) and, on a cold cache,
- * returns the conservative `warming` fallback for that single first request.
- * After warm-up every request is served from cache with zero network work.
- */
-export function getIslComputeAdmission(): AdmissionResolution {
-  const now = Date.now();
-  if (!isFresh(now) && _inflight === null) {
+/** Start (or join) one deduped refresh; never rejects, never wedges the cache. */
+function startRefresh(): Promise<void> {
+  if (_inflight === null) {
     _inflight = refresh()
       .catch(() => {
         // A thrown refresh (should not happen — fetchHealth swallows) must not
@@ -476,7 +544,44 @@ export function getIslComputeAdmission(): AdmissionResolution {
         _inflight = null;
       });
   }
-  return _cache ? _cache.value : WARMING;
+  return _inflight;
+}
+
+/**
+ * Resolve the ISL compute-admission capability for planning — SYNCHRONOUS and
+ * NON-BLOCKING. Serves the cached value immediately; when the cache is cold or
+ * stale it kicks off a background refresh (deduped). On a cold cache it returns
+ * `warming` when ISL is configured (first read in flight — the planner treats
+ * this conservatively, see {@link shouldPlanConservatively}) and `disabled`
+ * when it is not (there is no ISL to refuse anything, so nothing to be
+ * conservative about). After warm-up every request is served from cache with
+ * zero network work — in production the cache is already warm before the first
+ * request ({@link warmIslComputeAdmission} in main.ts).
+ */
+export function getIslComputeAdmission(): AdmissionResolution {
+  const now = Date.now();
+  if (!isFresh(now)) {
+    void startRefresh();
+  }
+  if (_cache) return _cache.value;
+  return isISLConfigured() ? WARMING : DISABLED;
+}
+
+/**
+ * Warm the admission cache with ONE awaited refresh (ROADMAP 2.289 fix a).
+ *
+ * Called by main.ts BEFORE `listen`, so in production no request is ever
+ * planned against the cold-cache fallback: the first request already prices
+ * with ISL's real advertised cost model. Bounded by the ISL health-check
+ * timeout (ISL_HEALTH_CHECK_TIMEOUT_MS, 5 s) when ISL is configured; instant
+ * (no network) when it is not. Never throws — a dead ISL warms to a NAMED skew
+ * state and boot proceeds; the route's conservative disclosure covers the gap.
+ */
+export async function warmIslComputeAdmission(): Promise<AdmissionResolution> {
+  if (!isFresh(Date.now())) {
+    await startRefresh();
+  }
+  return getIslComputeAdmission();
 }
 
 // ---------------------------------------------------------------------------
@@ -489,10 +594,11 @@ export function __setIslComputeAdmissionForTest(resolution: AdmissionResolution)
   _inflight = null;
 }
 
-/** Clear the cache + any in-flight refresh. */
+/** Clear the cache + any in-flight refresh + the retained last-known-good. */
 export function __resetIslComputeAdmission(): void {
   _cache = null;
   _inflight = null;
+  _lastKnownGood = null;
 }
 
 /** Run one real refresh (network via mocked fetch) and return the resolution. */

--- a/src/integrations/isl/compute-admission.ts
+++ b/src/integrations/isl/compute-admission.ts
@@ -18,14 +18,18 @@
  *    in KNOWN_COMPLEXITY_FORMULA_VERSIONS resolves 'ok'; anything else — an
  *    unreachable /health, a missing/malformed compute_admission block, or an
  *    unknown formula version — resolves to a SKEW state);
- *  - LAST-KNOWN-GOOD RETENTION (ROADMAP 2.289 fix b): a skewed refresh serves
- *    the most recent 'ok' admission (`retainedAdmissionVersion` set, skew still
- *    true and still alarmed) so weighted pricing AND the structural caps gate
- *    survive a transient /health outage instead of dropping to the blind legacy
- *    scalar — which can UNDER-price v5 (see LEGACY_FALLBACK_SCALAR_BUDGET in
- *    sampling.ts for the worked example). Only when NOTHING was ever retained
- *    does planning fall back to the conservative, wire-disclosed legacy mode
- *    ({@link shouldPlanConservatively});
+ *  - LAST-KNOWN-GOOD RETENTION (ROADMAP 2.289 fix b, scoped by the #305 review
+ *    ruling): an OUTAGE-class skew — the live read carries NO readable formula
+ *    version — serves the most recent 'ok' admission (`retainedAdmissionVersion`
+ *    set, skew still true and still alarmed) so weighted pricing AND the
+ *    structural caps gate survive a transient /health outage instead of
+ *    dropping to the blind legacy scalar — which can UNDER-price v5 (see
+ *    LEGACY_FALLBACK_SCALAR_BUDGET in sampling.ts for the worked example).
+ *    DRIFT-class skews (a READABLE advertised version PLoT cannot price) never
+ *    retain — live ISL is declaring a different cost model, so the retained
+ *    block would be obsolete pricing with stale caps; they take the
+ *    conservative, wire-disclosed fallback, as does any skew with nothing ever
+ *    retained ({@link shouldPlanConservatively});
  *  - the FAIL-LOUD signal on skew: a structured warning + a metric, emitted on
  *    each refresh that detects skew (≈ once per TTL — loud enough to alert on,
  *    quiet enough not to flood per request). Drift is VISIBLE, never silent
@@ -112,12 +116,13 @@ export interface AdmissionResolution {
    */
   foreignFormulaParameterGroups?: readonly string[];
   /**
-   * ROADMAP 2.289 fix (b) — set ONLY when a skewed live read is being served
-   * with the LAST KNOWN GOOD admission: `admission` is that retained block and
-   * this names its formula version (while `advertisedVersion`, when present,
-   * names what the UNUSABLE live read claimed). `status`/`skew` still describe
-   * the live read truthfully — retention changes what planning USES, never what
-   * the alarm SAYS.
+   * ROADMAP 2.289 fix (b) — set ONLY when an OUTAGE-class skewed read (no
+   * readable advertised version; #305 review ruling) is being served with the
+   * LAST KNOWN GOOD admission: `admission` is that retained block and this
+   * names its formula version. Mutually exclusive with `advertisedVersion` by
+   * construction — a readable advertised version is the DRIFT class, which
+   * never retains. `status`/`skew` still describe the live read truthfully —
+   * retention changes what planning USES, never what the alarm SAYS.
    */
   retainedAdmissionVersion?: string;
 }
@@ -158,10 +163,12 @@ let _inflight: Promise<void> | null = null;
 /**
  * The most recent 'ok' resolution (ROADMAP 2.289 fix b). Written ONLY by a
  * healthy refresh; served (with the skew reason and alarm intact) when a later
- * refresh is unusable. Deliberately unbounded within the process lifetime:
- * pricing against the most recently VERIFIED real gate is strictly more
- * accurate than the blind legacy scalar, refreshes keep retrying every TTL, and
- * every skewed refresh re-fires the alarm — the staleness is loud, never silent.
+ * refresh is an OUTAGE-class skew — no readable advertised version (#305
+ * review ruling; drift-class skews never retain). Deliberately unbounded
+ * within the process lifetime for that class: pricing against the most
+ * recently VERIFIED real gate is strictly more accurate than the blind legacy
+ * scalar, refreshes keep retrying every TTL, and every skewed refresh re-fires
+ * the alarm — the staleness is loud, never silent.
  */
 let _lastKnownGood: AdmissionResolution | null = null;
 
@@ -471,8 +478,8 @@ function signalSkew(resolution: AdmissionResolution): void {
       unexpected_formula_parameters: resolution.unexpectedFormulaParameters ?? null,
       action: retained ? 'retained_last_known_good_admission' : 'fail_loud_conservative_fallback',
       msg: retained
-        ? 'ISL /health compute-admission read unusable — planning continues against the LAST KNOWN GOOD advertisement (weighted pricing and structural caps stay live) while refreshes retry every TTL. If ISL genuinely changed its cost model, the retained pricing may drift from the live gate until the named reason is resolved.'
-        : 'ISL /health compute-admission handshake unusable and nothing retained — planning against the conservative legacy scalar bound (base depth capped) until the live capability is readable and its formula version is known. Every DEFAULTED analysis is now running at the reduced fallback depth and says so in its response (SAMPLES_REDUCED_FOR_COMPLEXITY).',
+        ? 'ISL /health compute-admission read unusable with NO readable formula version (outage class) — planning continues against the LAST KNOWN GOOD advertisement (weighted pricing and structural caps stay live) while refreshes retry every TTL and self-heal on recovery. A READABLE version PLoT cannot price (drift) never retains and never takes this branch.'
+        : 'ISL /health compute-admission handshake unusable and nothing retained (or the live read declares a formula PLoT cannot price — drift never retains) — planning against the conservative legacy scalar bound (base depth capped) until the live capability is readable and its formula version is known. Every DEFAULTED analysis is now running at the reduced fallback depth and says so in its response (SAMPLES_REDUCED_FOR_COMPLEXITY).',
     }),
   );
 }
@@ -514,11 +521,28 @@ async function refresh(): Promise<void> {
     resolution = classify(health);
     if (resolution.status === 'ok') {
       _lastKnownGood = resolution;
-    } else if (resolution.skew && _lastKnownGood?.admission) {
-      // ROADMAP 2.289 fix (b): the live read is unusable but a verified
-      // advertisement exists — serve it. `status`/`skew` keep describing the
-      // live read; `admission` carries the retained block so weighted pricing
-      // and the caps gate stay live. The alarm below names both.
+    } else if (
+      resolution.skew &&
+      resolution.advertisedVersion === undefined &&
+      _lastKnownGood?.admission
+    ) {
+      // ROADMAP 2.289 fix (b), SCOPED BY REVIEW RULING (#305 amendment 1):
+      // retention applies to the OUTAGE class ONLY — the live read carries NO
+      // readable formula version (unreachable /health, or a payload so garbled
+      // no version survives). There the last verified advertisement is almost
+      // certainly still ISL's real gate, the alarm re-fires every TTL, and the
+      // state self-heals on recovery.
+      //
+      // The DRIFT class — a READABLE advertised version PLoT cannot price
+      // (unknown_version / unknown_weight_keys / unknown_cap_keys /
+      // missing/unknown_formula_parameters) — must NOT retain: live ISL is
+      // positively declaring a different cost model, so the retained block is
+      // OBSOLETE pricing at full depth with stale caps and zero wire
+      // disclosure, healing only via a PLoT code change. Drift takes the
+      // conservative, wire-disclosed fallback instead. The discriminator is
+      // PAYLOAD-DERIVED (was a version readable?), never a hand-listed set of
+      // statuses (trap 12). Accepted edge, ruled: garbled weights under a
+      // readable version land conservative — the safe side.
       resolution = {
         ...resolution,
         admission: _lastKnownGood.admission,
@@ -573,9 +597,12 @@ export function getIslComputeAdmission(): AdmissionResolution {
  * Called by main.ts BEFORE `listen`, so in production no request is ever
  * planned against the cold-cache fallback: the first request already prices
  * with ISL's real advertised cost model. Bounded by the ISL health-check
- * timeout (ISL_HEALTH_CHECK_TIMEOUT_MS, 5 s) when ISL is configured; instant
- * (no network) when it is not. Never throws — a dead ISL warms to a NAMED skew
- * state and boot proceeds; the route's conservative disclosure covers the gap.
+ * timeout (ISL_HEALTH_CHECK_TIMEOUT_MS, 5 s) when ISL is configured — and that
+ * bound covers the ENTIRE /health read, headers AND body (#305 amendment 2:
+ * client.ts withHealthTimeout; a trickling body cannot extend boot). Instant
+ * (no network) when ISL is not configured. Never throws — a dead ISL warms to
+ * a NAMED skew state and boot proceeds; the route's conservative disclosure
+ * covers the gap.
  */
 export async function warmIslComputeAdmission(): Promise<AdmissionResolution> {
   if (!isFresh(Date.now())) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,9 +42,11 @@ async function start() {
   // accepting traffic, so the first analysis request is planned against ISL's
   // real advertised cost model — never the cold-cache fallback (whose legacy
   // scalar can UNDER-price ISL's v5 gate and draw a raw 422). Bounded by the
-  // ISL health-check timeout (5 s); never throws — a dead ISL warms to a NAMED
-  // skew state, boot proceeds, and the route's conservative disclosure covers
-  // the gap until the background refresh heals it.
+  // ISL health-check timeout (5 s) covering the ENTIRE /health read — headers
+  // AND body (#305 amendment 2, client.ts withHealthTimeout) — so a slow or
+  // trickling ISL cannot extend boot. Never throws — a dead ISL warms to a
+  // NAMED skew state, boot proceeds, and the route's conservative disclosure
+  // covers the gap until the background refresh heals it.
   const admissionWarm = await warmIslComputeAdmission();
   console.log('[STARTUP] ISL compute-admission warm:', {
     status: admissionWarm.status,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createServer } from './createServer.js';
 import { validateEnv } from './config-validator.js';
 import { loadFromFile } from './config/runtimeConfig.js';
 import { logResolvedTimeouts, validateTimeoutChain } from './config/timeouts.js';
+import { warmIslComputeAdmission } from './integrations/isl/compute-admission.js';
 
 const PORT = Number(process.env.PORT || 4311);
 const HOST = '0.0.0.0';
@@ -36,6 +37,19 @@ async function start() {
   // Inflight tracking is now handled by the inflight plugin (registered in createServer)
   // Plugin provides: decoration, onRequest/onResponse hooks, probe exclusion, double-dec guard
   const app = await createServer({ enableTestRoutes: process.env.TEST_ROUTES === '1' });
+
+  // ROADMAP 2.289 fix (a): warm the ISL compute-admission cache BEFORE
+  // accepting traffic, so the first analysis request is planned against ISL's
+  // real advertised cost model — never the cold-cache fallback (whose legacy
+  // scalar can UNDER-price ISL's v5 gate and draw a raw 422). Bounded by the
+  // ISL health-check timeout (5 s); never throws — a dead ISL warms to a NAMED
+  // skew state, boot proceeds, and the route's conservative disclosure covers
+  // the gap until the background refresh heals it.
+  const admissionWarm = await warmIslComputeAdmission();
+  console.log('[STARTUP] ISL compute-admission warm:', {
+    status: admissionWarm.status,
+    advertised_version: admissionWarm.advertisedVersion ?? null,
+  });
 
   await app.listen({ port: PORT, host: HOST });
 

--- a/src/routes/v2/robustness-display-verdict.ts
+++ b/src/routes/v2/robustness-display-verdict.ts
@@ -92,6 +92,16 @@ export const ROBUSTNESS_DISPLAY_VERDICT_REASONS: Record<
  * MEASURED, and they stop claiming flippability that this run's own evidence
  * refutes.
  *
+ * ⚠ ROADMAP 2.292 — SCOPED TO WHAT WAS TESTED. The first wording claimed "no
+ * single factor on its own changed which option leads" — a UNIVERSAL over every
+ * factor in the graph. ISL emits flip-threshold rows only for ELIGIBLE ROOT
+ * factors carrying observed values/uncertainty (robustness_analyzer_v2.py
+ * factor-eligibility selection, ISL tip f35975dc), so a non-root or unobserved
+ * factor was never probed and may still flip the leading option. The
+ * attestation is real but its scope is the PROBED SET; the copy now says
+ * "the factors we could test" so the claim matches the measurement. Same
+ * claim-safety rules as every reason here: one short phrase, no numbers.
+ *
  * `robust` and `not_assessed` are intentionally absent — neither original
  * carries flip language, so neither has anything to correct, and restating
  * them here would create a second copy to drift.
@@ -100,9 +110,9 @@ export const ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP: Partial<
   Record<RobustnessDisplayVerdict, string>
 > = {
   fragile:
-    'no single factor on its own changed which option leads, but this result scored low on our other robustness checks',
+    'none of the factors we could test changed which option leads on its own, but this result scored low on our other robustness checks',
   moderate:
-    'no single factor on its own changed which option leads, and this result mostly held up under the other changes we tested',
+    'none of the factors we could test changed which option leads on its own, and this result mostly held up under the other changes we tested',
 };
 
 /**

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -5754,10 +5754,12 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // the request was forwarded and ISL refused it with a hard 422 — a
         // silent legacy-arithmetic mode where an honest, disclosed downsize
         // belongs. In production the window is additionally closed at the
-        // source: main.ts warms the admission cache before listen, and a
-        // skewed refresh retains the last-known-good advertisement (both in
-        // compute-admission.ts), so this fallback is the LAST line, not the
-        // plan of record.
+        // source: main.ts warms the admission cache before listen, and an
+        // OUTAGE-class skew (unreadable /health, no advertised version)
+        // retains the last-known-good advertisement (both in
+        // compute-admission.ts — drift-class skews never retain, by the #305
+        // review ruling), so this fallback is the LAST line, not the plan of
+        // record.
         const complexityDecision = planSampleDepth(depthPlanInput, admissionResolution.admission, {
           conservative: shouldPlanConservatively(admissionResolution),
         });

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -141,7 +141,7 @@ import { FLAGS } from '../../config/flags.js';
 import { getAllFeatureFlags } from '../../config/feature-flags.js';
 import { resolveStandardNSamples, ADAPTIVE_N_SAMPLES_FLOOR, planSampleDepth, checkAdmissionCaps, type DepthPlanInput, type AdmissionCapsDecision, type AdmissionCapDimension, type DepthReductionReason } from '../../config/sampling.js';
 import { LIMITS_MAX_NODES, LIMITS_MAX_EDGES, LIMITS_MAX_OPTIONS } from '../../config/constants.js';
-import { getIslComputeAdmission } from '../../integrations/isl/compute-admission.js';
+import { getIslComputeAdmission, shouldPlanConservatively } from '../../integrations/isl/compute-admission.js';
 import { generateM1Coaching } from '../../coaching/m1-coaching.js';
 import { filterInterventionOverrides } from '../../coaching/sensitivity-filter.js';
 import type { M1Review } from '../../cee/validation/m1-review-types.js';
@@ -5740,12 +5740,26 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           controlGridPoints: 0,
         };
         // conservative (fail-loud: cap the depth-raise + tighten the scalar
-        // bound) ONLY on a genuine skew — ISL configured but its capability is
-        // unreadable / an unknown formula version. A benign no-gate state (ISL
-        // not configured, or the cold warm-up before the first /health read) is
-        // NOT skew and keeps the standard depth + historical scalar budget.
+        // bound) whenever ISL is configured but no version-validated admission
+        // is in hand — a genuine skew with nothing retained, or the cold
+        // 'warming' window. Only a truly benign no-gate state (ISL not
+        // configured — nothing downstream to refuse the request) keeps the
+        // standard depth + historical scalar budget.
+        //
+        // ⚠ ROADMAP 2.289 — this posture used to be `admissionResolution.skew`
+        // ALONE, so the cold cache (warming, skew=false) planned the FULL
+        // defaulted depth against the benign 30M scalar budget. That scalar can
+        // UNDER-price ISL's v5 weighted gate (worked example N=20/E=40/O=10/
+        // U=19: scalar 8.0M vs exact v5 34.9M against the live 24M ceiling), so
+        // the request was forwarded and ISL refused it with a hard 422 — a
+        // silent legacy-arithmetic mode where an honest, disclosed downsize
+        // belongs. In production the window is additionally closed at the
+        // source: main.ts warms the admission cache before listen, and a
+        // skewed refresh retains the last-known-good advertisement (both in
+        // compute-admission.ts), so this fallback is the LAST line, not the
+        // plan of record.
         const complexityDecision = planSampleDepth(depthPlanInput, admissionResolution.admission, {
-          conservative: admissionResolution.skew,
+          conservative: shouldPlanConservatively(admissionResolution),
         });
 
         if (complexityDecision.kind === 'refused') {

--- a/tests/adaptive-n-samples-complexity.test.ts
+++ b/tests/adaptive-n-samples-complexity.test.ts
@@ -38,6 +38,7 @@ import {
 import {
   __setIslComputeAdmissionForTest,
   __resetIslComputeAdmission,
+  __refreshForTest,
   __classifyForTest,
 } from '../src/integrations/isl/compute-admission.js';
 import type {
@@ -773,5 +774,157 @@ describe('adaptive n_samples via /v2/run (F8 handshake — weighted planning)', 
     // No constraints → no injection → u is exactly the 4 factor PUs.
     expect(new Set((call.parameter_uncertainties ?? []).map((p: any) => p.node_id)).size).toBe(4);
     expect(call.n_samples).toBe(10_000); // tiny graph, well under 24M → not reduced
+  });
+
+  // ---------------------------------------------------------------------------
+  // ROADMAP 2.289 — the COLD-CACHE hole, at the route.
+  //
+  // Codex-confirmed defect: on a cold admission cache getIslComputeAdmission()
+  // returns `{admission: null, skew: false, status: 'warming'}` while refreshing
+  // in the background, and the route derived its fallback posture from `skew`
+  // ALONE — so the very first request(s) after boot were planned on the BENIGN
+  // legacy path: full defaulted depth against the historical 30M scalar budget.
+  // That scalar can UNDER-price ISL's v5 gate (worked example N=20/E=40/O=10/
+  // U=19: scalar 8.0M vs exact v5 34.9M against the live 24M ceiling — see
+  // tests/isl-admission-unknown-honest-fallback.test.ts), so the request was
+  // forwarded and ISL refused it with a hard 422 where an honest structured
+  // outcome belongs.
+  // ---------------------------------------------------------------------------
+
+  it('ROADMAP 2.289: a COLD cache (ISL configured, first read in flight) plans CONSERVATIVELY and DISCLOSES — never the silent full-depth legacy mode', async () => {
+    const prevBase = process.env.ISL_BASE_URL;
+    const prevKey = process.env.ISL_API_KEY;
+    try {
+      // A genuinely cold cache with ISL configured: the route sees 'warming'
+      // organically (no seeded state a production process could never hold).
+      // The kicked-off background refresh must not touch a real network — a
+      // never-resolving fetch holds the cache cold for the whole request.
+      process.env.ISL_BASE_URL = 'https://isl.test';
+      process.env.ISL_API_KEY = 'k';
+      vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+      __resetIslComputeAdmission();
+
+      islCalls = [];
+      // The worked-example shape: denseGraph(19) → 20 causal nodes / 37 edges,
+      // 19 factor PUs, 10 options. Scalar cost 10k×20×37 = 7.4M fits EVERY
+      // scalar budget (10M conservative, 30M historical), while the exact v5
+      // cost at 10k is ~33.3M > the live 24M ceiling — the pass-then-422 shape.
+      const tenOptions = Array.from({ length: 10 }, (_, i) => ({
+        id: `opt-${i}`,
+        label: `Option ${i}`,
+        interventions: { [`factor-${i}`]: { value: 0.6 + i * 0.01, source: 'user_specified' } },
+      }));
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v2/run',
+        headers: { 'Content-Type': 'application/json' },
+        // n_samples DELIBERATELY omitted — the production shape (CEE never sends it).
+        payload: { graph: denseGraph(19), options: tenOptions, goal_node_id: 'goal', seed: '42' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      // The honest structured outcome: the depth-raise is DISABLED (defaulted
+      // 10,000 → 4,000), exactly as under a named skew...
+      expect(islCalls[0].n_samples).toBe(LEGACY_BASE_N_SAMPLES);
+      const body = JSON.parse(res.body);
+      expect(body.meta?.n_samples).toBe(LEGACY_BASE_N_SAMPLES);
+
+      // ...and the cut is DISCLOSED on the wire, attributed to the SEAM (the
+      // admission capability), never to the caller's graph.
+      const warnings = findSamplesReducedWarnings(body);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toContain('10000');
+      expect(warnings[0].message).toContain(String(LEGACY_BASE_N_SAMPLES));
+      expect(warnings[0].message).toContain('could not be confirmed');
+    } finally {
+      vi.unstubAllGlobals();
+      __resetIslComputeAdmission();
+      if (prevBase === undefined) delete process.env.ISL_BASE_URL; else process.env.ISL_BASE_URL = prevBase;
+      if (prevKey === undefined) delete process.env.ISL_API_KEY; else process.env.ISL_API_KEY = prevKey;
+    }
+  });
+
+  it('ROADMAP 2.289: after a healthy read, a FAILING refresh retains the admission — full depth, caps still enforced', async () => {
+    const prevBase = process.env.ISL_BASE_URL;
+    const prevKey = process.env.ISL_API_KEY;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      process.env.ISL_BASE_URL = 'https://isl.test';
+      process.env.ISL_API_KEY = 'k';
+      __resetIslComputeAdmission();
+
+      // Boot-shaped sequence: one healthy read, then ISL's /health goes dark.
+      vi.stubGlobal('fetch', vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ status: 'healthy', compute_admission: v5Admission() }),
+      })));
+      await __refreshForTest();
+      vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+      const retained = await __refreshForTest();
+      expect(retained.status).toBe('unreachable'); // the outage is not hidden...
+      expect(retained.admission).not.toBeNull(); // ...but planning keeps the real gate
+
+      islCalls = [];
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v2/run',
+        headers: { 'Content-Type': 'application/json' },
+        payload: { graph: denseGraph(2), options: OPTIONS, goal_node_id: 'goal', seed: '42' },
+      });
+
+      // Weighted planning survived the outage: full defaulted depth, no
+      // conservative cut, no reduction warning.
+      expect(res.statusCode).toBe(200);
+      expect(islCalls[0].n_samples).toBe(10_000);
+      expect(findSamplesReducedWarnings(JSON.parse(res.body))).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+      vi.unstubAllGlobals();
+      __resetIslComputeAdmission();
+      if (prevBase === undefined) delete process.env.ISL_BASE_URL; else process.env.ISL_BASE_URL = prevBase;
+      if (prevKey === undefined) delete process.env.ISL_API_KEY; else process.env.ISL_API_KEY = prevKey;
+    }
+  });
+
+  it('ROADMAP 2.289: the retained admission keeps the STRUCTURAL CAPS gate live through the outage', async () => {
+    const prevBase = process.env.ISL_BASE_URL;
+    const prevKey = process.env.ISL_API_KEY;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      process.env.ISL_BASE_URL = 'https://isl.test';
+      process.env.ISL_API_KEY = 'k';
+      __resetIslComputeAdmission();
+
+      // The healthy read advertises a node cap TIGHTER than the graph, then dies.
+      const tightened = v5Admission();
+      tightened.caps = { ...tightened.caps, max_nodes: 2 };
+      vi.stubGlobal('fetch', vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ status: 'healthy', compute_admission: tightened }),
+      })));
+      await __refreshForTest();
+      vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+      await __refreshForTest();
+
+      islCalls = [];
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v2/run',
+        headers: { 'Content-Type': 'application/json' },
+        payload: { graph: denseGraph(2), options: OPTIONS, goal_node_id: 'goal', seed: '42' },
+      });
+
+      // Under a NULL admission this gate is disabled (positive control above) —
+      // retention is what keeps the refusal structured and PLoT-originated.
+      expect(res.statusCode).toBe(422);
+      expect(JSON.stringify(JSON.parse(res.body))).toContain('GRAPH_TOO_COMPLEX');
+      expect(islCalls).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+      vi.unstubAllGlobals();
+      __resetIslComputeAdmission();
+      if (prevBase === undefined) delete process.env.ISL_BASE_URL; else process.env.ISL_BASE_URL = prevBase;
+      if (prevKey === undefined) delete process.env.ISL_API_KEY; else process.env.ISL_API_KEY = prevKey;
+    }
   });
 });

--- a/tests/isl-admission-unknown-honest-fallback.test.ts
+++ b/tests/isl-admission-unknown-honest-fallback.test.ts
@@ -1,0 +1,423 @@
+/**
+ * ROADMAP 2.289 — cold/skew admission fallbacks must never silently under-price
+ * ISL's v5 cost model.
+ *
+ * THE DEFECT (Codex-confirmed, term-by-term recomputed): on a COLD admission
+ * cache, `getIslComputeAdmission()` returned `{admission: null, skew: false,
+ * status: 'warming'}` while refreshing in the background. The /v2/run route
+ * derived its fallback posture from `skew` alone, so the warming state took the
+ * BENIGN legacy path: full defaulted depth (10,000) against the historical 30M
+ * scalar budget — whose safety argument ("S×N×E over-prices the weighted shape,
+ * so it never under-reduces") is FALSE for v5.
+ *
+ * WORKED EXAMPLE (pinned below): N=20, E=40, O=10, U=19 at S=10,000 →
+ * legacy scalar 8.0M — under the 10M conservative budget AND the 30M historical
+ * budget — while the EXACT v5 weighted cost is 34,930,600 against ISL's live
+ * 24M ceiling. PLoT forwarded; ISL refused at its cost guard (robustness.py
+ * cost-admission check) — a hard 422 where an honest refusal/downsize belongs.
+ *
+ * THE FIX, pinned here and at the route (adaptive-n-samples-complexity.test.ts):
+ *  (a) the admission cache is WARMABLE at process start (warmIslComputeAdmission,
+ *      awaited in main.ts before listen) so production requests plan against the
+ *      real advertisement;
+ *  (b) a skewed refresh RETAINS the last-known-good admission — weighted pricing
+ *      and the structural caps gate stay live through a transient /health outage
+ *      instead of dropping to blind scalar arithmetic;
+ *  (c) "admission unknown" (warming, or skew with nothing retained) is a
+ *      DISTINCT conservative state: the depth-raise is disabled and the cut is
+ *      DISCLOSED on the wire (reason `admission_unavailable`) — never the silent
+ *      benign-legacy mode;
+ *  (d) the false "never under-prices" comment on LEGACY_FALLBACK_SCALAR_BUDGET
+ *      is corrected (see sampling.ts; the arithmetic witness lives here).
+ *
+ * HONESTY NOTE, disclosed rather than implied away: (c) alone does NOT
+ * guarantee admission — on this worked example even the capped 4,000-sample
+ * fallback prices at 29.4M > 24M. The guarantee comes from (a)+(b) making the
+ * no-advertisement state vanishingly rare; (c) makes the residual window
+ * disclosed-and-conservative instead of silent-and-full-depth.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  estimateWeightedCostV5,
+  planSampleDepth,
+  LEGACY_FALLBACK_SCALAR_BUDGET,
+  ISL_COMPLEXITY_BUDGET_DEFAULT,
+  LEGACY_BASE_N_SAMPLES,
+  ADAPTIVE_N_SAMPLES_FLOOR,
+  type DepthPlanInput,
+  type WeightedCostRequest,
+} from '../src/config/sampling.js';
+import {
+  __classifyForTest,
+  __refreshForTest,
+  __resetIslComputeAdmission,
+  getIslComputeAdmission,
+  warmIslComputeAdmission,
+  shouldPlanConservatively,
+  type AdmissionResolution,
+} from '../src/integrations/isl/compute-admission.js';
+import type {
+  ISLComputeAdmission,
+  ISLComputeAdmissionWeights,
+  ISLComputeAdmissionFormulaParameters,
+  ISLHealthResponse,
+} from '../src/integrations/isl/types/isl-types.js';
+
+/** The live v5 advertisement (same dated capture as the handshake suite). */
+const V5_VERSION = 'v5-factor-flips-2026-08-01';
+
+const LIVE_V5_WEIGHTS = {
+  base_per_sample_per_option_per_struct: 1,
+  evpi_sample_cap: 2000,
+  evpc_coef: 1,
+  evppi_full_coef: 1,
+  evppi_null_permutations: 16,
+  factor_flip_coef: 1,
+  influence_walk_pool: 400_000,
+  sensitivity_coef: 4,
+  evalue_coef: 20,
+  bands_coef: 200,
+  path_coef: 1,
+  max_decomposition_paths: 20_000,
+} as unknown as ISLComputeAdmissionWeights;
+
+const LIVE_V5_FORMULA_PARAMETERS: ISLComputeAdmissionFormulaParameters = {
+  factor_flips: { max_candidates: 10, stability_seeds: 10 },
+  sensitivity: { subsample_cap: 100, subsample_divisor: 10 },
+};
+
+function v5Admission(maxCostUnits = 24_000_000): ISLComputeAdmission {
+  return {
+    max_cost_units: maxCostUnits,
+    complexity_formula_version: V5_VERSION,
+    weights: { ...LIVE_V5_WEIGHTS },
+    caps: {
+      max_options: 10,
+      max_nodes: 50,
+      max_edges: 200,
+      max_parameter_uncertainties: 50,
+      max_control_candidates: 5,
+      max_control_values: 7,
+    },
+    formula_parameters: {
+      factor_flips: { ...LIVE_V5_FORMULA_PARAMETERS.factor_flips! },
+      sensitivity: { ...LIVE_V5_FORMULA_PARAMETERS.sensitivity! },
+    },
+  };
+}
+
+/** The 2.289 worked example: N=20, E=40, O=10, U=19, base /v2/run phase flags. */
+function workedExample(nSamples: number): WeightedCostRequest {
+  return {
+    nSamples,
+    nodeCount: 20,
+    edgeCount: 40,
+    optionCount: 10,
+    uniqueParamUncertainties: 19,
+    includeVoi: true,
+    includeSensitivity: true,
+    includeEValues: true,
+    includePathDecomposition: false,
+    includeFactorFlips: true,
+    controlGridPoints: 0,
+  };
+}
+
+function workedExampleInput(): DepthPlanInput {
+  return { ...workedExample(10_000), nSamplesExplicit: false };
+}
+
+// ===========================================================================
+// A. The arithmetic witness — the false comment, killed with numbers.
+// ===========================================================================
+
+describe('2.289 worked example — the legacy scalar UNDER-prices v5', () => {
+  it('legacy scalar passes BOTH scalar budgets while the exact v5 cost exceeds the live ceiling', () => {
+    const scalar = 10_000 * 20 * 40;
+    expect(scalar).toBe(8_000_000);
+    // Under the conservative fallback budget AND the historical default —
+    // the scalar gate admits this request at full depth on every fallback path.
+    expect(scalar).toBeLessThanOrEqual(LEGACY_FALLBACK_SCALAR_BUDGET);
+    expect(scalar).toBeLessThanOrEqual(ISL_COMPLEXITY_BUDGET_DEFAULT);
+
+    // ...while ISL's REAL v5 gate prices the same request 4.4× higher, over the
+    // live 24M ceiling. This pair is the direct counter-example to the old
+    // sampling.ts claim that S×N×E "never under-reduces below what the
+    // weighted gate would accept".
+    const exact = estimateWeightedCostV5(
+      workedExample(10_000),
+      LIVE_V5_WEIGHTS,
+      LIVE_V5_FORMULA_PARAMETERS,
+    );
+    expect(exact).toBe(34_930_600);
+    expect(exact).toBeGreaterThan(24_000_000);
+  });
+
+  it('even the CAPPED conservative depth (4,000) still exceeds the live ceiling — only real pricing closes this graph', () => {
+    // Disclosed limitation of fix (c): the conservative fallback is honest and
+    // loud, but it cannot price what ISL never advertised. 29.4M > 24M.
+    const atCap = estimateWeightedCostV5(
+      workedExample(LEGACY_BASE_N_SAMPLES),
+      LIVE_V5_WEIGHTS,
+      LIVE_V5_FORMULA_PARAMETERS,
+    );
+    expect(atCap).toBe(29_392_600);
+    expect(atCap).toBeGreaterThan(24_000_000);
+  });
+
+  it('with the REAL advertisement the planner reduces to the maximal admissible depth (the honest outcome)', () => {
+    const d = planSampleDepth(workedExampleInput(), v5Admission(), { conservative: false });
+    expect(d.kind).toBe('reduced');
+    if (d.kind === 'reduced') {
+      expect(d.mode).toBe('weighted');
+      expect(d.reason).toBe('admission_budget');
+      expect(d.nSamples).toBeGreaterThanOrEqual(ADAPTIVE_N_SAMPLES_FLOOR);
+      // Maximal + never breaches: fits at the planned depth, breaches at +1.
+      const costAt = (s: number) =>
+        estimateWeightedCostV5(workedExample(s), LIVE_V5_WEIGHTS, LIVE_V5_FORMULA_PARAMETERS);
+      expect(costAt(d.nSamples)).toBeLessThanOrEqual(24_000_000);
+      expect(costAt(d.nSamples + 1)).toBeGreaterThan(24_000_000);
+    }
+  });
+});
+
+// ===========================================================================
+// B. shouldPlanConservatively — the posture is derived from USABILITY, not
+//    from `skew` alone (the 2.289 route defect in one function).
+// ===========================================================================
+
+describe('shouldPlanConservatively — admission-unknown is conservative, disabled is benign', () => {
+  const cases: Array<[string, AdmissionResolution, boolean]> = [
+    ['warming (cold cache, ISL configured)', { admission: null, skew: false, status: 'warming' }, true],
+    ['genuine skew, nothing retained', { admission: null, skew: true, status: 'unknown_version' }, true],
+    ['unreachable, nothing retained', { admission: null, skew: true, status: 'unreachable' }, true],
+    [
+      'skew WITH a retained admission (fail-safe if weighted planning declines it)',
+      {
+        admission: v5Admission(),
+        skew: true,
+        status: 'unreachable',
+        retainedAdmissionVersion: V5_VERSION,
+      },
+      true,
+    ],
+    ['healthy ok', { admission: v5Admission(), skew: false, status: 'ok' }, false],
+    ['ISL not configured', { admission: null, skew: false, status: 'disabled' }, false],
+  ];
+
+  it.each(cases)('%s → conservative=%j', (_name, resolution, expected) => {
+    void _name;
+    expect(shouldPlanConservatively(resolution)).toBe(expected);
+  });
+});
+
+// ===========================================================================
+// C. Retention — a skewed refresh serves the LAST KNOWN GOOD admission.
+// ===========================================================================
+
+describe('refresh retention — last-known-good survives a skewed read (fail-loud, not fail-blind)', () => {
+  const prevEnv = { ...process.env };
+
+  beforeEach(() => {
+    __resetIslComputeAdmission();
+    process.env.ISL_BASE_URL = 'https://isl.test';
+    process.env.ISL_API_KEY = 'k';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    __resetIslComputeAdmission();
+    process.env = { ...prevEnv };
+  });
+
+  function mockHealth(body: unknown | null, ok = true): void {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        if (body === null && !ok) throw new Error('ECONNREFUSED');
+        return { ok, json: async () => body } as unknown as Response;
+      }),
+    );
+  }
+
+  it('ok → unreachable: the admission is RETAINED, the skew is still named and loud', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockHealth({ status: 'healthy', compute_admission: v5Admission() });
+    const first = await __refreshForTest();
+    expect(first.status).toBe('ok');
+
+    mockHealth(null, false);
+    const second = await __refreshForTest();
+
+    // The live read really is unusable, and says so...
+    expect(second.status).toBe('unreachable');
+    expect(second.skew).toBe(true);
+    // ...but planning keeps the last-known-good advertisement: weighted pricing
+    // and the caps gate stay live instead of dropping to blind scalar arithmetic.
+    expect(second.admission).not.toBeNull();
+    expect(second.admission?.complexity_formula_version).toBe(V5_VERSION);
+    expect(second.retainedAdmissionVersion).toBe(V5_VERSION);
+
+    // The alarm names the retention (and stays a skew alarm — the metric and
+    // event are asserted in the handshake suite; here the ACTION matters).
+    const warned = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).toContain('isl_admission_version_skew');
+    expect(warned).toContain('retained_last_known_good_admission');
+  });
+
+  it('ok → unknown_version: retention also covers a formula-version change, naming BOTH versions', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockHealth({ status: 'healthy', compute_admission: v5Admission() });
+    await __refreshForTest();
+
+    mockHealth({
+      status: 'healthy',
+      compute_admission: v5Admission() && {
+        ...v5Admission(),
+        complexity_formula_version: 'v9-future',
+      },
+    });
+    const r = await __refreshForTest();
+
+    expect(r.status).toBe('unknown_version');
+    expect(r.advertisedVersion).toBe('v9-future'); // the live (unusable) claim
+    expect(r.retainedAdmissionVersion).toBe(V5_VERSION); // what planning uses
+    expect(r.admission?.complexity_formula_version).toBe(V5_VERSION);
+  });
+
+  it('a LATER healthy read replaces the retained value (retention is a bridge, not a pin)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockHealth({ status: 'healthy', compute_admission: v5Admission(24_000_000) });
+    await __refreshForTest();
+    mockHealth(null, false);
+    await __refreshForTest();
+    mockHealth({ status: 'healthy', compute_admission: v5Admission(20_000_000) });
+    const healed = await __refreshForTest();
+
+    expect(healed.status).toBe('ok');
+    expect(healed.admission?.max_cost_units).toBe(20_000_000);
+    expect(healed.retainedAdmissionVersion).toBeUndefined();
+
+    // ...and a NEW outage retains the NEW block, not the original one.
+    mockHealth(null, false);
+    const secondOutage = await __refreshForTest();
+    expect(secondOutage.admission?.max_cost_units).toBe(20_000_000);
+  });
+
+  it('with NOTHING ever retained, a skewed refresh still yields a null admission (fail-closed control)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockHealth(null, false);
+    const r = await __refreshForTest();
+    expect(r.status).toBe('unreachable');
+    expect(r.admission).toBeNull();
+    expect(r.retainedAdmissionVersion).toBeUndefined();
+  });
+
+  it('__resetIslComputeAdmission clears the retained value (test isolation is real)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockHealth({ status: 'healthy', compute_admission: v5Admission() });
+    await __refreshForTest();
+    __resetIslComputeAdmission();
+    mockHealth(null, false);
+    const r = await __refreshForTest();
+    expect(r.admission).toBeNull();
+  });
+});
+
+// ===========================================================================
+// D. warmIslComputeAdmission — the boot-time warm (fix a).
+// ===========================================================================
+
+describe('warmIslComputeAdmission — the cache is warm before the first request', () => {
+  const prevEnv = { ...process.env };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    __resetIslComputeAdmission();
+    process.env = { ...prevEnv };
+  });
+
+  it('configured: one awaited refresh; the NEXT synchronous read is ok with zero network', async () => {
+    __resetIslComputeAdmission();
+    process.env.ISL_BASE_URL = 'https://isl.test';
+    process.env.ISL_API_KEY = 'k';
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ status: 'healthy', compute_admission: v5Admission() }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmed = await warmIslComputeAdmission();
+    expect(warmed.status).toBe('ok');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The request path now serves the warmed value synchronously, no refetch.
+    const served = getIslComputeAdmission();
+    expect(served.status).toBe('ok');
+    expect(served.admission?.complexity_formula_version).toBe(V5_VERSION);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('unconfigured: resolves disabled immediately and never touches the network', async () => {
+    __resetIslComputeAdmission();
+    delete process.env.ISL_BASE_URL;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmed = await warmIslComputeAdmission();
+    expect(warmed.status).toBe('disabled');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('an unreachable ISL warms to a NAMED skew state (boot never wedges on a dead ISL)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    __resetIslComputeAdmission();
+    process.env.ISL_BASE_URL = 'https://isl.test';
+    process.env.ISL_API_KEY = 'k';
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+
+    const warmed = await warmIslComputeAdmission();
+    expect(warmed.status).toBe('unreachable');
+    expect(warmed.admission).toBeNull();
+  });
+});
+
+// ===========================================================================
+// E. Cold-cache semantics — warming is "configured, first read in flight";
+//    an unconfigured ISL is 'disabled' from the very first request.
+// ===========================================================================
+
+describe('getIslComputeAdmission cold-cache semantics', () => {
+  const prevEnv = { ...process.env };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    __resetIslComputeAdmission();
+    process.env = { ...prevEnv };
+  });
+
+  it('cold + unconfigured → disabled (benign), NOT warming (conservative)', () => {
+    __resetIslComputeAdmission();
+    delete process.env.ISL_BASE_URL;
+    const r = getIslComputeAdmission();
+    expect(r.status).toBe('disabled');
+    expect(shouldPlanConservatively(r)).toBe(false);
+  });
+
+  it('cold + configured → warming, which the route now treats as conservative', () => {
+    __resetIslComputeAdmission();
+    process.env.ISL_BASE_URL = 'https://isl.test';
+    process.env.ISL_API_KEY = 'k';
+    // Keep the kicked-off background refresh from touching a real network.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+    const r = getIslComputeAdmission();
+    expect(r.status).toBe('warming');
+    expect(shouldPlanConservatively(r)).toBe(true);
+  });
+});

--- a/tests/isl-admission-unknown-honest-fallback.test.ts
+++ b/tests/isl-admission-unknown-honest-fallback.test.ts
@@ -57,6 +57,7 @@ import {
   shouldPlanConservatively,
   type AdmissionResolution,
 } from '../src/integrations/isl/compute-admission.js';
+import { ISLClient } from '../src/integrations/isl/client.js';
 import type {
   ISLComputeAdmission,
   ISLComputeAdmissionWeights,
@@ -268,7 +269,16 @@ describe('refresh retention — last-known-good survives a skewed read (fail-lou
     expect(warned).toContain('retained_last_known_good_admission');
   });
 
-  it('ok → unknown_version: retention also covers a formula-version change, naming BOTH versions', async () => {
+  it('ok → unknown_version: DRIFT does NOT retain — conservative + disclosed fallback (review ruling on #305)', async () => {
+    // ⚠ FLIPPED PIN, by explicit review ruling. The first cut of this test
+    // pinned retention ACROSS a formula-version change — pinning the exposure
+    // IN: live ISL positively declares a cost model PLoT cannot price, and a
+    // retained block would serve OBSOLETE pricing at full depth with stale caps
+    // and ZERO wire disclosure, healing only via a PLoT code change (ISL
+    // redeployed its formula on 1 Aug — drift recurs here). Retention is for
+    // the OUTAGE class only (unreadable /health: no advertised version to
+    // read); the DRIFT class (a READABLE advertised version PLoT cannot price)
+    // takes the conservative, wire-disclosed fallback.
     vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     mockHealth({ status: 'healthy', compute_admission: v5Admission() });
@@ -276,17 +286,70 @@ describe('refresh retention — last-known-good survives a skewed read (fail-lou
 
     mockHealth({
       status: 'healthy',
-      compute_admission: v5Admission() && {
-        ...v5Admission(),
-        complexity_formula_version: 'v9-future',
-      },
+      compute_admission: { ...v5Admission(), complexity_formula_version: 'v9-future' },
     });
     const r = await __refreshForTest();
 
     expect(r.status).toBe('unknown_version');
-    expect(r.advertisedVersion).toBe('v9-future'); // the live (unusable) claim
-    expect(r.retainedAdmissionVersion).toBe(V5_VERSION); // what planning uses
-    expect(r.admission?.complexity_formula_version).toBe(V5_VERSION);
+    expect(r.advertisedVersion).toBe('v9-future'); // the live declaration is READABLE → drift
+    expect(r.admission).toBeNull(); // NOT retained
+    expect(r.retainedAdmissionVersion).toBeUndefined();
+  });
+
+  it('ok → unknown_weight_keys: CONTENT drift does not retain either (same class, same reason)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockHealth({ status: 'healthy', compute_admission: v5Admission() });
+    await __refreshForTest();
+
+    const grown = v5Admission();
+    (grown.weights as unknown as Record<string, unknown>).brand_new_coef = 1;
+    mockHealth({ status: 'healthy', compute_admission: grown });
+    const r = await __refreshForTest();
+
+    expect(r.status).toBe('unknown_weight_keys');
+    expect(r.advertisedVersion).toBe(V5_VERSION); // version readable → drift class
+    expect(r.admission).toBeNull();
+    expect(r.retainedAdmissionVersion).toBeUndefined();
+  });
+
+  it('ACCEPTED EDGE (ruled): garbled weights under a READABLE version land conservative, not retained', async () => {
+    // classify() reports this as missing_block WITH advertisedVersion set —
+    // the discriminator (advertisedVersion === undefined) therefore excludes
+    // it from retention. Conservative is the safe side: we cannot distinguish
+    // "transient corruption" from "ISL changed what this version means".
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockHealth({ status: 'healthy', compute_admission: v5Admission() });
+    await __refreshForTest();
+
+    const garbled = v5Admission();
+    delete (garbled.weights as unknown as Record<string, unknown>).bands_coef;
+    mockHealth({ status: 'healthy', compute_admission: garbled });
+    const r = await __refreshForTest();
+
+    expect(r.status).toBe('missing_block');
+    expect(r.advertisedVersion).toBe(V5_VERSION);
+    expect(r.admission).toBeNull();
+    expect(r.retainedAdmissionVersion).toBeUndefined();
+  });
+
+  it('ok → SHAPELESS payload (no readable version): outage-class, retained', async () => {
+    // A /health body whose compute_admission is not even block-shaped (an ISL
+    // mid-restart / proxy-error shape) carries NO advertised version — the
+    // payload-derived discriminator classes it with unreachable: outage.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockHealth({ status: 'healthy', compute_admission: v5Admission() });
+    await __refreshForTest();
+
+    mockHealth({ status: 'degraded', compute_admission: 42 });
+    const r = await __refreshForTest();
+
+    expect(r.status).toBe('missing_block');
+    expect(r.advertisedVersion).toBeUndefined(); // nothing readable → outage class
+    expect(r.admission).not.toBeNull();
+    expect(r.retainedAdmissionVersion).toBe(V5_VERSION);
   });
 
   it('a LATER healthy read replaces the retained value (retention is a bridge, not a pin)', async () => {
@@ -385,6 +448,44 @@ describe('warmIslComputeAdmission — the cache is warm before the first request
     const warmed = await warmIslComputeAdmission();
     expect(warmed.status).toBe('unreachable');
     expect(warmed.admission).toBeNull();
+  });
+
+  it('fetchHealth bounds the BODY read, not only the headers (a trickling /health cannot wedge the warm)', async () => {
+    // Review amendment 2 on #305: the health timeout used to be cleared the
+    // moment HEADERS arrived, leaving `response.json()` with no live timer —
+    // a pathologically trickling body extended boot toward undici's ~300 s
+    // idle default. The timeout must bound the ENTIRE read.
+    const client = new ISLClient({
+      baseUrl: 'https://isl.test',
+      apiKey: 'k',
+      timeoutMs: 1_000,
+      maxRetries: 0,
+      healthCheckTimeoutMs: 50,
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: unknown, init: { signal?: AbortSignal } | undefined) => ({
+        ok: true,
+        // A body that settles ONLY when the caller's timeout signal aborts —
+        // the trickling-response shape. If the implementation has dropped the
+        // timer by now, this promise never settles.
+        json: () =>
+          new Promise((_resolve, reject) => {
+            const signal = init?.signal;
+            const abort = () => reject(new DOMException('aborted', 'AbortError'));
+            if (signal?.aborted) return abort();
+            signal?.addEventListener('abort', abort);
+          }),
+      })),
+    );
+
+    const outcome = await Promise.race([
+      client.fetchHealth().then((r) => ({ settled: r })),
+      new Promise((resolve) => setTimeout(() => resolve('BODY_READ_UNBOUNDED'), 500)),
+    ]);
+    // Post-fix: the 50 ms timer aborts the body read; fetchHealth swallows the
+    // AbortError and resolves null well before the 500 ms tripwire.
+    expect(outcome).toEqual({ settled: null });
   });
 });
 

--- a/tests/robustness-display-verdict.flip-evidence.test.ts
+++ b/tests/robustness-display-verdict.flip-evidence.test.ts
@@ -111,8 +111,11 @@ describe('ROADMAP 2.278 — flip evidence informs the verdict REASON', () => {
 
   it('W1b: the reworded reason says what WAS measured', () => {
     const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, [noFlipRow('f')]);
-    // It must describe the flip measurement that actually ran...
-    expect(out.display_verdict_reason).toMatch(/no single factor/i);
+    // It must describe the flip measurement that actually ran — SCOPED to the
+    // probed set (ROADMAP 2.292 replaced the universal "no single factor"
+    // phrasing this pin used to assert: ISL probes only eligible root factors
+    // with observed values/uncertainty, so the universal claim overclaimed).
+    expect(out.display_verdict_reason).toMatch(/factors we could test/i);
     expect(out.display_verdict_reason).toMatch(/which option leads/i);
     // ...and still disclose that the run scored badly on the OTHER checks,
     // so the corrected copy cannot read as an all-clear.
@@ -201,6 +204,70 @@ describe('ROADMAP 2.278 — flip evidence informs the verdict REASON', () => {
       expect(reason, verdict).toBeTruthy();
       expect(reason!.length, verdict).toBeGreaterThan(0);
       expect(reason!, verdict).not.toMatch(/\d/);
+    }
+  });
+});
+
+// ===========================================================================
+// ROADMAP 2.292 — the no-flip reason must claim only the TESTED scope.
+//
+// ISL emits flip-threshold rows ONLY for ELIGIBLE ROOT factors carrying
+// observed values/uncertainty (robustness_analyzer_v2.py factor-eligibility
+// selection, ISL tip f35975dc). "No single factor on its own changed which
+// option leads" is therefore an OVERCLAIM: a non-root or unobserved factor was
+// never probed and may still flip the leading option. The sentence must scope
+// itself to what was actually tested — an attestation over the probed set,
+// never a universal over the whole graph.
+//
+// ⚠ 2.278's constraint carries forward unchanged: only the REASON COPY moves.
+// The verdict-stability pins above (W1/W3) and the wire-survival pins below
+// (R1–R4) must stay green against the reworded strings.
+// ===========================================================================
+
+describe('ROADMAP 2.292 — the no-flip reason claims only what was tested', () => {
+  it('S1: the fragile reason scopes its claim to the TESTED factors, not to every factor', () => {
+    const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, [noFlipRow('f')]);
+    // The corrected copy names the tested scope...
+    expect(out.display_verdict_reason).toMatch(/factors we could test/i);
+    // ...and no longer asserts the universal "no single factor" over factors
+    // ISL never probed (non-root / unobserved factors are not in the rows).
+    expect(out.display_verdict_reason).not.toMatch(/no single factor/i);
+  });
+
+  it('S2: the moderate reason is scoped the same way', () => {
+    const out = deriveRobustnessDisplayVerdict(MODERATE_FACTS, true, [noFlipRow('f')]);
+    expect(out.display_verdict_reason).toMatch(/factors we could test/i);
+    expect(out.display_verdict_reason).not.toMatch(/no single factor/i);
+  });
+
+  it('S3: the scoped copy still says what was measured and does not read as an all-clear', () => {
+    const out = deriveRobustnessDisplayVerdict(FRAGILE_FACTS, true, [noFlipRow('f')]);
+    // What was measured: the probed factors did not change the leading option.
+    expect(out.display_verdict_reason).toMatch(/which option leads/i);
+    // Not an all-clear: the fragile variant still discloses the low score on
+    // the other robustness checks.
+    expect(out.display_verdict_reason).toMatch(/robustness checks/i);
+    // And it still never claims a flip.
+    expect(out.display_verdict_reason).not.toMatch(/flip/i);
+  });
+
+  it('S4: no universal-scope wording anywhere in the attested-no-flip reason set', () => {
+    for (const [verdict, reason] of Object.entries(
+      ROBUSTNESS_DISPLAY_VERDICT_REASONS_ATTESTED_NO_FLIP,
+    )) {
+      expect(reason!, verdict).not.toMatch(/no single factor/i);
+      expect(reason!, verdict).not.toMatch(/\bany factor\b/i);
+      expect(reason!, verdict).not.toMatch(/\ball factors\b/i);
+    }
+  });
+
+  it('S5: VERDICT STABILITY under the reworded copy — the verdict never moves (2.278 invariant re-pinned)', () => {
+    // Same producer facts, with and without the attestation: the verdict is
+    // identical in every case; only the reason string may differ.
+    for (const facts of [FRAGILE_FACTS, MODERATE_FACTS, ROBUST_FACTS]) {
+      const withAttestation = deriveRobustnessDisplayVerdict(facts, true, [noFlipRow('f')]);
+      const without = deriveRobustnessDisplayVerdict(facts, true, undefined);
+      expect(withAttestation.display_verdict).toBe(without.display_verdict);
     }
   });
 });


### PR DESCRIPTION
Two Codex-confirmed rows, both term-by-term recomputed. Build-only lane: adversarial review follows; do not merge on green CI alone.

## Row 1 — ROADMAP 2.289: cold/skew fallbacks under-price the v5 cost model → ISL 422s

**Defect.** On a cold admission cache `getIslComputeAdmission()` returned `{admission: null, skew: false, status: 'warming'}` while refreshing in the background, and `/v2/run` derived its fallback posture from `skew` alone — so the first request(s) after boot planned the **full defaulted depth (10,000) against the benign 30M legacy scalar budget**. The `sampling.ts` comment claimed the scalar `S×N×E` "never under-reduces below what the weighted gate would accept". **Arithmetically false for v5** (no option factor, none of v5's EVPI/EVPPI/flip terms):

| Worked example: N=20, E=40, O=10, U=19, S=10,000 | value | vs gate |
|---|---:|---|
| legacy scalar `S×N×E` | 8,000,000 | passes 10M conservative AND 30M historical budgets |
| exact v5 weighted cost | **34,930,600** | **> ISL's live 24M ceiling → raw 422** |
| exact v5 at the capped fallback depth (4,000) | 29,392,600 | still > 24M — no scalar arithmetic can promise admission |
| honest weighted plan (real advertisement in hand) | reduced to 1,725 samples | fits at 1,725; breaches at 1,726 (pinned) |

**Fix (all four adopted from the audit; no new env vars/flags):**
- **(a) Boot warm** — `main.ts` awaits `warmIslComputeAdmission()` **before `listen`**: one bounded /health read (5 s health-check timeout, never throws), so production requests plan against ISL's real advertisement, never the cold fallback. A dead ISL warms to a **named** skew state and boot proceeds.
- **(b) Last-known-good retention** — a skewed refresh now serves the most recent `ok` admission (`retainedAdmissionVersion` set; `status`/`skew` still describe the live read truthfully; the alarm still fires with `action: retained_last_known_good_admission` naming **both** versions). Weighted pricing **and the structural caps gate** survive a transient /health outage instead of dropping to blind scalar arithmetic. Retention is refresh-driven only, cleared by the test reset seam, replaced by the next healthy read.
- **(c) Admission-unknown is a distinct conservative state** — the route posture is now `shouldPlanConservatively(resolution)`: `warming` and skew-with-nothing-retained take the conservative path (defaulted depth capped to 4,000 + the existing 2.260 `admission_unavailable` wire disclosure). Only `disabled` stays benign — with ISL unconfigured there is nothing downstream to refuse. Cold + unconfigured now resolves `disabled` from the very first request.
- **(d) The false comment is corrected** — `LEGACY_FALLBACK_SCALAR_BUDGET`'s docstring now carries the worked example and the honest framing: the scalar fallback is a **damage limiter, not a guarantee**; (a)+(b) close the window, (c) makes any residual window disclosed-and-conservative instead of silent-and-full-depth.

**Healthy path byte-identical (2.260 constraint).** `estimateWeightedCostV2/V5`, `planWeighted`, `tryPlanWeighted`, `classify`, `checkAdmissionCaps` untouched (see the diff); the #303 fixture/controls — all 66 handshake tests including the 2,530,746 term-by-term measurement pin and the declared⇔read Proxy pins — re-ran green on the final code, plus the route-level v5 acceptance pair (defaulted 10,000, no warning).

## Row 2 — ROADMAP 2.292: the no-flip verdict reason overclaimed

**Defect.** The 2.278 attested-no-flip reason said "**no single factor** on its own changed which option leads" — a universal over every factor in the graph. ISL emits flip-threshold rows only for **eligible root factors carrying observed values/uncertainty** (`robustness_analyzer_v2.py` factor-eligibility selection, ISL tip `f35975dc`), so a non-root/unobserved factor was never probed and may still flip the leading option.

**Fix.** Minimal copy change, scoped to what was actually tested — **new copy, flagged for Paul's deck**:
- fragile: `none of the factors we could test changed which option leads on its own, but this result scored low on our other robustness checks`
- moderate: `none of the factors we could test changed which option leads on its own, and this result mostly held up under the other changes we tested`

No coverage counts added: the reason doctrine is one short claim-safe phrase with no numbers (pinned), and the response carries no tested/omitted factor census today. `display_verdict_reason` is a free string on the wire (no schema enum) — contract-safe end to end.

**2.278 constraint held: the verdict never moves.** New pin S5 asserts verdict identity with/without the attestation across all three verdict classes; the existing verdict-stability (W1/W3) and wire-survival (R1–R4) pins re-ran green. One pre-existing pin (W1b) restated the old universal wording in a regex and is updated to assert the scoped phrase — a disclosed pin update, not a weakening (every other W1b assertion unchanged).

## Review amendments (landed in-PR at `a2c6a816`, per the #305 ruling: approve with amendments)

**Amendment 1 — retention is OUTAGE-class only (the lead ruling).** Retention as first built was honest for the outage class (unreachable / shape-garbled — alarm re-fires, self-heals on recovery) but NOT for the drift class (`unknown_version` / `unknown_weight_keys` / `unknown_cap_keys` / `unknown_formula_parameters` / `missing_formula_parameters`): live ISL positively declares a model PLoT cannot price, and the retained block would serve obsolete pricing at full depth with stale caps and zero wire disclosure, healing only via a PLoT code change — and ISL redeployed its formula on 1 Aug, so drift recurs here. Retention now requires `resolution.advertisedVersion === undefined` — payload-derived (was a version readable?), no env var, no hand-listed status set. Drift takes the existing conservative + wire-disclosed fallback. **The retention-covers-version-change pin is FLIPPED** (retain → conservative) per the explicit ruling, with new pins for weight-key drift, the **accepted edge** (garbled weights under a readable version land conservative — the safe side, ruled), and the retained shapeless-payload outage case.

**Amendment 2 — the health timeout now bounds the ENTIRE /health read.** `getHealthResponse` cleared its abort timer when headers arrived; `fetchHealth` then awaited `response.json()` with no live timer, so a pathologically trickling body could extend the read toward undici's ~300 s idle default — and, because the boot warm awaits one refresh, extend server boot with it. Replaced by `withHealthTimeout(read)`: the controller lives until the callback settles (headers AND body); `healthCheck`/`fetchHealth` share it; the "bounded by 5 s" comments now describe exactly what ships. Pinned by a trickling-body test whose body promise settles only on the caller's abort signal.

**Amendment RED signatures (pre-amendment, captured):** drift pins ×3 `expected { max_cost_units: 24000000, … } to be null`; body bound `expected 'BODY_READ_UNBOUNDED' to deeply equal { settled: null }`.

**Amendment mutation checks (throwaway worktrees outside repo root, removed before gates):** MA1 (discriminator dropped — retain on all skews) → RED, the 3 drift pins; MA2 (json() read moved back outside the timer) → RED, the trickling-body pin.

**Amended gates:** typecheck clean; full `npm test` EXIT=0, 604 files / 6697 tests passed, 0 failed (+4 = exactly the amendment pins; empty delta vs the pristine baseline holds).

## RED-first signatures (all captured pre-fix on tip `be6131e6`)

| Test | RED signature |
|---|---|
| route cold-cache (2.289) | `AssertionError: expected 10000 to be 4000` + zero disclosure warnings — the silent full-depth mode, witnessed |
| route retention | `expected null not to be null` |
| route caps-through-outage | `expected 200 to be 422` |
| unit retention | `expected undefined to be 'v5-factor-flips-2026-08-01'`, `expected undefined to be 20000000` |
| warm / posture / cold-semantics units | missing exports → not-a-function/undefined failures (14 in the new file) |
| 2.292 S1/S2 | `expected 'no single factor on its own changed w…' to match /factors we could test/i` |
| 2.292 S4 | `fragile: expected … not to match /no single factor/i` |

## Mutation table (throwaway worktrees outside the repo root, removed before gates)

| Mutant | Reverted behaviour | Result |
|---|---|---|
| M1: route posture back to `conservative: skew` | 2.289(c) defect restored | **RED** `expected 10000 to be 4000` |
| M2: retention branch removed | 2.289(b) defect restored | **RED** 5 failures (null admission; caps `200 vs 422`; `retainedAdmissionVersion` undefined) |
| M3: `warmIslComputeAdmission` made a no-op | 2.289(a) hollowed | **RED** `expected 'warming' to be 'ok'` / `'unreachable'` |
| M4: old universal copy restored | 2.292 defect restored | **RED** 4 failures (S1/S2/S4/W1b) |
| M5: cold fallback ternary reverted to bare `WARMING` | — | **SURVIVED — equivalent mutant, disclosed**: for the unconfigured case `refresh()` has no `await` before caching `DISABLED`, so the async body completes synchronously and the ternary is unreachable for that case. The ternary stays as defence-in-depth (protects against a future early `await` in `refresh()`); the behaviour is enforced upstream — see M5b |
| M5b: `refresh()` misclassifies unconfigured as warming | the real source of disabled-from-first-request | **RED** `expected 'warming' to be 'disabled'` — the pin is not vacuous |
| M6: attestation softens fragile→moderate | the exact 2.278/2.292 forbidden move | **RED** 5 failures incl. `expected 'moderate' to be 'fragile'` in W1, S5 and route R2 |

## Gates + empty-delta proof

- Pristine tip `be6131e6` control run (same clone, pre-edit, `npm test` = build + vitest + fixtures replay + OpenAPI + loadcheck): **EXIT=0, 603 files / 6666 tests passed, 0 failures** (this repo's standing red is CI-side `release.yml`, which fails on every push and is invisible in pr-checks — nothing standing locally).
- Branch run of the identical gate: **EXIT recorded in the lane report; target profile identical zero-failure — empty delta.**
- `npm run typecheck` clean.
- Composition check: #304 delta-gate fixtures (`goal-threshold-frame-synthesis-gate`, 12 tests) + the 2.260 measurement fixtures (`isl-compute-admission-handshake`, 66) + caps gate + cost-request-shape + both verdict suites + frame/ordering suites: **157/157 green** on the final code.

## Residuals / unverified, stated as such

- **ISL 422 passthrough residual (pre-existing, rowed by the coordinator):** if a request is forwarded during an admission-unknown window and ISL refuses it, an ISL 422 **without** structured critiques still surfaces as the generic `ISL_CALL_FAILED` failed-status path ("Please try again") — misleading for a cost refusal. The reviewer named two real triggers: (1) boot-during-outage, which remains; (2) retention-drift, which **dies with amendment 1** (drift no longer retains — it takes the conservative disclosed fallback). The remaining window is small (boot warm + outage-class retention + 60 s TTL) but not zero.
- **`main.ts` warm wiring has no automated test** (importing `main.ts` binds ports/executes `start()`). Reviewed by eye; the guarantee does not rest on it — if the warm never ran, fix (c) still makes every cold request conservative and disclosed. Suggested reviewer check: read the `main.ts` hunk.
- **Retention is unbounded within the process lifetime for the OUTAGE class** (no staleness cutoff; no new env vars allowed). Scope was tightened by amendment 1: drift-class skews never retain. For the outage class, pricing against the most recently verified real gate strictly dominates blind scalar arithmetic, refreshes retry every 60 s, self-heal on recovery, and every skewed refresh re-fires the alarm.
- **Not live-verified on staging** — no deploy performed by this lane (build-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
