### PR TITLE
[DO-NOT-MERGE — lane 2465] chore(lint): zero warnings + single gate — CI runs npm run lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint (ESLint)
-        # Ratchet baseline (not a quality target): 97 = current origin/staging
-        # warning count, 0 errors. Errors always fail; warnings above 97 fail CI.
-        # Lower as warnings are cleaned during normal product work; never raise.
-        run: npx eslint src tests --ext .ts --max-warnings 97
+        # Single gate, single threshold: CI runs the SAME npm script developers
+        # run locally (--max-warnings 0). Never inline an eslint command here —
+        # a second command with its own flags is how the 97-vs-0 split-brain
+        # happened (ROADMAP 2.465).
+        run: npm run lint
       - name: Validate contracts
         run: npm run validate:contracts
       - run: npm run build

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -18,10 +18,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint (ESLint)
-        # Ratchet baseline (not a quality target): 97 = current origin/staging
-        # warning count, 0 errors. Errors always fail; warnings above 97 fail CI.
-        # Lower as warnings are cleaned during normal product work; never raise.
-        run: npx eslint src tests --ext .ts --max-warnings 97
+        # Single gate, single threshold: CI runs the SAME npm script developers
+        # run locally (--max-warnings 0). Never inline an eslint command here —
+        # a second command with its own flags is how the 97-vs-0 split-brain
+        # happened (ROADMAP 2.465).
+        run: npm run lint
       - name: Run pr-verify (Node)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/analysis/flip-thresholds.ts
+++ b/src/analysis/flip-thresholds.ts
@@ -635,7 +635,7 @@ async function searchFlipForFactorInner(
       result: { ...candidate, flip_value: flipValue, flip_reason: 'found', iterations_used: iterations, probes_used: probes, alternative_winner_id: farWinner, margin_sensitivity: marginSensitivity },
       diagnostics: diag,
     };
