### PR TITLE
DO-NOT-MERGE (orchestrator merges) — feat(2.520 S1): carry human-confirmation provenance through PLoT ingress to the engine

### DIFF
--- a/src/integrations/isl/translator-v3.ts
+++ b/src/integrations/isl/translator-v3.ts
@@ -335,6 +335,41 @@ const _observedStateFieldsAreExhaustive: _ObservedStateFieldsAreExhaustive = tru
 void _observedStateFieldsAreExhaustive;
 
 /**
+ * ⭐ ROADMAP 2.520 S1 — COMPILE-TIME UNION PIN: PLoT's CANONICAL graph must be
+ * able to CARRY everything this projector promises to FORWARD.
+ *
+ * The two pins above make the egress list agree with the egress TYPE, and the
+ * mirror test makes it agree with ISL. All three can be perfectly consistent
+ * while the field never arrives — because `toISLObservedState` can only forward
+ * what the normalised graph actually holds, and that is `EngineNodeV3`, one hop
+ * upstream and previously unpinned to any of this.
+ *
+ * That gap is not hypothetical: it is the 2.520 defect. `source` and
+ * `extractionType` sat on this list, and on ISL's model, and were echoed back by
+ * ISL — while `EngineNodeV3['observed_state']` could not represent them, so
+ * PLoT's ingress dropped every one and the projector forwarded a field that was
+ * never there. Every guard on this path was green throughout.
+ *
+ * This is the union assertion the estate's trap-12 doctrine prescribes for
+ * exactly this shape: the canonical type must be a SUPERSET of every sibling
+ * lookup. It resolves to `never` — and so fails `npm run build`, a required
+ * check — the moment a field is added to the ISL list without the canonical
+ * graph being able to hold it.
+ *
+ * ⚠ Deliberately ONE-directional. The canonical type may legitimately carry
+ * more than ISL declares (e.g. the PLoT-internal `metadata` the projection
+ * strips on purpose), so the converse must NOT be asserted here.
+ */
+type _CanonicalGraphCanCarryEveryDeclaredField = Exclude<
+  (typeof ISL_DECLARED_OBSERVED_STATE_FIELDS)[number],
+  keyof NonNullable<EngineNodeV3['observed_state']>
+> extends never
+  ? true
+  : never;
+const _canonicalGraphCanCarryEveryDeclaredField: _CanonicalGraphCanCarryEveryDeclaredField = true;
+void _canonicalGraphCanCarryEveryDeclaredField;
+
+/**
  * Project a PLoT-internal `observed_state` onto the fields ISL declares.
  *
  * Slice 6: the previous code forwarded `node.observed_state` VERBATIM, so any

--- a/src/normalisation/graph-normaliser.ts
+++ b/src/normalisation/graph-normaliser.ts
@@ -290,7 +290,10 @@ export function normaliseNode(
       cap: os.cap,
       factor_type: os.factor_type,
       uncertainty_drivers: os.uncertainty_drivers,
-      // Value provenance — who asserted this number and how (2.520 S1).
+      // Value provenance (2.520 S1) — an upstream CLAIM about this number's
+      // origin, copied VERBATIM and validated in no way. Transport, not
+      // attestation: carrying `source: 'user_set'` here does not establish that
+      // a human set the value. See the field's own doc on `RawNodeV3`.
       source: os.source,
       extractionType: os.extractionType,
       // For constraint nodes, preserve metadata (contains operator) so the

--- a/src/normalisation/graph-normaliser.ts
+++ b/src/normalisation/graph-normaliser.ts
@@ -293,7 +293,7 @@ export function normaliseNode(
       // Value provenance (2.520 S1) — an upstream CLAIM about this number's
       // origin, copied VERBATIM and validated in no way. Transport, not
       // attestation: carrying `source: 'user_set'` here does not establish that
-      // a human set the value. See the field's own doc on `RawNodeV3`.
+      // a human set the value. See the field's own doc on `UpstreamNode`.
       source: os.source,
       extractionType: os.extractionType,
       // For constraint nodes, preserve metadata (contains operator) so the

--- a/src/normalisation/graph-normaliser.ts
+++ b/src/normalisation/graph-normaliser.ts
@@ -261,6 +261,25 @@ export function normaliseNode(
     // Explicit allowlist: core fields + V3 expansion metadata
     // This preserves V3 fields (raw_value, cap, factor_type, uncertainty_drivers)
     // without passing through arbitrary upstream garbage.
+    //
+    // ⚠ ROADMAP 2.520 S1 — THIS LIST IS THE INGRESS STRIP POINT, and it was
+    // silently discarding every human confirmation. `source` and
+    // `extractionType` were absent here while PLoT's OWN egress projector
+    // (`ISL_DECLARED_OBSERVED_STATE_FIELDS`, translator-v3.ts) already declared
+    // them and ISL already consumed AND echoed them back as `value_source` /
+    // `value_extraction_type`. So a user confirming an estimate produced a
+    // number the compute engine could not distinguish from an AI guess — not
+    // because anything downstream refused it, but because two keys were missing
+    // from this literal, one hop upstream of a list that had them.
+    //
+    // This list is a hand-maintained mirror (programme trap 12) and stays one:
+    // it is deliberately NOT a blind passthrough, because `metadata` below is
+    // PLoT-internal and must not reach ISL. What makes it safe now is that its
+    // AGREEMENT with the egress list is derived rather than remembered —
+    // `tests/observed-state-provenance-ingress.test.ts` T5 iterates
+    // `ISL_DECLARED_OBSERVED_STATE_FIELDS` (itself pinned to ISL's own
+    // machine-generated OpenAPI) and REDs if any declared field fails to survive
+    // this copy. Add a field to ISL and this literal must follow, or CI fails.
     const os = node.observed_state;
     observedState = {
       value: node.observed_state.value, // use narrowed path (TS knows !== undefined)
@@ -271,6 +290,9 @@ export function normaliseNode(
       cap: os.cap,
       factor_type: os.factor_type,
       uncertainty_drivers: os.uncertainty_drivers,
+      // Value provenance — who asserted this number and how (2.520 S1).
+      source: os.source,
+      extractionType: os.extractionType,
       // For constraint nodes, preserve metadata (contains operator) so the
       // constraint compiler can extract it via observed_state.metadata.operator.
       ...((os as any).metadata !== undefined && { metadata: (os as any).metadata }),

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -89,6 +89,21 @@ export interface UpstreamNode {
     factor_type?: string;
     /** V3 expansion: sources of uncertainty */
     uncertainty_drivers?: string[];
