### PR TITLE
test(voi): the VOI passthrough proof must be of a body the contract accepts (S5)

### DIFF
--- a/src/routes/v2/enrichment-egress-guard.ts
+++ b/src/routes/v2/enrichment-egress-guard.ts
@@ -25,12 +25,18 @@
  * and payload values are never logged. This matches CEE's shadow validator
  * (`v5.enrichment.schema_mismatch` — {path, code} only).
  *
- * The envelope (vendored @talchain/schemas — 0.30.0 at this tip, byte-identical
- * to the tarball CEE and DGAI vendor; see vendor/README.md for the five-way
- * derivation) is passthrough at every level with all root keys optional:
+ * The envelope (vendored @talchain/schemas, byte-identical to the tarball CEE and
+ * DGAI vendor; see vendor/README.md for the five-way derivation) is passthrough
+ * at every level with all root keys optional:
  * producer-ahead fields can never fail it; only type/enum corruption on the
  * typed keys can. So `ok: false` always means a REAL contract break, never
  * "PLoT moved ahead of the schema".
+ *
+ * ⚠ THE PINNED VERSION IS DELIBERATELY NOT RESTATED IN THIS COMMENT. It used to
+ * be ("0.30.0 at this tip"), and it was still saying so while the repo was on
+ * 0.31.0 — a hand-maintained mirror of a number that went stale exactly as trap
+ * 12 predicts. `package.json` is the pin. The two version facts BELOW are
+ * historical (what 0.22.0 lacked, what 0.30.0 added) and stay true as it moves.
  *
  * ⚠ THE COROLLARY IS THE TRAP (ROADMAP 2.160). `.passthrough()` means a key the
  * envelope does not TYPE is not validated at all — it is waved through, and this

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -25,6 +25,12 @@ import {
   MAX_OPTIONS as LIMITS_MAX_OPTIONS,
 } from '../constants/limits.js';
 
+// S5 (lane L45): the VOI family's row type comes from the SHARED contract, not
+// from a PLoT-local restatement. `@talchain/schemas` 0.31.0 owns this shape and
+// the egress guard validates against the same schema at runtime, so importing
+// the type is agreement with the contract rather than an invented one.
+import type { EnrichmentFactorEvppiEntry } from '@talchain/schemas/boundary';
+
 // Import CEE types for factor enrichments
 import type { FactorEnrichment } from '../cee/types.js';
 import type { RangeSource } from '../lib/intervention-normaliser.js';
