### PR TITLE
fix(L63): refuse goal-fit for constraints scored against unanchored samples

### DIFF
--- a/src/lib/constraint-reliability.ts
+++ b/src/lib/constraint-reliability.ts
@@ -58,7 +58,13 @@ export type ConstraintUnreliabilityReason =
   /** Threshold normalisation fell back to the default [0,1] range (range_source: "default") */
   | 'threshold_normalisation_defaulted'
   /** ISL defaulted the target node's base to 0.0 (no observed value / no parameter uncertainty) */
-  | 'target_base_defaulted';
+  | 'target_base_defaulted'
+  /**
+   * ROADMAP 2.xxx (L63). The target node's Monte-Carlo samples carry NO absolute
+   * anchor, so no absolute threshold can be compared against them. See
+   * `detectUnanchoredSampleFrameTargets` for the derivation.
+   */
+  | 'sample_frame_unanchored';
 
 export interface UnreliableConstraintTarget {
   constraint_id: string;
@@ -110,6 +116,244 @@ export function detectUnreliableConstraintTargets(
     }
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// L63 — the constraint SAMPLE-FRAME gate
+// ---------------------------------------------------------------------------
+
+/** How a constraint target's samples were proved to carry an absolute anchor. */
+export type ConstraintSampleFrameAnchor =
+  /** The producer attested that targets on this node are stated in the samples' own frame. */
+  | 'attested_delta'
+  /** Every option intervenes on this node, so each sample IS that absolute value. */
+  | 'pinned_by_every_option'
+  /** Root node with an observed value — the evaluator seeds it as the sample's base. */
+  | 'root_observed_level';
+
+/** Minimal shape of a graph node this module needs. Structural, not nominal. */
+interface AnchorNodeLike {
+  id?: unknown;
+  observed_state?: { value?: unknown } | null;
+}
+
+/** Minimal shape of an option this module needs. Structural, not nominal. */
+interface AnchorOptionLike {
+  interventions?: Record<string, unknown> | null;
+}
+
+/**
+ * Decide whether a constraint target node's samples carry an ABSOLUTE ANCHOR,
+ * and if so on what basis. `null` = no anchor could be proved.
+ *
+ * THE ARITHMETIC, read off ISL's own evaluator rather than assumed
+ * (`robustness_analyzer_v2.py` `SCMEvaluatorV2.evaluate`, @`80aa83f6`)::
+ *
+ *     if node in interventions:  sample = interventions[node]
+ *     else:                      sample = base + intercept + SUM(parent * strength)
+ *     where base = observed_state.value  iff  is_root AND it is present
+ *                = 0.0                   otherwise
+ *     and   is_root = the node has no parents in the DIRECTED edge set
+ *
+ * So a sample is an absolute quantity in exactly three cases, and in no others:
+ *
+ *   1. `pinned_by_every_option` — an intervention overrides the structural
+ *      equation entirely, so the sample IS the intervened value. Required for
+ *      EVERY option: if one option leaves the node free, that option's samples
+ *      are unanchored and the constraint is not comparable ACROSS options,
+ *      which is the only way a constraint is ever read.
+ *   2. `root_observed_level` — a root's base is its observed value and its
+ *      parent contribution is empty, so the sample is that level (plus the
+ *      node's own intercept and noise). This is ISL's own reading: its
+ *      goal-threshold resolver REFUSES a level conversion for a root goal
+ *      precisely because "a root goal takes its base from observed_state.value,
+ *      so its samples are not in the non-root change-from-origin frame".
+ *   3. `attested_delta` — the producer stamped `goal_threshold_frame: 'delta'`
+ *      on the node, attesting that targets on it are already expressed in the
+ *      samples' own frame. This is the SAME attestation, read the SAME way, as
+ *      the auto-synthesis gate (ROADMAP 2.266, `routes/v2/run.ts`) — not a
+ *      second doctrine. ISL has no way to verify a caller's attestation and
+ *      neither has PLoT; what it buys is that a wrong number is then the
+ *      producer's stated frame, not a silent assumption by us.
+ *
+ * ⚠ WHY A NON-ROOT NODE IS NOT ANCHORED, EVEN WHEN ITS PARENTS ALL CARRY DATA.
+ * The tempting reading is that `intercept + SUM(parent * strength)` is a
+ * CALIBRATED LEVEL: the parents hold their absolute current values, so the sum
+ * ought to predict the node's actual level. ISL tried exactly that reading and
+ * MEASURED it wrong. The ROADMAP 2.286 correction
+ * (`robustness_analyzer_v2.py:3455-3487`) records the case: baseline 0.7,
+ * status-quo sample 0.25 — the sample and the level disagree by more than the
+ * whole comparison — and the fix was to stop reading the sample's absolute
+ * position at all, recovering levels per draw against a status-quo reference
+ * (`level_i = B + (option_sample_i - status_quo_sample_i)`). Only sample
+ * DIFFERENCES survive that derivation. Nothing calibrates `intercept` — it
+ * defaults to 0.0, and no witnessed live graph sets it (both scenarios in
+ * `PHASE0-EVIDENCE-2026-07-28/l60-artefacts/scenario-*.json`: every node's
+ * `intercept` is absent) — so in practice the sample is bare parent
+ * propagation. An absolute threshold compared against it answers a question
+ * nobody asked, and answers it with a structural zero.
+ *
+ * ⚠ WHY `ParameterUncertainty` IS NOT AN ANCHOR HERE, THOUGH ISL'S OWN
+ * `CONSTRAINT_NODE_DEFAULT_BASE` CRITIQUE TREATS IT AS ONE. That critique asks
+ * "will this node's base silently default to 0.0?", and a PU answers it: the
+ * FactorSampler supplies a base. This function asks a DIFFERENT question — "is
+ * the sample an absolute level?" — and for a NON-ROOT node a PU does not make
+ * it one: the sampled base REPLACES `base` and the parent contribution is still
+ * ADDED on top, giving `observed + intercept + S`, which double-counts rather
+ * than anchors. ISL says as much where it excludes non-root nodes from factor
+ * flips: "`factor_values` would ADD to their parent contribution rather than
+ * replace a base". Deliberately divergent from that list, for a stated reason.
+ */
+export function resolveConstraintSampleFrameAnchor(
+  nodeId: string,
+  nodes: readonly AnchorNodeLike[] | undefined,
+  directedEdgeTargets: ReadonlySet<string>,
+  options: readonly AnchorOptionLike[] | undefined,
+  goalThresholdFrameByNodeId: ReadonlyMap<string, string> | undefined,
+): ConstraintSampleFrameAnchor | null {
+  if (goalThresholdFrameByNodeId?.get(nodeId) === 'delta') return 'attested_delta';
+
+  // Pinned by EVERY option. An empty option list proves nothing (`[].every()`
+  // is vacuously true), so it must not mint an anchor — the same vacuous-true
+  // trap the constraints_decision_grade aggregate documents.
+  //
+  // ⚠ THIS LIMB READS INTERVENTION KEYS ONLY, AND THAT IS LOAD-BEARING. The
+  // caller passes the options held at response-assembly time, which are not the
+  // same OBJECTS as the ones sent to ISL (`optionsForISL` — Phase 4a rescales
+  // the values). Keys are safe to read across that boundary because
+  // `normaliseOptions` cannot drop one: ROADMAP 1.278 established that omitting
+  // an intervention "would silently change WHAT WAS ANALYSED while still
+  // returning a confident answer", so the normaliser REFUSES instead of
+  // omitting. Reading a VALUE here would be reading the wrong number; reading a
+  // key is reading the same set ISL receives. If that invariant is ever
+  // relaxed, this limb becomes fail-OPEN (a pin PLoT sees and ISL does not) and
+  // must be re-pointed at the egress options.
+  //
+  // Note the direction of every other limb's error is fail-CLOSED, so this is
+  // the one place in the gate where an upstream change could cost truth rather
+  // than coverage.
+  if (
+    Array.isArray(options) &&
+    options.length > 0 &&
+    options.every((o) => {
+      const interventions = o?.interventions;
+      return (
+        interventions !== null &&
+        typeof interventions === 'object' &&
+        Object.prototype.hasOwnProperty.call(interventions, nodeId)
+      );
+    })
+  ) {
+    return 'pinned_by_every_option';
+  }
+
+  if (directedEdgeTargets.has(nodeId)) return null; // non-root ⇒ base = 0.0
+
+  const node = Array.isArray(nodes) ? nodes.find((n) => n?.id === nodeId) : undefined;
+  const observedValue = node?.observed_state?.value;
+  if (typeof observedValue === 'number' && Number.isFinite(observedValue)) {
+    return 'root_observed_level';
+  }
+  return null;
+}
+
+/**
+ * Detect constraints whose target node's samples carry no absolute anchor
+ * (L63 — the constraint-frame hole).
+ *
+ * WHY THIS EXISTS AS A SEPARATE DETECTOR, next to
+ * `detectUnreliableConstraintTargets`. That function reads ISL's emitted
+ * `CONSTRAINT_NODE_DEFAULT_BASE` warnings — it MIRRORS an upstream list, and
+ * so it inherits every gap in it (a PU'd non-root target, for instance, is
+ * never flagged there, yet its samples are just as unanchored). This one is
+ * DERIVED, from the very graph and options PLoT is sending on this request, so
+ * the predicate and the payload cannot disagree and no upstream emission
+ * change can silently open a hole in it.
+ *
+ * FAIL CLOSED. An anchor must be PROVED. A missing graph, a missing node, a
+ * missing observed value — none of them establish an anchor, so all of them
+ * refuse. This is the same posture as ISL's own frame resolver ("FAIL CLOSED.
+ * Every path that cannot be proved returns (None, warning)").
+ *
+ * @param directedEdgeTargets  node ids with >=1 DIRECTED incoming edge. Derived
+ *   by the caller from the same edge set the ISL translator forwards
+ *   (`edge_type !== 'bidirected'`) — bidirected edges are stripped from the
+ *   forward model, so they create no parent and cannot un-root a node.
+ */
+export function detectUnanchoredSampleFrameTargets(
+  goalConstraints: GoalConstraint[] | undefined,
+  nodes: readonly AnchorNodeLike[] | undefined,
+  directedEdgeTargets: ReadonlySet<string>,
+  options: readonly AnchorOptionLike[] | undefined,
+  goalThresholdFrameByNodeId: ReadonlyMap<string, string> | undefined,
+): UnreliableConstraintTarget[] {
+  if (!goalConstraints || goalConstraints.length === 0) return [];
+
+  const out: UnreliableConstraintTarget[] = [];
+  for (const gc of goalConstraints) {
+    const anchor = resolveConstraintSampleFrameAnchor(
+      gc.node_id,
+      nodes,
+      directedEdgeTargets,
+      options,
+      goalThresholdFrameByNodeId,
+    );
+    if (anchor === null) {
+      out.push({
+        constraint_id: gc.constraint_id,
+        node_id: gc.node_id,
+        reasons: ['sample_frame_unanchored'],
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Union two unreliability detections by constraint_id, preserving reason order
+ * and de-duplicating. Neither detector is authoritative over the other: they
+ * answer different questions (see `detectUnanchoredSampleFrameTargets`), and a
+ * constraint can fail both.
+ */
+export function mergeUnreliableConstraintTargets(
+  ...detections: UnreliableConstraintTarget[][]
+): UnreliableConstraintTarget[] {
+  const byConstraintId = new Map<string, UnreliableConstraintTarget>();
+  for (const detection of detections) {
+    for (const target of detection) {
+      const existing = byConstraintId.get(target.constraint_id);
+      if (existing === undefined) {
+        byConstraintId.set(target.constraint_id, {
+          constraint_id: target.constraint_id,
+          node_id: target.node_id,
+          reasons: [...target.reasons],
+        });
+        continue;
+      }
+      for (const reason of target.reasons) {
+        if (!existing.reasons.includes(reason)) existing.reasons.push(reason);
+      }
+    }
+  }
+  return [...byConstraintId.values()];
+}
+
+/**
+ * Node ids carrying >=1 DIRECTED incoming edge, derived from the edge set PLoT
+ * forwards to ISL. Single-sourced so the doctrine-B forward-propagation test
+ * and the L63 root test can never drift apart — they are the same question
+ * ("does this node have parents in ISL's forward model?") asked twice.
+ */
+export function collectDirectedEdgeTargets(
+  edges: ReadonlyArray<{ from?: string; to?: string; edge_type?: string }> | undefined,
+): Set<string> {
+  const targets = new Set<string>();
+  if (!Array.isArray(edges)) return targets;
+  for (const edge of edges) {
+    if (edge?.edge_type === 'bidirected') continue;
+    if (typeof edge?.to === 'string' && edge.to.length > 0) targets.add(edge.to);
+  }
+  return targets;
 }
 
 /** Extract node ids named by ISL CONSTRAINT_NODE_DEFAULT_BASE signals. */
@@ -193,19 +437,41 @@ export function partitionConstraintTargets(
   const suppressed: UnreliableConstraintTarget[] = [];
   const modelledBasis: UnreliableConstraintTarget[] = [];
 
-  // Node ids with ≥1 directed (non-bidirected) incoming edge — mirrors the
-  // ISL translator's directed-edge filter (edge_type !== 'bidirected').
-  const forwardPropagatedNodeIds = new Set<string>();
-  if (Array.isArray(graph?.edges)) {
-    for (const edge of graph.edges) {
-      if (edge?.edge_type === 'bidirected') continue;
-      if (typeof edge?.to === 'string' && edge.to.length > 0) {
-        forwardPropagatedNodeIds.add(edge.to);
-      }
-    }
-  }
+  // Node ids with ≥1 directed (non-bidirected) incoming edge. Single-sourced
+  // with the L63 root test (`collectDirectedEdgeTargets`) so the two cannot
+  // drift: doctrine B's "forward-propagated" and L63's "non-root" are the same
+  // predicate, and they must stay the same predicate.
+  const forwardPropagatedNodeIds = collectDirectedEdgeTargets(graph?.edges);
 
   for (const target of targets) {
+    // ⚠ L63 OVERRIDE — a target whose SAMPLE FRAME is unanchored can never be
+    // delivered under doctrine B, whatever else is true of it.
+    //
+    // Doctrine B's ratified rationale was, verbatim: ISL "scores the constraint
+    // from the target node's forward-propagated outcome-sample series …
+    // prob_satisfied compares the SAME normalised samples the already-delivered
+    // `probability_of_goal` uses". That premise was TRUE when it was ratified
+    // (2026-07-07) and was INVALIDATED by ROADMAP 2.258/2.286 without this rule
+    // being revisited: `probability_of_goal` no longer compares the threshold
+    // against raw samples at all — it rides a per-draw GoalThresholdPlan
+    // (`level_i = B + (option_i − sq_i)`) or REFUSES. The constraint path still
+    // compares raw. The two are no longer the same comparison, so the reason to
+    // trust the second because the first was delivered has gone.
+    //
+    // It is not a theoretical drift. On the witnessed live run
+    // (`PHASE0-EVIDENCE-2026-07-28/diagnosis-goalfit-untruth.md` §6, deployed
+    // tips) the two channels answered in OPPOSITE directions inside one
+    // response: `probability_of_goal` ABSENT (the frame guard refusing) beside
+    // `probability_of_joint_goal` = 0 DELIVERED under this very exception —
+    // and the UI substituted the delivered zero into the goal-fit surface the
+    // refusal had honestly left empty. Doctrine B is therefore restricted, not
+    // repealed: it still delivers where an anchor is PROVED (a pinned or
+    // root-observed target, or a producer-attested 'delta' frame), which is
+    // exactly where its rationale still holds.
+    if (target.reasons.includes('sample_frame_unanchored')) {
+      suppressed.push(target);
+      continue;
+    }
     const baseDefaultedOnly =
       target.reasons.length === 1 && target.reasons[0] === 'target_base_defaulted';
     if (baseDefaultedOnly && forwardPropagatedNodeIds.has(target.node_id)) {
@@ -249,6 +515,22 @@ export function buildConstraintTargetUnreliableMessage(
   nodeLabel: string,
   reasons: ConstraintUnreliabilityReason[],
 ): string {
+  // L63 takes priority when present: it is the strongest statement available
+  // about this target (the comparison itself is not well-posed), and the other
+  // reasons describe inputs to a comparison that is not going to happen.
+  // Claim-safe, same rules as its siblings: says what was and was not compared,
+  // never quotes the withheld probability, and names a concrete user action.
+  if (reasons.includes('sample_frame_unanchored')) {
+    return (
+      `The target on "${nodeLabel}" can't be scored against this model: "${nodeLabel}" is ` +
+      `calculated from the factors feeding into it, so the analysis produces a modelled ` +
+      `change for it, not a reading on the same scale as your target. Comparing the two ` +
+      `would report a near-zero chance for every option no matter how good the options are, ` +
+      `so goal-fit probabilities were withheld for this run rather than shown. ` +
+      `Set a current value for "${nodeLabel}" — or state the target as the change you want ` +
+      `from today — to make it comparable.`
+    );
+  }
   const because = reasons.includes('target_base_defaulted')
     ? `"${nodeLabel}" has no observed value or uncertainty range, so the analysis substituted a placeholder`
     : `the target for "${nodeLabel}" could not be scaled against any known range for that node`;

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -162,6 +162,9 @@ import {
 import { buildDriverOrder, readIslSuppressedAttributions } from '../../lib/driver-order.js';
 import {
   detectUnreliableConstraintTargets,
+  detectUnanchoredSampleFrameTargets,
+  mergeUnreliableConstraintTargets,
+  collectDirectedEdgeTargets,
   partitionConstraintTargets,
   buildConstraintTargetUnreliableMessage,
   buildConstraintGoalFitModelledMessage,
@@ -2488,7 +2491,13 @@ function buildResponse(
   // constraint_margins margin_precision site below — independent of the
   // per-option intervention clamp (a threshold can clamp while every
   // intervention sits inside the range: the response-1 defect).
-  constraintScaleProvenanceByConstraintId?: Map<string, ConstraintScaleProvenance>
+  constraintScaleProvenanceByConstraintId?: Map<string, ConstraintScaleProvenance>,
+  // L63: the producer's per-node `goal_threshold_frame` stamps, read off the RAW
+  // upstream nodes (the canonical EngineNodeV3 drops them, so `graph` above
+  // cannot carry them). Appended rather than inserted for the same reason 2.258
+  // gave: the call sites pass these positionally. Feeds the ONE limb of the
+  // sample-frame gate that a producer can open — an attested 'delta' target.
+  goalThresholdFrameByNodeId?: ReadonlyMap<string, string>
 ): RunResponseV3 {
   // Producer honesty (lane PLoT-H item A): detect goal constraints whose
   // targets are NOT decision-grade — threshold normalisation fell back to the
@@ -2507,10 +2516,27 @@ function buildResponse(
   // Any other reason combination (default-range normalisation, root-node
   // targets, mixed multi-constraint runs) keeps suppressing exactly as
   // before. See src/lib/constraint-reliability.ts for the classification.
-  const unreliableConstraintTargets = detectUnreliableConstraintTargets(
-    goalConstraints,
-    constraintNormRanges,
-    islResult,
+  //
+  // L63 (the constraint SAMPLE-FRAME hole): a SECOND, DERIVED detection runs
+  // beside the ISL-warning-driven one above. The detector above reads ISL's
+  // emitted CONSTRAINT_NODE_DEFAULT_BASE list — it mirrors an upstream list and
+  // inherits its gaps. This one is computed from the graph and options PLoT is
+  // sending on THIS request, and asks the question that actually decides
+  // whether the comparison is well-posed: do the target node's samples carry an
+  // absolute anchor at all? A non-root, un-pinned target's samples are
+  // `intercept + SUM(parent * strength)` with base 0.0 — anchored to nothing —
+  // so no absolute threshold can be compared against them, and the near-zero
+  // that comes back is arithmetic, not a finding. Derivation + the measured
+  // 2.286 counter-example: src/lib/constraint-reliability.ts.
+  const unreliableConstraintTargets = mergeUnreliableConstraintTargets(
+    detectUnreliableConstraintTargets(goalConstraints, constraintNormRanges, islResult),
+    detectUnanchoredSampleFrameTargets(
+      goalConstraints,
+      graph?.nodes,
+      collectDirectedEdgeTargets(graph?.edges),
+      options,
+      goalThresholdFrameByNodeId,
+    ),
   );
   const constraintTargetPartition = partitionConstraintTargets(
     unreliableConstraintTargets,
@@ -5122,6 +5148,20 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // the default [0,1] range and is clamped to 1.0 (the live 2026-07-07
         // silent-nullification defect).
         const goalThresholdMetaByNodeId = collectGoalThresholdNodeMeta(body.graph?.nodes);
+        // L63: the same capture, for the FRAME stamp. Collected for EVERY raw
+        // node rather than just the goal node — a constraint can target any
+        // node, and the stamp means the same thing wherever a producer puts it.
+        // `parseGoalThresholdFrame` validates against the contract's own enum,
+        // so a junk token degrades to ABSENT (⇒ refused) rather than opening the
+        // gate. PLoT never mints one: an unstamped node stays unstamped.
+        const goalThresholdFrameByNodeId = new Map<string, string>();
+        for (const rawNode of (body.graph?.nodes as any[]) ?? []) {
+          if (!rawNode || typeof rawNode.id !== 'string' || rawNode.id.length === 0) continue;
+          const frame = parseGoalThresholdFrame(
+            rawNode.goal_threshold_frame ?? rawNode.data?.goal_threshold_frame
+          );
+          if (frame !== undefined) goalThresholdFrameByNodeId.set(rawNode.id, frame);
+        }
         const constraintUnitsByConstraintId = new Map<string, string>();
         for (const c of constraintCompilation.constraints as RawGoalConstraint[]) {
           if (typeof c.unit === 'string' && c.unit.length > 0) {
@@ -6020,7 +6060,11 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             undefined, // thresholdAnalysis
             toIdentifiabilityResponse(identifiabilityResult),  // B1.5a: always-present mapped response
             undefined,  // factorStability
-            req.log  // logger for fact_objects assembly logging
+            req.log,  // logger for fact_objects assembly logging
+            undefined,  // optionClampDirectionByFactor (no ISL call on this path)
+            undefined,  // optionDiagnosedFactors (no ISL call on this path)
+            undefined,  // constraintScaleProvenanceByConstraintId (no ISL call on this path)
+            goalThresholdFrameByNodeId  // L63: constraint sample-frame gate input
           ));
         }
 
@@ -8144,7 +8188,8 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
           req.log,  // logger for fact_objects assembly logging
           optionClampDirectionByFactor,  // 1d + Codex F1: per-option clamp DIRECTION map for margin_precision
           optionDiagnosedFactors,  // Codex F1: factors with a recorded diagnostic (exact vs unknown)
-          constraintScaleProvenanceByConstraintId  // A3 trust marker: scale_provenance + constraints_decision_grade (also carries F2a threshold_clamped)
+          constraintScaleProvenanceByConstraintId,  // A3 trust marker: scale_provenance + constraints_decision_grade (also carries F2a threshold_clamped)
+          goalThresholdFrameByNodeId  // L63: constraint sample-frame gate input (producer 'delta' attestation)
         ));
       } catch (err) {
         req.log.error({

--- a/tests/boundary-isl-to-ui.contract.test.ts
+++ b/tests/boundary-isl-to-ui.contract.test.ts
@@ -167,7 +167,7 @@ import { createServer } from '../src/createServer.js';
 
 const GRAPH = {
   nodes: [
-    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue' },
     { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
   ],
   edges: [

--- a/tests/cil-constraint-auto-pu.test.ts
+++ b/tests/cil-constraint-auto-pu.test.ts
@@ -133,7 +133,7 @@ import { createServer } from '../src/createServer.js';
 
 const GRAPH = {
   nodes: [
-    { id: 'goal', kind: 'goal', label: 'Revenue' },
+    { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue' },
     { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
     { id: 'factor-b', kind: 'factor', label: 'Customer Churn', observed_state: { value: 0.5 } },
   ],
@@ -257,7 +257,7 @@ describe('CIL: Constraint auto-PU integration (Phase 4b+)', () => {
     // Use a graph where the constrained node (factor-b) has NO observed_state
     const graphNoObserved = {
       nodes: [
-        { id: 'goal', kind: 'goal', label: 'Revenue' },
+        { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue' },
         { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
         { id: 'factor-b', kind: 'factor', label: 'Customer Churn' }, // no observed_state
       ],
@@ -303,7 +303,7 @@ describe('CIL: Constraint auto-PU integration (Phase 4b+)', () => {
     // Graph has factor-a → outcome-x → goal, options intervene on factor-a only.
     const graphWithOutcome = {
       nodes: [
-        { id: 'goal', kind: 'goal', label: 'Revenue' },
+        { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue' },
         { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
         { id: 'outcome-x', kind: 'outcome', label: 'Customer Satisfaction', observed_state: { value: 0.75 } },
       ],
@@ -370,9 +370,9 @@ describe('CIL: Constraint auto-PU integration (Phase 4b+)', () => {
     // Graph with a constrained factor node: threshold at 0.5, observed_state.value 0.5
     const constrainedGraph = {
       nodes: [
-        { id: 'goal', kind: 'goal', label: 'Revenue' },
+        { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue' },
         { id: 'factor-a', kind: 'factor', label: 'Marketing', observed_state: { value: 0.5 } },
-        { id: 'constrained-node', kind: 'outcome', label: 'Satisfaction', observed_state: { value: 0.5 } },
+        { id: 'constrained-node', kind: 'outcome', goal_threshold_frame: 'delta', label: 'Satisfaction', observed_state: { value: 0.5 } },
       ],
       edges: [
         { from: 'factor-a', to: 'constrained-node', strength: { mean: 0.5, std: 0.1 } },

--- a/tests/cil-constraint-passthrough.test.ts
+++ b/tests/cil-constraint-passthrough.test.ts
@@ -118,7 +118,7 @@ const GRAPH = {
     // honesty (CONSTRAINT_TARGET_UNRELIABLE) would rightly SUPPRESS the
     // per-option probability fields this suite pins the mapping of — see
     // tests/constraint-target-unreliable.fixture.test.ts for that contract.
-    { id: 'goal', kind: 'goal', label: 'Revenue', observed_state: { value: 15000 } },
+    { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue', observed_state: { value: 15000 } },
     { id: 'factor-a', kind: 'factor', label: 'Market Size' },
     { id: 'factor-b', kind: 'factor', label: 'Retention', observed_state: { value: 4000 } },
   ],

--- a/tests/conditional-probabilities-bad-index-hardening.fixture.test.ts
+++ b/tests/conditional-probabilities-bad-index-hardening.fixture.test.ts
@@ -101,9 +101,9 @@ import { createServer } from '../src/createServer.js';
 
 const GRAPH = {
   nodes: [
-    { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
-    { id: 'out_effectiveness', kind: 'outcome', label: 'Campaign effectiveness', observed_state: { value: 50 } },
-    { id: 'out_retention', kind: 'outcome', label: 'Customer retention', observed_state: { value: 50 } },
+    { id: 'goal_growth', kind: 'goal', goal_threshold_frame: 'delta', label: 'Grow revenue' },
+    { id: 'out_effectiveness', kind: 'outcome', goal_threshold_frame: 'delta', label: 'Campaign effectiveness', observed_state: { value: 50 } },
+    { id: 'out_retention', kind: 'outcome', goal_threshold_frame: 'delta', label: 'Customer retention', observed_state: { value: 50 } },
     { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
   ],
   edges: [

--- a/tests/constraint-id-echo-consumer.fixture.test.ts
+++ b/tests/constraint-id-echo-consumer.fixture.test.ts
@@ -213,7 +213,7 @@ import { createServer } from '../src/createServer.js';
 const GRAPH = {
   nodes: [
     {
-      id: NODE_ALPHA, kind: 'goal', label: 'Net revenue change',
+      id: NODE_ALPHA, kind: 'goal', goal_threshold_frame: 'delta', label: 'Net revenue change',
       observed_state: { value: 50 }, state_space: { range: { min: 0, max: 100 } },
     },
     {

--- a/tests/constraint-reliability.unit.test.ts
+++ b/tests/constraint-reliability.unit.test.ts
@@ -9,11 +9,16 @@
 import { describe, it, expect } from 'vitest';
 import {
   detectUnreliableConstraintTargets,
+  detectUnanchoredSampleFrameTargets,
+  mergeUnreliableConstraintTargets,
+  collectDirectedEdgeTargets,
+  resolveConstraintSampleFrameAnchor,
   partitionConstraintTargets,
   buildConstraintTargetUnreliableMessage,
   buildConstraintGoalFitModelledMessage,
   GOAL_FIT_SCORED_FROM_MODELLED_OUTCOME,
   type UnreliableConstraintTarget,
+  type ConstraintUnreliabilityReason,
 } from '../src/lib/constraint-reliability.js';
 import type { NormalisationRange } from '../src/lib/intervention-normaliser.js';
 
@@ -226,5 +231,213 @@ describe('buildConstraintTargetUnreliableMessage (provisional_doctrine_v0 wordin
     expect(msg).not.toMatch(/\bEVPI\b/i);
     expect(msg).not.toMatch(/expected value/i);
     expect(msg).not.toMatch(/0(\.0+)?%/);
+  });
+});
+
+// ===========================================================================
+// L63 — the constraint SAMPLE-FRAME gate
+// ===========================================================================
+
+describe('resolveConstraintSampleFrameAnchor (L63)', () => {
+  const nodes = [
+    { id: 'goal_g' },
+    { id: 'out_x' },
+    { id: 'fac_a', observed_state: { value: 0.49 } },
+    { id: 'fac_bare' },
+    { id: 'risk_r', observed_state: { value: 0.02 } },
+  ];
+  const edges = [
+    { from: 'fac_a', to: 'out_x' },
+    { from: 'out_x', to: 'goal_g' },
+    { from: 'fac_a', to: 'risk_r' },
+  ];
+  const directed = collectDirectedEdgeTargets(edges);
+  const twoOptions = [
+    { interventions: { fac_a: { value: 0.4 } } },
+    { interventions: { fac_a: { value: 0.6 } } },
+  ];
+
+  // `twoOptions` PINS fac_a, and the pinning limb is checked first — so asking
+  // about fac_a with those options would report 'pinned_by_every_option' and
+  // prove nothing about the root limb. Use options that leave fac_a free.
+  const optionsNotPinningFacA = [
+    { interventions: { out_x: { value: 0.4 } } },
+    { interventions: { out_x: { value: 0.6 } } },
+  ];
+
+  it('a ROOT node carrying an observed value is anchored — the evaluator seeds it as the base', () => {
+    expect(
+      resolveConstraintSampleFrameAnchor('fac_a', nodes, directed, optionsNotPinningFacA, undefined),
+    ).toBe('root_observed_level');
+  });
+
+  it('a ROOT node with NO observed value is NOT anchored (base falls to 0.0)', () => {
+    expect(resolveConstraintSampleFrameAnchor('fac_bare', nodes, directed, twoOptions, undefined))
+      .toBeNull();
+  });
+
+  it('a NON-ROOT node is NOT anchored EVEN WITH an observed value — observed_state is read for roots only', () => {
+    expect(resolveConstraintSampleFrameAnchor('risk_r', nodes, directed, twoOptions, undefined))
+      .toBeNull();
+    expect(resolveConstraintSampleFrameAnchor('goal_g', nodes, directed, twoOptions, undefined))
+      .toBeNull();
+  });
+
+  it("a producer-attested 'delta' frame anchors a non-root node; 'level' does not", () => {
+    expect(
+      resolveConstraintSampleFrameAnchor('goal_g', nodes, directed, twoOptions, new Map([['goal_g', 'delta']])),
+    ).toBe('attested_delta');
+    expect(
+      resolveConstraintSampleFrameAnchor('goal_g', nodes, directed, twoOptions, new Map([['goal_g', 'level']])),
+    ).toBeNull();
+  });
+
+  it('pinning must hold for EVERY option, and an EMPTY option list must not mint an anchor', () => {
+    const pinned = [
+      { interventions: { out_x: { value: 0.8 } } },
+      { interventions: { out_x: { value: 0.9 } } },
+    ];
+    expect(resolveConstraintSampleFrameAnchor('out_x', nodes, directed, pinned, undefined))
+      .toBe('pinned_by_every_option');
+
+    const halfPinned = [pinned[0], { interventions: { fac_a: { value: 0.5 } } }];
+    expect(resolveConstraintSampleFrameAnchor('out_x', nodes, directed, halfPinned, undefined))
+      .toBeNull();
+
+    // `[].every()` is vacuously true — it must not read as "every option pins it".
+    expect(resolveConstraintSampleFrameAnchor('out_x', nodes, directed, [], undefined)).toBeNull();
+    expect(resolveConstraintSampleFrameAnchor('out_x', nodes, directed, undefined, undefined)).toBeNull();
+  });
+
+  it('FAILS CLOSED on absent inputs — an anchor must be proved, never assumed', () => {
+    expect(resolveConstraintSampleFrameAnchor('goal_g', undefined, new Set(), undefined, undefined)).toBeNull();
+    expect(resolveConstraintSampleFrameAnchor('nonexistent_node', nodes, directed, twoOptions, undefined)).toBeNull();
+  });
+
+  it('a non-finite observed value is not an anchor', () => {
+    const bad = [{ id: 'fac_nan', observed_state: { value: Number.NaN } }];
+    expect(resolveConstraintSampleFrameAnchor('fac_nan', bad, new Set(), undefined, undefined)).toBeNull();
+  });
+});
+
+describe('collectDirectedEdgeTargets (L63) — bidirected edges create no parent', () => {
+  it('ignores bidirected edges, matching the ISL translator’s forward-model filter', () => {
+    const targets = collectDirectedEdgeTargets([
+      { from: 'a', to: 'b' },
+      { from: 'c', to: 'd', edge_type: 'bidirected' },
+    ]);
+    expect([...targets].sort()).toEqual(['b']);
+  });
+
+  it('is total on absent input', () => {
+    expect(collectDirectedEdgeTargets(undefined).size).toBe(0);
+  });
+});
+
+describe('detectUnanchoredSampleFrameTargets (L63)', () => {
+  const nodes = [{ id: 'goal_g' }, { id: 'fac_a', observed_state: { value: 0.49 } }];
+  const directed = collectDirectedEdgeTargets([{ from: 'fac_a', to: 'goal_g' }]);
+  const options = [{ interventions: { fac_a: { value: 0.4 } } }];
+
+  it('flags only the unanchored constraint, by constraint identity', () => {
+    const out = detectUnanchoredSampleFrameTargets(
+      [
+        { constraint_id: 'c_goal', node_id: 'goal_g', operator: '>=', value: 0.8 } as any,
+        { constraint_id: 'c_root', node_id: 'fac_a', operator: '>=', value: 0.5 } as any,
+      ],
+      nodes,
+      directed,
+      options,
+      undefined,
+    );
+    expect(out.map((t) => t.constraint_id)).toEqual(['c_goal']);
+    expect(out[0].reasons).toEqual(['sample_frame_unanchored']);
+  });
+
+  it('returns nothing when there are no constraints', () => {
+    expect(detectUnanchoredSampleFrameTargets(undefined, nodes, directed, options, undefined)).toEqual([]);
+    expect(detectUnanchoredSampleFrameTargets([], nodes, directed, options, undefined)).toEqual([]);
+  });
+});
+
+describe('mergeUnreliableConstraintTargets (L63)', () => {
+  it('unions reasons for the same constraint without duplicating', () => {
+    const merged = mergeUnreliableConstraintTargets(
+      [{ constraint_id: 'c1', node_id: 'n1', reasons: ['target_base_defaulted'] }],
+      [{ constraint_id: 'c1', node_id: 'n1', reasons: ['sample_frame_unanchored'] }],
+      [{ constraint_id: 'c1', node_id: 'n1', reasons: ['sample_frame_unanchored'] }],
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0].reasons).toEqual(['target_base_defaulted', 'sample_frame_unanchored']);
+  });
+
+  it('does not mutate its inputs', () => {
+    const a: UnreliableConstraintTarget[] = [
+      { constraint_id: 'c1', node_id: 'n1', reasons: ['target_base_defaulted'] },
+    ];
+    mergeUnreliableConstraintTargets(a, [
+      { constraint_id: 'c1', node_id: 'n1', reasons: ['sample_frame_unanchored'] },
+    ]);
+    expect(a[0].reasons).toEqual(['target_base_defaulted']);
+  });
+});
+
+describe('doctrine B may never deliver an unanchored target (L63 restriction)', () => {
+  // A hand-written corpus over the WHOLE reason vocabulary rather than a
+  // derivation from it: a derived check would agree with whatever the code
+  // does, and could never notice that a future edit had widened the delivery
+  // condition. Enumerated here so adding a reason to the union type without
+  // considering delivery is a compile error away from being noticed, and
+  // widening doctrine B is one assertion away from RED.
+  const ALL_REASONS: ConstraintUnreliabilityReason[] = [
+    'threshold_normalisation_defaulted',
+    'target_base_defaulted',
+    'sample_frame_unanchored',
+  ];
+  const graph = { edges: [{ from: 'fac_a', to: 'goal_g' }] };
+
+  const subsetsContainingUnanchored = ALL_REASONS.flatMap((_, i) =>
+    ALL_REASONS.flatMap((__, j) =>
+      i <= j
+        ? [[...new Set(ALL_REASONS.slice(i, j + 1))].filter((r) => r !== undefined)]
+        : [],
+    ),
+  ).filter((subset) => subset.includes('sample_frame_unanchored'));
+
+  it('every reason set containing sample_frame_unanchored is SUPPRESSED, on a forward-propagated node', () => {
+    expect(subsetsContainingUnanchored.length).toBeGreaterThan(0);
+    for (const reasons of subsetsContainingUnanchored) {
+      const out = partitionConstraintTargets(
+        [{ constraint_id: 'c1', node_id: 'goal_g', reasons: [...reasons] }],
+        graph,
+      );
+      expect(out.modelledBasis, `reasons=${reasons.join('+')}`).toEqual([]);
+      expect(out.suppressed.map((t) => t.node_id), `reasons=${reasons.join('+')}`).toEqual(['goal_g']);
+    }
+  });
+
+  it('CONTROL — doctrine B still delivers when the target is NOT unanchored', () => {
+    const out = partitionConstraintTargets(
+      [{ constraint_id: 'c1', node_id: 'goal_g', reasons: ['target_base_defaulted'] }],
+      graph,
+    );
+    expect(out.modelledBasis.map((t) => t.node_id)).toEqual(['goal_g']);
+  });
+});
+
+describe('buildConstraintTargetUnreliableMessage — L63 wording', () => {
+  it('names the node, says the figure was withheld, and never quotes a probability', () => {
+    const msg = buildConstraintTargetUnreliableMessage('Gross margin', ['sample_frame_unanchored']);
+    expect(msg).toContain('Gross margin');
+    expect(msg).toContain('withheld');
+    expect(msg).not.toMatch(/\d+(\.\d+)?\s*%/);
+  });
+
+  it('takes priority over the older reasons when both are present', () => {
+    const both = buildConstraintTargetUnreliableMessage('Gross margin', [
+      'target_base_defaulted',
+      'sample_frame_unanchored',
+    ]);
+    expect(both).toBe(buildConstraintTargetUnreliableMessage('Gross margin', ['sample_frame_unanchored']));
   });
 });

--- a/tests/constraint-results-top-level-gating.fixture.test.ts
+++ b/tests/constraint-results-top-level-gating.fixture.test.ts
@@ -127,7 +127,11 @@ import { createServer } from '../src/createServer.js';
 const GRAPH_VALUELESS_TARGET = {
   nodes: [
     { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
-    { id: 'out_campaign_effectiveness', kind: 'outcome', label: 'Campaign effectiveness' },
+    // L63: the frame attestation keeps this fixture inside doctrine B's
+    // (now anchor-conditional) delivery scope, so this suite goes on pinning
+    // TOP-LEVEL BLOCK GATING rather than silently becoming a second copy of
+    // the sample-frame refusal test.
+    { id: 'out_campaign_effectiveness', kind: 'outcome', goal_threshold_frame: 'delta', label: 'Campaign effectiveness' },
     { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
   ],
   edges: [
@@ -141,7 +145,7 @@ const GRAPH_VALUED_TARGET = {
   nodes: [
     { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
     // observed value 50 → deriveRange() infers [0, 100] (inferred_value tier).
-    { id: 'out_campaign_effectiveness', kind: 'outcome', label: 'Campaign effectiveness', observed_state: { value: 50 } },
+    { id: 'out_campaign_effectiveness', kind: 'outcome', goal_threshold_frame: 'delta', label: 'Campaign effectiveness', observed_state: { value: 50 } },
     { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
   ],
   edges: [

--- a/tests/constraint-sample-frame-gate.test.ts
+++ b/tests/constraint-sample-frame-gate.test.ts
@@ -1,0 +1,468 @@
+/**
+ * L63 — a constraint may not be scored against samples that carry no absolute
+ * anchor.
+ *
+ * WHY THIS FILE EXISTS. ROADMAP 2.258/2.286 taught ISL's goal-threshold channel
+ * to convert a LEVEL target into the samples' frame or REFUSE. 2.266 taught
+ * PLoT's auto-SYNTHESIS path the same discipline. The third path — an actual
+ * `goal_constraints` row, whether the user authored it, the draft minted it, or
+ * a chat turn added it — was left comparing the threshold to raw Monte-Carlo
+ * samples with no frame plan, no baseline and no refusal
+ * (`robustness_analyzer_v2.py:7329` `_check_constraint_satisfied`:
+ * `value >= constraint.threshold`).
+ *
+ * WITNESSED, on the deployed tips PLoT `2864b0c` / ISL `80aa83f`
+ * (`PHASE0-EVIDENCE-2026-07-28/diagnosis-goalfit-untruth.md`, artefacts in
+ * `l60-artefacts/`, probe request_id `l60-goalfit-diagnosis-probe-20260804`):
+ * `probability_of_joint_goal` came back 0 for EVERY option in EVERY witnessed
+ * shape, marked `constraints_status: "computed"` and
+ * `scale_provenance.decision_grade: true`, while the guarded channel's
+ * `probability_of_goal` was ABSENT — the two channels answering in opposite
+ * directions inside one response. The UI then substituted the delivered zero
+ * into the goal-fit surface the refusal had honestly left empty
+ * (`joint_goal_substituted`), rendering "< 1% chance of meeting every target".
+ *
+ * THE THREE WITNESSED FLAVOURS ARE ALL REPRODUCED BELOW, at their measured
+ * shapes, because they arrive by three different routes and the earlier fixes
+ * each covered only one route:
+ *   F1  goal-target       goal_mrr >= 250000 '£'      cap 312500, frame 'level'
+ *   F2  draft-minted      out_gross_margin >= 0.8     bare outcome node, no cap
+ *   F3  chat-minted       risk_ae_attrition <= 2      'count', observed cap
+ *
+ * ⚠ EVERY ONE OF THE THREE PASSES THE PRE-EXISTING RELIABILITY DETECTION. None
+ * normalises against the default range, so `threshold_normalisation_defaulted`
+ * never fires; and the ISL mock here emits no CONSTRAINT_NODE_DEFAULT_BASE, so
+ * `target_base_defaulted` never fires either. That is the hole, stated as a
+ * test property: if the new derived detector is removed, these three deliver.
+ *
+ * THE ASSERTION SURFACE. The mock returns a NON-ZERO joint probability (0.0054,
+ * the witnessed magnitude) for whatever it is sent, so every "withheld"
+ * assertion below is proving an ABSENCE that the mock was able to produce as a
+ * PRESENCE — the positive controls prove exactly that on the same wire. A test
+ * that cannot observe the presence cannot prove the absence.
+ *
+ * Assertions bind to constraints and nodes BY IDENTITY (constraint_id, node_id,
+ * option_id), never by a value predicate another object could satisfy.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// ISL mock — captures the outbound request and always returns a constraint
+// analysis when constraints were sent, at the witnessed near-zero magnitude.
+// ---------------------------------------------------------------------------
+
+let capturedISLRequestBody: any = null;
+
+const WITNESSED_JOINT = 0.0054;
+
+function mockOptionRows(body: any) {
+  const options = body.options || [];
+  const constraints = body.goal_constraints || [];
+  return options.map((opt: any, idx: number) => ({
+    option_id: opt.id,
+    outcome: {
+      mean: 0.1578, std: 0.2048, p10: -0.142, p50: 0.1578, p90: 0.376,
+      n_samples: 2000, n_valid_samples: 2000, validity_ratio: 1.0,
+    },
+    rank: idx + 1,
+    ...(constraints.length > 0
+      ? {
+          constraint_analysis: {
+            constraints: constraints.map((c: any) => ({
+              constraint_id: c.constraint_id,
+              node_id: c.node_id,
+              operator: c.operator,
+              value: c.value,
+              prob_satisfied: WITNESSED_JOINT,
+              satisfied: false,
+            })),
+            joint_probability: WITNESSED_JOINT,
+            constraint_probabilities: Object.fromEntries(
+              constraints.map((c: any) => [c.constraint_id, WITNESSED_JOINT]),
+            ),
+          },
+        }
+      : {}),
+  }));
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high',
+      adjustment_sets: [], minimal_set: [], backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[]) {
+    return {
+      options: options.map((opt: any, idx: number) => ({
+        option_id: opt.id,
+        outcome: {
+          mean: 0.1578, std: 0.2048, p10: -0.142, p50: 0.1578, p90: 0.376,
+          n_samples: 2000, n_valid_samples: 2000, validity_ratio: 1.0,
+        },
+        rank: idx + 1,
+      })),
+      edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [], value_of_information: [],
+      factors_provenance: 'unavailable' as const,
+      factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.8,
+      fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return { factors: [], value_of_information: [], robustness_label: 'robust' as const, robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    capturedISLRequestBody = body;
+    return {
+      data: {
+        options: mockOptionRows(body),
+        edges: [], factors: [], value_of_information: [],
+        overall_robustness: 'robust', robustness_score: 0.8,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+const { createServer } = await import('../src/createServer.js');
+
+// ---------------------------------------------------------------------------
+// Graph fixture — the witnessed pricing scenario's topology, at the measured
+// in-edge counts (l60-artefacts/scenario-pricing.json):
+//   goal_mrr           kind goal     in_edges 4   observed_state null
+//   out_gross_margin   kind outcome  in_edges 1   observed_state null
+//   risk_logo_churn    kind risk     in_edges 3   observed_state {value .02, cap 100}
+//   fac_price_sens     kind factor   in_edges 0   observed_state {value .75}   <- ROOT
+// NOTE `intercept` is absent on every node, exactly as in both witnessed live
+// graphs — so a non-root node's samples are bare parent propagation.
+// ---------------------------------------------------------------------------
+
+function baseGraph(goalNodeExtras: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      { id: 'goal_mrr', kind: 'goal', label: 'Grow MRR to £250,000', ...goalNodeExtras },
+      { id: 'out_gross_margin', kind: 'outcome', label: 'Gross margin' },
+      { id: 'risk_logo_churn', kind: 'risk', label: 'Logo churn', observed_state: { value: 0.02, cap: 100, unit: '%' } },
+      { id: 'fac_price_level', kind: 'factor', label: 'Seat price level', observed_state: { value: 0.49 } },
+      { id: 'fac_price_sens', kind: 'factor', label: 'Customer price sensitivity', observed_state: { value: 0.75 } },
+    ],
+    edges: [
+      { from: 'fac_price_level', to: 'goal_mrr', exists_probability: 0.9, strength: { mean: 0.5, std: 0.15 } },
+      { from: 'fac_price_sens', to: 'goal_mrr', exists_probability: 0.9, strength: { mean: -0.4, std: 0.15 } },
+      { from: 'fac_price_level', to: 'out_gross_margin', exists_probability: 0.9, strength: { mean: 0.4, std: 0.1 } },
+      { from: 'fac_price_sens', to: 'risk_logo_churn', exists_probability: 0.9, strength: { mean: 0.3, std: 0.1 } },
+      // out_gross_margin and risk_logo_churn need a path to the goal or
+      // preflight blocks any option that intervenes on them (NO_PATH_TO_GOAL).
+      // Both keep their incoming edges, so both stay NON-ROOT — which is what
+      // these fixtures are here to exercise.
+      { from: 'out_gross_margin', to: 'goal_mrr', exists_probability: 0.9, strength: { mean: 0.3, std: 0.1 } },
+      { from: 'risk_logo_churn', to: 'goal_mrr', exists_probability: 0.9, strength: { mean: -0.2, std: 0.1 } },
+    ],
+  };
+}
+
+const OPTIONS = [
+  { id: 'opt_hold', label: 'Hold at £49', interventions: { fac_price_level: { value: 0.49, source: 'user_specified' } } },
+  { id: 'opt_raise', label: 'Raise to £59', interventions: { fac_price_level: { value: 0.59, source: 'user_specified' } } },
+];
+
+/** The manual-path goal node, exactly as CEE stamps it (diagnosis §2.2). */
+const GOAL_NODE_LEVEL_STAMPED = {
+  goal_threshold_raw: 250000,
+  goal_threshold_cap: 312500,
+  goal_threshold: 0.8,
+  goal_threshold_unit: '£',
+  goal_threshold_frame: 'level',
+};
+
+describe('L63 — constraints are not scored against unanchored samples', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.RATE_LIMIT_ENABLED;
+    delete process.env.CEE_ORCHESTRATOR_ENABLED;
+    capturedISLRequestBody = null;
+  });
+
+  async function run(payload: Record<string, unknown>) {
+    capturedISLRequestBody = null;
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload });
+    return { res, body: res.json() as any, isl: capturedISLRequestBody };
+  }
+
+  function payloadWith(
+    goalConstraints: unknown[],
+    goalNodeExtras: Record<string, unknown> = {},
+    options: unknown[] = OPTIONS,
+  ) {
+    return {
+      graph: baseGraph(goalNodeExtras),
+      options,
+      goal_node_id: 'goal_mrr',
+      seed: 'l63-sample-frame',
+      n_samples: 2000,
+      goal_constraints: goalConstraints,
+    };
+  }
+
+  /** Every option's joint-goal figure, keyed by option id (identity, not order). */
+  function jointByOption(body: any): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const o of body.option_comparison ?? []) out[o.option_id] = o.probability_of_joint_goal;
+    return out;
+  }
+
+  function unreliableWarnings(body: any): any[] {
+    return (body.inference_warnings ?? []).filter(
+      (w: any) => w.code === 'CONSTRAINT_TARGET_UNRELIABLE',
+    );
+  }
+
+  // =========================================================================
+  // F1 — the goal-target flavour (diagnosis §6, the synthetic live probe)
+  // =========================================================================
+  it('F1: a LEVEL goal target on a non-root goal node is WITHHELD, not scored', async () => {
+    const { res, body, isl } = await run(
+      payloadWith(
+        [{ constraint_id: 'gc_goal_target', node_id: 'goal_mrr', operator: '>=', value: 250000, unit: '£', label: 'Grow MRR to £250,000' }],
+        GOAL_NODE_LEVEL_STAMPED,
+      ),
+    );
+
+    expect(res.statusCode).toBe(200);
+
+    // The mock WAS given the constraint and DID answer — so the absence below
+    // is a decision, not an empty pipeline (trap 13: prove it can see presence).
+    expect((isl.goal_constraints ?? []).map((c: any) => c.constraint_id)).toContain('gc_goal_target');
+
+    // The fabricated joint figure reaches NO option.
+    const joint = jointByOption(body);
+    expect(Object.keys(joint).sort()).toEqual(['opt_hold', 'opt_raise']);
+    expect(joint.opt_hold).toBeUndefined();
+    expect(joint.opt_raise).toBeUndefined();
+
+    // ...and it is not smuggled in per-constraint either.
+    for (const o of body.option_comparison ?? []) {
+      expect(o.constraint_probabilities).toBeUndefined();
+    }
+
+    // Nothing about this run may read as decision-grade.
+    expect(body.constraints_status).not.toBe('computed');
+    for (const o of body.option_comparison ?? []) {
+      expect(o.constraints_decision_grade).not.toBe(true);
+    }
+
+    // The refusal is DISCLOSED, at warning severity, naming the node.
+    const warned = unreliableWarnings(body);
+    expect(warned).toHaveLength(1);
+    expect(warned[0].severity).toBe('warning');
+    expect(warned[0].message).toContain('Grow MRR to £250,000');
+
+    // And it is NOT downgraded to the info-severity modelled-basis note, which
+    // is the exception that delivered this exact number on the live run.
+    expect(
+      (body.inference_warnings ?? []).some(
+        (w: any) => w.code === 'CONSTRAINT_GOALFIT_MODELLED_BASIS',
+      ),
+    ).toBe(false);
+  });
+
+  // =========================================================================
+  // F2 — the draft-minted flavour (diagnosis §8.2, pricing runs 1+2)
+  // "and gross margin above 80%" on a bare outcome node with no cap.
+  // =========================================================================
+  it('F2: a draft-minted fraction target on a non-root outcome node is WITHHELD', async () => {
+    const { body, isl } = await run(
+      payloadWith([
+        { constraint_id: 'constraint_out_gross_margin_min', node_id: 'out_gross_margin', operator: '>=', value: 0.8, unit: 'fraction' },
+      ]),
+    );
+
+    expect((isl.goal_constraints ?? []).map((c: any) => c.constraint_id)).toContain(
+      'constraint_out_gross_margin_min',
+    );
+
+    const joint = jointByOption(body);
+    expect(joint.opt_hold).toBeUndefined();
+    expect(joint.opt_raise).toBeUndefined();
+    expect(body.constraints_status).not.toBe('computed');
+
+    const warned = unreliableWarnings(body);
+    expect(warned.map((w: any) => w.message).join(' ')).toContain('Gross margin');
+  });
+
+  // =========================================================================
+  // F3 — the chat-minted flavour (diagnosis §8.2, people run).
+  // A COUNT target on a non-root risk node. This node DOES carry an
+  // observed_state value+cap — and it is still refused, because ISL reads
+  // observed_state.value as a base for ROOT nodes only. That discrimination is
+  // the whole point: a present observed value is not an anchor on a non-root.
+  // =========================================================================
+  it('F3: a COUNT target on a non-root risk node is WITHHELD even though it has an observed value', async () => {
+    const { body, isl } = await run(
+      payloadWith([
+        { constraint_id: 'constraint_churn_max', node_id: 'risk_logo_churn', operator: '<=', value: 3, unit: '%' },
+      ]),
+    );
+
+    expect((isl.goal_constraints ?? []).map((c: any) => c.constraint_id)).toContain(
+      'constraint_churn_max',
+    );
+
+    const joint = jointByOption(body);
+    expect(joint.opt_hold).toBeUndefined();
+    expect(joint.opt_raise).toBeUndefined();
+
+    const warned = unreliableWarnings(body);
+    expect(warned.map((w: any) => w.message).join(' ')).toContain('Logo churn');
+  });
+
+  // =========================================================================
+  // PC1 — POSITIVE CONTROL (topology). A ROOT node carrying an observed value
+  // IS anchored: ISL seeds its sample base from observed_state.value, so a
+  // level threshold on it is exactly what the samples are in. This is the
+  // live-reachable control — it must keep delivering.
+  // =========================================================================
+  it('PC1: a target on a ROOT node with an observed value STILL delivers', async () => {
+    const { body, isl } = await run(
+      payloadWith([
+        { constraint_id: 'gc_root_factor', node_id: 'fac_price_sens', operator: '>=', value: 0.5 },
+      ]),
+    );
+
+    expect((isl.goal_constraints ?? []).map((c: any) => c.constraint_id)).toContain('gc_root_factor');
+
+    const joint = jointByOption(body);
+    expect(joint.opt_hold).toBe(WITNESSED_JOINT);
+    expect(joint.opt_raise).toBe(WITNESSED_JOINT);
+    expect(unreliableWarnings(body)).toHaveLength(0);
+  });
+
+  // =========================================================================
+  // PC2 — POSITIVE CONTROL (attestation). The producer stamps 'delta' on the
+  // goal node: targets on it are attested to be in the samples' own frame.
+  // Same attestation, same reading, as the 2.266 auto-synthesis gate — this
+  // control is what stops L63 from silently repealing 2.266's T5/T5b.
+  // =========================================================================
+  it("PC2: a target on a non-root node attested 'delta' STILL delivers", async () => {
+    const { body } = await run(
+      payloadWith(
+        [{ constraint_id: 'gc_delta_target', node_id: 'goal_mrr', operator: '>=', value: 0.3 }],
+        { goal_threshold: 0.3, goal_threshold_frame: 'delta' },
+      ),
+    );
+
+    const joint = jointByOption(body);
+    expect(joint.opt_hold).toBe(WITNESSED_JOINT);
+    expect(joint.opt_raise).toBe(WITNESSED_JOINT);
+    expect(unreliableWarnings(body)).toHaveLength(0);
+  });
+
+  // =========================================================================
+  // PC3 — POSITIVE CONTROL (pinning). Every option intervenes on the target,
+  // so each sample IS that absolute value and the comparison is well-posed.
+  //
+  // ⚠ THE TARGET IS `out_gross_margin`, A NON-ROOT NODE WITH NO OBSERVED VALUE,
+  // ON PURPOSE. An earlier draft of this control pinned a ROOT factor that
+  // already carried an observed value — so it passed through the
+  // `root_observed_level` limb and would have stayed green with the pinning
+  // limb deleted entirely. A control must fail for the reason it names.
+  // =========================================================================
+  const PIN_OPTIONS = [
+    { id: 'opt_hold', label: 'Hold at £49', interventions: { out_gross_margin: { value: 0.82, source: 'user_specified' } } },
+    { id: 'opt_raise', label: 'Raise to £59', interventions: { out_gross_margin: { value: 0.86, source: 'user_specified' } } },
+  ];
+
+  it('PC3: a target on a NON-ROOT node pinned by EVERY option STILL delivers', async () => {
+    const { body } = await run(
+      payloadWith(
+        [{ constraint_id: 'gc_pinned', node_id: 'out_gross_margin', operator: '>=', value: 0.8 }],
+        {},
+        PIN_OPTIONS,
+      ),
+    );
+
+    const joint = jointByOption(body);
+    expect(joint.opt_hold).toBe(WITNESSED_JOINT);
+    expect(joint.opt_raise).toBe(WITNESSED_JOINT);
+    expect(unreliableWarnings(body)).toHaveLength(0);
+  });
+
+  // =========================================================================
+  // PC3b — the pinning limb must require EVERY option, not merely one. A node
+  // one option pins and another leaves free is not comparable across options.
+  // Same node and same constraint as PC3 — only the option set differs, so the
+  // pinning limb is the ONLY thing that can explain the difference in verdict.
+  // =========================================================================
+  it('PC3b: the SAME target pinned by only ONE option is WITHHELD', async () => {
+    const { body } = await run(
+      payloadWith(
+        [{ constraint_id: 'gc_pinned', node_id: 'out_gross_margin', operator: '>=', value: 0.8 }],
+        {},
+        [
+          PIN_OPTIONS[0],
+          { id: 'opt_raise', label: 'Raise to £59', interventions: { fac_price_level: { value: 0.59, source: 'user_specified' } } },
+        ],
+      ),
+    );
+
+    const joint = jointByOption(body);
+    expect(joint.opt_hold).toBeUndefined();
+    expect(joint.opt_raise).toBeUndefined();
+    expect(unreliableWarnings(body)).toHaveLength(1);
+  });
+
+  // =========================================================================
+  // MIX — one anchored constraint beside one unanchored one. The run-level
+  // suppression must win: a joint figure computed over a SUBSET, presented as
+  // "every target", is the same untruth in a quieter register.
+  // =========================================================================
+  it('MIX: one unanchored constraint suppresses the whole run, not just itself', async () => {
+    const { body } = await run(
+      payloadWith(
+        [
+          { constraint_id: 'gc_root_factor', node_id: 'fac_price_sens', operator: '>=', value: 0.5 },
+          { constraint_id: 'gc_goal_target', node_id: 'goal_mrr', operator: '>=', value: 250000, unit: '£' },
+        ],
+        GOAL_NODE_LEVEL_STAMPED,
+      ),
+    );
+
+    const joint = jointByOption(body);
+    expect(joint.opt_hold).toBeUndefined();
+    expect(joint.opt_raise).toBeUndefined();
+
+    // Exactly one node is named — the unanchored one, by identity.
+    const warned = unreliableWarnings(body);
+    expect(warned).toHaveLength(1);
+    expect(warned[0].message).toContain('Grow MRR to £250,000');
+    expect(warned[0].message).not.toContain('Customer price sensitivity');
+  });
+});

--- a/tests/constraint-target-unreliable.fixture.test.ts
+++ b/tests/constraint-target-unreliable.fixture.test.ts
@@ -148,7 +148,7 @@ const GRAPH_VALUED_TARGET = {
     { id: 'goal_growth', kind: 'goal', label: 'Grow revenue' },
     // observed value 50 → deriveRange() infers [0, 100] (inferred_value tier),
     // NOT the default fallback.
-    { id: 'out_campaign_effectiveness', kind: 'outcome', label: 'Campaign effectiveness', observed_state: { value: 50 } },
+    { id: 'out_campaign_effectiveness', kind: 'outcome', goal_threshold_frame: 'delta', label: 'Campaign effectiveness', observed_state: { value: 50 } },
     { id: 'fac_budget', kind: 'factor', label: 'Marketing budget', observed_state: { value: 0.6 } },
   ],
   edges: [
@@ -255,7 +255,16 @@ describe('CONSTRAINT_TARGET_UNRELIABLE (item A — Paul\'s 20/% valueless-node c
       // … says the numbers were withheld …
       expect(warnings[0].message).toContain('withheld');
       // … and tells the user what to do about it.
-      expect(warnings[0].message).toContain('Set a value or range');
+      //
+      // ⚠ L63 changed WHICH action this names, on purpose. This fixture's
+      // target is BOTH un-scalable (no derivable range) AND unanchored (a
+      // non-root node, so ISL reads no absolute base for it), and the
+      // unanchored reason now takes priority in the copy: scaling the
+      // threshold correctly would not make it comparable, so "set a range"
+      // would send the user to fix the lesser of the two problems. The
+      // message still names a concrete action — set a current value, or
+      // state the target as a change — which subsumes the old advice.
+      expect(warnings[0].message).toContain('Set a current value');
       // The raw suppressed numbers are never quoted in the warning.
       expect(warnings[0].message).not.toContain('0%');
     } finally {

--- a/tests/enrichment-emission-contract.test.ts
+++ b/tests/enrichment-emission-contract.test.ts
@@ -198,7 +198,7 @@ describe('enrichment emission contract (route-level mixed-case fixture)', () => 
       body: JSON.stringify({
         graph: {
           nodes: [
-            { id: 'goal', kind: 'goal', label: 'Revenue' },
+            { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue' },
             { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
             { id: 'factor-b', kind: 'factor', label: 'Brand Awareness', observed_state: { value: 0.5 } },
           ],
@@ -304,7 +304,7 @@ describe('enrichment emission contract (route-level mixed-case fixture)', () => 
       body: JSON.stringify({
         graph: {
           nodes: [
-            { id: 'goal', kind: 'goal', label: 'Revenue' },
+            { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue' },
             { id: 'factor-a', kind: 'factor', label: 'Marketing Spend', observed_state: { value: 0.6 } },
             { id: 'factor-b', kind: 'factor', label: 'Brand Awareness', observed_state: { value: 0.5 } },
           ],

--- a/tests/gates/constraint-scale-correctness.test.ts
+++ b/tests/gates/constraint-scale-correctness.test.ts
@@ -69,7 +69,7 @@ describe('WP1 gate · constraint scale symmetry (PLoT-owned)', () => {
   it('normalises a user-scale constraint via shared deriveRange and preserves original_value', () => {
     // Goal node with an explicit range [0, 40000] (deriveRange source: 'explicit').
     const nodes = [
-      { id: 'goal', kind: 'goal', state_space: { range: { min: 0, max: 40000 } } },
+      { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', state_space: { range: { min: 0, max: 40000 } } },
     ] as unknown as EngineNodeV3[];
 
     const constraints: GoalConstraint[] = [
@@ -108,7 +108,7 @@ describe('WP1 gate · constraint scale symmetry (PLoT-owned)', () => {
   it('SHARED ARGUMENT: constraint and interventions on a spread node resolve the IDENTICAL range', () => {
     // cost: observed value 30000, NO cap, NO state_space.range → heuristic node.
     const nodes = [
-      { id: 'goal', kind: 'goal', label: 'Goal', observed_state: { value: 0.4 } },
+      { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Goal', observed_state: { value: 0.4 } },
       { id: 'cost', kind: 'factor', label: 'Cost', observed_state: { value: 30000 } },
     ] as unknown as EngineNodeV3[];
     const options = [
@@ -248,7 +248,7 @@ const BASE_PAYLOAD = {
       // suite tests the buildConstraintFields correspondence/validity
       // mechanics, so its target must be RELIABLE. Reliability suppression
       // itself is pinned in tests/constraint-results-top-level-gating.fixture.test.ts.
-      { id: 'goal', kind: 'goal', label: 'Revenue', observed_state: { value: 40000 } },
+      { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue', observed_state: { value: 40000 } },
       { id: 'factor-a', kind: 'factor', label: 'Market Size' },
     ],
     edges: [{ from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } }],

--- a/tests/goal-threshold-frame-synthesis-gate.test.ts
+++ b/tests/goal-threshold-frame-synthesis-gate.test.ts
@@ -303,6 +303,23 @@ describe('ROADMAP 2.266 — auto-synthesis is gated on the ISL sample frame', ()
   // T6 — SCOPE PIN. A USER-authored goal constraint is never touched by this
   // gate, frame or no frame: it does not come from the goal target and PLoT has
   // no standing to second-guess the frame the user stated it in.
+  //
+  // ⚠ L63 AMENDMENT — STILL TRUE ON THE WIRE, NO LONGER TRUE OF THE ANSWER, and
+  // the second half of that sentence was the load-bearing mistake. PLoT indeed
+  // has no standing to second-guess the frame the USER stated a target in — but
+  // that was never the question. The question is what ISL's SAMPLES for the
+  // target node mean, and for a non-root, un-pinned node they are
+  // `intercept + SUM(parent*strength)` anchored to nothing, so no absolute
+  // threshold is comparable against them in ANY frame the user might have meant.
+  // Reasoning about the user's frame instead of the samples' frame is how the
+  // constraints channel stayed open for three more rows after 2.258 closed the
+  // goal-threshold one.
+  //
+  // What L63 changed, precisely: the user's constraint STILL travels to ISL
+  // (this test's assertion is unchanged and still correct — L63 makes no wire
+  // change), but the probability that comes back is WITHHELD, with a
+  // warning-severity CONSTRAINT_TARGET_UNRELIABLE, unless the target's samples
+  // carry an absolute anchor. See tests/constraint-sample-frame-gate.test.ts.
   // -------------------------------------------------------------------------
   it('T6: a USER-authored goal_constraint survives with the frame ABSENT', async () => {
     const { isl } = await run(

--- a/tests/goal-threshold-normalisation.fixture.test.ts
+++ b/tests/goal-threshold-normalisation.fixture.test.ts
@@ -125,6 +125,11 @@ const GRAPH_GOAL_WITH_THRESHOLD_CAP = {
   nodes: [
     {
       id: 'goal_productivity', kind: 'goal', label: 'Improve productivity',
+      // L63: this suite pins THRESHOLD NORMALISATION / gating mechanics, not
+      // sample-frame truth. The producer attests the target is in the samples'
+      // own frame so those mechanics stay observable; the frame refusal itself
+      // is pinned in tests/constraint-sample-frame-gate.test.ts.
+      goal_threshold_frame: 'delta',
       // CEE stamps these on the goal node for exactly this normalisation:
       goal_threshold: 0.2,
       goal_threshold_cap: 100,
@@ -141,7 +146,7 @@ const GRAPH_GOAL_WITH_THRESHOLD_CAP = {
 /** Same graph but WITHOUT the CEE stamps — only the constraint's '%' unit travels. */
 const GRAPH_GOAL_NO_STAMPS = {
   nodes: [
-    { id: 'goal_productivity', kind: 'goal', label: 'Improve productivity' },
+    { id: 'goal_productivity', kind: 'goal', goal_threshold_frame: 'delta', label: 'Improve productivity' },
     { id: 'out_focus', kind: 'outcome', label: 'Focus time' },
     { id: 'fac_training', kind: 'factor', label: 'Training investment', observed_state: { value: 0.6 } },
   ],
@@ -157,6 +162,7 @@ const GRAPH_EXPLICIT_RANGE_TARGET = {
     { id: 'goal_productivity', kind: 'goal', label: 'Improve productivity' },
     {
       id: 'out_focus', kind: 'outcome', label: 'Focus time',
+      goal_threshold_frame: 'delta', // L63: pins normalisation, not frame truth
       state_space: { range: { min: 0, max: 200 } },
     },
     { id: 'fac_training', kind: 'factor', label: 'Training investment', observed_state: { value: 0.6 } },

--- a/tests/goalfit-doctrine-b.fixture.test.ts
+++ b/tests/goalfit-doctrine-b.fixture.test.ts
@@ -16,6 +16,34 @@
  * shares the outcome code path; prob_satisfied compares the same samples the
  * delivered probability_of_goal already uses).
  *
+ * ⚠⚠ L63 AMENDMENT — THE SENTENCE DIRECTLY ABOVE EXPIRED, AND THIS SUITE WAS
+ * STILL ASSERTING IT. "prob_satisfied compares the same samples the delivered
+ * probability_of_goal already uses" was true when this doctrine was ratified
+ * (2026-07-07) and was invalidated by ROADMAP 2.258/2.286: probability_of_goal
+ * no longer compares a threshold against raw samples at all — it rides a
+ * per-draw GoalThresholdPlan (`level_i = B + (option_i − sq_i)`) or REFUSES
+ * outright. The constraint path still compares raw. So the two are no longer
+ * the same comparison, and "deliver the second because the first was
+ * delivered" no longer follows from anything.
+ *
+ * Measured consequence, deployed staging 2026-08-04 (PLoT 2864b0c / ISL
+ * 80aa83f, `PHASE0-EVIDENCE-2026-07-28/diagnosis-goalfit-untruth.md`): on the
+ * witnessed runs `probability_of_goal` was ABSENT (the 2.258 guard honestly
+ * refusing) while `probability_of_joint_goal` = 0 was DELIVERED under this very
+ * exception and marked decision-grade — two channels answering in opposite
+ * directions inside one response, with the UI substituting the delivered zero
+ * into the goal-fit surface the refusal had left empty.
+ *
+ * DOCTRINE B IS THEREFORE RESTRICTED, NOT REPEALED. It still delivers wherever
+ * its rationale still holds — i.e. wherever the target node's samples carry an
+ * absolute anchor (root-with-observed-value, pinned by every option, or a
+ * producer-attested 'delta' frame). It no longer delivers for a target whose
+ * samples are `intercept + SUM(parent*strength)` with base 0.0, because no
+ * absolute threshold is comparable against those. The delivery fixtures below
+ * therefore carry the producer's `goal_threshold_frame: 'delta'` attestation,
+ * and the L63 block at the end of this file pins the un-attested shape — the
+ * exact live one — as SUPPRESSED.
+ *
  * Contract under test (RED on origin/staging ff423310 — suppressed today):
  *   1. probability_of_joint_goal / constraint_probabilities are DELIVERED,
  *      differentiated per option;
@@ -135,6 +163,13 @@ const GRAPH_GOAL_TARGET = {
       id: 'goal_productivity', kind: 'goal', label: 'Improve productivity',
       goal_threshold: 0.2,
       goal_threshold_cap: 100,
+      // L63: the producer attests that targets on this node are stated in the
+      // samples' own frame. Doctrine B's delivery scope is now conditional on
+      // an anchor, and this is the limb that supplies one here. Removing this
+      // line moves every DELIVERS/annotates/downgrades case below into the
+      // suppressed population — which is what GRAPH_GOAL_TARGET_UNATTESTED
+      // (the live shape) exists to pin.
+      goal_threshold_frame: 'delta',
     },
     { id: 'out_focus', kind: 'outcome', label: 'Focus time' },
     { id: 'fac_training', kind: 'factor', label: 'Training investment', observed_state: { value: 0.6 } },
@@ -386,6 +421,75 @@ describe('goal-fit doctrine B (P0-C2 — scored from the modelled outcome distri
     }
     expect(warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE')).toHaveLength(0);
     expect(warningsByCode(body, 'CONSTRAINT_GOALFIT_MODELLED_BASIS')).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // L63 — THE LIVE SHAPE, UN-ATTESTED: doctrine B no longer delivers it.
+  //
+  // This is GRAPH_GOAL_TARGET with the 'delta' attestation removed, i.e. the
+  // exact shape measured on deployed staging: a goal target normalised against
+  // a producer cap, on a non-root goal node whose samples are
+  // `intercept + SUM(parent*strength)` with base 0.0. Every input doctrine B
+  // keys on is unchanged — same node, same constraint, same ISL marker, same
+  // forward-propagated inputs — so the ONLY thing that can move the verdict
+  // between this test and the DELIVERS test above is the sample-frame anchor.
+  // -------------------------------------------------------------------------
+  it('L63: the un-attested live shape is SUPPRESSED, not delivered under doctrine B', async () => {
+    defaultBaseNodeId = 'goal_productivity';
+    try {
+      const body = await run(
+        {
+          ...GRAPH_GOAL_TARGET,
+          nodes: GRAPH_GOAL_TARGET.nodes.map((n) => {
+            if (n.id !== 'goal_productivity') return n;
+            const { goal_threshold_frame: _dropped, ...unattested } = n as any;
+            return unattested;
+          }),
+        },
+        [AT_LEAST_20_PCT],
+      );
+
+      for (const opt of body.option_comparison) {
+        expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+        expect(opt, opt.option_id).not.toHaveProperty('constraint_probabilities');
+        expect(opt, opt.option_id).not.toHaveProperty('goal_fit_basis');
+      }
+
+      // The honesty signal is the WARNING, not the info-severity modelled-basis
+      // note — PLoT hides severity 'info', and this is a degradation to
+      // disclose, not a basis footnote under a headline number.
+      const warnings = warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].severity).toBe('warning');
+      expect(warnings[0].message).toContain('Improve productivity');
+      expect(warningsByCode(body, 'CONSTRAINT_GOALFIT_MODELLED_BASIS')).toHaveLength(0);
+    } finally {
+      defaultBaseNodeId = null;
+    }
+  });
+
+  it("L63: the same shape suppresses even with NO ISL base marker — PLoT derives it, not mirrors it", async () => {
+    // defaultBaseNodeId stays null, so the ISL CONSTRAINT_NODE_DEFAULT_BASE
+    // channel emits nothing and the pre-existing detector sees a clean run.
+    // The refusal must still fire, because it is derived from the graph PLoT
+    // is sending rather than read off an upstream warning list.
+    defaultBaseNodeId = null;
+    const body = await run(
+      {
+        ...GRAPH_GOAL_TARGET,
+        nodes: GRAPH_GOAL_TARGET.nodes.map((n) => {
+          if (n.id !== 'goal_productivity') return n;
+          const { goal_threshold_frame: _dropped, ...unattested } = n as any;
+          return unattested;
+        }),
+      },
+      [AT_LEAST_20_PCT],
+    );
+
+    for (const opt of body.option_comparison) {
+      expect(opt, opt.option_id).not.toHaveProperty('probability_of_joint_goal');
+    }
+    expect(warningsByCode(body, 'CONSTRAINT_TARGET_UNRELIABLE')).toHaveLength(1);
   });
 
   it('regression: a run without goal constraints carries no constraint fields, annotation, or note', async () => {


### PR DESCRIPTION
**Lane L63 · P0 science seat · closes the constraint-frame hole at the source.** Evidence: `PHASE0-EVIDENCE-2026-07-28/l63-constraint-frame.md`. Diagnosis: `diagnosis-goalfit-untruth.md` OBS 1 (fix-stack item 1). **PLoT only — ISL is not touched, and the ISL request is byte-identical.**

## The defect

ISL evaluates every `goal_constraint` with `value >= constraint.threshold` against raw Monte-Carlo samples (`robustness_analyzer_v2.py:7329`) — no frame plan, no baseline, no refusal limb. Read off ISL's evaluator (`SCMEvaluatorV2.evaluate:1310-1394`):

```
sample = base + intercept + SUM(parent * strength)
base   = observed_state.value  iff is_root and present ;  0.0 otherwise
```

So for a **non-root, un-pinned** target the sample is `intercept + SUM(...)` anchored to nothing, and an absolute threshold — a level, a count, a fraction — forces P≈0 for every option regardless of option quality. Witnessed live on the deployed tips (PLoT `2864b0c` / ISL `80aa83f`) in all three flavours: a goal target (`£250,000` against a cap), a draft-minted fraction (`gross margin >= 0.8`), a chat-minted count (`<= 2 AEs`). Every one came back `probability_of_joint_goal: 0`, `constraints_status: "computed"`, `decision_grade: true`.

**The tempting counter-reading — that `intercept + SUM(...)` is a calibrated level and the gap is mis-calibration — is one ISL already tried and measured wrong.** The ROADMAP 2.286 correction records baseline `0.7` against a status-quo sample of `0.25` ("a confident inversion rendered to a user as certainty") and responded by refusing to read a sample's absolute position at all, recovering levels per draw against a status-quo reference. Only differences survive that derivation. No witnessed live graph sets `intercept` on any node.

## Why it survived three previous fixes

2.258/2.286 closed this on `goal_threshold`. 2.266 closed it on PLoT's auto-synthesis path. The third route — an actual `goal_constraints` row (user-authored, draft-minted, chat-minted) — was left open, and the UI's `joint_goal_substituted` fallback routes the unguarded zero into the goal-fit surface *precisely when* the guarded channel honestly refuses.

**And the number was not missed by PLoT's honesty machinery — it was delivered by an explicit exception inside it.** `partitionConstraintTargets`' doctrine B delivers a base-defaulted target *because* it has forward-propagated inputs — i.e. because it is non-root, exactly the unanchored population. Its ratified rationale was:

> "prob_satisfied compares the SAME normalised samples the already-delivered `probability_of_goal` uses"

That was true when ratified (2026-07-07) and was **invalidated by 2.258/2.286 without the rule being revisited**: `probability_of_goal` now rides a per-draw `GoalThresholdPlan` or refuses. Not theoretical — on the witnessed runs `probability_of_goal` was ABSENT while `probability_of_joint_goal` = 0 was DELIVERED under this exception, in the same response.

## The change

Doctrine B is **restricted, not repealed**. A new **derived** detector asks whether the target's samples carry an absolute anchor — `pinned_by_every_option`, `root_observed_level`, or a producer-attested `'delta'` frame — computed from the graph and options **PLoT is sending on this request**, so predicate and payload cannot disagree. (The pre-existing detector reads ISL's emitted `CONSTRAINT_NODE_DEFAULT_BASE` list — a mirror, with gaps: it asks "will the base default to 0.0?", not "is this sample a level?".)

Unanchored targets take the **existing** run-level suppression: `probability_of_joint_goal` and `constraint_probabilities` withheld, raw values in diagnostics logs only, warning-severity `CONSTRAINT_TARGET_UNRELIABLE` naming the node and the fix.

**Why withhold rather than drop before egress:** dropping changes the ISL request and churns egress-contract, determinism-replay and response-hash fixtures — a large plumbing diff wrapped around a small honesty diff. Both satisfy "never computed-anyway"; withholding does it inside machinery that already exists for this exact purpose.

## Proof

| Mutant (worktrees **outside** the repo root) | F1 goal-target | F2 fraction | F3 count | PC1 root+observed | PC2 attested delta | PC3 pinned | PC3b half-pinned | MIX |
|---|---|---|---|---|---|---|---|---|
| *(the fix)* | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| drop the gate | **RED** | **RED** | **RED** | ✓ | ✓ | ✓ | **RED** | **RED** |
| refuse everything | ✓ | ✓ | ✓ | **RED** | **RED** | **RED** | ✓ | **RED** |
| delete `attested_delta` limb | ✓ | ✓ | ✓ | ✓ | **RED** | ✓ | ✓ | ✓ |
| delete `root_observed_level` limb | ✓ | ✓ | ✓ | **RED** | ✓ | ✓ | ✓ | **RED** |
| delete `pinned_by_every_option` limb | ✓ | ✓ | ✓ | ✓ | ✓ | **RED** | ✓ | ✓ |

Under "drop the gate" every refusal test fails **with the exact witnessed `0.0054` delivered to every option** — the mutant reproduces the live defect rather than merely failing. Each limb mutant reds **only its own control**, so no control is passing through a limb other than its own. The ISL mock returns a non-zero joint for whatever it is sent, so every "withheld" assertion proves an absence the mock demonstrably *can* produce as a presence.

⚠ **One control was caught passing through the wrong limb and was rewritten.** PC3 ("pinned by every option") first targeted a root factor that already carried an observed value, so it stayed green with the pinning limb deleted. It now targets a non-root node with no observed value, and PC3b holds node and constraint identical while changing only the option set.

⚠ **Honest negative result:** the explicit `reasons.includes('sample_frame_unanchored')` early-return in `partitionConstraintTargets` does **not** RED any test when removed — the merged reason set already fails doctrine B's `reasons.length === 1` test. It is kept as an explicit statement of intent and is **not claimed as a mutation-proven guard**; a hand-written corpus over the whole reason vocabulary guards the property against a future broadening.

## Blast radius — measured and triaged, nothing absorbed

First full run: **11 files / 32 tests** failing against a `606 files / 6722 tests` green baseline. Every one read and classified.

- **4 doctrine suites** updated as doctrine changes with the reason written into the file — including `goalfit-doctrine-b.fixture.test.ts`, whose header now records that its own stated premise expired, plus **two new tests pinning the un-attested live shape as SUPPRESSED** (one with the ISL base-marker channel silent, proving the refusal is derived at PLoT).
- **7 plumbing suites** (id-echo mapping, field mapping, `constraints_status` honesty, bad-index hardening, enrichment emission) had their constraint target given the producer `'delta'` attestation. **This follows the convention these files already documented** for the previous honesty gate — e.g. `cil-constraint-passthrough.test.ts` already carried a comment explaining that its targets carry observed values so producer honesty would not "rightly SUPPRESS the per-option probability fields this suite pins the mapping of".

**Final: 6749 passed | 28 skipped, 0 failing.** No test deleted, skipped or excluded. `scripts/pre-push-validate.sh` green on the pushed tree (6/6 substantive checks).

## Deploy

**Single repo, no ordering constraint.** PLoT ahead of ISL: no risk (byte-identical request). Consumers ahead of PLoT: no risk (the change only makes two fields absent more often, and absence there is the already-live contract 2.266 has produced since it landed). Rollback = revert; no migration, no flag.

**L62 (UI) is independent** — this removes the fabricated number at the producer, so the substitution fallback has nothing to substitute and falls through to honest absence with no UI change. L62 remains worth having as defence in depth; neither lane blocks the other.

## Scope — what this does NOT fix

1. `constraint_margins` denormalisation is untouched for *delivered* constraints — the "£200k short" arithmetic is the same category error applied to distance, silenced here only because the constraint is withheld. Needs its own row.
2. **No conversion is implemented.** The honest answer needs `observed_state.baseline` (2.281) and per-draw ISL samples. Once 2.281 lands, the better fix for the goal-node case is to route a user-authored goal-target constraint into the guarded `goal_threshold` channel — deliberately not done here (two numbers describing one target on one wire is the divergence 2.266's carry exists to prevent).
3. The reason is not on the wire as a machine-readable per-constraint field; the typed signal is the `CONSTRAINT_TARGET_UNRELIABLE` code plus the absence, matching the pre-existing contract.
4. Nothing here addresses the **root** of the witnessed session — that the success target never registered server-side at all (CEE lane).

## ⚠ Adjacent finding, rowed not fixed

The trust bit and the suppression gate read the same fact in opposite directions. For a constraint that underwent no normalisation, `buildConstraintScaleProvenance` maps the missing entry to source `'default'` ⇒ `decision_grade: false` (fail-closed), while `detectUnreliableConstraintTargets` matches nothing ⇒ **no suppression** (fail-open). That is the mechanism behind L60's observation that "decision_grade=false did not suppress the substitution". L63 closes the witnessed instance incidentally; the asymmetry itself needs its own reachability analysis and blast-radius measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)