+    /**
+     * ROADMAP 2.520 S1 — value PROVENANCE, carried from CEE to the engine.
+     *
+     * `source` says WHO asserted this number (e.g. `'user_set'` when a human
+     * confirmed it, vs a brief-extraction or model-inferred origin) and
+     * `extractionType` HOW it was obtained. ISL declares both on its
+     * `ObservedState` and echoes them back on `FactorSensitivityV2` as
+     * `value_source` / `value_extraction_type`.
+     *
+     * Declared here because PLoT's normaliser must be ABLE to carry what CEE
+     * sends: until 2.520 these were absent from this type, so the ingress copy
+     * could not name them and dropped every human confirmation on the floor.
+     */
+    source?: string;
+    extractionType?: string;
   };
   /** State space bounds for the factor (used for uncertainty calculation) */
   state_space?: {
@@ -200,6 +215,19 @@ export interface EngineNodeV3 {
     factor_type?: string;
     /** V3 expansion: sources of uncertainty */
     uncertainty_drivers?: string[];
+    /**
+     * ROADMAP 2.520 S1 — value provenance (see `RawNodeV3.observed_state`).
+     *
+     * ⚠ THIS TYPE IS LOAD-BEARING FOR THE WHOLE PATH, in a way the egress side
+     * cannot see. `ISL_DECLARED_OBSERVED_STATE_FIELDS` promises to forward ten
+     * fields to ISL, but it can only ever forward what the CANONICAL graph is
+     * able to carry — so a field declared there and missing HERE is forwarded in
+     * name only, silently, for every request. That is exactly how `source` and
+     * `extractionType` were lost. A compile-time union pin in `translator-v3.ts`
+     * now forbids that divergence in both directions.
+     */
+    source?: string;
+    extractionType?: string;
   };
   /** State space bounds for the factor (used for uncertainty calculation) */
   state_space?: {

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -231,7 +231,7 @@ export interface EngineNodeV3 {
     /** V3 expansion: sources of uncertainty */
     uncertainty_drivers?: string[];
     /**
-     * ROADMAP 2.520 S1 — value provenance (see `RawNodeV3.observed_state`).
+     * ROADMAP 2.520 S1 — value provenance (see `UpstreamNode.observed_state`).
      *
      * ⚠ THIS TYPE IS LOAD-BEARING FOR THE WHOLE PATH, in a way the egress side
      * cannot see. `ISL_DECLARED_OBSERVED_STATE_FIELDS` promises to forward ten

--- a/src/types/engine-v3.ts
+++ b/src/types/engine-v3.ts
@@ -92,15 +92,30 @@ export interface UpstreamNode {
     /**
      * ROADMAP 2.520 S1 — value PROVENANCE, carried from CEE to the engine.
      *
-     * `source` says WHO asserted this number (e.g. `'user_set'` when a human
-     * confirmed it, vs a brief-extraction or model-inferred origin) and
-     * `extractionType` HOW it was obtained. ISL declares both on its
-     * `ObservedState` and echoes them back on `FactorSensitivityV2` as
+     * `source` carries an upstream CLAIM about where this number came from
+     * (e.g. `'user_set'`, a brief extraction, a model inference) and
+     * `extractionType` a claim about how it was obtained. ISL declares both on
+     * its `ObservedState` and echoes them back on `FactorSensitivityV2` as
      * `value_source` / `value_extraction_type`.
+     *
+     * ⚠ THESE ARE UNVALIDATED FREE-TEXT STRINGS, NOT AN ATTESTATION — say so
+     * here, because the tempting one-line gloss ("`source` says a human set
+     * this value") is false and would be read as a guarantee by whoever wires
+     * the next slice. PLoT copies the value VERBATIM: no enum, no schema
+     * membership check, no server-side re-derivation, and — since PLoT does not
+     * Zod-parse the incoming graph at all — no place where one could happen
+     * today. `string` (not a union) is deliberate and matches ISL's own
+     * `Optional[str]`.
+     *
+     * So a `user_*` value reaching the engine means THE FIELD ARRIVED. It does
+     * not mean a human set the number, and nothing on this path can tell a
+     * genuine stamp from a forged one. Forgeability upstream is ROADMAP 2.525;
+     * any slice that makes provenance WEIGH in the maths depends on it, and
+     * must not treat this field as trusted until it is closed.
      *
      * Declared here because PLoT's normaliser must be ABLE to carry what CEE
      * sends: until 2.520 these were absent from this type, so the ingress copy
-     * could not name them and dropped every human confirmation on the floor.
+     * could not name them and dropped every such claim on the floor.
      */
     source?: string;
     extractionType?: string;

--- a/src/util/structural-keys.generated.ts
+++ b/src/util/structural-keys.generated.ts
@@ -168,6 +168,7 @@ export const STRUCTURAL_KEYS: ReadonlySet<string> = new Set([
   "exists_probability",
   "expected_outcome",
   "explanation",
+  "extractionType",
   "fact_objects",
   "factorSensitivitySource",
   "factor_a",

--- a/tests/observed-state-provenance-ingress.test.ts
+++ b/tests/observed-state-provenance-ingress.test.ts
@@ -58,6 +58,7 @@ import { describe, it, expect } from 'vitest';
 import { normaliseGraph, normaliseNode } from '../src/normalisation/graph-normaliser.js';
 import {
   toISLNode,
+  toISLRobustnessRequest,
   ISL_DECLARED_OBSERVED_STATE_FIELDS,
 } from '../src/integrations/isl/translator-v3.js';
 
@@ -244,5 +245,39 @@ describe('2.520 S1 — human-confirmation provenance survives PLoT ingress', () 
         sample[field],
       );
     }
+  });
+
+  it('T6 the provenance reaches the SERIALISED ISL request body, not just an in-memory object', () => {
+    // The closest this repo can get to the wire without standing up ISL. T3
+    // stops at `toISLNode`; the live `/v2/run` path continues through
+    // `toISLRobustnessRequest` (`graph.nodes.map(toISLNode)`) and then through
+    // `JSON.stringify` at the fetch boundary. Both of those could still lose the
+    // field — the builder by re-projecting, the serializer by dropping an
+    // `undefined`. Asserting on the parsed BYTES closes that gap.
+    const normalised = normaliseGraph(upstreamGraphWithProvenance());
+    const request = toISLRobustnessRequest(
+      normalised.graph,
+      [
+        { id: 'opt_a', label: 'Option A', interventions: {} },
+        { id: 'opt_b', label: 'Option B', interventions: {} },
+      ] as any,
+      'goal_margin',
+      'req_2520_s1_provenance',
+    );
+
+    // Round-trip through the serializer the fetch boundary uses.
+    const wire = JSON.parse(JSON.stringify(request));
+    const onWire = wire.graph.nodes.find((n: any) => n.id === CONFIRMED_ID);
+
+    expect(onWire, `${CONFIRMED_ID} missing from the serialised ISL request`).toBeDefined();
+    expect(onWire.observed_state).toHaveProperty('source', CONFIRMED_SOURCE);
+    expect(onWire.observed_state).toHaveProperty('extractionType', CONFIRMED_EXTRACTION);
+
+    // Same positive control as T1, at the wire: a node that carried no
+    // provenance must not acquire any, and must not gain an explicit `null`.
+    // `JSON.stringify` drops undefined keys, so absence here is real absence.
+    const goal = wire.graph.nodes.find((n: any) => n.id === 'goal_margin');
+    expect(goal?.observed_state ?? {}).not.toHaveProperty('source');
+    expect(goal?.observed_state ?? {}).not.toHaveProperty('extractionType');
   });
 });

