### PR TITLE
Fix 2.480(a) P1: never coalesce an absent ISL mean to zero

### DIFF
--- a/src/cee/decision-review-request.ts
+++ b/src/cee/decision-review-request.ts
@@ -167,12 +167,17 @@ export function buildDecisionReviewRequest(
       robustness,
     },
     deterministic_coaching: deterministicCoaching,
+    // 2.480(a): outcome_mean is emitted ONLY when extractOptionComparison
+    // measured one. The key is omitted rather than sent as an explicit
+    // undefined, so the in-memory object and the wire agree.
     winner: winner
       ? {
           id: winner.option_id,
           label: winner.option_label ?? winner.option_id,
           win_probability: winner.win_probability,
-          outcome_mean: winner.expected_outcome,
+          ...(winner.expected_outcome !== undefined
+            ? { outcome_mean: winner.expected_outcome }
+            : {}),
         }
       : { id: '', label: '', win_probability: 0 },
     runner_up: runnerUp
@@ -180,7 +185,9 @@ export function buildDecisionReviewRequest(
           id: runnerUp.option_id,
           label: runnerUp.option_label ?? runnerUp.option_id,
           win_probability: runnerUp.win_probability,
-          outcome_mean: runnerUp.expected_outcome,
+          ...(runnerUp.expected_outcome !== undefined
+            ? { outcome_mean: runnerUp.expected_outcome }
+            : {}),
         }
       : null,
     flip_threshold_data: flipThresholdData,
@@ -241,11 +248,32 @@ function extractOptionComparison(
     const optionId = opt.option_id ?? opt.id ?? '';
     const requestOption = options.find((o) => o.id === optionId);
 
+    // ROADMAP 2.480(a) — never coalesce an absent expected outcome to 0.
+    //
+    // ISL #125 made `outcome.mean` Optional: it is OMITTED when the option's
+    // Monte Carlo produced no finite draws, because there is no honest mean for
+    // a distribution with no draws. This previously ended `?? 0`, which handed
+    // CEE a fabricated zero as a GROUNDED ISL figure — it egresses here as
+    // `isl_results.option_comparison[].expected_outcome` and, via
+    // getWinnerAndRunnerUp, as `winner`/`runner_up.outcome_mean`, i.e. straight
+    // into the reviewing model's context as a measured number.
+    //
+    // The option itself stays VISIBLE (silent loss would be the other dishonest
+    // answer); only the unmeasurable number is absent. This now matches the
+    // already-honest sibling builder `buildIslResultsForCorrection`
+    // (decision-review-orchestrator.ts), whose consumer number-corrector.ts
+    // branches on `expected_outcome !== undefined`, and the same treatment
+    // `switch_probability` received on FragileEdgeData. A MEASURED 0 is a real
+    // measurement and is preserved.
+    const measuredOutcome = opt.expected_outcome ?? opt.outcome?.mean;
+
     return {
       option_id: optionId,
       option_label: requestOption?.label ?? opt.option_label ?? opt.label ?? optionId,
       win_probability: opt.win_probability ?? 0,
-      expected_outcome: opt.expected_outcome ?? opt.outcome?.mean ?? 0,
+      ...(typeof measuredOutcome === 'number' && Number.isFinite(measuredOutcome)
+        ? { expected_outcome: measuredOutcome }
+        : {}),
     };
   });
 }