-  } catch (err) {
+  } catch {
     // Cancellation (F3): an error after the deadline is a cancelled probe →
     // disclose 'timeout'; else a genuine ISL fault → 'error'. (Mirror of the
     // Step-0 rejection branch above.)

--- a/src/cee/client.ts
+++ b/src/cee/client.ts
@@ -179,6 +179,7 @@ export async function callCEEWithSchemaV2<T>(
     // Log payload for debugging (only for options endpoint)
     if (path.includes('/options')) {
       const payloadObj = payload as Record<string, unknown>;
+      // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
       console.log('[CEE_V2_OPTIONS_PAYLOAD]', JSON.stringify({
         path,
         payload_keys: Object.keys(payloadObj),
@@ -263,6 +264,7 @@ export async function callCEEWithSchemaV2<T>(
     const hasEffectDirection = edgeCount > 0 && edges.every((e: any) => e.effect_direction !== undefined);
     const hasStrengthStd = edgeCount > 0 && edges.every((e: any) => typeof e.strength_std === 'number' && e.strength_std > 0);
 
+    // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
     console.log('[CEE_V2_RESPONSE]', JSON.stringify({
       path,
       cee_api_version: ceeApiVersion,
@@ -481,6 +483,7 @@ export async function factorReviewV2(
       echoedRequestId,
     });
 
+    // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
     console.log(JSON.stringify({
       event: 'cee_factor_review_success',
       request_id: requestId,
@@ -650,6 +653,7 @@ export async function callDecisionReview(
       echoedRequestId,
     });
 
+    // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
     console.log(JSON.stringify({
       event: 'cee_decision_review_success',
       request_id: requestId,

--- a/src/cee/decision-review-orchestrator.ts
+++ b/src/cee/decision-review-orchestrator.ts
@@ -18,7 +18,7 @@ import { createHash } from 'node:crypto';
 import { FLAGS } from '../config/flags.js';
 import type { EngineGraphV3, OptionV3 } from '../types/engine-v3.js';
 import type { M1Coaching } from '../coaching/types.js';
-import type { M1Review, DecisionReviewResult, FlipThresholdInputData } from './validation/m1-review-types.js';
+import type { DecisionReviewResult, FlipThresholdInputData } from './validation/m1-review-types.js';
 import { safeParseM1Review } from './validation/m1-review-types.js';
 import { validateM1Review, buildValidationContext, capScenarioContexts } from './validation/m1-review-validator.js';
 import { buildDecisionReviewRequest, type ISLResultInput } from './decision-review-request.js';

--- a/src/cee/decision-review-request.ts
+++ b/src/cee/decision-review-request.ts
@@ -9,7 +9,7 @@
 
 import { createHash } from 'node:crypto';
 import type { EngineGraphV3, OptionV3 } from '../types/engine-v3.js';
-import type { M1Coaching, EvidenceGap, Critique } from '../coaching/types.js';
+import type { M1Coaching } from '../coaching/types.js';
 import {
   interventionTargetIdsFromOptions,
   isOptionControlledLever,
@@ -25,8 +25,6 @@ import type {
   FragileEdgeData,
   RobustnessData,
   DeterministicCoachingData,
-  WinnerData,
-  FlipThresholdInputData,
 } from './validation/m1-review-types.js';
 import {
   computeFlipThresholdData,

--- a/src/cee/orchestrator.ts
+++ b/src/cee/orchestrator.ts
@@ -323,6 +323,7 @@ export async function runDecisionReviewViaV2Http(
   const requestId = callerRequestId ?? `cee-v2-${Date.now()}`;
 
   // Log v2 path entry for debugging
+  // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
   console.log('[CEE_V2_START]', JSON.stringify({
     base_url: env.baseUrl,
     timeout_ms: v2Config.timeoutMs,
@@ -339,10 +340,12 @@ export async function runDecisionReviewViaV2Http(
     // Verify v2 format - log first edge for debugging
     const firstEdge = draft?.graph?.edges?.[0];
     if (firstEdge) {
+      // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
       console.log(`[CEE_V2_VERIFY] draft-graph edge: effect_direction=${firstEdge.effect_direction} strength_std=${firstEdge.strength_std}`);
     }
 
     // Diagnostic logging for options request payload
+    // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
     console.log('[CEE_V2_OPTIONS_REQUEST]', JSON.stringify({
       draft_keys: draft ? Object.keys(draft) : 'DRAFT_UNDEFINED',
       graph_present: draft?.graph !== undefined,
@@ -483,7 +486,7 @@ function extractCeeReadiness(review: unknown): CeeReviewReadiness | undefined {
   };
 }
 
-function sdkSupportsReview(client: ReturnType<typeof createCEEClient>): boolean {
+function sdkSupportsReview(_client: ReturnType<typeof createCEEClient>): boolean {
   // TODO: Update when SDK v1.12.0 is published
   // return typeof (client as any).review === 'function';
   return false; // Currently SDK v1.11.1 does not have review()
@@ -552,7 +555,6 @@ export async function orchestrateCeeReview(
 
   // Sanitize request ID per M1 spec
   const sanitisedId = sanitizeRequestId(plotRequestId);
-  const wasSanitised = sanitisedId !== plotRequestId;
 
   // Diagnostic logging for CEE enrichment timeout investigation (Pino)
   const v2Enabled = isCeeSchemaV2Enabled();
@@ -631,6 +633,7 @@ export async function orchestrateCeeReview(
     } else if (isCeeSchemaV2Enabled()) {
       // V2 Path: Use direct HTTP with ?schema=v2 for v2 format responses
       // This path returns effect_direction, strength_std, observed_state fields
+      // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
       console.log('[CEE_ORCHESTRATOR] Using schema v2 HTTP path');
       const brief = 'Decision review for inference results';
       const briefContext = {

--- a/src/cee/validation/m1-review-validator.ts
+++ b/src/cee/validation/m1-review-validator.ts
@@ -26,11 +26,9 @@
 import type { M1Review, FlipThresholdInputData } from './m1-review-types.js';
 import {
   M1ReviewFailureCodes,
-  M1ReviewWarningCodes,
   M1_REVIEW_LIMITS,
   M1_REVIEW_GROUNDING_MAP,
   READINESS_RULES,
-  type GroundingType,
 } from './m1-review-constants.js';
 
 // =============================================================================

--- a/src/cee/validation/number-corrector.ts
+++ b/src/cee/validation/number-corrector.ts
@@ -10,7 +10,6 @@
 
 import type { M1Review } from './m1-review-types.js';
 import { M1_REVIEW_GROUNDING_MAP } from './m1-review-constants.js';
-import { extractNumbers } from './m1-review-validator.js';
 
 // =============================================================================
 // Types

--- a/src/coaching/assumptions-ledger.ts
+++ b/src/coaching/assumptions-ledger.ts
@@ -231,7 +231,7 @@ function extractISLAssumptions(inputs: CoachingInputs): AssumptionRecord[] {
  */
 function mapCEECritiqueToAssumption(
   critique: { type: string; message: string; severity?: string },
-  inputs: CoachingInputs
+  _inputs: CoachingInputs
 ): AssumptionRecord | null {
   // Only map critiques that represent assumptions (not all do)
   if (
@@ -269,7 +269,7 @@ function classifyRepairImpact(
     from_value: number | string | null;
     to_value: number | string;
   },
-  inputs: CoachingInputs
+  _inputs: CoachingInputs
 ): { level: 'high' | 'medium' | 'low'; code: AssumptionRecord['impact_reason_code'] } {
   // High impact: affects outcome directly
   if (
@@ -294,7 +294,7 @@ function classifyRepairImpact(
  */
 function classifyFactorImpact(
   factor: { node_id: string; label: string; elasticity?: number; influence_score?: number; importance_rank?: number },
-  inputs: CoachingInputs
+  _inputs: CoachingInputs
 ): { level: 'high' | 'medium' | 'low'; code: AssumptionRecord['impact_reason_code'] } {
   const influence = Math.abs(factor.elasticity ?? factor.influence_score ?? 0);
 

--- a/src/coaching/critiques.ts
+++ b/src/coaching/critiques.ts
@@ -4,7 +4,7 @@
  * Surfaces structural issues that may affect decision quality.
  */
 
-import type { CoachingInputs, Critique, CritiqueType } from './types.js';
+import type { CoachingInputs, Critique } from './types.js';
 import { getThresholds } from './thresholds.js';
 import { isInterventionOverride, filterInterventionOverrides } from './sensitivity-filter.js';
 

--- a/src/coaching/flip-thresholds.ts
+++ b/src/coaching/flip-thresholds.ts
@@ -17,7 +17,7 @@
  * @see Brief: M2 Decision Review Integration, Task 2
  */
 
-import type { EngineGraphV3, EngineNodeV3 } from '../types/engine-v3.js';
+import type { EngineGraphV3 } from '../types/engine-v3.js';
 import type { FlipThresholdInputData } from '../cee/validation/m1-review-types.js';
 
 // =============================================================================

--- a/src/coaching/types.ts
+++ b/src/coaching/types.ts
@@ -4,7 +4,7 @@
  * Type definitions for Phase 2 deterministic coaching layer.
  */
 
-import type { EngineGraphV3, OptionV3 } from '../types/engine-v3.js';
+import type { EngineGraphV3 } from '../types/engine-v3.js';
 import type { ReadinessTone, ReadinessToneReason } from './readiness-tone.js';
 
 // =============================================================================

--- a/src/config/timeouts.ts
+++ b/src/config/timeouts.ts
@@ -240,6 +240,7 @@ export const FASTIFY_REQUEST_TIMEOUT_MS = Number(
 
 /** Log all resolved timeout values. Call once at startup. */
 export function logResolvedTimeouts(): void {
+  // eslint-disable-next-line no-console -- startup diagnostic; boot logs are deliberately plain stdout, outside request scope (log-boundary.ts)
   console.log('[STARTUP] Resolved timeouts (ms):', {
     FASTIFY_REQUEST_TIMEOUT_MS,
     CEE_TIMEOUT_MS,
@@ -287,6 +288,7 @@ export function validateTimeoutChain(): boolean {
     return false;
   }
 
+  // eslint-disable-next-line no-console -- startup diagnostic; boot logs are deliberately plain stdout, outside request scope (log-boundary.ts)
   console.log('[STARTUP] ✓ Timeout chain valid:', {
     FASTIFY_REQUEST_TIMEOUT_MS,
     CEE_PROXY_TIMEOUT_MS,

--- a/src/critique-humaniser.ts
+++ b/src/critique-humaniser.ts
@@ -7,7 +7,7 @@
  * @see PLoT brief: critique message humanisation
  */
 
-import type { CritiqueV3, EngineGraphV3, OptionV3 } from './types/engine-v3.js';
+import type { CritiqueV3 } from './types/engine-v3.js';
 
 // ---------------------------------------------------------------------------
 // Minimal graph shape for label resolution

--- a/src/engine/correlation-sampling.ts
+++ b/src/engine/correlation-sampling.ts
@@ -346,7 +346,7 @@ export function validateCorrelationMatrix(
  */
 export function repairCorrelationMatrix(
   matrix: number[][],
-  minEigenvalue = 0
+  _minEigenvalue = 0
 ): number[][] | null {
   const n = matrix.length;
 

--- a/src/engine/edge-function-sensitivity.ts
+++ b/src/engine/edge-function-sensitivity.ts
@@ -8,7 +8,7 @@
  * and reports when ranking would change.
  */
 
-import type { Graph, GraphEdge, EdgeFunctionType } from '../trust/types.js';
+import type { Graph, EdgeFunctionType } from '../trust/types.js';
 import type { CoherenceWarning, CoherenceWarningCode } from '../trust/result-coherence.js';
 import { applyEdgeFunction } from './edge-functions.js';
 
@@ -83,7 +83,7 @@ export function getTopSensitiveEdges(
   edges: Array<{ from: string; to: string; weight?: number; belief?: number; function_type?: EdgeFunctionType }>,
   topN: number
 ): EdgeSensitivityData[] {
-  const scored = edges.map((edge, idx) => {
+  const scored = edges.map((edge) => {
     const weight = edge.weight ?? 1;
     const belief = edge.belief ?? 0.7;
     const score = Math.abs(weight) * belief;

--- a/src/engine/edge-functions.ts
+++ b/src/engine/edge-functions.ts
@@ -20,7 +20,7 @@
  * - noisy_and_not models preventative causes where active parents reduce probability
  */
 
-import type { GraphEdge, EdgeFunctionType, EdgeFunctionParams, FunctionalForm } from '../trust/types.js';
+import type { GraphEdge, EdgeFunctionParams, FunctionalForm } from '../trust/types.js';
 import { FLAGS } from '../config/flags.js';
 import { getFunctionalForm } from './edge-migration.js';
 

--- a/src/integrations/isl/adapters/factor-sensitivity.ts
+++ b/src/integrations/isl/adapters/factor-sensitivity.ts
@@ -66,10 +66,10 @@ export function adaptFactorSensitivityResponse(
 /**
  * Create a fallback factor sensitivity result when ISL is unavailable
  *
- * @param reason - Why fallback is being used
+ * @param _reason - Why fallback is being used
  * @returns Fallback factor sensitivity result
  */
-export function createFallbackFactorSensitivity(reason: string): PLoTFactorSensitivityResult {
+export function createFallbackFactorSensitivity(_reason: string): PLoTFactorSensitivityResult {
   return {
     factors: [],
     value_of_information: [],

--- a/src/integrations/isl/client.ts
+++ b/src/integrations/isl/client.ts
@@ -224,6 +224,7 @@ export class ISLClient {
         const duration = Date.now() - startTime;
 
         // Always log downstream elapsed time (not suppressed)
+        // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
         console.log(JSON.stringify({
           event: 'isl_downstream_elapsed',
           endpoint,

--- a/src/integrations/isl/compute-admission.ts
+++ b/src/integrations/isl/compute-admission.ts
@@ -761,7 +761,6 @@ export type AdmissionPlanningOutcome =
  */
 export async function resolveAdmissionForPlanning(): Promise<AdmissionPlanningOutcome> {
   const decide = (resolution: AdmissionResolution): AdmissionPlanningOutcome | null => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (resolution.status === 'disabled') {
       return { kind: 'plan', resolution, conservative: false };
     }

--- a/src/integrations/isl/index.ts
+++ b/src/integrations/isl/index.ts
@@ -72,7 +72,6 @@ import type {
   PLoTCounterfactualResult,
   PLoTFactorSensitivityResult,
   PLoTRobustnessAnalysisResult,
-  ISLPreflightResult,
 } from './types/plot-types.js';
 import type { Graph } from '../../trust/types.js';
 import { DEFAULT_EXISTS_PROBABILITY } from '../../constants/limits.js';
@@ -395,6 +394,7 @@ export function createISLService(): ISLService {
         };
 
         if (ISL_DEBUG) {
+          // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
           console.log(JSON.stringify({
             level: 'debug', time: Date.now(),
             event: 'isl_parameter_uncertainties_passthrough',
@@ -491,6 +491,7 @@ export function createISLService(): ISLService {
           preflight_factor_status: preflight.factor_sensitivity_status,
           analysis_types: ['comparison', 'sensitivity', 'robustness'],
         };
+        // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
         console.log(JSON.stringify(islRequestLog));
 
         // Build ISL request payload with all three analysis types
@@ -536,6 +537,7 @@ export function createISLService(): ISLService {
         };
 
         if (ISL_DEBUG) {
+          // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
           console.log(JSON.stringify({
             level: 'debug', time: Date.now(),
             event: 'isl_parameter_uncertainties_passthrough',
@@ -592,6 +594,7 @@ export function createISLService(): ISLService {
           option_comparison_count: response.results?.length ?? 0,
           has_voi: response.factor_sensitivity?.some((f) => typeof f.value_of_information === 'number' && f.value_of_information > 0) ?? false,
         };
+        // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
         console.log(JSON.stringify(islResponseLog));
 
         return adaptRobustnessAnalysisResponse(response, durationMs, actualEdgeStatus, actualFactorStatus);
@@ -620,6 +623,7 @@ export function createISLService(): ISLService {
           preflight_edge_status: preflight.edge_sensitivity_status,
           preflight_factor_status: preflight.factor_sensitivity_status,
         };
+        // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
         console.log(JSON.stringify(islErrorLog));
 
         logError('isl_robustness_analysis_failed', error, requestId);

--- a/src/integrations/isl/preflight.ts
+++ b/src/integrations/isl/preflight.ts
@@ -265,6 +265,7 @@ export function logPreflightResult(
     factor_sensitivity_status: preflight.factor_sensitivity_status,
     skip_reasons: preflight.skipReasons,
   };
+  // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
   console.log(JSON.stringify(entry));
 }
 

--- a/src/lib/retry-strategy.ts
+++ b/src/lib/retry-strategy.ts
@@ -315,6 +315,7 @@ export async function withRetry<T>(
 
     try {
       // Log attempt
+      // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
       console.log(
         JSON.stringify({
           event: 'retry_attempt',
@@ -337,6 +338,7 @@ export async function withRetry<T>(
       const isLastAttempt = attempt >= config.maxAttempts - 1;
 
       // Log failure
+      // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
       console.log(
         JSON.stringify({
           event: 'retry_failure',

--- a/src/logging/preflight-logger.ts
+++ b/src/logging/preflight-logger.ts
@@ -268,6 +268,7 @@ export function addISLResponseToLog(
  * Uses structured JSON logging.
  */
 export function logPreflight(entry: PreflightLogEntry): void {
+  // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
   console.log(JSON.stringify(entry));
 }
 
@@ -277,5 +278,6 @@ export function logPreflight(entry: PreflightLogEntry): void {
  * Uses structured JSON logging.
  */
 export function logISLCall(entry: ISLCallLogEntry): void {
+  // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
   console.log(JSON.stringify(entry));
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ async function start() {
   validateTimeoutChain();
 
   // CEE config diagnostic - helps debug V2 path activation and timeout issues
+  // eslint-disable-next-line no-console -- startup diagnostic; boot logs are deliberately plain stdout, outside request scope (log-boundary.ts)
   console.log('[STARTUP] CEE config:', {
     CEE_TIMEOUT_MS: process.env.CEE_TIMEOUT_MS,
     CEE_TIMEOUT_MS_parsed: Number(process.env.CEE_TIMEOUT_MS),
@@ -48,6 +49,7 @@ async function start() {
   // NAMED skew state, boot proceeds, and the route's conservative disclosure
   // covers the gap until the background refresh heals it.
   const admissionWarm = await warmIslComputeAdmission();
+  // eslint-disable-next-line no-console -- startup diagnostic; boot logs are deliberately plain stdout, outside request scope (log-boundary.ts)
   console.log('[STARTUP] ISL compute-admission warm:', {
     status: admissionWarm.status,
     advertised_version: admissionWarm.advertisedVersion ?? null,

--- a/src/normalisation/canonicalise.ts
+++ b/src/normalisation/canonicalise.ts
@@ -107,7 +107,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import type { RunRequestV3, OptionV3, EngineGraphV3, GoalConstraint, IdentifiabilityAssessment, FactorStabilityEntry } from '../types/engine-v3.js';
+import type { RunRequestV3, OptionV3, EngineGraphV3, IdentifiabilityAssessment, FactorStabilityEntry } from '../types/engine-v3.js';
 import { STANDARD_N_SAMPLES_DEFAULT } from '../config/sampling.js';
 
 // -----------------------------------------------------------------------------
@@ -156,12 +156,6 @@ function canonicaliseNumber(value: number | undefined | null): number {
   return normaliseFloat(value);
 }
 
-/**
- * Normalise an optional float (undefined-safe).
- */
-function normaliseOptionalFloat(n: number | undefined): number | undefined {
-  return n !== undefined ? normaliseFloat(n) : undefined;
-}
 
 // -----------------------------------------------------------------------------
 // Canonical Node

--- a/src/normalisation/constraint-compiler.ts
+++ b/src/normalisation/constraint-compiler.ts
@@ -22,10 +22,6 @@ import type { EngineGraphV3, EngineNodeV3, EngineEdgeV3, GoalConstraint, RawGoal
  */
 const INFERENCE_PARTICIPATING_KINDS = ['goal', 'factor', 'outcome', 'risk', 'action'] as const;
 
-/**
- * Node kinds excluded from inference.
- */
-const INFERENCE_EXCLUDED_KINDS = ['decision', 'option', 'constraint'] as const;
 
 /**
  * Valid constraint operators.

--- a/src/normalisation/normalise-and-repair.ts
+++ b/src/normalisation/normalise-and-repair.ts
@@ -10,7 +10,7 @@
  * @see repair-codes.ts for the canonical repair code enum (SSOT)
  */
 
-import { normaliseGraph, NormalisationError, type NormalisationWarning, type NormalisationResult } from './graph-normaliser.js';
+import { normaliseGraph, type NormalisationWarning, type NormalisationResult } from './graph-normaliser.js';
 import type { RepairEntry, RepairCode, RepairAction } from './repair-codes.js';
 import { REPAIR_CODES } from './repair-codes.js';
 import type { UpstreamGraph, EngineGraphV3, EngineEdgeV3 } from '../types/engine-v3.js';

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -15,7 +15,7 @@ import { getCeeCircuitBreakerStats } from '../cee/circuit-breaker.js';
 import { getIslCircuitBreakerStats } from '../integrations/isl-circuit-breaker.js';
 import { getRouteCallerSnapshot } from '../observability/routeCallerTelemetry.js';
 import { WEIGHT_SCHEMAS, DEFAULT_WEIGHT_SCHEMA, type WeightSchemaVersion } from '../engine/weight-schema.js';
-import { getBeliefSpreadCapability, CURRENT_BELIEF_SPREAD_VERSION } from '../engine/belief-spread.js';
+import { getBeliefSpreadCapability } from '../engine/belief-spread.js';
 
 export interface HealthRoutesOptions {
   enableTestRoutes?: boolean;

--- a/src/routes/v1/cee-draft-graph.ts
+++ b/src/routes/v1/cee-draft-graph.ts
@@ -21,11 +21,7 @@ import { replyWithAppError } from '../../errors.js';
 import { CEE_PROXY_TIMEOUT_MS } from '../../config/timeouts.js';
 import { CEE_PROXY_BODY_LIMIT } from '../../config/constants.js';
 // CIL Phase 1: Shared error schemas from @talchain/schemas
-import {
-  CeeTypedErrorSchema,
-  PlotCeeUpstreamEnvelopeSchema,
-  PlotProxyTimeoutErrorSchema,
-} from '@talchain/schemas';
+import { CeeTypedErrorSchema } from '@talchain/schemas';
 import type { PlotCeeUpstreamEnvelope, PlotProxyTimeoutError } from '@talchain/schemas';
 
 export async function registerCeeDraftGraphRoute(app: FastifyInstance) {

--- a/src/routes/v1/helpers/cee-integration.ts
+++ b/src/routes/v1/helpers/cee-integration.ts
@@ -6,7 +6,7 @@
  */
 
 import type { FastifyRequest, FastifyReply } from 'fastify';
-import { normalizeCeeCode, isFlagOn } from '../../../cee/codes.js';
+import { normalizeCeeCode } from '../../../cee/codes.js';
 import { shouldAllowCeeCall, recordCeeSuccess, recordCeeFailure } from '../../../cee/circuit-breaker.js';
 import { callDecisionReviewFromEngine } from '../../../cee/client.js';
 import type { CeeTrace } from '../../../cee/types.js';

--- a/src/routes/v1/key-insight.ts
+++ b/src/routes/v1/key-insight.ts
@@ -380,13 +380,11 @@ export async function registerKeyInsightRoute(app: FastifyInstance) {
       // Detect primary outcome
       const seed = body.seed ?? 4242;
       let outcomeNode: string = body.outcome_node ?? '';
-      let outcomeInferred = false;
 
       if (!outcomeNode) {
         const detection = detectPrimaryOutcome(graph);
         if (detection.detected && detection.node_id) {
           outcomeNode = detection.node_id;
-          outcomeInferred = true;
           warnings.push({
             code: 'PRIMARY_OUTCOME_INFERRED',
             message: `Primary outcome inferred as '${detection.node_id}' (${detection.strategy})`,
@@ -395,7 +393,6 @@ export async function registerKeyInsightRoute(app: FastifyInstance) {
           });
         } else {
           outcomeNode = graph.nodes[graph.nodes.length - 1]?.id ?? '';
-          outcomeInferred = true;
           warnings.push({
             code: 'PRIMARY_OUTCOME_INFERRED',
             message: `No outcome node detected; using last node '${outcomeNode}'`,
@@ -436,7 +433,6 @@ export async function registerKeyInsightRoute(app: FastifyInstance) {
       // For a single graph, we have one result - would need multiple options for ranking
       // In this case, we extract option nodes and their contributions
       const optionNodes = graph.nodes.filter((n: any) => n.kind === 'option' || n.kind === 'action');
-      const baselineValue = 100;
 
       const rankedActions: RankedAction[] = [];
 

--- a/src/routes/v1/run.ts
+++ b/src/routes/v1/run.ts
@@ -20,8 +20,6 @@ import type {
   RunResponseEnrichment,
   CausalValidationEnrichment,
   SensitivityAnalysisEnrichment,
-  FactorSensitivityEnrichment,
-  VOIEnrichment,
 } from '../../trust/types.js';
 import { DETAIL_LEVEL_CONFIG } from '../../trust/types.js';
 import { getInferenceEngine } from '../../inference/index.js';
@@ -44,7 +42,7 @@ import {
   recordMetaReasoningMetrics,
 } from '../../metrics/registry.js';
 import { normalizeCeeCode, isFlagOn } from '../../cee/codes.js';
-import { shouldAllowCeeCall, recordCeeSuccess, recordCeeFailure } from '../../cee/circuit-breaker.js';
+import { shouldAllowCeeCall } from '../../cee/circuit-breaker.js';
 // runResponseSchema used in OpenAPI documentation
 import { normalizeGraphWithWarnings } from '../../util/normalize.js';
 import { FLAGS } from '../../config/flags.js';
@@ -131,7 +129,7 @@ function transformSensitivityToEnrichment(
   if (!sensitivity) return undefined;
 
   // Build edge list from sensitive parameters - map to new EdgeSensitivityEnrichment format
-  const edges: SensitivityAnalysisEnrichment['edges'] = sensitivity.sensitive_parameters.map((param, idx) => {
+  const edges: SensitivityAnalysisEnrichment['edges'] = sensitivity.sensitive_parameters.map((param) => {
     // Try to find the corresponding edge in the graph
     const edge = graph.edges.find((e: any) =>
       param.parameter === `${e.from}->${e.to}` ||
@@ -404,6 +402,7 @@ export async function registerRunRoute(app: FastifyInstance) {
         graph_summary: graphSummary,
         detail_level: body.detail_level ?? 'standard',
       };
+      // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
       console.log(JSON.stringify(entryLog));
     } catch { /* ignore logging errors */ }
     
@@ -1152,6 +1151,7 @@ export async function registerRunRoute(app: FastifyInstance) {
         isl_sensitivity_robustness: isl_sensitivity?.overall_robustness,
         identifiable: identifiability.identifiable,
       };
+      // eslint-disable-next-line no-console -- structured log on the sanctioned console channel (Wave1-L1 boundary arm 2, src/logging/log-boundary.ts); no redaction-covered standalone logger exists
       console.log(JSON.stringify(critiqueLog));
     } catch { /* ignore logging errors */ }
 

--- a/src/routes/v1/simulate-batch.ts
+++ b/src/routes/v1/simulate-batch.ts
@@ -20,7 +20,6 @@ import {
   getSamplingMetrics,
 } from '../../sampling/engine.js';
 import { getTraceCache } from '../../sampling/trace-cache.js';
-import { hashGraph } from '../../sampling/graph-hash.js';
 import type {
   BatchSimulationRequest,
   BatchSimulationResponse,

--- a/src/routes/v1/suggest-edge-function.ts
+++ b/src/routes/v1/suggest-edge-function.ts
@@ -112,8 +112,8 @@ async function callCeeSuggestEdgeFunction(
  * Generate fallback edge function suggestion when CEE is unavailable
  */
 function generateFallbackSuggestion(
-  sourceNode: EdgeNodeContext,
-  targetNode: EdgeNodeContext
+  _sourceNode: EdgeNodeContext,
+  _targetNode: EdgeNodeContext
 ): CeeEdgeFunctionSuggestionResponse {
   return {
     suggested_function: 'linear',

--- a/src/routes/v1/types/proxy.types.ts
+++ b/src/routes/v1/types/proxy.types.ts
@@ -709,7 +709,7 @@ export interface ProxyRequestContext {
 // Edge Function Suggestion Types
 // ============================================================================
 
-import type { EdgeFunctionType, EdgeFunctionParams, StageDefinition, SequentialMetadata } from '../../../trust/types.js';
+import type { EdgeFunctionType, EdgeFunctionParams, SequentialMetadata } from '../../../trust/types.js';
 
 /**
  * Node context for edge function suggestion

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -79,7 +79,7 @@ import { compileConstraintNodes } from '../../normalisation/constraint-compiler.
 import { filterTemporalConstraints } from '../../normalisation/constraint-filter.js';
 import { REPAIR_CODES } from '../../normalisation/repair-codes.js';
 import { MAX_CONSTRAINTS } from '../../constants/limits.js';
-import type { RawGoalConstraint, FilteredConstraintRecord, InternalMetadata } from '../../types/engine-v3.js';
+import type { RawGoalConstraint, InternalMetadata } from '../../types/engine-v3.js';
 import type { IslThresholdResponse, ThresholdPoint } from '../v1/types/proxy.types.js';
 import { toISLRobustnessRequest, validateISLRequest, buildParameterUncertaintiesV3, parseGoalThresholdFrame } from '../../integrations/isl/translator-v3.js';
 import { injectConstraintParameterUncertainties, selectConstraintInjectedPuNodeIds } from '../../integrations/isl/constraint-pu-injection.js';
@@ -100,7 +100,7 @@ import {
   normalizeRobustEdges,
 } from '../../integrations/isl/adapters/robustness-analysis.js';
 import { deriveRobustnessDisplayVerdict } from './robustness-display-verdict.js';
-import type { RobustnessDataForCee, NormalizedEdgeInfo } from '../../integrations/isl/types/plot-types.js';
+import type { RobustnessDataForCee } from '../../integrations/isl/types/plot-types.js';
 import type { ISLConstraintResult, ISLEdgeEValue, ISLConditionalWinner } from '../../integrations/isl/types/isl-types.js';
 import { getIslEdgeEValues, getIslEdgeSensitivity, getIslComputedAt } from '../../integrations/isl/v2-envelope.js';
 import { V2_RUN_ALLOWED_KEYS, islEnrichmentPassthrough } from './run-contract-keys.js';
@@ -141,7 +141,7 @@ import { FLAGS } from '../../config/flags.js';
 import { getAllFeatureFlags } from '../../config/feature-flags.js';
 import { resolveStandardNSamples, ADAPTIVE_N_SAMPLES_FLOOR, planSampleDepth, checkAdmissionCaps, type DepthPlanInput, type AdmissionCapsDecision, type AdmissionCapDimension, type DepthReductionReason } from '../../config/sampling.js';
 import { LIMITS_MAX_NODES, LIMITS_MAX_EDGES, LIMITS_MAX_OPTIONS } from '../../config/constants.js';
-import { getIslComputeAdmission, resolveAdmissionForPlanning, shouldPlanConservatively } from '../../integrations/isl/compute-admission.js';
+import { resolveAdmissionForPlanning } from '../../integrations/isl/compute-admission.js';
 import { generateM1Coaching } from '../../coaching/m1-coaching.js';
 import { filterInterventionOverrides } from '../../coaching/sensitivity-filter.js';
 import type { M1Review } from '../../cee/validation/m1-review-types.js';

--- a/src/sampling/advanced-sampling.ts
+++ b/src/sampling/advanced-sampling.ts
@@ -17,20 +17,6 @@ import type {
 } from './types.js';
 
 /**
- * Stratum definition for stratified sampling
- */
-interface Stratum {
-  /** Parameter name */
-  param: string;
-  /** Lower bound of stratum */
-  lower: number;
-  /** Upper bound of stratum */
-  upper: number;
-  /** Target number of samples from this stratum */
-  target_samples: number;
-}
-
-/**
  * Importance weight for a sample
  */
 interface ImportanceWeight {
@@ -82,7 +68,7 @@ export function generateStratifiedSamples(
     if (paramIndex >= nParams) {
       // Generate samples for this stratum
       for (let i = 0; i < samplesPerStratum && result.length < totalSamples; i++) {
-        const sample = accumulator.map((stratumIdx, pIdx) => {
+        const sample = accumulator.map((stratumIdx) => {
           // Sample uniformly within the stratum
           const stratumSize = 1.0 / nStrata;
           const lower = stratumIdx * stratumSize;

--- a/src/sampling/engine.ts
+++ b/src/sampling/engine.ts
@@ -11,15 +11,12 @@ import { createHash } from 'node:crypto';
 import type {
   SimulationTraces,
   Trace,
-  TraceMeta,
-  TraceAggregates,
   Distribution,
   TraceConfig,
   Perturbation,
   BatchSimulationRequest,
   BatchSimulationResponse,
   SamplingMetrics,
-  SAMPLING_CONFIG_VERSION,
 } from './types.js';
 import { SAMPLING_CONFIG_VERSION as CONFIG_VERSION } from './types.js';
 import { hashGraph, generateSeedSequence } from './graph-hash.js';
@@ -28,7 +25,7 @@ import { XorShift128Plus } from '../scm-lite/rng.js';
 import { applyEdgeFunction } from '../engine/edge-functions.js';
 import { FLAGS } from '../config/flags.js';
 import { getBeliefExists, getEdgeStd, sampleNormal } from '../engine/edge-migration.js';
-import type { Intervention, InferenceMode } from '../scm-lite/types.js';
+import type { InferenceMode } from '../scm-lite/types.js';
 
 import type { FunctionalForm, EdgeFunctionType } from '../trust/types.js';
 
@@ -271,7 +268,6 @@ export function generateTraces(
   graph: GraphInput,
   config: TraceConfig
 ): SimulationTraces {
-  const startTime = performance.now();
   const timing: TimingTracker = { sampling_ms: 0, propagation_ms: 0, aggregation_ms: 0 };
 
   // Configuration

--- a/src/trust/drivers-builder.ts
+++ b/src/trust/drivers-builder.ts
@@ -9,8 +9,6 @@ import type { SensitivityEdge } from '../lib/sensitivity-simple.js';
 import type {
   DriversPayload,
   DriverItem,
-  DriversStatus,
-  RemediationAction,
   DiscriminationSignal,
 } from '../types/drivers.js';
 

--- a/src/trust/option-probabilities.ts
+++ b/src/trust/option-probabilities.ts
@@ -8,7 +8,7 @@
  * based on actual conditional probability from Monte Carlo simulation.
  */
 
-import { computeThresholdProbability, type ThresholdProbabilityResult } from '../scm-lite/kernel.js';
+import { computeThresholdProbability } from '../scm-lite/kernel.js';
 import type { DAG } from '../scm-lite/types.js';
 import { MAX_NODES, MAX_EDGES } from '../constants/limits.js';
 
@@ -189,7 +189,7 @@ export function computeOptionProbabilities(
         goal_probability: Math.round(thresholdResult.probability * 1000) / 1000,
         confidence: Math.round(thresholdResult.confidence * 1000) / 1000,
       };
-    } catch (err) {
+    } catch {
       // Log error but continue with other options
       // Option may be isolated or have graph issues
       result[option.id] = {

--- a/src/util/sequential-validation.ts
+++ b/src/util/sequential-validation.ts
@@ -162,7 +162,6 @@ export function validateSequentialGraph(graph: Graph): SequentialValidationResul
   const graphNodes = asArray<GraphNode>(graph?.nodes);
   const graphEdges = asArray<GraphEdge>(graph?.edges);
   const nodeMap = new Map<string, GraphNode>(graphNodes.map((n) => [n.id, n]));
-  const edgeMap = buildEdgeMap(graphEdges);
   const nodesByStage = new Map<number, string[]>();
 
   // If no sequential_metadata, check for node-level stage assignments
@@ -367,19 +366,6 @@ function buildNodeStageMap(graph: Graph): Map<string, number> {
   return nodeStages;
 }
 
-/**
- * Build adjacency map for edges
- */
-function buildEdgeMap(edges: GraphEdge[]): Map<string, string[]> {
-  const edgeMap = new Map<string, string[]>();
-  for (const edge of asArray<GraphEdge>(edges)) {
-    if (!edge || typeof edge !== 'object') continue;
-    const targets = edgeMap.get(edge.from) ?? [];
-    targets.push(edge.to);
-    edgeMap.set(edge.from, targets);
-  }
-  return edgeMap;
-}
 
 /**
  * Check if a graph is sequential (has multi-stage structure)

--- a/src/validation/preflight-v2.ts
+++ b/src/validation/preflight-v2.ts
@@ -27,7 +27,6 @@ import type {
 import {
   validateOptionPaths,
   allOptionsHavePaths,
-  getBlockedInterventionTargets,
   buildAdjacencyList,
   checkPathToGoal,
 } from './path-to-goal.js';
@@ -472,7 +471,6 @@ function validatePathsToGoal(
 
   // Generate critiques for options without paths
   const critiques: CritiqueV3[] = [];
-  const blockedTargets = getBlockedInterventionTargets(pathResults);
 
   for (const result of pathResults.values()) {
     if (!result.hasPath) {

--- a/tests/golden/integration.test.ts
+++ b/tests/golden/integration.test.ts
@@ -224,7 +224,6 @@ describe('Golden Integration: ISL -> PLoT Transformation', () => {
        * implementation, so it doesn't contain these fields. We test the transformation logic
        * directly by simulating the spread pattern used in src/routes/v2/run.ts:733-741.
        */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const islRobustness = islResponse.robustness as any;
 
       it('ISL provides is_robust, level, confidence fields', () => {
@@ -537,9 +536,7 @@ describe('Golden Integration: ISL -> PLoT Transformation', () => {
 
     // Full CEE assertions - only reached if CEE graph data AND ISL request present
     describe('CEE-ISL Coherence', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const islRequest = ceeScenario.islRequest as any;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const islResponse = ceeScenario.islResponse as any;
       const ceeGraphData = ceeScenario.ceeGraph as CEEGraph;
 


### PR DESCRIPTION
# DO NOT MERGE — orchestrator merges after adversarial review

## ROADMAP 2.465 — kill the lint split-brain: `npm run lint` green at `--max-warnings 0`, CI runs the same command

### The defect (re-derived at pristine `d011b996`, not inherited from the brief)
- Local `npm run lint` (`eslint src tests --ext .ts --max-warnings 0`): **exit 1, 90 warnings, 0 errors** (brief quoted 93 at the same SHA; 90 is the measured figure — full output archived in lane evidence).
- CI lint-command manifest (complete, from `.github/workflows/*`): exactly **two** steps run eslint, both `npx eslint src tests --ext .ts --max-warnings 97` — `ci.yml:29` and `pr-verify.yml:24`. No other workflow runs eslint (spectral/redocly OpenAPI lint and olumi-tools pack-lint are different tools). So the split-brain is npm-script(0) vs CI(97) in two places, same flags.

### Pristine warning breakdown
61 `@typescript-eslint/no-unused-vars` · 25 `no-console` · 4 unused eslint-disable directives, across 42 src files + 1 test file.

### Per-class fix table
| Class | Count | Treatment |
|---|---|---|
| Unused named imports | 37 | Name removed from import list (2 whole-line removals: `extractNumbers`, `hashGraph` — pure util modules, no side-effect loss) |
| Unused function args | 8 | Underscore-prefixed — sanctioned by config `argsIgnorePattern: '^_'`; no arity/signature change |
| Unused callback params | 3 | Dropped (`idx` ×2, `pIdx`) — JS callback arity, zero behaviour change |
| Unused `catch (err)` | 2 | `catch {` (optional catch binding); blocks verified to not reference `err` |
| Dead locals, pure RHS | 8 | Statement removed; each RHS verified side-effect-free (`wasSanitised`, `outcomeInferred` + 2 assignments, `baselineValue`, `startTime` — the unused one; the used twin at engine.ts:443 untouched — `edgeMap`, `blockedTargets`) |
| Dead module-local declarations | 4 | Removed: `INFERENCE_EXCLUDED_KINDS`, `normaliseOptionalFloat`, `interface Stratum`, and cascade `buildEdgeMap` (only caller was the dead local) |
| Unused eslint-disable directives | 4 | Removed |
| `no-console` | 25 | Per-site `// eslint-disable-next-line no-console -- <reason>`; never file-level or global |

### Why per-site disables for `no-console` (the load-bearing finding)
The repo's Wave1-L1 logger boundary (`src/logging/log-boundary.ts`) names `console.*` as a first-class log channel (arm 2, `installConsoleBoundary()` = PII redaction). These 25 sites are load-bearing structured observability (dashboards parse their `event:` fields, per that file's own doc). **Swapping them to pino would escape the redaction boundary**: redaction is installed on the Fastify pino instance (`createServer.ts`), and no shared redaction-covered standalone logger exists — a new `pino()` would be un-redacted. Deleting the sites changes the observability surface. Both alternatives are behavioural; disables-with-reason are the only lint-frame-only fix.

### CI alignment
Both workflow steps now `run: npm run lint`. The npm script is the single command and single threshold; the comment at each site explains why an inline eslint command must never return.

### Behaviour preservation (this diff is lint-frame only)
- 45 files, +69/−110. Complete non-comment/non-import added- and removed-line audits are in the lane evidence: only the classes in the table above appear. **Zero changes to live control flow or computed values.**
- Gates at this head: `npm run lint` exit 0 · `npm run build` exit 0 · `npm run typecheck` exit 0 · `npm run validate:contracts` 0 failed · full `RATE_LIMIT_ENABLED=0 CI=true npm test` (result in evidence + comments).

### Flagged judgment calls (NOT changed)
1. **Real latent defect found**: `repairCorrelationMatrix(matrix, _minEigenvalue = 0)` ignores its second parameter, and a real caller (`correlation-sampling.ts:320`) passes `cfg.min_eigenvalue` — the config knob does nothing. Needs its own ROADMAP row.
2. `sdkSupportsReview(_client)` hardcodes `false` (TODO SDK v1.12.0) — param kept.
3. `outcomeInferred` / `wasSanitised` look like they were meant to be surfaced in warnings/logs and never were; removal preserves current behaviour.
4. A disable for `@typescript-eslint/no-unnecessary-condition` existed although that rule is not enabled in `eslint.config.js` (now removed).

Evidence: `PHASE0-EVIDENCE-2026-07-28/lane-2465-plotlint-2026-08-04.md` (orchestrator estate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