--- a/tests/observed-state-provenance-ingress.test.ts
+++ b/tests/observed-state-provenance-ingress.test.ts
@@ -26,6 +26,17 @@
  * other and to ISL mechanically (ROADMAP 2.274), and the three upstream of them
  * were free-floating.
  *
+ * ⚠ WHAT THIS SUITE DOES **NOT** ESTABLISH. It proves the FIELD ARRIVES. It does
+ * not prove — and nothing on this path can — that a `user_*` value was set by a
+ * human. `source` is an unvalidated free-text string at every hop: PLoT copies
+ * it verbatim (no enum, no membership check, and PLoT does not Zod-parse the
+ * incoming graph at all), and ISL declares it `Optional[str]` and treats it as
+ * echo-only. A forged stamp is therefore indistinguishable from a genuine one
+ * here, by construction. Upstream forgeability is ROADMAP 2.525. Read every
+ * assertion below as "the claim transited intact", never as "a human said so" —
+ * this slice is transport, and the treatment slices that let provenance WEIGH in
+ * the maths must not treat the field as trusted until 2.525 is closed.
+ *
  * WHAT THIS SUITE GUARDS, and why each test exists:
  *  - T1 is the POSITIVE CONTROL (trap 13). Every other test here asserts a
  *    PRESENCE; T1 is the only one that proves the harness can see an ABSENCE.