--- a/src/cee/validation/m1-review-types.ts
+++ b/src/cee/validation/m1-review-types.ts
@@ -212,7 +212,18 @@ export interface OptionComparisonData {
   option_id: string;
   option_label: string;
   win_probability: number;
-  expected_outcome: number;
+  /**
+   * OPTIONAL: absent when ISL did not measure a finite outcome for this option.
+   *
+   * ISL #125 made `outcome.mean` Optional — omitted (never null, never 0.0) when
+   * the option's Monte Carlo produced no finite draws. Previously required,
+   * which forced `extractOptionComparison` to default a missing value to 0 —
+   * telling CEE "this option's expected outcome is zero" where the truth was
+   * "not computed", and putting that fabricated 0 into the model's grounded-number
+   * context. Optional so that absence is representable; consumers MUST branch on
+   * presence, never coalesce. (Same treatment as FragileEdgeData.switch_probability.)
+   */
+  expected_outcome?: number;
 }
 
 /**

--- a/src/coaching/normalise-inputs.ts
+++ b/src/coaching/normalise-inputs.ts
@@ -139,7 +139,21 @@ export function normaliseCoachingInputs(
         id: islOpt.id,
         label: matchingOption?.label ?? islOpt.label ?? islOpt.id,
         winProbability: islOpt.win_probability ?? 0,
-        outcomeMean: islOpt.outcome?.mean ?? 0,
+        // ROADMAP 2.480(a) — outcomeMean obeys the same never-coalesce rule this
+        // file states above for switch_probability, and for the same reason.
+        // ISL #125 made `outcome.mean` Optional: it is OMITTED when the option's
+        // Monte Carlo produced no finite draws (n_valid_samples === 0,
+        // percentiles_source === 'unavailable'), because there is no honest mean
+        // for a distribution with no draws. This previously read `?? 0`, which
+        // turned that honest absence into the assertion "measured, and it is
+        // zero" — and did not even guard non-finiteness, since `??` passes NaN
+        // straight through. ONLY a measured, finite mean populates outcomeMean;
+        // absence propagates as absence, exactly like outcomeP10/outcomeP90
+        // below and like switchProb above. A MEASURED 0 is a real measurement
+        // and is preserved.
+        ...(typeof islOpt.outcome?.mean === 'number' && Number.isFinite(islOpt.outcome.mean)
+          ? { outcomeMean: islOpt.outcome.mean }
+          : {}),
         outcomeP10: islOpt.outcome?.p10,
         outcomeP90: islOpt.outcome?.p90,
       };

--- a/src/coaching/types.ts
+++ b/src/coaching/types.ts
@@ -45,7 +45,18 @@ export interface NormalisedOption {
   id: string;
   label: string;
   winProbability: number;
-  outcomeMean: number;
+  /**
+   * OPTIONAL: absent when ISL did not measure a finite mean for this option.
+   *
+   * ISL #125 made `outcome.mean` Optional — omitted (never null, never 0.0) when
+   * the option's Monte Carlo produced no finite draws. Previously required here,
+   * which forced `normaliseCoachingInputs` to coalesce a missing value to 0 —
+   * asserting "this option's expected outcome was measured at zero" where the
+   * truth was "not computed". Optional so that absence is representable, per the
+   * never-coalesce rule this module states for switch_probability. Consumers
+   * MUST branch on presence and MUST omit anything derived from it.
+   */
+  outcomeMean?: number;
   outcomeP10: number | undefined;
   outcomeP90: number | undefined;
 }

--- a/tests/isl-absent-outcome-mean-honesty.test.ts
+++ b/tests/isl-absent-outcome-mean-honesty.test.ts
@@ -28,12 +28,21 @@
  * whose consumer `number-corrector.ts:158` branches on `!== undefined`).
  *
  * FIXTURE PROVENANCE — pinned to a historical artefact, not to "current" (trap 12b).
- * The degenerate shape below is transcribed from ISL's OWN contract test at that
- * pinned SHA, `tests/integration/test_numerics_honesty_batch.py`
- * (`TestAllNonFiniteOptionShipsOn200`): `status: 'failed'`, `n_valid_samples: 0`,
+ * Field shapes are transcribed from ISL at the pinned SHA: the absent-stat shape
+ * from `tests/integration/test_numerics_honesty_batch.py`
+ * (`TestAllNonFiniteOptionShipsOn200` — `n_valid_samples: 0`,
  * `validity_ratio: 0.0`, `percentiles_source: 'unavailable'`, `mean`/`std`/
- * `downside` ABSENT — never null, never a fabricated 0.0 — plus a
- * MONTE_CARLO_FAILED blocker critique naming the option, and a healthy sibling.
+ * `downside` ABSENT, never null and never a fabricated 0.0), and the critique
+ * severities from `src/models/critique.py`. See the reachability note on
+ * `makeIslResult` for why this fixture is NON-blocking rather than a copy of
+ * that test's blocker case.
+ *
+ * ⚠ WHAT THESE TESTS DO NOT SHOW. They pin two builders in isolation. They are
+ * not evidence that the degeneracy is DISCLOSED to whoever reads the output —
+ * for site 2 it demonstrably is not: the decision-review payload has no
+ * `critiques` key at all, and an `option_comparison` entry reduces to
+ * `{option_id, option_label, win_probability}`. Absence is honest; absence with
+ * no stated reason is not the same thing as disclosure. Rowed separately.
  *
  * EVERY assertion binds to its option by IDENTITY (`id === 'opt_degraded'`),
  * never by a value predicate another option could satisfy (trap 19), and the
