### PR TITLE
[DO-NOT-MERGE — lane 3 Car 4] fix(v2/run): ISL critiques merge on both paths + affected_node_ids (2.410)

### DIFF
--- a/src/critique-humaniser.ts
+++ b/src/critique-humaniser.ts
@@ -429,6 +429,16 @@ export const TEMPLATE_MAP: Record<string, TemplateEntry> = {
 
   POC_CONSTRAINT_LIMIT:
     'Model exceeds the 20-constraint limit. Remove less important constraints.',
+
+  // ROADMAP 2.410 — ISL success-body coverage disclosure (critique.py:357).
+  // ISL computes fine-grained switch detail for the most elastic fragile
+  // edges only, bounded by its compute budget; retained values are computed
+  // independently and are unaffected. Product copy: name the coverage limit
+  // honestly, no internal jargon (field names / sample counts stay in
+  // `message` for the debug surface).
+  MARGINAL_SWITCH_TRUNCATED:
+    'Tipping-point detail was computed for the most sensitive fragile connections only; ' +
+    'the least sensitive were skipped to keep the analysis fast. All values shown are unaffected.',
 };
 
 // ---------------------------------------------------------------------------

--- a/src/integrations/isl/errors.ts
+++ b/src/integrations/isl/errors.ts
@@ -46,13 +46,28 @@ export interface ISLError422 {
 }
 
 /**
- * ISL critique from 422 response.
+ * ISL critique from a 422 response — or, since ROADMAP 2.410, from the v2
+ * SUCCESS body (`islResult.critiques`, "always a list, never None" in ISL's
+ * response builder).
+ *
+ * ⚠ FIELD NAMES (2.410 / 2.394(a)): ISL's CritiqueV2 serialises
+ * `affected_node_ids` / `affected_option_ids` (models/critique.py `build()`)
+ * — it has NEVER emitted `affected_nodes`. That legacy name is kept for
+ * tolerance of older/alternate producers, but a reader that consults ONLY
+ * `affected_nodes` silently drops node identity for every v2-format critique
+ * (which is what run.ts did until the 2.410 fix).
  */
 export interface ISLCritique {
+  id?: string;
   code: string;
   severity: string;
   message: string;
   suggestion?: string;
+  /** ISL v2 wire field (CritiqueV2). Prefer this. */
+  affected_node_ids?: string[];
+  /** ISL v2 wire field (CritiqueV2). */
+  affected_option_ids?: string[];
+  /** Legacy/alternate-producer field name — tolerated, never emitted by ISL v2. */
   affected_nodes?: string[];
 }
 

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -4013,17 +4013,32 @@ function buildResponse(
 // -----------------------------------------------------------------------------
 
 /**
- * Map ISL critiques to V2 critique format.
+ * Map ISL critiques to V2 critique format. ONE mapper for BOTH paths
+ * (ROADMAP 2.410): the 422 branch (structured validation critiques) and the
+ * 200 branch (success-body coverage disclosures such as
+ * MARGINAL_SWITCH_TRUNCATED — ISL "publishes what it computed and names what
+ * it did not", critique.py:357, and PLoT dropped that disclosure on every
+ * successful response until this fix).
+ *
+ * Field fix (2.394(a)): ISL's CritiqueV2 serialises `affected_node_ids` /
+ * `affected_option_ids` and has never emitted `affected_nodes` — reading
+ * only the legacy name silently dropped node identity for every v2-format
+ * critique. Prefer the producer's field, tolerate the legacy one.
+ * ISL's deterministic critique id is carried when present (cross-service
+ * identity); a local UUID is minted only when the producer sent none.
  */
 function mapISLCritiquesToV2(islCritiques: Array<{
+  id?: string;
   code: string;
   severity: string;
   message: string;
   suggestion?: string;
+  affected_node_ids?: string[];
+  affected_option_ids?: string[];
   affected_nodes?: string[];
 }>): CritiqueV3[] {
   return islCritiques.map((c) => ({
-    id: randomUUID(),
+    id: typeof c.id === 'string' && c.id.length > 0 ? c.id : randomUUID(),
     code: c.code,
     severity: c.severity === 'blocker' ? 'blocker' :
               c.severity === 'error' ? 'error' :
@@ -4031,7 +4046,8 @@ function mapISLCritiquesToV2(islCritiques: Array<{
     message: c.message,
     suggestion: c.suggestion,
     source: 'isl' as const,
-    affected_node_ids: c.affected_nodes,
+    affected_node_ids: c.affected_node_ids ?? c.affected_nodes,
+    ...(c.affected_option_ids ? { affected_option_ids: c.affected_option_ids } : {}),
     blocks_analysis: c.severity === 'blocker',
   }));
 }
@@ -7021,6 +7037,25 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             computedAt: computedAt ?? requestComputedAt,
             critiques,
           }));