--- a/tests/observed-state-provenance-ingress.test.ts
+++ b/tests/observed-state-provenance-ingress.test.ts
@@ -1,0 +1,248 @@
+/**
+ * ROADMAP 2.520 slice S1 — carry human-confirmation provenance to the engine.
+ *
+ * THE DEFECT THIS PINS. When a user confirms an estimate ("yes, I'm fairly sure
+ * that's 52%"), CEE forwards `observed_state.source` and `observed_state
+ * .extractionType` to PLoT. PLoT's `normaliseNode` then rebuilt `observed_state`
+ * from an explicit 8-member object literal (`graph-normaliser.ts`, the
+ * `value/baseline/unit/std/raw_value/cap/factor_type/uncertainty_drivers` copy)
+ * which named neither key, so both were dropped at ingress — before anything
+ * else ran. The compute engine therefore treated a human-confirmed number as
+ * indistinguishable from an AI guess.
+ *
+ * ⚠ AND THE DROP WAS GRATUITOUS — every other hop already supported the field:
+ *  - PLoT's OWN egress projector declares both (`ISL_DECLARED_OBSERVED_STATE_
+ *    FIELDS`, translator-v3.ts) and `toISLObservedState` forwards them by
+ *    presence, so they only ever needed to SURVIVE ingress to reach the wire;
+ *  - ISL declares both on `ObservedState` and echoes them onto
+ *    `FactorSensitivityV2` as `value_source` / `value_extraction_type` — see the
+ *    sha256-pinned, machine-generated `tests/fixtures/isl-pinned/isl-openapi
+ *    .json`, which is Pydantic's own description of the mounted models.
+ *
+ * So the entire blockage was two keys missing from one hand-maintained ingress
+ * list, sitting one hop upstream of a list that already had them. That is
+ * programme trap 12 (the hand-maintained mirror) in its purest form: FIVE lists
+ * describe `observed_state` on this path, the two nearest ISL are pinned to each
+ * other and to ISL mechanically (ROADMAP 2.274), and the three upstream of them
+ * were free-floating.
+ *
+ * WHAT THIS SUITE GUARDS, and why each test exists:
+ *  - T1 is the POSITIVE CONTROL (trap 13). Every other test here asserts a
+ *    PRESENCE; T1 is the only one that proves the harness can see an ABSENCE.
+ *    Without it "the keys came through" is indistinguishable from "the harness
+ *    reports these keys no matter what" — and this estate has shipped exactly
+ *    that shape of vacuous test before.
+ *  - T2 pins the fixture's own PRECONDITION. If a later tidy-up strips the
+ *    provenance from the input, T3/T4 would go on passing while testing nothing.
+ *  - T3/T4 bind by IDENTITY (`n.id === ...`), never by a value predicate another
+ *    node could satisfy (trap 19), and carry DISTINCT provenance per node so a
+ *    swap is observable rather than silently green.
+ *  - T5 is the anti-mirror guard and the reason this is not just a two-key
+ *    patch: it DERIVES its expectation from `ISL_DECLARED_OBSERVED_STATE_FIELDS`
+ *    — the list already pinned to ISL's own OpenAPI — and asserts every member
+ *    survives the real ingress→egress chain. A field added to ISL now forces the
+ *    re-pin, which grows that list, which REDs here until the normaliser carries
+ *    it. That closes the loop the narrow fix would have left open: without T5,
+ *    the NEXT field ISL adds repeats this exact bug, silently.
+ *    ⚠ Per trap 12d, T5 proves AGREEMENT, not completeness — completeness of the
+ *    list itself is what `tests/isl-observed-state-mirror.test.ts` establishes
+ *    against ISL's machine-generated spec. The two are not redundant; this suite
+ *    needs that one to be meaningful.
+ *
+ * The chain exercised is the real one, both real producers, no re-implementation:
+ *   normaliseGraph/normaliseNode  (ingress — where the strip was)
+ *     → toISLNode → toISLObservedState  (egress — what actually hits the wire)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normaliseGraph, normaliseNode } from '../src/normalisation/graph-normaliser.js';
+import {
+  toISLNode,
+  ISL_DECLARED_OBSERVED_STATE_FIELDS,
+} from '../src/integrations/isl/translator-v3.js';
+
+/** The node a human confirmed. Provenance values are unique to it. */
+const CONFIRMED_ID = 'fac_confirmed_by_human';
+const CONFIRMED_SOURCE = 'user_set';
+const CONFIRMED_EXTRACTION = 'user_confirmed';
+
+/** A second node with DIFFERENT provenance, so a mix-up cannot read as green. */
+const AI_ID = 'fac_estimated_by_ai';
+const AI_SOURCE = 'brief_extraction';
+const AI_EXTRACTION = 'llm_inferred';
+
+/**
+ * The upstream (CEE-shaped) graph. Both factors carry provenance, with distinct
+ * values; the goal node carries none.
+ */
+function upstreamGraphWithProvenance(): any {
+  return {
+    nodes: [
+      {
+        id: CONFIRMED_ID,
+        kind: 'factor',
+        label: 'Confirmed by human',
+        observed_state: {
+          value: 0.52,
+          std: 0.08,
+          source: CONFIRMED_SOURCE,
+          extractionType: CONFIRMED_EXTRACTION,
+        },
+      },
+      {
+        id: AI_ID,
+        kind: 'factor',
+        label: 'Estimated by AI',
+        observed_state: {
+          value: 0.45,
+          std: 0.2,
+          source: AI_SOURCE,
+          extractionType: AI_EXTRACTION,
+        },
+      },
+      { id: 'goal_margin', kind: 'outcome', label: 'Margin' },
+    ],
+    edges: [
+      { from: CONFIRMED_ID, to: 'goal_margin', exists_probability: 0.9, strength: { mean: 0.5, std: 0.1 } },
+      { from: AI_ID, to: 'goal_margin', exists_probability: 0.8, strength: { mean: 0.3, std: 0.12 } },
+    ],
+  };
+}
+
+/** Drive the REAL ingress→egress chain for a single upstream node. */
+function throughChain(upstreamNode: any): Record<string, unknown> {
+  const islNode = toISLNode(normaliseNode(upstreamNode));
+  return (islNode.observed_state ?? {}) as Record<string, unknown>;
+}
+
+/** Drive the real chain for a whole graph, returning ISL nodes by id. */
+function graphThroughChain(upstream: any): Map<string, Record<string, unknown>> {
+  const normalised = normaliseGraph(upstream);
+  const out = new Map<string, Record<string, unknown>>();
+  for (const n of normalised.graph.nodes) {
+    out.set(n.id, (toISLNode(n).observed_state ?? {}) as Record<string, unknown>);
+  }
+  return out;
+}
+
+describe('2.520 S1 — human-confirmation provenance survives PLoT ingress', () => {
+  it('T1 POSITIVE CONTROL: the harness can see these keys ABSENT', () => {
+    // The crux of this suite. Every other test asserts a PRESENCE; if the
+    // harness reported `source`/`extractionType` unconditionally — because it
+    // echoed its own input, or because the projection injected the keys — those
+    // tests would pass while the pipeline dropped everything. This is the only
+    // test that can distinguish "carried through" from "the fixture never had
+    // them". An absence assertion that cannot see a presence tests nothing; the
+    // converse is just as vacuous, and that is what this pins.
+    const os = throughChain({
+      id: 'fac_no_provenance',
+      kind: 'factor',
+      label: 'No provenance',
+      observed_state: { value: 0.5, std: 0.1 },
+    });
+
+    // The chain demonstrably produced a real observed_state...
+    expect(os).toHaveProperty('value', 0.5);
+    expect(os).toHaveProperty('std', 0.1);
+    // ...and yet reports both provenance keys ABSENT. Absent, not null:
+    // a fabricated null would be a value nobody stated.
+    expect(os).not.toHaveProperty('source');
+    expect(os).not.toHaveProperty('extractionType');
+  });
+
+  it('T2 PRECONDITION: the fixture actually carries provenance on the named node', () => {
+    // Pin the guard's own precondition. If someone later tidies the fixture and
+    // drops these keys from the INPUT, T3/T4 would keep passing while asserting
+    // nothing — the test would rot silently. This makes that a RED.
+    const input = upstreamGraphWithProvenance();
+    const confirmed = input.nodes.find((n: any) => n.id === CONFIRMED_ID);
+    expect(confirmed, `fixture must contain node ${CONFIRMED_ID}`).toBeDefined();
+    expect(confirmed.observed_state.source).toBe(CONFIRMED_SOURCE);
+    expect(confirmed.observed_state.extractionType).toBe(CONFIRMED_EXTRACTION);
+    // ...and the rival node carries DIFFERENT provenance, so T3's identity
+    // binding is falsifiable rather than trivially satisfied.
+    const ai = input.nodes.find((n: any) => n.id === AI_ID);
+    expect(ai.observed_state.source).toBe(AI_SOURCE);
+    expect(ai.observed_state.extractionType).toBe(AI_EXTRACTION);
+    expect(AI_SOURCE).not.toBe(CONFIRMED_SOURCE);
+  });
+
+  it('T3 the confirmed factor reaches the ISL request body carrying its provenance, bound by id', () => {
+    // ⭐ The assertion the slice exists for, and the one the discriminating
+    // mutant pair is evaluated against.
+    // Bound by IDENTITY (`id === CONFIRMED_ID`), never by a value predicate:
+    // `find(n => n.observed_state.source === 'user_set')` would also match any
+    // other node that happened to be user_set, so it could not tell "this
+    // factor's provenance survived" from "some factor's did".
+    // Deliberately asserts about CONFIRMED_ID ONLY — degrading a DIFFERENT node
+    // must not RED this test, which is what proves the binding.
+    const byId = graphThroughChain(upstreamGraphWithProvenance());
+    const os = byId.get(CONFIRMED_ID);
+
+    expect(os, `no ISL node emitted for ${CONFIRMED_ID}`).toBeDefined();
+    expect(os).toHaveProperty('source', CONFIRMED_SOURCE);
+    expect(os).toHaveProperty('extractionType', CONFIRMED_EXTRACTION);
+    // The value itself must be untouched — this slice changes no maths.
+    expect(os).toHaveProperty('value', 0.52);
+    expect(os).toHaveProperty('std', 0.08);
+  });
+
+  it('T4 provenance lands on the right node — the AI-estimated factor keeps its own, not the human’s', () => {
+    // Identity binding from the other side: a chain that stamped one node's
+    // provenance onto every node, or crossed the two, would pass T3 and RED here.
+    const byId = graphThroughChain(upstreamGraphWithProvenance());
+
+    const confirmed = byId.get(CONFIRMED_ID);
+    const ai = byId.get(AI_ID);
+    expect(confirmed).toHaveProperty('source', CONFIRMED_SOURCE);
+    expect(ai).toHaveProperty('source', AI_SOURCE);
+    expect(ai).toHaveProperty('extractionType', AI_EXTRACTION);
+
+    // The outcome node was given no observed_state at all and must not acquire one.
+    expect(byId.get('goal_margin') ?? {}).not.toHaveProperty('source');
+  });
+
+  it('T5 DERIVED: every field ISL declares survives the ingress→egress chain', () => {
+    // The anti-mirror guard (trap 12). This does NOT hand-list the fields — it
+    // iterates `ISL_DECLARED_OBSERVED_STATE_FIELDS`, which
+    // `tests/isl-observed-state-mirror.test.ts` pins to ISL's own
+    // machine-generated OpenAPI at a sha256-verified pin. So the chain is:
+    //   ISL's Pydantic models → that list → this assertion → the normaliser.
+    // Adding a field to ISL forces a re-pin, which grows the list, which REDs
+    // here until PLoT's ingress carries it. Without this, the two keys are a
+    // patch and the NEXT field ISL adds is dropped exactly as silently.
+    const sample: Record<string, unknown> = {
+      value: 0.52,
+      baseline: 0.3,
+      unit: 'people',
+      source: CONFIRMED_SOURCE,
+      std: 0.08,
+      raw_value: 40,
+      cap: 100,
+      extractionType: CONFIRMED_EXTRACTION,
+      factor_type: 'quantitative',
+      uncertainty_drivers: ['hiring_pipeline'],
+    };
+
+    // Positive control for the derivation itself: an empty or truncated list
+    // would make the loop below pass by iterating nothing.
+    expect(ISL_DECLARED_OBSERVED_STATE_FIELDS.length).toBeGreaterThan(0);
+    for (const field of ISL_DECLARED_OBSERVED_STATE_FIELDS) {
+      expect(sample, `fixture lacks a value for declared field '${field}'`).toHaveProperty(field);
+    }
+
+    const os = throughChain({
+      id: 'fac_all_declared',
+      kind: 'factor',
+      label: 'All declared fields',
+      observed_state: sample,
+    });
+
+    for (const field of ISL_DECLARED_OBSERVED_STATE_FIELDS) {
+      expect(os, `declared field '${field}' was dropped at PLoT ingress`).toHaveProperty(
+        field,
+        sample[field],
+      );
+    }
+  });
+});