@@ -74,10 +83,27 @@ const makeOptions = (): OptionV3[] => [
 const N_SAMPLES = 500;
 
 /**
- * A real ISL 200 body in which one option's Monte-Carlo population was entirely
- * non-finite. Note what IS present: the degeneracy is fully disclosed by
- * `status`, `n_valid_samples`, `validity_ratio`, `percentiles_source` and the
- * MONTE_CARLO_FAILED critique. Only the unmeasurable numbers are absent.
+ * An ISL 200 body carrying an option whose `outcome.mean` is ABSENT.
+ *
+ * ⚠ REACHABILITY — corrected by adversarial review, and narrower than this file
+ * first claimed. The obvious producer of an absent mean (every draw non-finite)
+ * emits MONTE_CARLO_FAILED, whose severity is `blocker`
+ * (ISL `src/models/critique.py:263`, verified at the pinned SHA). A blocker
+ * drives `analysis_status: 'failed'`, and PLoT SHORT-CIRCUITS a failed status at
+ * `src/routes/v2/run.ts:7026` — `return reply.send(buildV2RunError(...))`, whose
+ * own comment reads "No blockers can arrive here" — which is BEFORE both sites
+ * under test. **So the all-non-finite scenario does NOT reach these two
+ * builders**, and a fixture pairing `analysis_status: 'partial'` with a blocker
+ * critique is a body ISL cannot emit.
+ *
+ * This fixture is therefore internally consistent and non-blocking: `partial`
+ * status with LOW_EFFECTIVE_SAMPLES (severity `warning`, ISL `critique.py:317`),
+ * carrying an option whose mean is absent. The reviewer identifies ISL's
+ * `dist.samples`-empty branch as a producer of an absent mean with NO blocker,
+ * which WOULD reach both sites; **I did not measure that branch and make no
+ * claim about it.** What these tests pin is the builders' behaviour GIVEN an
+ * absent mean, whatever produced it — which is the property that must hold
+ * regardless of which upstream branch delivers it.
  */
 const makeIslResult = (overrides: { degradedOutcome?: Record<string, unknown> } = {}) => ({
   analysis_status: 'partial',
@@ -85,7 +111,7 @@ const makeIslResult = (overrides: { degradedOutcome?: Record<string, unknown> } 
     {
       id: DEGRADED,
       label: 'Degraded Option',
-      status: 'failed',
+      status: 'partial',
       // win_probability is absent for an option with no valid draws.
       outcome: overrides.degradedOutcome ?? {
         // mean, std, p10, p50, p90 are ABSENT — omitted, never null.
@@ -114,13 +140,17 @@ const makeIslResult = (overrides: { degradedOutcome?: Record<string, unknown> } 
       },
     },
   ],
+  // Non-blocking disclosure, so this body does NOT trip run.ts:7026. Shape and
+  // severity from ISL `src/models/critique.py:317` at the pinned SHA.
+  // ⚠ Neither function under test reads `critiques` — this is documentary, and
+  // it is NOT a disclosure channel for site 2 (see the wire test below).
   critiques: [
     {
-      id: 'critique_mc_failed_1',
-      code: 'MONTE_CARLO_FAILED',
-      severity: 'blocker',
-      message: 'Monte Carlo simulation produced no valid samples for this option',
-      source: 'engine',
+      id: 'critique_low_effective_samples_1',
+      code: 'LOW_EFFECTIVE_SAMPLES',
+      severity: 'warning',
+      message: 'Only 0 of 500 samples were numerically valid',
+      source: 'analysis',
       affected_option_ids: [DEGRADED],
     },
   ],
@@ -280,6 +310,57 @@ describe('2.480(a) site 2 — decision-review request never coalesces an absent 
       (o: { option_id: string }) => o.option_id === HEALTHY
     );
     expect(healthy.expected_outcome).toBe(HEALTHY_MEAN);
+  });
+
+  /**
+   * M4 CLOSER — added after adversarial review, which executed the mutant and
+   * found it SURVIVED: dropping site 2's FINITENESS guard (leaving a
+   * presence-only `!== undefined` check) kept the suite 12/12 GREEN while the
+   * CEE wire gained `"expected_outcome": null` and `"outcome_mean": null`.
+   *
+   * Site 1's non-finite twin already bit; site 2's had no pin, and the PR body
+   * claimed the non-finiteness fix at BOTH sites. `null` on the wire is the same
+   * lie in a different costume — CEE cannot tell "not computed" from "computed
+   * as null", and JSON.stringify converts NaN to null silently, so ONLY a
+   * wire-level key-absence assertion can see this.
+   */
+  it('does NOT emit a null expected_outcome when the mean is non-finite', () => {
+    const nanIsl = makeIslResult({
+      degradedOutcome: {
+        mean: Number.NaN,
+        n_samples: N_SAMPLES,
+        n_valid_samples: 0,
+        validity_ratio: 0.0,
+        percentiles_source: 'unavailable',
+      },
+    });
+
+    const request = buildRequest(nanIsl);
+
+    // In memory: never NaN, never null.
+    const degraded = request.isl_results.option_comparison.find((o) => o.option_id === DEGRADED);
+    expect(degraded, 'the degenerate option must still be present').toBeDefined();
+    expect(degraded!.expected_outcome).toBeUndefined();
+
+    // On the wire: the KEY must be absent. `expected_outcome: NaN` serialises to
+    // `null`, which a presence-only guard would happily emit.
+    const wire = JSON.parse(JSON.stringify(request));
+    const wireDegraded = wire.isl_results.option_comparison.find(
+      (o: { option_id: string }) => o.option_id === DEGRADED
+    );
+    expect(Object.prototype.hasOwnProperty.call(wireDegraded, 'expected_outcome')).toBe(false);
+
+    // Same for the winner/runner_up projection of the same value.
+    expect(request.runner_up?.id).toBe(DEGRADED);
+    expect(request.runner_up!.outcome_mean).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(wire.runner_up, 'outcome_mean')).toBe(false);
+
+    // POSITIVE CONTROL — the healthy sibling still carries its real number, so
+    // this test cannot pass by the whole payload being empty.
+    const wireHealthy = wire.isl_results.option_comparison.find(
+      (o: { option_id: string }) => o.option_id === HEALTHY
+    );
+    expect(wireHealthy.expected_outcome).toBe(HEALTHY_MEAN);
   });
 
   it('preserves a MEASURED 0 expected_outcome', () => {

--- a/tests/isl-absent-outcome-mean-honesty.test.ts
+++ b/tests/isl-absent-outcome-mean-honesty.test.ts
@@ -1,0 +1,314 @@
+/**
+ * ROADMAP 2.480(a) — an ABSENT ISL `outcome.mean` must never become a fabricated 0.
+ *
+ * WHAT CHANGED UPSTREAM. Until ISL PR #125 (merged 2026-08-05, staging
+ * `88275e5c8cb12486601052e971ff179ef3675958`), `OutcomeDistributionV2.mean` and
+ * `.std` were REQUIRED floats: a degenerate Monte-Carlo population (every draw
+ * non-finite) made the whole response unserializable and the run 500'd, taking
+ * its own MONTE_CARLO_FAILED critique with it. #125 made both `Optional` and
+ * OMITTED under `exclude_none` — "there is no honest mean for a distribution
+ * with no draws". So absence became REACHABLE on a 200 for the first time.
+ *
+ * THE DEFECT THIS PINS. Two PLoT sites read the RAW ISL result, upstream of and
+ * unprotected by the `hasAllRequiredOutcomeStats` egress guard, and coalesced
+ * that honest absence into a fabricated `0`:
+ *   - `src/coaching/normalise-inputs.ts:142`  `outcomeMean: islOpt.outcome?.mean ?? 0`
+ *   - `src/cee/decision-review-request.ts:248`
+ *       `expected_outcome: opt.expected_outcome ?? opt.outcome?.mean ?? 0`
+ * The second is the live-harm path: that value egresses to CEE as
+ * `isl_results.option_comparison[].expected_outcome` and as
+ * `winner`/`runner_up.outcome_mean`, i.e. it is handed to the reviewing model as
+ * a GROUNDED ISL figure. `normalise-inputs.ts` states the never-coalesce rule in
+ * its own file (lines 84-95) and violated it 47 lines later.
+ *
+ * HOUSE PATTERN (the fix these pins describe). Absence propagates as absence,
+ * exactly as this repo already does for `switch_probability`
+ * (`tests/coaching/switchprob-absence-honesty.test.ts`, `FragileEdgeData`) and
+ * for `buildIslResultsForCorrection` (`decision-review-orchestrator.ts:406`,
+ * whose consumer `number-corrector.ts:158` branches on `!== undefined`).
+ *
+ * FIXTURE PROVENANCE — pinned to a historical artefact, not to "current" (trap 12b).
+ * The degenerate shape below is transcribed from ISL's OWN contract test at that
+ * pinned SHA, `tests/integration/test_numerics_honesty_batch.py`
+ * (`TestAllNonFiniteOptionShipsOn200`): `status: 'failed'`, `n_valid_samples: 0`,
+ * `validity_ratio: 0.0`, `percentiles_source: 'unavailable'`, `mean`/`std`/
+ * `downside` ABSENT — never null, never a fabricated 0.0 — plus a
+ * MONTE_CARLO_FAILED blocker critique naming the option, and a healthy sibling.
+ *
+ * EVERY assertion binds to its option by IDENTITY (`id === 'opt_degraded'`),
+ * never by a value predicate another option could satisfy (trap 19), and the
+ * healthy sibling is the in-run POSITIVE CONTROL: a test that proves an absence
+ * must first prove it can see a presence (trap 13).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normaliseCoachingInputs } from '../src/coaching/normalise-inputs.js';
+import { buildDecisionReviewRequest } from '../src/cee/decision-review-request.js';
+import type { EngineGraphV3, OptionV3 } from '../src/types/engine-v3.js';
+import type { M1Coaching } from '../src/coaching/types.js';
+
+const DEGRADED = 'opt_degraded';
+const HEALTHY = 'opt_healthy';
+
+/** The healthy sibling's real mean. Deliberately NOT 0 and NOT near 0, so a
+ *  fabricated 0 can never be mistaken for it. */
+const HEALTHY_MEAN = 42.5;
+
+const makeGraph = (): EngineGraphV3 => ({
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Maximize Revenue' },
+    { id: 'factor_a', kind: 'factor', label: 'Market Size' },
+    { id: 'factor_b', kind: 'factor', label: 'Competition' },
+  ],
+  edges: [
+    { from: 'factor_a', to: 'goal', strength: { mean: 0.6, std: 0.15 }, exists_probability: 0.9 },
+    { from: 'factor_b', to: 'goal', strength: { mean: -0.4, std: 0.1 }, exists_probability: 0.85 },
+  ],
+});
+
+const makeOptions = (): OptionV3[] => [
+  { id: DEGRADED, label: 'Degraded Option', interventions: { factor_a: 0.8 } },
+  { id: HEALTHY, label: 'Healthy Option', interventions: { factor_b: 0.6 } },
+];
+
+const N_SAMPLES = 500;
+
+/**
+ * A real ISL 200 body in which one option's Monte-Carlo population was entirely
+ * non-finite. Note what IS present: the degeneracy is fully disclosed by
+ * `status`, `n_valid_samples`, `validity_ratio`, `percentiles_source` and the
+ * MONTE_CARLO_FAILED critique. Only the unmeasurable numbers are absent.
+ */
+const makeIslResult = (overrides: { degradedOutcome?: Record<string, unknown> } = {}) => ({
+  analysis_status: 'partial',
+  options: [
+    {
+      id: DEGRADED,
+      label: 'Degraded Option',
+      status: 'failed',
+      // win_probability is absent for an option with no valid draws.
+      outcome: overrides.degradedOutcome ?? {
+        // mean, std, p10, p50, p90 are ABSENT — omitted, never null.
+        n_samples: N_SAMPLES,
+        n_valid_samples: 0,
+        validity_ratio: 0.0,
+        percentiles_source: 'unavailable',
+      },
+      // downside absent
+    },
+    {
+      id: HEALTHY,
+      label: 'Healthy Option',
+      status: 'computed',
+      win_probability: 1.0,
+      outcome: {
+        mean: HEALTHY_MEAN,
+        std: 3.1,
+        p10: 38.2,
+        p50: 42.4,
+        p90: 47.1,
+        n_samples: N_SAMPLES,
+        n_valid_samples: N_SAMPLES,
+        validity_ratio: 1.0,
+        percentiles_source: 'samples',
+      },
+    },
+  ],
+  critiques: [
+    {
+      id: 'critique_mc_failed_1',
+      code: 'MONTE_CARLO_FAILED',
+      severity: 'blocker',
+      message: 'Monte Carlo simulation produced no valid samples for this option',
+      source: 'engine',
+      affected_option_ids: [DEGRADED],
+    },
+  ],
+  factor_sensitivity: [
+    { factor_id: 'factor_c', factor_label: 'Brand Strength', elasticity: 0.15, confidence: 0.6 },
+  ],
+  robustness: { recommendation_stability: 0.78, fragile_edges: [] },
+});
+
+const makeM1Coaching = (): M1Coaching => ({
+  readiness: 'ready',
+  headline_type: 'clear_winner',
+  evidence_gaps: [],
+  model_critiques: [],
+});
+
+const buildRequest = (islResult: unknown) =>
+  buildDecisionReviewRequest(
+    'Should we expand?',
+    makeGraph(),
+    makeOptions(),
+    islResult as Parameters<typeof buildDecisionReviewRequest>[3],
+    makeM1Coaching()
+  );
+
+// =============================================================================
+// SITE 1 — src/coaching/normalise-inputs.ts
+// =============================================================================
+
+describe('2.480(a) site 1 — coaching normaliser never coalesces an absent mean', () => {
+  it('does NOT fabricate 0 for an option whose outcome.mean is absent', () => {
+    const inputs = normaliseCoachingInputs(makeGraph(), makeOptions(), makeIslResult());
+
+    const degraded = inputs.options.find((o) => o.id === DEGRADED);
+    expect(degraded, 'the degenerate option must still be present').toBeDefined();
+
+    // The defect: this read 0 — an assertion that the option's expected outcome
+    // was MEASURED and found to be zero.
+    expect(degraded!.outcomeMean).not.toBe(0);
+    expect(degraded!.outcomeMean).toBeUndefined();
+  });
+
+  it('keeps the degenerate option VISIBLE rather than dropping it', () => {
+    const inputs = normaliseCoachingInputs(makeGraph(), makeOptions(), makeIslResult());
+
+    // Silent loss is the other dishonest answer. Both options survive.
+    expect(inputs.options.map((o) => o.id).sort()).toEqual([DEGRADED, HEALTHY].sort());
+  });
+
+  it('POSITIVE CONTROL — the healthy sibling keeps its measured mean verbatim', () => {
+    const inputs = normaliseCoachingInputs(makeGraph(), makeOptions(), makeIslResult());
+
+    const healthy = inputs.options.find((o) => o.id === HEALTHY);
+    expect(healthy!.outcomeMean).toBe(HEALTHY_MEAN);
+  });
+
+  it('preserves a MEASURED 0 — a real measurement is not an absence', () => {
+    const inputs = normaliseCoachingInputs(
+      makeGraph(),
+      makeOptions(),
+      makeIslResult({
+        degradedOutcome: {
+          mean: 0,
+          std: 1.2,
+          p10: -2,
+          p50: 0,
+          p90: 2,
+          n_samples: N_SAMPLES,
+          n_valid_samples: N_SAMPLES,
+          validity_ratio: 1.0,
+          percentiles_source: 'samples',
+        },
+      })
+    );
+
+    const measured = inputs.options.find((o) => o.id === DEGRADED);
+    expect(measured!.outcomeMean).toBe(0);
+  });
+
+  it('does not pass a non-finite mean through as a number', () => {
+    const inputs = normaliseCoachingInputs(
+      makeGraph(),
+      makeOptions(),
+      makeIslResult({
+        degradedOutcome: {
+          mean: Number.NaN,
+          n_samples: N_SAMPLES,
+          n_valid_samples: 0,
+          validity_ratio: 0.0,
+          percentiles_source: 'unavailable',
+        },
+      })
+    );
+
+    const degraded = inputs.options.find((o) => o.id === DEGRADED);
+    expect(degraded!.outcomeMean).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// SITE 2 — src/cee/decision-review-request.ts (the egress path to CEE)
+// =============================================================================
+
+describe('2.480(a) site 2 — decision-review request never coalesces an absent mean', () => {
+  it('does NOT fabricate 0 in option_comparison for the degenerate option', () => {
+    const request = buildRequest(makeIslResult());
+
+    const degraded = request.isl_results.option_comparison.find((o) => o.option_id === DEGRADED);
+    expect(degraded, 'the degenerate option must still be present').toBeDefined();
+
+    // The defect: CEE was told this option's expected outcome IS 0, as a
+    // grounded ISL figure.
+    expect(degraded!.expected_outcome).not.toBe(0);
+    expect(degraded!.expected_outcome).toBeUndefined();
+  });
+
+  it('keeps the degenerate option VISIBLE in option_comparison', () => {
+    const request = buildRequest(makeIslResult());
+
+    expect(request.isl_results.option_comparison.map((o) => o.option_id).sort()).toEqual(
+      [DEGRADED, HEALTHY].sort()
+    );
+  });
+
+  it('POSITIVE CONTROL — the healthy sibling keeps its measured expected_outcome', () => {
+    const request = buildRequest(makeIslResult());
+
+    const healthy = request.isl_results.option_comparison.find((o) => o.option_id === HEALTHY);
+    expect(healthy!.expected_outcome).toBe(HEALTHY_MEAN);
+  });
+
+  it('does NOT fabricate 0 for runner_up.outcome_mean', () => {
+    const request = buildRequest(makeIslResult());
+
+    // Identity, not position: the healthy option wins on win_probability.
+    expect(request.winner.id).toBe(HEALTHY);
+    expect(request.runner_up?.id).toBe(DEGRADED);
+
+    expect(request.runner_up!.outcome_mean).not.toBe(0);
+    expect(request.runner_up!.outcome_mean).toBeUndefined();
+    // Positive control on the same object family.
+    expect(request.winner.outcome_mean).toBe(HEALTHY_MEAN);
+  });
+
+  it('carries no fabricated 0 ON THE WIRE for the degenerate option', () => {
+    const request = buildRequest(makeIslResult());
+    const wire = JSON.parse(JSON.stringify(request));
+
+    const degraded = wire.isl_results.option_comparison.find(
+      (o: { option_id: string }) => o.option_id === DEGRADED
+    );
+    expect(Object.prototype.hasOwnProperty.call(degraded, 'expected_outcome')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(wire.runner_up, 'outcome_mean')).toBe(false);
+
+    // The healthy sibling still carries its real number on the same wire.
+    const healthy = wire.isl_results.option_comparison.find(
+      (o: { option_id: string }) => o.option_id === HEALTHY
+    );
+    expect(healthy.expected_outcome).toBe(HEALTHY_MEAN);
+  });
+
+  it('preserves a MEASURED 0 expected_outcome', () => {
+    const request = buildRequest(
+      makeIslResult({
+        degradedOutcome: {
+          mean: 0,
+          std: 1.2,
+          p10: -2,
+          p50: 0,
+          p90: 2,
+          n_samples: N_SAMPLES,
+          n_valid_samples: N_SAMPLES,
+          validity_ratio: 1.0,
+          percentiles_source: 'samples',
+        },
+      })
+    );
+
+    const measured = request.isl_results.option_comparison.find((o) => o.option_id === DEGRADED);
+    expect(measured!.expected_outcome).toBe(0);
+  });
+
+  it('still prefers an explicit expected_outcome over outcome.mean', () => {
+    const isl = makeIslResult();
+    (isl.options[1] as Record<string, unknown>).expected_outcome = 99.5;
+
+    const request = buildRequest(isl);
+    const healthy = request.isl_results.option_comparison.find((o) => o.option_id === HEALTHY);
+    expect(healthy!.expected_outcome).toBe(99.5);
+  });
+});


### PR DESCRIPTION
## ⚠ DO-NOT-MERGE — for adversarial review first. PLoT `staging` is UNPROTECTED, so the merge is the gate.

ROADMAP **2.480(a)**. Pillar: **trust**. Head `47244a3`.

> **Review round 2 landed** (fix-first, no code change asked). One test added, three claims in this body corrected. **The corrections are in-line below and marked ⚠ — the original text was wrong and is not quietly deleted.**

## What was wrong

ISL PR #125 (**merged**, ISL staging `88275e5c`) made `OutcomeDistributionV2.mean`/`.std` `Optional` — **omitted** under `exclude_none` when an option's Monte Carlo produced no finite draws, because *there is no honest mean for a distribution with no draws*. Before #125 `mean` was a **required** float, so absence was impossible on a 200.

Two PLoT sites read the **raw** ISL result — upstream of, and unprotected by, the `hasAllRequiredOutcomeStats` egress guard (`run.ts:2594`, downstream of both) — and turned that honest absence into a fabricated `0`:

| site | code |
|---|---|
| `src/coaching/normalise-inputs.ts:142` | `islOpt.outcome?.mean ?? 0` — in a file that **states the never-coalesce rule in its own header** (lines 84–95) and violated it 47 lines later |
| `src/cee/decision-review-request.ts:248` | `opt.expected_outcome ?? opt.outcome?.mean ?? 0` — egresses to CEE as `isl_results.option_comparison[].expected_outcome` and `winner`/`runner_up.outcome_mean` |

## ⚠ CORRECTION 1 — "this is live now / live harm" is **WITHDRAWN**

This PR originally claimed site 2 was live harm. **Not reproducible on the deployed control flow**, verified at my own bytes:

- `MONTE_CARLO_FAILED` (ISL's emission for an all-non-finite option) has severity **`blocker`** — ISL `src/models/critique.py:263`.
- A blocker drives `analysis_status: 'failed'`.
- **PLoT short-circuits that at `src/routes/v2/run.ts:7026`** — `return reply.send(buildV2RunError(…))` — whose neighbouring comment reads *"No blockers can arrive here."* **That return is upstream of both fixed sites.**

My original fixture was also internally inconsistent (`analysis_status: 'partial'` + a blocker critique — a body ISL cannot emit). **Fixture corrected** to a consistent non-blocking body (`partial` + `LOW_EFFECTIVE_SAMPLES`, severity `warning`, `critique.py:317`).

The reviewer identifies ISL's `dist.samples`-empty branch as a producer of an absent mean with **no** blocker, which *would* reach both sites. **I could not locate it at the SHA I searched and did not measure it — recorded as the reviewer's claim, explicitly unmeasured.**

**What survives:** the builders must not fabricate given an absent `mean`, whatever delivers it — now pinned and mutation-proven. **But this is a correctness fix on a path whose live reachability is unproven, not a live-fabrication stop.** Whether it still merits P1 should be re-derived, not inherited from this PR's original framing.

## ⚠ CORRECTION 2 — "degeneracy stays disclosed" is **FALSE** for site 2's wire

Executed by the reviewer: the decision-review payload carries **no `critiques` key at all**, and each `option_comparison` entry reduces to **`{option_id, option_label, win_probability}`** — none of `status` / `n_valid_samples` / `validity_ratio` / `percentiles_source` is on that wire. **After this fix the reviewing model gets an absence with no stated reason.** Better than a fabricated zero; not disclosure.

Worse, on the very object the "stays VISIBLE" test asserts, **`win_probability: 0` is still fabricated** by the untouched `?? 0` one line above (`:247`) — being visible is not being honestly described. Rowed.

(Critique flow on the **V2 run response** via `mapISLCritiquesToV2` is real and untouched — it is simply not a channel for *this* payload.)

## ⚠ CORRECTION 3 — I applied trap 10 asymmetrically, in my own favour

I demanded a full reader manifest for site 1, found **zero readers**, and downgraded it — then escalated `facts/mapper.ts` to "the one that matters, LIVE on staging" **without running the same test**. The reviewer did: `fact_objects` has **zero production reads in CEE** and **zero UI references**. Same loaded gun, not a live wound. The mechanism I proved stands; the severity I stacked on it does not. *I applied the stricter standard to the claim that inflated my finding and the looser one to the claim that deflated it — that direction is not random.*

## The fix: propagate the absence — the pattern this repo already ruled on twice

- **`FragileEdgeData.switch_probability`** was made optional for precisely this defect; `m1-review-validator.ts` documents the harm as a fabricated 0 *"licensing the reviewer to state it as a grounded figure."*
- **`buildIslResultsForCorrection`** (`decision-review-orchestrator.ts:406`) already reads `opt.expected_outcome ?? opt.outcome?.mean` with **no `?? 0`**; `number-corrector.ts:158` branches on `!== undefined`.

The repo held **two builders of the same field side by side — one honest, one fabricating.** This makes the fabricating one match its twin. **Contract-safe, proven by the repo's own contract test:** `option_comparison` items are `.passthrough()` and `winner.outcome_mean` is **already** `z.number().optional()`; that test passes unchanged. **The `?? 0` was the single point destroying the honest value.**

Neither fix drops an option (pinned per site). A **measured** 0 is preserved. `?? 0` also never guarded non-finiteness — a `NaN` mean passed straight through both sites.

## Verification

- **RED-first at pristine `45e23f10`: `5 failed | 7 passed (12)`** — each RED the defect's own signature. The 7 passing are deliberate positive/preserved-behaviour controls (trap 13). **13/13 green at head.** ⚠ The 13th test was written against a surviving mutant, **not** RED-first against pristine — not dressed up as such.
- **Assertions bind by IDENTITY** (`id === 'opt_degraded'`), never a value predicate (trap 19).
- **Mutants** — throwaway worktree outside the repo root, committed state, applied-check scoped to `src/`, control asserting exactly 0; missing summary / zero collected / collected≠control are hard errors:

```
CONTROL                          | applied=0 | collected=13 | 13 passed |  0 failed
M1-site1-normalise-inputs        | applied=1 | collected=13 | 11 passed |  2 failed  BITES
M2-site2-decision-review-request | applied=1 | collected=13 |  9 passed |  4 failed  BITES
M3-both-sites                    | applied=2 | collected=13 |  7 passed |  6 failed  BITES
M4-site2-finiteness-guard        | applied=1 | collected=13 | 12 passed |  1 failed  BITES (was SURVIVING)
M5-site1-finiteness-guard        | applied=1 | collected=13 | 12 passed |  1 failed  BITES
```

**⚠ M4 survived my first round.** M1–M3 are *revert*-mutants — too coarse to ask which **clause** of the guard is load-bearing. Weakening site 2's finiteness guard to presence-only left the suite **12/12 GREEN** while the CEE wire gained **`"expected_outcome": null`** and **`"outcome_mean": null`** — the same lie in a different costume, invisible because **`JSON.stringify` silently turns `NaN` into `null`**, so only a **wire-level key-absence** assertion can see it. Site 1's twin bit; site 2's had no pin while this body claimed the fix at both. Now closed, with a healthy-sibling positive control. *A revert-mutant proves the fix matters; it cannot prove each clause matters.*

- **Named gates at head:** `npm run lint` **PASS, zero warnings** · `npm run typecheck` **PASS** · `npm run build` **PASS** · `npm run validate:contracts` **PASS** · `npm test` **PASS — `609 passed | 4 skipped (613)` files, `6768 passed | 28 skipped (6807)` tests, 0 failed**.
- **⚠ Flake, measured and disclosed:** one full-suite run failed on `tests/v2-run.integration.test.ts` with `waitFor(server ready) timed out after 10000ms` — not an assertion. Proven unattributable: `git diff 0e848c97..47244a3 -- src/` is **empty**, so `src/` is byte-identical to a head that ran fully green. Isolation: 23/23. **2 of 3 full-suite runs green.** Rowed as a broken alarm — a flake that trains lanes to re-run until green is how a real failure gets waved through.
- **`audit` red is pre-existing**, proven two ways: **empty dependency surface** (0 manifest files changed) and the job's history — **red on every PR since 4 Aug across four unrelated branches, green before 3 Aug**. Read at the job's actual output, not a registry label: **5 high, all one advisory — `fast-uri`**, already rowed as **2.385**; the fix is a `fastify` breaking change.

## Not verified

- **The UI half** — not touched, no claim either way.
- **Render dashboard posture** (trap 18) — code defaults claimed, not deployed env.
- **No live witness** — unmerged, undeployed.
- **Whether any deployed flow reaches these two sites at all** — see Correction 1. This is the open question the row should carry.

Full evidence, the corrected manifest (PLoT has ≥9 more ISL-outcome coalesces; the row's "five" is 2 PLoT + 3 UI refs), and the rows this lane owes: `PHASE0-EVIDENCE-2026-07-28/lane-plot-2480a-2026-08-05.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)