+        }
+
+        // =================================================================
+        // ISL success-body critiques merge (ROADMAP 2.410, folds 2.394(a))
+        // =================================================================
+        // ISL's v2 SUCCESS response carries `critiques` too ("always a list,
+        // never None" — its response builder), including coverage disclosures
+        // like MARGINAL_SWITCH_TRUNCATED whose entire purpose is to name what
+        // was NOT computed on an otherwise-good run. Until this merge, those
+        // rows were read on the 422 path only, so every success warning died
+        // here — the same one-hop-before-the-consumer death the CEE→UI
+        // keep-list had. Same mapper as the 422 path (one function, both
+        // paths); appended AFTER PLoT-authored rows so `critiques[0]`
+        // consumers (CEE plot-client renders critiques[0].message) keep
+        // seeing request-shape issues first. No blockers can arrive here —
+        // a blocking condition surfaces as 422 or analysis_status 'failed',
+        // both already returned above.
+        if (Array.isArray(islResult?.critiques) && islResult.critiques.length > 0) {
+          critiques.push(...mapISLCritiquesToV2(islResult.critiques));
         }
 
         // =================================================================

--- a/tests/isl-success-critiques-merge.test.ts
+++ b/tests/isl-success-critiques-merge.test.ts
@@ -1,0 +1,215 @@
+/**
+ * LANE 3 Car 4 (P1/P4) — ISL critiques merge on BOTH paths (ROADMAP 2.410,
+ * folding 2.394(a)): success-path critiques + the affected_node_ids field fix.
+ *
+ * Two defects, both verified at the bytes (PLoT `d011b996`, ISL staging):
+ *
+ *  D1 — ISL's v2 SUCCESS body carries `critiques` ("always a list, never
+ *       None" — src/api/robustness.py response builder), including the
+ *       MARGINAL_SWITCH_TRUNCATED coverage disclosure ISL's own comment says
+ *       exists so "we publish what we computed and name what we did not"
+ *       (critique.py:357). PLoT's success path builds its critiques from
+ *       pre-detection + preflight + normalisation only (run.ts:6906) and
+ *       never reads `islResult.critiques` — the disclosure is dropped on
+ *       every 200.
+ *  D2 — ISL serialises `affected_node_ids` / `affected_option_ids`
+ *       (CritiqueV2, models/critique.py build()); PLoT's `ISLCritique`
+ *       declares `affected_nodes` and `mapISLCritiquesToV2` reads ONLY
+ *       `c.affected_nodes` (run.ts:4018) — so on the live 422 path, node
+ *       identity silently drops for every v2-format critique.
+ *
+ * RED-FIRST at pristine: D1/D2 tests fail; the two named controls pass.
+ * Assertions bind by IDENTITY (code + exact ids), never bare counts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Switchable ISL mock — same pattern as v2-typed-failure-envelope.test.ts.
+// ---------------------------------------------------------------------------
+type IslBehaviour =
+  | { kind: 'computed' }
+  | { kind: 'computed-with-critiques'; critiques: unknown[] }
+  | {
+      kind: 'error';
+      error: {
+        code: string;
+        message: string;
+        retryable: boolean;
+        status?: number;
+        critiques?: unknown[];
+      };
+    };
+
+let islBehaviour: IslBehaviour = { kind: 'computed' };
+
+const mockISLService = {
+  isEnabled: () => true,
+  async callAnalysisEndpoint<T>(): Promise<unknown> {
+    if (islBehaviour.kind === 'error') {
+      return { data: null, error: islBehaviour.error, latency_ms: 5, isl_echoed_request_id: null };
+    }
+    const data = makeComputedIslResponse() as Record<string, unknown>;
+    if (islBehaviour.kind === 'computed-with-critiques') {
+      data.critiques = islBehaviour.critiques;
+    }
+    return { data: data as T, latency_ms: 5, isl_echoed_request_id: null };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+import { makeValidRunBody, makeComputedIslResponse } from './helpers/run-fixtures.js';
+
+/** ISL v2-format critique rows EXACTLY as CritiqueV2 serialises them
+ * (id/code/severity/source/message/affected_option_ids/affected_node_ids/
+ * suggestion — models/critique.py build(), fetched at ISL staging tip). */
+const MARGINAL_SWITCH_ROW = {
+  id: 'isl-det-0001',
+  code: 'MARGINAL_SWITCH_TRUNCATED',
+  severity: 'warning',
+  source: 'analysis',
+  message:
+    'Marginal switch probability was computed for the 3 most elastic fragile edge(s) of 7; ' +
+    'the remaining 4 carry marginal_switch_probability=null. Each edge\'s sweep costs 40 ' +
+    'isolated re-evaluations per option, so the set is bounded to keep the analysis inside ' +
+    'its compute-admission budget. Retained values are unaffected — each is computed ' +
+    'independently of the others',
+  affected_node_ids: ['edge_a', 'edge_b'],
+  suggestion:
+    'The omitted edges are the least elastic of the fragile set; if a specific edge\'s ' +
+    'marginal contribution matters, re-run with a graph scoped to it',
+};
+
+const GOAL_GAP_ROW = {
+  id: 'isl-det-0002',
+  code: 'GOAL_ANCESTOR_DATA_GAP',
+  severity: 'warning',
+  source: 'analysis',
+  message: 'Goal ancestor n_low has no observed data',
+  affected_node_ids: ['n_low'],
+};
+
+describe('/v2/run — ISL critiques merge on both paths (2.410)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    process.env.DECISION_REVIEW_ENABLE = '0';
+    process.env.ENABLE_REVIEW_PASS = '0';
+    app = await createServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ── D1: success path (RED at pristine) ────────────────────────────────
+  it('RED D1 — a 200 response carries ISL success-body critiques, identity-bound', async () => {
+    islBehaviour = { kind: 'computed-with-critiques', critiques: [MARGINAL_SWITCH_ROW, GOAL_GAP_ROW] };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: makeValidRunBody() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.analysis_status).toBe('computed');
+
+    const marginal = (body.critiques ?? []).filter((c: any) => c.code === 'MARGINAL_SWITCH_TRUNCATED');
+    expect(marginal).toHaveLength(1);
+    expect(marginal[0].severity).toBe('warning');
+    expect(marginal[0].source).toBe('isl');
+    expect(marginal[0].blocks_analysis).toBe(false);
+    // D2's field fix must apply here too: ISL v2 rows carry affected_node_ids.
+    expect(marginal[0].affected_node_ids).toEqual(['edge_a', 'edge_b']);
+    expect(marginal[0].user_message).toBeTruthy();
+
+    const gap = (body.critiques ?? []).filter((c: any) => c.code === 'GOAL_ANCESTOR_DATA_GAP');
+    expect(gap).toHaveLength(1);
+    expect(gap[0].affected_node_ids).toEqual(['n_low']);
+  });
+
+  it('RED D1b — product copy: MARGINAL_SWITCH_TRUNCATED user_message is real copy, not the unknown-code fallback, and leaks no internals', async () => {
+    islBehaviour = { kind: 'computed-with-critiques', critiques: [MARGINAL_SWITCH_ROW] };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: makeValidRunBody() });
+    const row = res.json().critiques.find((c: any) => c.code === 'MARGINAL_SWITCH_TRUNCATED');
+    expect(row).toBeDefined();
+    // 2.410: "add product copy for MARGINAL_SWITCH_TRUNCATED" — the generic
+    // fallback sentence is not product copy.
+    expect(row.user_message).not.toContain('An issue was detected in your model');
+    // No internal jargon on the user surface.
+    expect(row.user_message).not.toContain('marginal_switch_probability');
+    expect(row.user_message).not.toContain('null');
+  });
+
+  // ── D2: 422 path field fix (RED at pristine) ──────────────────────────
+  it('RED D2 — a 422 blocked response carries affected_node_ids from ISL v2-format critiques', async () => {
+    islBehaviour = {
+      kind: 'error',
+      error: {
+        code: 'ISL_HTTP_422',
+        message: 'ISL validation failed',
+        retryable: false,
+        status: 422,
+        critiques: [
+          {
+            id: 'isl-det-0003',
+            code: 'GRAPH_DISCONNECTED',
+            severity: 'blocker',
+            source: 'validation',
+            message: 'Nodes n_orphan unreachable from goal',
+            affected_node_ids: ['n_orphan'],
+            suggestion: 'Connect or remove the disconnected nodes',
+          },
+        ],
+      },
+    };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: makeValidRunBody() });
+    expect(res.statusCode).toBe(422);
+    const row = res.json().critiques.find((c: any) => c.code === 'GRAPH_DISCONNECTED');
+    expect(row).toBeDefined();
+    expect(row.affected_node_ids).toEqual(['n_orphan']);
+    expect(row.blocks_analysis).toBe(true);
+  });
+
+  // ── Controls (named; GREEN at pristine) ───────────────────────────────
+  it('CONTROL (green at pristine) — legacy affected_nodes 422 shape still carries node identity after the fix', async () => {
+    islBehaviour = {
+      kind: 'error',
+      error: {
+        code: 'ISL_HTTP_422',
+        message: 'ISL validation failed',
+        retryable: false,
+        status: 422,
+        critiques: [
+          {
+            code: 'INVALID_NODE_ID',
+            severity: 'blocker',
+            message: 'Node ref broken',
+            affected_nodes: ['n_legacy'],
+          },
+        ],
+      },
+    };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: makeValidRunBody() });
+    expect(res.statusCode).toBe(422);
+    const row = res.json().critiques.find((c: any) => c.code === 'INVALID_NODE_ID');
+    expect(row).toBeDefined();
+    expect(row.affected_node_ids).toEqual(['n_legacy']);
+  });
+
+  it('CONTROL (green at pristine) — a computed run whose ISL body has NO critiques fabricates none (no isl-source rows)', async () => {
+    islBehaviour = { kind: 'computed' };
+    const res = await app.inject({ method: 'POST', url: '/v2/run', payload: makeValidRunBody() });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.analysis_status).toBe('computed');
+    const islRows = (body.critiques ?? []).filter((c: any) => c.source === 'isl');
+    expect(islRows).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Pillar
P1/P4 — the model's own critiques reach the tester (POC-DONE step 2 + pass-condition 2). ROADMAP 2.410, folds 2.394(a) / feeds 2.358's surface.

## Defects (verified at the bytes before building)
- **D1 — success-path drop:** ISL's v2 SUCCESS body carries `critiques` ("always a list, never None" — `src/api/robustness.py` builder), incl. `MARGINAL_SWITCH_TRUNCATED`, whose stated purpose is "we publish what we computed and name what we did not" (`critique.py:357`). PLoT's success path built critiques from pre-detection + preflight + normalisation only (`run.ts:6906`) and never read `islResult.critiques` — the disclosure died on every 200.
- **D2 — field mismatch:** ISL's `CritiqueV2` serialises `affected_node_ids` / `affected_option_ids` and has NEVER emitted `affected_nodes`; `mapISLCritiquesToV2` read only the legacy name — node identity silently dropped for every v2-format critique on the 422 path.

## Fix
One mapper, both paths (2.410's shape): `affected_node_ids ?? affected_nodes` (producer-preferred, legacy-tolerant), `affected_option_ids` carried, ISL's deterministic `id` carried when present. Success-body rows are appended AFTER PLoT-authored rows (`critiques[0]` consumers — CEE plot-client renders `critiques[0].message` — keep seeing request-shape issues first; blockers cannot reach the success path: 422/failed return upstream). `TEMPLATE_MAP` product copy added for `MARGINAL_SWITCH_TRUNCATED`; internals stay in `message`.

## Proof
- RED-first at pristine `d011b996`: 3 RED (D1 merge / D1b product copy / D2 field) + 2 named GREEN controls (legacy-shape tolerance; no fabrication on a critique-less 200).
- After: 5/5 · neighbours green (`v2-typed-failure-envelope` 8, `critique-humaniser` 165+6) · `npm run typecheck` clean · **full named gate `npm test` (build+vitest+fixtures+OpenAPI+loadcheck) EXIT=0** before push.
- Mutants (throwaway worktree outside repo root on committed `28f9f03`; applied-check `src/`-scoped, control exactly zero): M1 delete success-merge · M2 legacy-only field · M3 delete template · M4 drop legacy tolerance — ALL BITE.
- ⚠ `npm run lint` (`--max-warnings 0`) is a STANDING RED at pristine: 93 warnings on untouched `d011b996`, warning set byte-identical to this branch (diffed in a control worktree) — delta from this PR = 0. Flagged separately for repair.

## Visibility caveat (honest scope)
CEE→UI still suppresses `MARGINAL_SWITCH_TRUNCATED` (explicit 'D' after lane 3 Car 3; S-promotion needs Paul-approved copy — rowed). This PR restores the PLoT seam so success warnings stop disappearing at it.

Evidence: `PHASE0-EVIDENCE-2026-07-28/lane3-critiques-2026-08-04.md` (workspace repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)