### PR DESCRIPTION
**DO-NOT-MERGE — orchestrator merges.** ROADMAP **2.520 (slice S1)**. Pillar **P4 — human–AI collaboration**.

## What this changes, in one sentence
`observed_state.source` and `observed_state.extractionType` now survive PLoT's ingress and reach the ISL request body, so the compute engine receives the claim about where a factor's value came from. **Zero maths change** — no weighting, no confidence narrowing, no treatment.

## ⚠ Transport, NOT attestation — read before building on this
`source` is an **unvalidated free-text string at every hop**. PLoT copies it verbatim (no enum, no membership check, and PLoT does not Zod-parse the incoming graph at all, so there is no seam where validation could happen today); ISL declares it `Optional[str]` and treats it as echo-only.

**A `user_*` value reaching the engine means THE FIELD ARRIVED. It does not mean a human set the number, and nothing on this path can distinguish a genuine stamp from a forged one.** Upstream forgeability is ROADMAP 2.525. Any slice that lets provenance *weigh* in the maths depends on 2.525 being closed first. This is recorded at the type, at the copy site, and in the suite header so the false gloss cannot be inherited.

## Premise, verified at the bytes (not inherited)
The blockage was real, and it is **five lists**, not two:

| # | List | had the keys? | pinned? |
|---|---|---|---|
| 1 | `UpstreamNode['observed_state']` | NO | free-floating |
| 2 | `normaliseNode` literal — **the strip** | NO | free-floating |
| 3 | `EngineNodeV3['observed_state']` | NO | free-floating |
| 4 | `ISLNodeV3['observed_state']` | YES | ↔5 compile-time, both directions |
| 5 | `ISL_DECLARED_OBSERVED_STATE_FIELDS` | YES | ↔4 compile; ↔ISL's OpenAPI at test time |