@@ -1080,18 +1086,67 @@ export interface RunResponseV3 {
    * present (additive, omit-when-absent). PLoT does the raw passthrough only —
    * "PLoT passthrough-forwards meanwhile" (D-23.4); the richer outcome-unit
    * reconciliation + method-tagging to the UI is a separate gated lane
-   * (D-23.8 S5) and firm wire typing rides the @talchain/schemas batch. Typed
-   * permissively (`unknown`) here so PLoT neither invents nor constrains a
-   * shape ISL owns. NOT in response_hash (response_hash canonicalises the
-   * request; these are computed enrichment).
+   * (D-23.8 S5) and firm wire typing rides the @talchain/schemas batch.
+   * NOT in response_hash (response_hash canonicalises the request; these are
+   * computed enrichment).
+   *
+   * ⭐ S5 (lane L45) — EACH FIELD IS TYPED EXACTLY AS THE SHARED CONTRACT TYPES
+   * IT, AND NO TIGHTER. `@talchain/schemas` 0.31.0 adopted this family
+   * (`AnalysisEnrichmentSchema`), so the shape is no longer PLoT's to guess:
+   * mirroring the contract here is the opposite of inventing one. Two of the
+   * four stay `unknown` because the CONTRACT types them open — `p_win_sensitivity`
+   * as `z.array(z.record(z.string(), z.unknown()))` and `correlation_model` as
+   * `z.object({}).passthrough()` — and claiming more than the contract does is
+   * how a type becomes a promise nothing checks.
+   *
+   * ⚠ THE TYPES ARE BACKED BY A RUNTIME CHECK, WHICH IS WHY THEY ARE SAFE TO
+   * NARROW. These values are forwarded VERBATIM (`islEnrichmentPassthrough`) —
+   * a declared type alone would assert a shape nothing validates. The egress
+   * guard parses the outgoing body against the SAME schema, and
+   * `tests/gates/voi-family-wire-conformance.test.ts` pins that its verdict is
+   * `true` on the real `/v2/run` route, WITH a positive control proving the
+   * verdict can still say no. Before that pin existed, the repo's own
+   * passthrough fixture carried `decision_evpi` as an OBJECT: the contract
+   * rejected it, the guard said so inside the same response, and every test was
+   * green. Narrow the types only as far as something executes.
    */
-  /** Correlation model disclosure (Gaussian copula, PSD/tail-independence status). */
+  /**
+   * Correlation model disclosure (Gaussian copula, PSD/tail-independence status).
+   * OPEN by contract. Also THE DISCRIMINATOR for an absent `p_win_sensitivity`:
+   * `suppressed_attributions` naming it means suppressed-under-correlation, not
+   * never-computed.
+   */
   correlation_model?: unknown;
-  /** Decision-EVPI on the joint samples (E[max]−max E). */
-  decision_evpi?: unknown;
-  /** Per-factor Strong-Oakley EVPPI (outcome-unit value of perfect partial information). */
-  factor_evppi?: unknown;
-  /** Per-factor win-probability sensitivity (honestly-named successor to factor_evpi). */
+  /**
+   * Decision-EVPI on the joint samples (E[max]−max E), OUTCOME units.
+   *
+   * ⚠ ABSENT ≠ 0. Key-absent means NOT COMPUTED; a `0` is a real measurement
+   * ("nothing about this decision is worth learning"). The wire carries no
+   * discriminator beyond key presence, so `?? 0` at any consumer converts one
+   * into the other. `number | null` mirrors the contract exactly — `null` is
+   * admitted because the contract admits it, not because PLoT emits it.
+   */
+  decision_evpi?: number | null;
+  /**
+   * Per-factor Strong-Oakley EVPPI (outcome-unit value of perfect partial
+   * information), rows sorted by `evppi` DESCENDING by the producer — that
+   * ORDER is the contract, and a consumer renders it verbatim.
+   *
+   * ⚠ A factor ABSENT from a present array was NOT ASSESSED (a lever an option
+   * intervenes on, or a row whose estimator failed — disclosed as
+   * `FACTOR_EVPPI_PARTIAL`). Absent is never zero and must not be imputed.
+   */
+  factor_evppi?: EnrichmentFactorEvppiEntry[] | null;
+  /**
+   * Per-factor win-probability sensitivity (honestly-named successor to
+   * factor_evpi). OPEN by contract — ISL declares `List[dict]`.
+   *
+   * ABSENT UNDER ACTIVE CORRELATION BY DESIGN: ISL suppresses it and names it in
+   * `correlation_model.suppressed_attributions`, so absence here is a
+   * suppression VERDICT. It is also the only VOI quantity in CHANCE units
+   * (`current_metric` → `perfect_metric`); a consumer may not render those
+   * members until the contract types the row.
+   */
   p_win_sensitivity?: unknown;
 
   /** Factor sensitivity results (if available) */

--- a/tests/factor-correlation-forwarding.test.ts
+++ b/tests/factor-correlation-forwarding.test.ts
@@ -31,6 +31,7 @@ import {
   toISLRobustnessRequest,
 } from '../src/integrations/isl/translator-v3.js';
 import type { EngineGraphV3, OptionV3, FactorCorrelation } from '../src/types/engine-v3.js';
+import { VOI_TRANSPORT_ALL_FOUR } from './fixtures/voi-family-wire.js';
 
 // ---------------------------------------------------------------------------
 // (1) FORWARDING — translator unit (no server, byte-precise)
@@ -105,18 +106,22 @@ const requestA = JSON.parse(
 );
 
 // ISL-shaped correlated-factors outputs used by the passthrough proof.
-const CORRELATION_MODEL = {
-  model: 'gaussian_copula',
-  psd: { status: 'valid', method: 'none' },
-  tail_independence_disclosed: true,
-};
-const DECISION_EVPI = { value: 0.042, method: 'joint_samples', units: 'outcome' };
-const FACTOR_EVPPI = [
-  { factor_id: 'fac_dev_headcount', evppi: 0.031, method: 'strong_oakley' },
-];
-const P_WIN_SENSITIVITY = [
-  { factor_id: 'fac_dev_headcount', p_win_sensitivity: 0.12 },
-];
+//
+// ⭐ L45: these were four HAND-INVENTED constants, and `decision_evpi` was an
+// OBJECT where the shared contract types a number — so this "verbatim
+// passthrough" proof ran against a body that PLoT's OWN egress guard, sitting
+// in the same response, marked `enrichment_contract_ok: false` with an
+// ENRICHMENT_CONTRACT_MISMATCH warning. The test passed 8/8 green throughout.
+// They now come from ONE canonical module derived from the live guest-walk
+// capture + the ISL producer at `80aa83f`; the full derivation, the measured
+// pristine failure, and why the all-four combination is a TRANSPORT fixture
+// rather than a semantic claim are in that module's header.
+const {
+  correlation_model: CORRELATION_MODEL,
+  decision_evpi: DECISION_EVPI,
+  factor_evppi: FACTOR_EVPPI,
+  p_win_sensitivity: P_WIN_SENSITIVITY,
+} = VOI_TRANSPORT_ALL_FOUR;
 
 // Mutable mock state (mock-prefixed so Vitest permits it inside the factory).
 const mockState: { augment: boolean; error: unknown | null } = { augment: false, error: null };
@@ -269,6 +274,20 @@ describe('capability #100 — /v2/run route (allowlist, passthrough, 422)', () =
     expect(body.decision_evpi).toEqual(DECISION_EVPI);
     expect(body.factor_evppi).toEqual(FACTOR_EVPPI);
     expect(body.p_win_sensitivity).toEqual(P_WIN_SENSITIVITY);
+
+    // ⭐ L45 — THE PASSTHROUGH PROOF MUST BE OF A BODY THE CONTRACT ACCEPTS.
+    // `enrichment_contract_ok` is PLoT's own egress verdict on this very body
+    // (assessEnrichmentContract → AnalysisEnrichmentSchema). Without this the
+    // test proved transport of a shape the shared envelope REJECTS, while the
+    // guard sitting in the same response declared it broken — two guards, one
+    // body, never introduced (trap 19: a pin that passes on the wrong object).
+    expect(
+      body?._meta?.evidence?.enrichment_contract_ok,
+      'the forwarded VOI body must parse against the shared enrichment envelope',
+    ).toBe(true);
+    expect(
+      (body.inference_warnings ?? []).map((w: { code: string }) => w.code),
+    ).not.toContain('ENRICHMENT_CONTRACT_MISMATCH');
   });
 
   it('OMITS the correlated-factors keys when ISL does not emit them', async () => {

--- a/tests/fixtures/voi-family-wire.ts
+++ b/tests/fixtures/voi-family-wire.ts
@@ -45,16 +45,35 @@
  * inside the one chain S5 exists to make honest.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * PROVENANCE OF EVERY VALUE BELOW
+ * PROVENANCE OF EVERY VALUE BELOW — INCLUDING WHAT IS CONSTRUCTED
  * ─────────────────────────────────────────────────────────────────────────────
- * Row shapes and values are taken from the live guest-walk capture
+ * ⚠ READ THIS BEFORE THE SENTENCE AFTER IT. Every row SHAPE, and most values,
+ * come from the live capture. THREE THINGS ARE CONSTRUCTED, and saying so first
+ * is the point of this file:
+ *
+ *   1. THE TWO `status: 'resolved'` ROWS AND THEIR `evppi` HEADLINE VALUES
+ *      (`fac_market_demand` 0.0184, `fac_current_arr` 0.0002, and the
+ *      `conditional_max_expected_utility` figures that follow from them) ARE
+ *      CONSTRUCTED. The real capture carries `below_resolution` on EVERY row
+ *      with `evppi: 0`, so the resolved band cannot be taken from it at all —
+ *      and a fixture that exercised only one band would let N4 pass without
+ *      ever meeting a `resolved` row (which is why N4b asserts BOTH bands are
+ *      present). Constructed to be internally consistent with the capture's own
+ *      audit legs: same `baseline_max_expected_utility`, same `method`,
+ *      `n_samples`, `regression_degree`, and each `evppi` above its row's real
+ *      `noise_floor` — the condition ISL uses to stamp `resolved`.
+ *   2. `VOI_CORRELATION_MODEL_ACTIVE` — the capture ran INDEPENDENT
+ *      (`correlation_model: null`), so the whole block is built from the ISL
+ *      producer at `80aa83f`, field by field, referenced per value below.
+ *   3. `VOI_TRANSPORT_ALL_FOUR`'s combination — see the ⚠ below.
+ *
+ * Everything else — the `below_resolution` row, both `p_win_sensitivity` rows,
+ * `VOI_DECISION_EVPI`, and every row shape — is verbatim from the live
+ * guest-walk capture
  * `DecisionGuideAI/src/canvas/compare-tab/__tests__/__fixtures__/
  * v5GuestWalkAnalysisBlocks.json` (`created_at 2026-08-03T07:55:35.688Z`,
- * `runA.enrichment`) — a real CEE turn payload, i.e. these bytes have actually
- * crossed ISL → PLoT → CEE → UI. Constants that the capture cannot show (the
- * ACTIVE correlation disclosure, which that run did not exercise —
- * `correlation_model: null` there) are taken from the ISL producer at
- * `80aa83f`, named per value below.
+ * `runA.enrichment`) — a real CEE turn payload, i.e. those bytes have actually
+ * crossed ISL → PLoT → CEE → UI.
  *
  * ⚠ ONE FIXTURE IS A TRANSPORT FIXTURE AND SAYS SO: `VOI_TRANSPORT_ALL_FOUR`
  * presents all four keys together to prove `buildResponse` drops none of them.
@@ -88,8 +107,17 @@ export const VOI_DECISION_EVPI = 0.0789680300194515;
  * (`evppi` descending — the contract's `EnrichmentFactorEvppiEntrySchema`
  * docstring: "PRODUCER RANK ORDER IS THE CONTRACT").
  *
- * Row 1 is `status: 'resolved'` and row 3 `below_resolution` so a consumer's
- * two bands are BOTH exercised; the audit legs are the capture's real ones.
+ * ⚠ ROWS 1 AND 2 ARE CONSTRUCTED, ROW 3 IS THE CAPTURE'S. The live run produced
+ * `below_resolution` on every row, so the `resolved` band had to be built or the
+ * consumer's two bands could never both be exercised (N4b pins that they are).
+ * The construction is disciplined, not invented freely: same
+ * `baseline_max_expected_utility` / `method` / `n_samples` / `regression_degree`
+ * as the capture, `conditional_max_expected_utility = baseline + evppi` exactly,
+ * each row's real `noise_floor` kept, and each `evppi` set ABOVE its own
+ * `noise_floor` — which is the condition ISL uses to stamp `resolved`
+ * (`robustness_analyzer_v2.py:6464`: `below_resolution = evppi <= est.noise_floor`,
+ * stamped at `:6500`). Row 3 keeps `evppi: 0` with `noise_floor: 0`, which
+ * satisfies `<=` and is why the capture's own row reads `below_resolution`.
  * `factor_id`s are distinct so any order assertion binds by IDENTITY rather
  * than by a value another row could satisfy.
  */
@@ -201,8 +229,17 @@ export const VOI_CORRELATION_MODEL_ACTIVE = {
   correlated_factors: ['fac_market_demand', 'fac_content_spend'],
   n_pairs: 1,
   tail_dependence: 'none',
+  // ISL `_CORRELATION_TAIL_NOTE` VERBATIM (`robustness_analyzer_v2.py:147-152`).
+  // This was a PARAPHRASE on first submission — nothing asserts on the string, so
+  // the paraphrase could not have failed anything, which is exactly why it needed
+  // fixing rather than disclosing: an unasserted value in a fixture whose whole
+  // claim is "these are the producer's bytes" is where the next invented shape
+  // starts.
   tail_dependence_note:
-    'A Gaussian copula has zero tail dependence: joint extremes are modelled as less likely than a tail-dependent model would imply.',
+    'The Gaussian copula has zero tail dependence: it does not model factors ' +
+    'moving to their extremes together, so joint tail (worst-case) co-movements ' +
+    'may be understated. Downside metrics (CVaR, p05, expected_regret) can be ' +
+    'optimistic when correlated factors are strongly dependent.',
   psd_projection: null,
   suppressed_attributions: [ISL_SUPPRESSED_ATTR_P_WIN_SENSITIVITY],
   suppression_reason: ISL_CORRELATION_SUPPRESSION_REASON,

--- a/tests/fixtures/voi-family-wire.ts
+++ b/tests/fixtures/voi-family-wire.ts
@@ -1,0 +1,246 @@
+/**
+ * THE canonical VOI-family wire fixtures (lane L45, S5 typed surface).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS FILE EXISTS: THE OLD FIXTURES WERE INVENTED, AND THE PIN THEY BACKED
+ * PROVED TRANSPORT OF A BODY THIS REPO'S OWN EGRESS GUARD REJECTS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Before this lane, `tests/factor-correlation-forwarding.test.ts` carried three
+ * hand-written constants as its passthrough proof:
+ *
+ *     const DECISION_EVPI    = { value: 0.042, method: 'joint_samples', units: 'outcome' };
+ *     const FACTOR_EVPPI     = [{ factor_id: 'fac_dev_headcount', evppi: 0.031, method: 'strong_oakley' }];
+ *     const P_WIN_SENSITIVITY= [{ factor_id: 'fac_dev_headcount', p_win_sensitivity: 0.12 }];
+ *     const CORRELATION_MODEL= { model: 'gaussian_copula', psd: {…}, tail_independence_disclosed: true };
+ *
+ * NONE of those is a shape ISL emits, and the first is one the shared contract
+ * REJECTS. Measured at PLoT `3177fd3` / schemas 0.31.0 / ISL `80aa83f`:
+ *
+ *   · `AnalysisEnrichmentSchema.safeParse` on a body carrying that
+ *     `decision_evpi` → `success: false`, issue `{path:'decision_evpi',
+ *     code:'invalid_type'}`. The contract types it `z.number().nullable()
+ *     .optional()`; ISL's producer declares `self.decision_evpi:
+ *     Optional[float]` (`src/utils/response_builder.py:157`) and the live
+ *     guest-walk capture carries the bare float `0.0789680300194515`.
+ *   · Run through the REAL `/v2/run` route, the response body those constants
+ *     produced carried `_meta.evidence.enrichment_contract_ok: false` and an
+ *     `ENRICHMENT_CONTRACT_MISMATCH` inference warning — and the test passed
+ *     8/8 green, because nothing asserted on either.
+ *   · `correlation_model`'s real key set is `{method, active,
+ *     correlated_factors, n_pairs, tail_dependence, tail_dependence_note,
+ *     psd_projection, suppressed_attributions, suppression_reason}`
+ *     (ISL `_build_correlation_disclosure`,
+ *     `src/services/robustness_analyzer_v2.py:2770`). The old constant shared
+ *     not one key name with it.
+ *   · a real `factor_evppi` row carries `status` — and the LICENSED CONSUMER
+ *     (`DecisionGuideAI/src/components/results/voi/voiRanking.ts`) DROPS any row
+ *     whose `status` is absent or outside `{resolved, below_resolution}`. So the
+ *     old fixture's rows would have been dropped one hop later and the ranking
+ *     would have collapsed to its honest gate. The transport pin could not see
+ *     that, because it never asked whether the thing transported was readable.
+ *
+ * Two guards in this repo — the passthrough pin and the egress contract guard —
+ * were looking at the SAME response body and disagreeing about it, and nothing
+ * introduced them. That is trap 19 (a pin that passes on the wrong object) sitting
+ * inside the one chain S5 exists to make honest.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * PROVENANCE OF EVERY VALUE BELOW
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Row shapes and values are taken from the live guest-walk capture
+ * `DecisionGuideAI/src/canvas/compare-tab/__tests__/__fixtures__/
+ * v5GuestWalkAnalysisBlocks.json` (`created_at 2026-08-03T07:55:35.688Z`,
+ * `runA.enrichment`) — a real CEE turn payload, i.e. these bytes have actually
+ * crossed ISL → PLoT → CEE → UI. Constants that the capture cannot show (the
+ * ACTIVE correlation disclosure, which that run did not exercise —
+ * `correlation_model: null` there) are taken from the ISL producer at
+ * `80aa83f`, named per value below.
+ *
+ * ⚠ ONE FIXTURE IS A TRANSPORT FIXTURE AND SAYS SO: `VOI_TRANSPORT_ALL_FOUR`
+ * presents all four keys together to prove `buildResponse` drops none of them.
+ * ISL does NOT emit that combination — under active correlation it SUPPRESSES
+ * `p_win_sensitivity` entirely and names it in
+ * `correlation_model.suppressed_attributions`
+ * (`robustness_analyzer_v2.py:2431-2434`). The two SEMANTICALLY real
+ * combinations are `VOI_INDEPENDENT_RUN` and `VOI_CORRELATED_RUN`, and the
+ * suppression discriminator is pinned on those. Labelling the transport fixture
+ * as a transport claim is the point: the defect this file repairs was a fixture
+ * that made a semantic claim nobody had checked.
+ */
+
+/** ISL `CORRELATION_METHOD` (`src/utils/correlation.py:37`). */
+export const ISL_CORRELATION_METHOD = 'gaussian_copula_v1';
+
+/** ISL `_CORRELATION_SUPPRESSION_REASON` (`robustness_analyzer_v2.py:154`). */
+export const ISL_CORRELATION_SUPPRESSION_REASON = 'not_separable_under_correlation';
+
+/** ISL `SUPPRESSED_ATTR_P_WIN_SENSITIVITY` (`src/models/response_v2.py:1351`). */
+export const ISL_SUPPRESSED_ATTR_P_WIN_SENSITIVITY = 'p_win_sensitivity';
+
+/**
+ * Whole-decision EVPI, OUTCOME units, a BARE FLOAT.
+ * Live capture `runA.enrichment.decision_evpi`.
+ */
+export const VOI_DECISION_EVPI = 0.0789680300194515;
+
+/**
+ * Per-factor Strong–Oakley regression EVPPI rows, in PRODUCER RANK ORDER
+ * (`evppi` descending — the contract's `EnrichmentFactorEvppiEntrySchema`
+ * docstring: "PRODUCER RANK ORDER IS THE CONTRACT").
+ *
+ * Row 1 is `status: 'resolved'` and row 3 `below_resolution` so a consumer's
+ * two bands are BOTH exercised; the audit legs are the capture's real ones.
+ * `factor_id`s are distinct so any order assertion binds by IDENTITY rather
+ * than by a value another row could satisfy.
+ */
+export const VOI_FACTOR_EVPPI = [
+  {
+    factor_id: 'fac_market_demand',
+    evppi: 0.0184,
+    evppi_raw: 0.0184,
+    baseline_max_expected_utility: 0.252812,
+    conditional_max_expected_utility: 0.271212,
+    units: 'outcome',
+    method: 'regression_evppi_v1',
+    regression_degree: 4,
+    n_samples: 10000,
+    clamped_low: false,
+    clamped_high: false,
+    noise_floor: 0.000006,
+    status: 'resolved',
+    correlation_active: false,
+  },
+  {
+    factor_id: 'fac_current_arr',
+    evppi: 0.0002,
+    evppi_raw: 0.0002,
+    baseline_max_expected_utility: 0.252812,
+    conditional_max_expected_utility: 0.253012,
+    units: 'outcome',
+    method: 'regression_evppi_v1',
+    regression_degree: 4,
+    n_samples: 10000,
+    clamped_low: false,
+    clamped_high: false,
+    noise_floor: 0.000017,
+    status: 'resolved',
+    correlation_active: false,
+  },
+  {
+    factor_id: 'fac_budget',
+    evppi: 0,
+    evppi_raw: 0,
+    baseline_max_expected_utility: 0.252812,
+    conditional_max_expected_utility: 0.252812,
+    units: 'outcome',
+    method: 'regression_evppi_v1',
+    regression_degree: 4,
+    n_samples: 10000,
+    clamped_low: false,
+    clamped_high: false,
+    noise_floor: 0,
+    status: 'below_resolution',
+    correlation_active: false,
+  },
+] as const;
+
+/**
+ * Win-probability sensitivity rows — the ONLY VOI quantity in CHANCE units.
+ * Live capture `runA.enrichment.p_win_sensitivity` (first two rows verbatim).
+ *
+ * `current_metric` → `perfect_metric` is the pair a plain-language surface
+ * renders as "from 53% to 55%". ⚠ The ROW SHAPE IS UNTYPED BY THE CONTRACT at
+ * 0.31.0 (`p_win_sensitivity: z.array(z.record(z.string(), z.unknown()))`), so
+ * no consumer may render these members until the contract types them — that is
+ * the minimal contract delta this lane hands over, not something to ship
+ * through the untyped passthrough.
+ */
+export const VOI_P_WIN_SENSITIVITY = [
+  {
+    factor_id: 'fac_market_demand',
+    metric_type: 'p_win_recommended',
+    method: 'p_win_delta_at_mean_v1',
+    current_metric: 0.53275,
+    perfect_metric: 0.547458,
+    p_win_delta: 0.014708,
+    p_win_delta_percentage_points: 1.47,
+    noise_floor: 0.03099,
+    noise_floor_method: 'z95_worst_case_bernoulli_diff',
+    n_samples: 2000,
+    clamped: false,
+    labelling_doctrine: 'provisional_doctrine_v0',
+    status: 'below_resolution',
+  },
+  {
+    factor_id: 'fac_content_spend',
+    metric_type: 'p_win_recommended',
+    method: 'p_win_delta_at_mean_v1',
+    current_metric: 0.53275,
+    perfect_metric: 0.5405,
+    p_win_delta: 0.00775,
+    p_win_delta_percentage_points: 0.78,
+    noise_floor: 0.03099,
+    noise_floor_method: 'z95_worst_case_bernoulli_diff',
+    n_samples: 2000,
+    clamped: false,
+    labelling_doctrine: 'provisional_doctrine_v0',
+    status: 'below_resolution',
+  },
+] as const;
+
+/**
+ * The ACTIVE correlation disclosure, shaped from ISL
+ * `_build_correlation_disclosure` (`robustness_analyzer_v2.py:2770-2781`).
+ * It NAMES `p_win_sensitivity` in `suppressed_attributions` — that naming is
+ * what makes an absent `p_win_sensitivity` readable as a SUPPRESSION VERDICT
+ * rather than as "never computed" (schemas 0.31.0, `enrichment.js:898-906`).
+ */
+export const VOI_CORRELATION_MODEL_ACTIVE = {
+  method: ISL_CORRELATION_METHOD,
+  active: true,
+  correlated_factors: ['fac_market_demand', 'fac_content_spend'],
+  n_pairs: 1,
+  tail_dependence: 'none',
+  tail_dependence_note:
+    'A Gaussian copula has zero tail dependence: joint extremes are modelled as less likely than a tail-dependent model would imply.',
+  psd_projection: null,
+  suppressed_attributions: [ISL_SUPPRESSED_ATTR_P_WIN_SENSITIVITY],
+  suppression_reason: ISL_CORRELATION_SUPPRESSION_REASON,
+} as const;
+
+/**
+ * SEMANTIC case 1 — an INDEPENDENT run (the live capture's own shape).
+ * `correlation_model` is explicitly `null`, and `p_win_sensitivity` is present.
+ */
+export const VOI_INDEPENDENT_RUN = {
+  correlation_model: null,
+  decision_evpi: VOI_DECISION_EVPI,
+  factor_evppi: VOI_FACTOR_EVPPI,
+  p_win_sensitivity: VOI_P_WIN_SENSITIVITY,
+} as const;
+
+/**
+ * SEMANTIC case 2 — a CORRELATED run. `p_win_sensitivity` is ABSENT (ISL
+ * suppresses it at the skip site) while `factor_evppi` stays EMITTED (it is
+ * honest under correlation: the retained samples are joint copula draws —
+ * `robustness_analyzer_v2.py:2489-2494`), with `correlation_active: true` on
+ * each row.
+ */
+export const VOI_CORRELATED_RUN = {
+  correlation_model: VOI_CORRELATION_MODEL_ACTIVE,
+  decision_evpi: VOI_DECISION_EVPI,
+  factor_evppi: VOI_FACTOR_EVPPI.map((r) => ({ ...r, correlation_active: true })),
+} as const;
+
+/**
+ * TRANSPORT fixture — all four keys together, to prove `buildResponse`'s
+ * field-by-field rebuild drops none of them. Deliberately NOT a semantic claim:
+ * see the file header. Uses the INDEPENDENT run's real shapes plus an active
+ * disclosure block, which is why it must never be read as "what ISL sends".
+ */
+export const VOI_TRANSPORT_ALL_FOUR = {
+  correlation_model: VOI_CORRELATION_MODEL_ACTIVE,
+  decision_evpi: VOI_DECISION_EVPI,
+  factor_evppi: VOI_FACTOR_EVPPI,
+  p_win_sensitivity: VOI_P_WIN_SENSITIVITY,
+} as const;

--- a/tests/gates/voi-family-wire-conformance.test.ts
+++ b/tests/gates/voi-family-wire-conformance.test.ts
@@ -1,0 +1,334 @@
+/**
+ * SCIENTIFIC REGRESSION GATE — S5 · the VOI family reaches the wire in a shape a
+ * consumer can actually READ (lane L45).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT WAS ALREADY COVERED, AND WHAT THE HOLE WAS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Three existing pins between them cover a lot and NONE of them covers this:
+ *
+ *   · `tests/contract/voi-enrichment-typed.test.ts` — STRUCTURAL: every key in
+ *     `ISL_TOPLEVEL_ENRICHMENT_KEYS` is a TYPED property of
+ *     `AnalysisEnrichmentSchema`. It asks whether the contract types the keys.
+ *     It never asks whether the BODY PLoT emits satisfies that typing.
+ *   · `tests/contract/openapi-runtime-drift.test.ts` — the keys are DOCUMENTED
+ *     as `runResponseV3` properties. Presence, explicitly not shape.
+ *   · `tests/factor-correlation-forwarding.test.ts` — BEHAVIOURAL: present-in ⇒
+ *     present-out, absent-in ⇒ absent-out, on the real route. Until this lane it
+ *     did that against three HAND-INVENTED shapes, one of which the contract
+ *     rejects outright, so it proved transport of a body that this repo's own
+ *     egress guard — computing its verdict INSIDE the same response — marked
+ *     `enrichment_contract_ok: false`. Measured at `3177fd3`; the test was green.
+ *
+ * So the chain had a pin for "the contract types it", a pin for "the doc
+ * mentions it", and a pin for "the key survives the rebuild" — and no pin at all
+ * for **is what we put on the wire a thing the next consumer can read**. This
+ * gate is that pin. It matters now because the consumer is live: DGAI's
+ * `src/components/results/voi/voiRanking.ts` renders the "Resolve next" view off
+ * `enrichment.factor_evppi`, and it DROPS any row without a usable `status` —
+ * so an unreadable row does not error, it silently collapses the ranking to its
+ * honest gate, which looks exactly like "the science found nothing".
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * CLAIM TYPES (each pin proves one thing, and no more)
+ * ─────────────────────────────────────────────────────────────────────────────
+ *  N1 CONFORMANCE   — the emitted body parses against the SHARED envelope, per
+ *                     PLoT's own egress verdict. Paired with N1c, its positive
+ *                     control (trap 13: an "it validates" assertion is vacuous
+ *                     until it is shown to be capable of saying no).
+ *  N2 MEASURED-ZERO — `decision_evpi: 0` from ISL arrives as exactly `0`, key
+ *                     PRESENT. The contract's own `.describe()` names this seam:
+ *                     absence means NOT COMPUTED, a measured 0 is a real result,
+ *                     and the wire carries no discriminator beyond key presence.
+ *  N3 ORDER         — `factor_evppi` rows arrive in PRODUCER order, asserted by
+ *                     the `factor_id` SEQUENCE (identity), never by a magnitude
+ *                     another row could satisfy.
+ *  N4 READABILITY   — every emitted row satisfies the licensed consumer's row
+ *                     contract, DERIVED from `EnrichmentFactorEvppiEntrySchema`
+ *                     rather than re-listed here.
+ *  N5 SUPPRESSION   — under active correlation `p_win_sensitivity` is absent AND
+ *                     `correlation_model.suppressed_attributions` names it, so
+ *                     absence is readable as a verdict rather than as silence.
+ *  N6 COMPLETENESS  — every VOI key CEE keeps for the UI is a key PLoT forwards.
+ *                     A UNION assertion between two importable lists, which is
+ *                     the only kind of completeness check that is itself derived
+ *                     (trap 12d: deriving a guard from a list moves the risk onto
+ *                     the list; this one derives from the OTHER repo's list).
+ *
+ * NOT claimed here: that ISL's numbers are correct, that any row is above its
+ * noise floor, or that anything renders. Rendering lives in DGAI.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  AnalysisEnrichmentSchema,
+  EnrichmentFactorEvppiEntrySchema,
+  CEE_UI_ENRICHMENT_KEEP_LIST,
+} from '@talchain/schemas/boundary';
+import { ISL_TOPLEVEL_ENRICHMENT_KEYS } from '../../src/routes/v2/run-contract-keys.js';
+import {
+  VOI_TRANSPORT_ALL_FOUR,
+  VOI_INDEPENDENT_RUN,
+  VOI_CORRELATED_RUN,
+  VOI_FACTOR_EVPPI,
+  ISL_SUPPRESSED_ATTR_P_WIN_SENSITIVITY,
+} from '../fixtures/voi-family-wire.js';
+
+const FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'fixtures',
+  'isl-v2-live-20260707',
+);
+const captureA = JSON.parse(readFileSync(join(FIXTURE_DIR, 'isl-staging-capture.json'), 'utf8'));
+const requestA = JSON.parse(readFileSync(join(FIXTURE_DIR, 'isl-v2-request.json'), 'utf8'));
+
+/**
+ * The VOI block the mocked ISL merges into its envelope for the next request.
+ * `null` = emit no VOI keys at all.
+ */
+const mockState: { voi: Record<string, unknown> | null } = { voi: null };
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseFactorSensitivity() {
+    return {
+      factors: [], value_of_information: [], robustness_label: 'robust' as const,
+      robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const,
+    };
+  },
+  async analyseRobustness(): Promise<never> { throw new Error('not called'); },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(): Promise<{ data: T | null; error: unknown | null; latency_ms: number }> {
+    const payload = JSON.parse(JSON.stringify(captureA));
+    if (mockState.voi) Object.assign(payload, JSON.parse(JSON.stringify(mockState.voi)));
+    return { data: payload as T, error: null, latency_ms: 0 };
+  },
+};
+
+vi.mock('../../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../../src/createServer.js';
+
+function buildPlotBody() {
+  return {
+    graph: {
+      nodes: requestA.graph.nodes.map((n: any) => ({
+        id: n.id,
+        kind: n.kind,
+        label: n.label,
+        ...(n.observed_state?.value !== undefined && n.observed_state?.value !== null
+          ? { observed_state: { value: n.observed_state.value } }
+          : {}),
+      })),
+      edges: requestA.graph.edges.map((e: any) => ({
+        from: e.from, to: e.to,
+        exists_probability: e.exists_probability,
+        strength: { mean: e.strength.mean, std: e.strength.std },
+      })),
+    },
+    options: requestA.options.map((o: any) => ({
+      id: o.id, label: o.label,
+      interventions: Object.fromEntries(
+        Object.entries(o.interventions).map(([nodeId, value]) => [
+          nodeId, { value, source: 'user_specified' },
+        ]),
+      ),
+    })),
+    goal_node_id: requestA.goal_node_id,
+    seed: String(requestA.seed),
+  };
+}
+
+describe('S5 gate · the VOI family reaches the wire in a READABLE shape', () => {
+  let app: FastifyInstance;
+
+  /** POST /v2/run with `voi` merged into the mocked ISL envelope. */
+  async function run(voi: Record<string, unknown> | null): Promise<any> {
+    mockState.voi = voi;
+    const res = await app.inject({
+      method: 'POST', url: '/v2/run',
+      headers: { 'Content-Type': 'application/json' },
+      payload: buildPlotBody(),
+    });
+    expect(res.statusCode, 'the run must succeed before any VOI claim is made').toBe(200);
+    return JSON.parse(res.body);
+  }
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    mockState.voi = null;
+    await app.close();
+  });
+
+  // ── N1 · CONFORMANCE, with its positive control ───────────────────────────
+
+  it('N1 the emitted VOI body parses against the SHARED enrichment envelope', async () => {
+    const body = await run({ ...VOI_TRANSPORT_ALL_FOUR });
+    const parsed = AnalysisEnrichmentSchema.safeParse(body);
+    expect(
+      parsed.success
+        ? []
+        : parsed.error.issues.map((i) => ({ path: i.path.join('.'), code: i.code })),
+      'the /v2/run body must satisfy the envelope CEE and the UI parse it against',
+    ).toEqual([]);
+  });
+
+  it("N1b PLoT's own egress verdict on that body agrees: enrichment_contract_ok", async () => {
+    const body = await run({ ...VOI_TRANSPORT_ALL_FOUR });
+    expect(body?._meta?.evidence?.enrichment_contract_ok).toBe(true);
+    expect(
+      (body.inference_warnings ?? []).map((w: { code: string }) => w.code),
+    ).not.toContain('ENRICHMENT_CONTRACT_MISMATCH');
+  });
+
+  it('N1c POSITIVE CONTROL — a wrong-typed decision_evpi IS caught (N1/N1b are not vacuous)', async () => {
+    // The EXACT shape this gate's lane found in the repo's own passthrough
+    // fixture: an object where the contract types a number.
+    const body = await run({
+      ...VOI_TRANSPORT_ALL_FOUR,
+      decision_evpi: { value: 0.042, method: 'joint_samples', units: 'outcome' },
+    });
+    const parsed = AnalysisEnrichmentSchema.safeParse(body);
+    expect(parsed.success, 'a wrong-typed decision_evpi must NOT parse clean').toBe(false);
+    expect(body?._meta?.evidence?.enrichment_contract_ok).toBe(false);
+    expect(
+      (body.inference_warnings ?? []).map((w: { code: string }) => w.code),
+    ).toContain('ENRICHMENT_CONTRACT_MISMATCH');
+  });
+
+  // ── N2 · MEASURED ZERO ≠ NOT COMPUTED ─────────────────────────────────────
+
+  it('N2 an ISL decision_evpi of exactly 0 arrives as 0 with the key PRESENT', async () => {
+    const body = await run({ ...VOI_INDEPENDENT_RUN, decision_evpi: 0 });
+    expect(
+      Object.prototype.hasOwnProperty.call(body, 'decision_evpi'),
+      'a measured 0 must not be dropped — absence would mean NOT COMPUTED',
+    ).toBe(true);
+    expect(body.decision_evpi).toBe(0);
+    expect(body.decision_evpi).not.toBeNull();
+  });
+
+  it('N2b an ISL decision_evpi that is ABSENT stays absent — never coerced to 0 or null', async () => {
+    const { decision_evpi: _omitted, ...withoutDecisionEvpi } = VOI_INDEPENDENT_RUN;
+    const body = await run({ ...withoutDecisionEvpi });
+    expect(
+      Object.prototype.hasOwnProperty.call(body, 'decision_evpi'),
+      'NOT COMPUTED must reach the consumer as key-absent, never as 0',
+    ).toBe(false);
+  });
+
+  // ── N3 · PRODUCER RANK ORDER IS THE CONTRACT ──────────────────────────────
+
+  it('N3 factor_evppi arrives in PRODUCER order, asserted by factor_id sequence', async () => {
+    const body = await run({ ...VOI_INDEPENDENT_RUN });
+    const producerOrder = VOI_FACTOR_EVPPI.map((r) => r.factor_id);
+    // Identity binding: the SEQUENCE of ids, not a magnitude another row could
+    // satisfy. `toEqual` on the array pins position, so a reversal or a
+    // re-sort REDs even when every row survives.
+    expect(body.factor_evppi.map((r: { factor_id: string }) => r.factor_id)).toEqual(producerOrder);
+    expect(producerOrder.length, 'the order claim needs >1 row to be falsifiable').toBeGreaterThan(1);
+  });
+
+  // ── N4 · READABLE BY THE LICENSED CONSUMER ────────────────────────────────
+
+  /**
+   * The consumer's row contract, DERIVED from the pinned schema exactly as
+   * DGAI's `voiRanking.ts` derives it (`EnrichmentFactorEvppiEntrySchema.pick`),
+   * plus the same three consumer tightenings that reader applies. Re-listing the
+   * field names here would be a second definition of a contract whose whole
+   * point is that there is one.
+   */
+  const ConsumerRowSchema = EnrichmentFactorEvppiEntrySchema.pick({
+    factor_id: true, evppi: true, status: true,
+  });
+  const RENDERABLE_STATUSES = ['resolved', 'below_resolution'];
+
+  it('N4 every emitted factor_evppi row is one the licensed consumer can render', async () => {
+    const body = await run({ ...VOI_INDEPENDENT_RUN });
+    const unreadable: Array<{ factor_id: unknown; why: string }> = [];
+    for (const raw of body.factor_evppi as unknown[]) {
+      const parsed = ConsumerRowSchema.safeParse(raw);
+      const id = (raw as { factor_id?: unknown })?.factor_id;
+      if (!parsed.success) { unreadable.push({ factor_id: id, why: 'schema' }); continue; }
+      if (!(parsed.data.factor_id.length > 0)) { unreadable.push({ factor_id: id, why: 'empty id' }); continue; }
+      if (!Number.isFinite(parsed.data.evppi)) { unreadable.push({ factor_id: id, why: 'evppi not finite' }); continue; }
+      if (parsed.data.status === undefined || !RENDERABLE_STATUSES.includes(parsed.data.status)) {
+        unreadable.push({ factor_id: id, why: `status ${String(parsed.data.status)}` });
+      }
+    }
+    expect(
+      unreadable,
+      'a row the consumer drops does not error — it silently shrinks the ranking',
+    ).toEqual([]);
+  });
+
+  it('N4b both renderable bands are exercised, so N4 cannot pass on one band alone', async () => {
+    const body = await run({ ...VOI_INDEPENDENT_RUN });
+    const statuses = new Set((body.factor_evppi as Array<{ status: string }>).map((r) => r.status));
+    expect([...statuses].sort()).toEqual(['below_resolution', 'resolved']);
+  });
+
+  // ── N5 · SUPPRESSION IS A VERDICT, NOT SILENCE ────────────────────────────
+
+  it('N5 under active correlation p_win_sensitivity is absent AND named as suppressed', async () => {
+    const body = await run({ ...VOI_CORRELATED_RUN });
+    expect(
+      Object.prototype.hasOwnProperty.call(body, 'p_win_sensitivity'),
+      'ISL suppresses this array under active correlation',
+    ).toBe(false);
+    // The discriminator that makes the absence readable. Without it, "suppressed"
+    // and "never computed" are the same bytes.
+    expect(body.correlation_model?.suppressed_attributions)
+      .toContain(ISL_SUPPRESSED_ATTR_P_WIN_SENSITIVITY);
+    // factor_evppi stays EMITTED under correlation — it is honest there.
+    expect(Array.isArray(body.factor_evppi)).toBe(true);
+    expect(body.factor_evppi.length).toBeGreaterThan(0);
+  });
+
+  // ── N6 · UNION COMPLETENESS ACROSS THE TWO IMPORTABLE LISTS ───────────────
+
+  it('N6 every VOI key CEE keeps for the UI is a key PLoT forwards', () => {
+    const forwarded = new Set<string>(ISL_TOPLEVEL_ENRICHMENT_KEYS);
+    const voiKeepListMembers = (CEE_UI_ENRICHMENT_KEEP_LIST as readonly string[]).filter((k) =>
+      ['correlation_model', 'decision_evpi', 'factor_evppi', 'p_win_sensitivity'].includes(k),
+    );
+    // The corpus half of trap 12d: this literal is what notices the LIST is
+    // short. The derived half is the subset check below.
+    expect(voiKeepListMembers.sort()).toEqual(
+      ['correlation_model', 'decision_evpi', 'factor_evppi', 'p_win_sensitivity'],
+    );
+    const keptButNotForwarded = voiKeepListMembers.filter((k) => !forwarded.has(k));
+    expect(
+      keptButNotForwarded,
+      'CEE would transport a key PLoT no longer sends — the consumer sees silence, not an error',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this is

**The registered premise for this lane was wrong, and the corrected premise is the main deliverable.** The dispatch was to "un-withhold `factor_evppi` at PLoT". Derived as a live call chain at PLoT `3177fd3` / ISL `80aa83f` / CEE `210c0ff` / UI `0c4e2cc3` (all four pinned `@talchain/schemas` 0.31.0, no skew):

- PLoT **already forwards all four VOI keys verbatim** (`ISL_TOPLEVEL_ENRICHMENT_KEYS` → `islEnrichmentPassthrough` → `run.ts:3581`).
- The withholding at `run.ts:7157-7170` is **real but narrow and CORRECT**: it keeps an OUTCOME-unit EVPPI out of a WIN-PROBABILITY-points field. Doing what the dispatch asked would have shipped a wrong-unit defect.
- 0.31.0 **already types the family** (`factor_evppi` rows, `decision_evpi: z.number()`) and keeps all four on `CEE_UI_ENRICHMENT_KEEP_LIST`. **No contract delta was needed for `factor_evppi`.**
- The chain is **live end to end**: DGAI's `src/components/results/voi/voiRanking.ts` reads `enrichment.factor_evppi` into the V7 "Resolve next" view, mounted with **no flag**, and the UI's own 3 Aug guest-walk capture carries real `factor_evppi` / `decision_evpi` / `p_win_sensitivity` values.

So there was nothing to un-withhold. What there WAS, was this.

## The defect, measured

PLoT's only end-to-end proof that the VOI family reaches the wire ran against **three hand-invented shapes**. `decision_evpi` was an **object** where the shared contract types a number — a shape ISL provably never emits (`self.decision_evpi: Optional[float]`; the live capture carries the bare float `0.0789680300194515`). Measured at `3177fd3` on the real `/v2/run` route:

```
L45_PROBE enrichment_contract_ok = false
L45_PROBE warning_codes = [...,"ENRICHMENT_CONTRACT_MISMATCH"]
L45_PROBE decision_evpi typeof = object
Tests  8 passed (8)
```

**Two guards in this repo, computing verdicts on the same response body, disagreeing — and nothing introduced them.** The passthrough pin proved transport of a body the egress guard declared broken, and stayed green. Trap 19, inside the one chain S5 exists to make honest.

Worse than cosmetic: a real `factor_evppi` row carries `status`, and the licensed consumer **drops** any row whose status is absent or outside `{resolved, below_resolution}`. The old fixture's rows had no `status`, so a payload shaped like PLoT's own proof would have been dropped one hop later and the ranking would have collapsed to its honest gate — which looks exactly like *"the science found nothing"*. `correlation_model`'s invented shape shared **not one key name** with ISL's real disclosure block.

## What changed

| file | change |
|---|---|
| `tests/fixtures/voi-family-wire.ts` (new) | ONE canonical fixture set. Every value's provenance is named in the header, **including what is constructed**: the two `status: 'resolved'` rows and their `evppi` headline values are CONSTRUCTED (the live run produced `below_resolution` on every row, so the resolved band could not come from it and both consumer bands required construction), disciplined to ISL's own `resolved` condition — `conditional = baseline + evppi` exactly, each `evppi` above its row's real `noise_floor`. Everything else, and every row SHAPE, is verbatim from the live guest-walk capture or the ISL producer at `80aa83f`. The all-four combination is **labelled a TRANSPORT fixture** — ISL suppresses `p_win_sensitivity` under active correlation, so "all four together" is a transport claim, not a semantic one. The two semantically real combinations are separate. |
| `tests/factor-correlation-forwarding.test.ts` | consumes it; **asserts the egress contract verdict on the body it proves**. |
| `tests/gates/voi-family-wire-conformance.test.ts` (new) | N1 conformance (+ **N1c positive control**) · N2/N2b measured-zero vs absent · N3 producer rank order by `factor_id` **identity** · N4/N4b consumer-readability **derived from `EnrichmentFactorEvppiEntrySchema`** · N5 suppression-as-verdict · N6 union completeness against CEE's keep-list. |
| `src/types/engine-v3.ts` | `decision_evpi?: number \| null`, `factor_evppi?: EnrichmentFactorEvppiEntry[] \| null` — **exactly as the contract types them, no tighter**. `correlation_model` and `p_win_sensitivity` stay `unknown` **because the CONTRACT types them open**; claiming more than the contract is how a type becomes a promise nothing checks. |

## Evidence

**RED-first, named, at pristine src.** Adding only the conformance assertion (no fixture change) →
`AssertionError: the forwarded VOI body must parse against the shared enrichment envelope: expected false to be true` (`Tests 1 failed | 7 passed`). Fixture corrected → 8/8.

**7 mutants, throwaway worktree OUTSIDE the repo root, on COMMITTED state, applied-check scoped to `src`/`tests`, control asserted exactly 0 before and after every one:**

| # | mutation | RED |
|---|---|---|
| M1 | restore the pristine object-shaped `decision_evpi` | passthrough VERBATIM · N1 · N1b |
| M2 | egress guard never records a schema issue (verdict always ok) | **N1c** — proves the conformance pins are not vacuous |
| M3 | **null-path:** `out[key] = islResult[key] ?? 0` | N2b · N5 · absent-in⇒absent-out |
| M4 | drop `factor_evppi` from the forward list | N3 · N4 · N4b · N5 · **N6** · the existing typed-contract pin |
| M5 | silently reverse producer rank order | **N3** · passthrough VERBATIM |
| M6 | strip `status` from forwarded rows | **N4 · N4b** — the silent-consumer-drop case |
| M7 | truthiness guard drops a **measured zero** | **N2** |

Disclosed survivor: a first M2 attempt (issue-report cap → 0) survived 10/10 and was **replaced**, not counted — it caps reporting, not the verdict.

**Review amendments (commit `7600747`, honesty only — no assertion or behaviour changed):** the provenance header now DISCLOSES the constructed values in its opening line rather than lower down; `tail_dependence_note` was a paraphrase and is now ISL's `_CORRELATION_TAIL_NOTE` verbatim (nothing asserts on it, which is why it was fixed rather than disclosed); and `enrichment-egress-guard.ts`'s stale "0.30.0 at this tip" clause now points at `package.json` instead of carrying a version number that had already gone stale once.

**Gate:** `bash scripts/pre-push-validate.sh` at this tip — **6/6 PASS**, `Tests 6722 passed | 28 skipped (6761)`, tsc clean, spectral clean.

**Disclosed, not buried:** one earlier full-suite run on this branch showed `tests/run.factor-values.test.ts:239` fail (`60` vs `100`). It **did not reproduce**: green in isolation at pristine AND on this branch, the full suite is green at pristine (`605/605`, 6712 tests) and green on this branch on re-run and again under the gate. Recorded as a non-reproducing flake, **not** absorbed into a baseline.

## What this does NOT claim, and what is still owed

- **Not claimed:** that any VOI number is above its noise floor, or that anything renders. Rendering is DGAI's.
- **⚠ GAP A — the live surface is SILENT on every real run.** On the 3 Aug capture every `factor_evppi` row is `below_resolution` (`evppi: 0`, baseline MEU == conditional MEU) and every `p_win_sensitivity` row is too — `noise_floor: 0.03099` at `n_samples: 2000` against a largest measured signal of `1.47pp`, i.e. **the floor is 2.1× the strongest signal**. `EVPI_SAMPLE_CAP = 2000` is an **ISL** constant (ROADMAP **2.261**, a costed ⛔ decision whose stated blocker was the 50 s phase deadline — the exact constraint 2.356's repricing just changed). Escalated, not taken: it is a Paul-ruled default and an ISL latency call.
- **⚠ GAP B — the minimal contract delta this lane hands over.** Paul's ruling needs *chance* units ("could raise the chance from 62% to 66%"). `factor_evppi` is OUTCOME units and can never carry that sentence. `p_win_sensitivity` rows carry `current_metric` → `perfect_metric` — literally those two chances — but the contract types the row **OPEN** (`z.array(z.record(z.string(), z.unknown()))`), so rendering them is reading load-bearing values through the untyped passthrough (hazard 2). **The delta is in `parallel-briefs/L45-UI-VOI-DISPLAY-SPEC-2026-08-04.md` §5** — exact field names, types, and which repos must bump. Deliberately NOT shipped unilaterally.

Full derivation: `PHASE0-EVIDENCE-2026-07-28/l45-voi-surface.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