ROADMAP 2.274 already solved 4↔5↔ISL. The three lists upstream of them were unpinned to anything — which is why every guard on this path stayed green while the field never arrived.

**No second blockage:** `/v2/run` types `graph.nodes` as `{type:'array'}` (permissive). The `additionalProperties:false` `observed_state` schema in `input-validation.ts` is wired only to `draft`/`diff`, not the analysis path.

## ⭐ Prior art: this was diagnosed two months ago
- **#178** (response side — ISL echo → `/v2/run` response) **MERGED 2 Jun 2026**.
- **#182** (request side — this exact fix) **OPEN since 5 Jun, never merged.**

So PLoT has been able to *display* echoed provenance since 2 June while never *sending* any. Recommend closing #182 as superseded: it lacks the union pin, the derived conformance test, the positive control and identity binding, and its `ISLNodeV3` widening is now redundant (2.274 did it).

## Why not just the two keys — the union pin
Adding two keys fixes today's field and leaves the next one to be dropped exactly as silently. This adds a **compile-time union pin**: PLoT's canonical graph must be able to CARRY every field the ISL projector promises to FORWARD.

**Measured, not asserted:** reconstructing the true pre-2.520 state (keys removed from `EngineNodeV3` *and* from the normaliser literal) yields **exactly one error — the pin**. It would have caught the original defect at build time, on its own.

Deliberately one-directional: the canonical type may legitimately carry more than ISL declares (e.g. the PLoT-internal `metadata` the projection strips on purpose).

## Proof
RED-first at pristine, `tests/observed-state-provenance-ingress.test.ts`:
- **T1 POSITIVE CONTROL — GREEN** (harness demonstrably sees the keys ABSENT)
- **T2 PRECONDITION — GREEN** (fixture genuinely carries provenance)
- T3 **RED** — `expected { value: 0.52, std: 0.08 } to have property "source" with value 'user_set'` → `undefined`
- T4 **RED** · T5 **RED** — `declared field 'source' was dropped at PLoT ingress`

T1-green + T3-red *together* are the discrimination: the pipeline dropped them; the fixture did not lack them.

**Mutation kit** (throwaway worktree at an absolute path outside the repo root, committed state only, applied-check scoped to `src/`, control read exactly 0 at pristine and after every revert):

| Mutant | Expectation | Result |
|---|---|---|
| **M1** drop provenance for ALL factors | T3 RED | **T3 RED** |
| **M2** drop for a DIFFERENT factor only | T3 stays GREEN | **T3 GREEN, T4 RED** |
| M3 drop an unrelated declared field (`factor_type`) | T5 RED | **T5 RED**, rest GREEN |
| M4 inject provenance unconditionally | T1 RED | **T1 RED** |
| M5 revert `EngineNodeV3` | pin errors | `translator-v3.ts(369,7) TS2322` |
| **M5b** revert type AND literal (true pre-fix state) | pin alone fires | **exactly 1 error, and it is the pin** |

**M1/M2 are the discriminating pair** — T3 binds to `fac_confirmed_by_human` by id, not to "some node". **M4** proves the positive control is not vacuous. **M3** proves the derived guard catches the *next* field, not just these two.

## Schemas pin — not implicated for S1
PLoT is on `@talchain/schemas` **0.31.0** vs CEE's 0.34.0. Measured: the `observed_state` shape on this path is declared **locally** in `engine-v3.ts`, not imported from the shared contract, and there is **no Zod parse of the incoming graph** anywhere in `src/`. The fields transit as PLoT-local typed passthrough. The pin *would* be implicated for a later slice that wants them typed in the shared contract.

## Gates at this tip
- `npm run build` (required check; carries the compile-time pins) — **PASS**
- `npm run lint` (`--max-warnings 0`; row 2.465 threshold untouched) — **PASS**
- `npm test` — one **real** failure caught and fixed: `structural-keys.generated.ts` is derived from the contract types, so `extractionType` made it stale. Regenerated via `node tools/gen-structural-keys.mjs` (one line; `source` was already registered). The drift test doing exactly its job.
- Six further suites failed under ~30 concurrent sibling vitest processes; **all six pass when run in isolation** (171/171 + 6/6 perf). Measured, not assumed.

## Files
- `src/types/engine-v3.ts` — declare the fields on `UpstreamNode` and `EngineNodeV3`
- `src/normalisation/graph-normaliser.ts` — the ingress copy (owned by this lane)
- `src/integrations/isl/translator-v3.ts` — **type-level only**, the union pin; zero runtime change
- `src/util/structural-keys.generated.ts` — regenerated
- `tests/observed-state-provenance-ingress.test.ts` — new

🤖 Generated with [Claude Code](https://claude.com/claude-code)