### PR TITLE
[P0 2.878] refuse a 'delta' constraint whose value normalisation would alter — PLoT clamped -0.15 to 0 and forwarded the attestation

### DIFF
--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -1209,6 +1209,43 @@ export interface ConstraintNormalisationResult {
     /** True when the node's CEE-stamped goal_threshold was preferred (P0-C1) */
     used_node_goal_threshold?: boolean;
   }>;
+  /**
+   * ROADMAP 2.878 — constraints REFUSED rather than forwarded, because
+   * normalisation would have changed the number a `delta` attestation stands
+   * behind. Empty on every path that does not hit that case. See
+   * `DELTA_FRAME_VALUE_ALTERED` for the full reasoning.
+   */
+  refused: RefusedConstraintRecord[];
+}
+
+/**
+ * ROADMAP 2.878 — the single reason PLoT refuses to forward a constraint it
+ * successfully normalised. A union of one, deliberately: a new refusal reason
+ * must be added HERE and every consumer's exhaustiveness check moves with it,
+ * rather than a bare string that can accrete meanings silently.
+ */
+export type ConstraintRefusalReason = 'delta_frame_value_altered_by_normalisation';
+
+/** ROADMAP 2.878 — see {@link ConstraintRefusalReason}. */
+export const DELTA_FRAME_VALUE_ALTERED: ConstraintRefusalReason =
+  'delta_frame_value_altered_by_normalisation';
+
+/**
+ * ROADMAP 2.878 — a constraint that PLoT declined to send to ISL, with the
+ * quantities that made the refusal necessary. Shaped so it can be widened into
+ * `FilteredConstraintRecord` (`{constraint_id, node_id, reason}`) for
+ * `_meta.filtered_constraints` without a second hand-copy.
+ */
+export interface RefusedConstraintRecord {
+  constraint_id: string;
+  node_id: string;
+  reason: ConstraintRefusalReason;
+  /** The quantity the user stated, exactly as it arrived. */
+  stated_value: number;
+  /** The number normalisation would have sent in its place. */
+  would_have_sent: number;
+  /** The range whose scale produced that substitution. */
+  range: NormalisationRange;
 }
 
 /**
@@ -1259,6 +1296,8 @@ export function normaliseGoalConstraints(
   const repairs: RepairRecord[] = [];
   const diagnostics: ConstraintNormalisationResult['diagnostics'] = [];
   const normalisedConstraints: NormalisedGoalConstraint[] = [];
+  // ROADMAP 2.878 — constraints refused rather than forwarded with an altered value.
+  const refused: RefusedConstraintRecord[] = [];
 
   // Build node lookup map
   const nodeMap = new Map<string, EngineNodeV3>();
@@ -1414,6 +1453,94 @@ export function normaliseGoalConstraints(
       usedNodeGoalThreshold = true;
     }
 
+    // ROADMAP 2.878 — FRAME FIDELITY. A constraint attested `delta` reaches ISL
+    // as the quantity the user stated, or it does not reach ISL at all.
+    //
+    // WHY THIS IS NOT "the clamp is wrong". `normaliseFiniteValue` computes
+    // `(v − min) / (max − min)` and clamps to [0,1]. For a LEVEL — an absolute
+    // position on a factor's own bounded scale, which is what every other
+    // producer mints — that is correct and the clamp is a DOMAIN GUARD: ISL's
+    // sample space is [0,1] by construction, so a level outside the derived
+    // range must be pinned to the nearest endpoint, and `clamped: true` is the
+    // honest signal that the derived range was too narrow to contain the stated
+    // level. Downstream depends on exactly that (see
+    // `constraintThresholdClampByConstraintId` in routes/v2/run.ts, which reads
+    // the clamp DIRECTION so the margin egress never labels an understated
+    // failure margin 'exact'). The clamp is right, and it is left alone.
+    //
+    // It is category-wrong for a DELTA, in two independent ways, both measured:
+    //   1. the translation term. `− min` is meaningless on a DIFFERENCE. A
+    //      delta of −0.15 against a sign-preserving range [−1,1] normalises to
+    //      **+0.425** — not clamped, not flagged, and not the user's quantity.
+    //   2. the clamp itself. Against every range whose floor is 0 — which is
+    //      `default`, `unit_percent`, `goal_threshold_cap`, `explicit_cap`, and
+    //      `inferred_value` on any positive-domain node, i.e. the overwhelming
+    //      majority — a negative delta normalises to **0** for EVERY width.
+    //      `−0.15` → `{normalised: 0, clamped: true}`.
+    //
+    // Case 2 is the P0 this guard exists for. `extractReductionConstraints`
+    // mints `{operator: '<=', value: −N}` for "reduce X by N" and attests it
+    // `delta`; the clamp turns `<= −0.15` into `<= 0`, so ISL is asked
+    // *"P(cost changes by at most 0)"* — **the probability cost falls AT ALL** —
+    // and answers it with a confident `prob_satisfied` and no warning, because a
+    // frame-faithful `0` is a perfectly well-formed delta. Nothing downstream
+    // can recover the question: `original_value` is carried on the PLoT-internal
+    // struct and is NOT a field the ISL translator sends.
+    //
+    // THE PREDICATE IS THE INVARIANT ITSELF — "the number that would reach ISL
+    // is not the number the user stated" — and deliberately NOT `clamped`, nor
+    // the value's SIGN, nor the range's source. `clamped` is one CAUSE of the
+    // harm and would miss case 1 entirely; the sign is what the defective
+    // `constraintsNeedNormalisation` gate already keys on and would miss a
+    // rescaled positive delta; a source list would be a hand-maintained mirror
+    // that a new ladder rung silently escapes. An outcome test cannot be escaped
+    // by any of those. Note it also passes the identity cases for free: the
+    // forward-raw branch and a [0,1] range both leave `normalised === value`, so
+    // a faithfully-forwarded delta is never refused.
+    //
+    // WHY REFUSE RATHER THAN RESCALE. Rescaling a delta correctly means
+    // dividing by the range WIDTH with no offset — but whether ISL's `delta`
+    // frame expects a raw-unit difference or a normalised-space difference is
+    // NOT established at the bytes. The only witness we hold (arm B of
+    // tests/fixtures/isl-constraint-value-frame-20260807) sent `0.05` already on
+    // the normalised scale. Minting an arithmetic on an unverified semantics is
+    // precisely the fabrication class this chain exists to remove, so PLoT
+    // refuses and says so. When ISL's delta scale contract is established, this
+    // guard is where the conversion goes — and it will still be the place that
+    // refuses anything it cannot convert faithfully.
+    //
+    // WHY DROP RATHER THAN THROW. A throw would take out the whole analysis —
+    // every option result — over one constraint. The refusal is per-constraint:
+    // the run proceeds, every other constraint delivers, and this one is
+    // reported by name in `_meta.filtered_constraints` with a `removed` repair
+    // record. Dropping the `value_frame` instead was considered and rejected:
+    // ISL fail-closes an unstamped constraint by omitting the ENTIRE
+    // `constraint_analysis` block, so one bad constraint would silently delete
+    // every other constraint's verdict — and it would still send the corrupted
+    // number, merely unattested.
+    if (value_frame === 'delta' && normalised !== value) {
+      refused.push({
+        constraint_id,
+        node_id,
+        reason: DELTA_FRAME_VALUE_ALTERED,
+        stated_value: value,
+        would_have_sent: normalised,
+        range,
+      });
+      repairs.push({
+        field: `constraint.value.${constraint_id}`,
+        action: 'removed',
+        from_value: value,
+        to_value: 'refused',
+        reason:
+          `refused: a 'delta'-framed constraint value cannot be normalised without ` +
+          `changing the quantity it attests (range=[${range.min},${range.max}] ` +
+          `source=${range.source} would have sent ${normalised} in place of ${value}). ` +
+          `Forwarding it would ask ISL a different question than the user asked.`,
+      });
+      continue;
+    }
+
     // UNIT COMPATIBILITY (the goal-fit unit collision). Decided HERE, at
     // ladder-decision time, for the same reason range_unified is: this is the
     // only place that holds BOTH the constraint's own declared unit and the
@@ -1505,6 +1632,7 @@ export function normaliseGoalConstraints(
     constraints: normalisedConstraints,
     repairs,
     diagnostics,
+    refused,
   };
 }
 

--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -1478,6 +1478,20 @@ export function normaliseGoalConstraints(
     //      majority — a negative delta normalises to **0** for EVERY width.
     //      `−0.15` → `{normalised: 0, clamped: true}`.
     //
+    // ⚠ WHAT IS *NOT* CLAIMED, and an earlier draft of this comment got wrong.
+    // For a min-0 range the map reduces to `v / width`, which IS the
+    // arithmetically correct NORMALISED-SPACE delta — so `+0.05` on `[0,200]`
+    // → `0.00025` is only a corruption under the RAW-UNIT reading, and this
+    // very file states below that which reading ISL takes is NOT established.
+    // The substitution is therefore **unverifiable in either direction**, not a
+    // measured 200× error. That is precisely why refusing is right: under
+    // genuine uncertainty a gap beats a number nobody can check. Stating it as
+    // a settled corruption would be the same over-read this guard exists to
+    // prevent (an honest unknown hardening into a claim the next reader
+    // inherits without its scope).
+    // Case 2's CLAMP, by contrast, is a corruption under BOTH readings: no
+    // reading of a delta frame makes `<= 0` mean `<= −0.15`.
+    //
     // Case 2 is the P0 this guard exists for. `extractReductionConstraints`
     // mints `{operator: '<=', value: −N}` for "reduce X by N" and attests it
     // `delta`; the clamp turns `<= −0.15` into `<= 0`, so ISL is asked
@@ -1487,16 +1501,33 @@ export function normaliseGoalConstraints(
     // can recover the question: `original_value` is carried on the PLoT-internal
     // struct and is NOT a field the ISL translator sends.
     //
-    // THE PREDICATE IS THE INVARIANT ITSELF — "the number that would reach ISL
-    // is not the number the user stated" — and deliberately NOT `clamped`, nor
-    // the value's SIGN, nor the range's source. `clamped` is one CAUSE of the
-    // harm and would miss case 1 entirely; the sign is what the defective
-    // `constraintsNeedNormalisation` gate already keys on and would miss a
-    // rescaled positive delta; a source list would be a hand-maintained mirror
-    // that a new ladder rung silently escapes. An outcome test cannot be escaped
-    // by any of those. Note it also passes the identity cases for free: the
-    // forward-raw branch and a [0,1] range both leave `normalised === value`, so
-    // a faithfully-forwarded delta is never refused.
+    // THE PREDICATE IS A UNION OF TWO GUARDS WITH DISJOINT BLIND SPOTS, and
+    // that is the whole point — ⚠ an earlier version of this comment claimed
+    // the outcome test "cannot be escaped" by the alternatives. THAT WAS FALSE,
+    // and it was refuted by execution in review.
+    //
+    //   `normalised !== value`  — the invariant itself: the number that would
+    //      reach ISL is not the number the user stated. Catches case 1 (the
+    //      translation term), which `clamped` cannot see at all, and catches a
+    //      rescaled positive delta, which a SIGN test cannot see.
+    //   `clamped`               — catches what the outcome test provably
+    //      misses: THE AFFINE MAP HAS FIXED POINTS, so identity of the OUTPUT
+    //      does not imply identity of the TRANSFORM. Measured: range [0,0.5],
+    //      delta `1` → raw `2` → clamped DOWN to `1` → `normalised === value`
+    //      → the outcome test does not fire, and a HALVING ships with the
+    //      'delta' attestation intact. General form: the fixed point
+    //      `v = min / (1 − width)` for `width ≠ 1`, plus `v ∈ {0,1}` whenever
+    //      the clamp happens to land on the stated value itself.
+    //
+    // Neither dominates the other, so neither is a "winner" — the OR is
+    // load-bearing in both directions and removing either arm reopens a class.
+    // A range-SOURCE list was also considered and rejected: it would be a
+    // hand-maintained mirror a new ladder rung silently escapes.
+    //
+    // No false positives from floating point: the only exact-identity path is
+    // `min = 0 ∧ width = 1`, where `(v − 0) / 1 === v` exactly in IEEE-754 (and
+    // `-0 === 0` under `!==`). So the forward-raw branch and a [0,1] range both
+    // leave a faithful delta untouched and unrefused.
     //
     // WHY REFUSE RATHER THAN RESCALE. Rescaling a delta correctly means
     // dividing by the range WIDTH with no offset — but whether ISL's `delta`
@@ -1509,6 +1540,18 @@ export function normaliseGoalConstraints(
     // guard is where the conversion goes — and it will still be the place that
     // refuses anything it cannot convert faithfully.
     //
+    // ⚠ SCOPE OF THE REFUSAL — this is NOT a narrow edge case, and it must not
+    // be read as one. `normalised === value` requires `min = 0 ∧ width = 1`,
+    // and every producer-declared rung has width ≠ 1 by construction
+    // (`unit_percent` [0,100], `goal_threshold_cap` [0,cap], `explicit_cap`),
+    // while `inferred_value` yields [0, 2·observed] — identity only when the
+    // observed value is exactly 0.5. **So in practice this refuses essentially
+    // the WHOLE delta class on any in-graph node: delta-framed constraints are
+    // non-functional until ISL's delta scale contract is established at the
+    // bytes.** That is a deliberate fail-closed posture, not an oversight, and
+    // it is the honest state of the capability — recorded here so a later
+    // reader does not inherit "refuses what it cannot convert" as an edge case.
+    //
     // WHY DROP RATHER THAN THROW. A throw would take out the whole analysis —
     // every option result — over one constraint. The refusal is per-constraint:
     // the run proceeds, every other constraint delivers, and this one is
@@ -1518,7 +1561,21 @@ export function normaliseGoalConstraints(
     // `constraint_analysis` block, so one bad constraint would silently delete
     // every other constraint's verdict — and it would still send the corrupted
     // number, merely unattested.
-    if (value_frame === 'delta' && normalised !== value) {
+    //
+    // ⚠⚠ AND THE FIRST VERSION OF THIS FIX REPRODUCED THAT EXACT HARM — the one
+    // the paragraph above says it rejected the alternative to avoid. Removing a
+    // constraint HERE is only half the job: PLoT's own one-to-one honesty guard
+    // (`buildConstraintFields`, routes/v2/run.ts) compares ISL's result count
+    // against the ACTIVE constraint list, so a constraint dropped from the ISL
+    // payload but left in the active list makes the counts disagree and the
+    // WHOLE run reports `constraints_status: 'unavailable'` with zero results.
+    // Proven by execution in review: 2 levels + 1 refused delta → 0 results;
+    // the same payload with 'level' instead of 'delta' → 3 results. **The
+    // caller MUST also remove the refused ids from the active set** — see the
+    // `refusedConstraintRecords` handling in routes/v2/run.ts, which mirrors
+    // what the temporal filter does by REPLACING the list before the active set
+    // is derived. Pinned by tests/constraint-delta-frame-refusal.route.test.ts.
+    if (value_frame === 'delta' && (normalised !== value || clamped)) {
       refused.push({
         constraint_id,
         node_id,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -202,6 +202,7 @@ import {
   type RangeSource,
   type GoalThresholdNodeMeta,
   type ConstraintUnitMismatch,
+  type RefusedConstraintRecord,
 } from '../../lib/intervention-normaliser.js';
 import { assembleBrief } from '../../assembly/decision-brief.js';
 import { buildEvidencePriorityCard, type FactorInput } from '../../review-pass/evidence-priority.js';
@@ -5485,6 +5486,14 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // Stash filtered records for _meta
         const filteredConstraintRecords = temporalFilterResult.filtered;
 
+        // ROADMAP 2.878 — constraints REFUSED at normalisation (a `delta`
+        // attestation whose value normalisation would have altered). Declared
+        // here, beside the temporal records, because both answer the same
+        // question for a consumer — "which constraints did NOT reach the engine,
+        // and why" — and both land in `_meta.filtered_constraints`. Populated
+        // ~1,000 lines below, once the normaliser has run.
+        const refusedConstraintRecords: RefusedConstraintRecord[] = [];
+
         if (filteredConstraintRecords.length > 0) {
           req.log.info({
             event: 'plot.temporal_constraints_filtered',
@@ -6527,6 +6536,22 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             );
             constraintsForISL = constraintNormResult.constraints;
 
+            // ROADMAP 2.878 — a `delta`-framed constraint whose value
+            // normalisation would have changed is REFUSED, not forwarded: it is
+            // already absent from `constraintNormResult.constraints`, so it
+            // reaches neither the ISL translator nor the constraint-PU
+            // injection below. Report it by name — a constraint that silently
+            // disappears is the failure this refusal exists to replace.
+            if (constraintNormResult.refused.length > 0) {
+              refusedConstraintRecords.push(...constraintNormResult.refused);
+              req.log.warn({
+                event: 'plot.constraint_refused',
+                refused_count: constraintNormResult.refused.length,
+                forwarded_count: constraintNormResult.constraints.length,
+                refused: constraintNormResult.refused,
+              });
+            }
+
             // Single pass over the constraint diagnostics builds BOTH per-constraint
             // maps from the SAME source of truth (derive-don't-mirror):
             //  - constraintNormalisationRanges: the range each threshold normalised
@@ -6642,6 +6667,28 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             message: `${filteredConstraintRecords.length} temporal constraint(s) filtered before analysis: [${ids}]. Temporal constraints cannot be evaluated on a static causal graph.`,
             source: 'validation',
             affected_node_ids: filteredConstraintRecords.map(f => f.node_id),
+            blocks_analysis: false,
+          });
+        }
+
+        // ROADMAP 2.878 — surface refused constraints to the API consumer.
+        // `severity: 'warning'`, not 'info': the user asked a question that this
+        // run did NOT answer, and the only honest thing is to say so. It does
+        // not block the analysis — every other constraint and every option
+        // result still delivers.
+        if (refusedConstraintRecords.length > 0) {
+          const refusedIds = refusedConstraintRecords.map(r => r.constraint_id).join(', ');
+          preflight.warnings.push({
+            id: randomUUID(),
+            code: 'CONSTRAINT_REFUSED_FRAME_FIDELITY',
+            severity: 'warning',
+            message:
+              `${refusedConstraintRecords.length} constraint(s) were not evaluated: [${refusedIds}]. ` +
+              `Each states a CHANGE (a 'delta'), and the scale this graph resolves for its target ` +
+              `node cannot carry that change without altering the amount stated. Rather than ask ` +
+              `the engine a different question, the constraint was left out of the analysis.`,
+            source: 'validation',
+            affected_node_ids: refusedConstraintRecords.map(r => r.node_id),
             blocks_analysis: false,
           });
         }
@@ -8551,7 +8598,21 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             ceeBuild: ceeOrchestrationResult.ceeTrace?.source ?? undefined,
             computedAt,
             requestIdChain: chain,
-            filteredConstraints: filteredConstraintRecords,
+            // ROADMAP 2.878 — refusals join the temporal filter's records in the
+            // ONE place a consumer already looks for "constraints that did not
+            // reach the engine". Widened to FilteredConstraintRecord by taking
+            // the three shared fields; the refusal's quantities stay in the log
+            // event and the repair record. Appended (not interleaved) so the
+            // existing temporal ordering is byte-identical for every run that
+            // refuses nothing — which is every run today.
+            filteredConstraints: [
+              ...filteredConstraintRecords,
+              ...refusedConstraintRecords.map(r => ({
+                constraint_id: r.constraint_id,
+                node_id: r.node_id,
+                reason: r.reason,
+              })),
+            ],
             rangeDerivationSources: normalisationContext
               ? Object.fromEntries([...normalisationContext.factors].map(([id, ctx]) => [id, ctx.range.source]))
               : buildDefaultRangeDerivationSources(normalizedOptions),

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -6544,11 +6544,68 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             // disappears is the failure this refusal exists to replace.
             if (constraintNormResult.refused.length > 0) {
               refusedConstraintRecords.push(...constraintNormResult.refused);
+
+              // ⚠⚠ ROADMAP 2.878 F1 — REMOVING IT FROM THE ISL PAYLOAD IS ONLY
+              // HALF THE JOB. `buildConstraintFields` enforces an EXACT
+              // one-to-one correspondence between ISL's constraint results and
+              // the ACTIVE constraint list (`constraintResults.length ===
+              // goalConstraints.length && …`, ~line 2364), and it is handed
+              // `activeGoalConstraints`. A constraint dropped from the payload
+              // but left in the active list makes those counts disagree, so the
+              // guard returns `constraints_status: 'unavailable'` and the run
+              // reports **ZERO** constraint results — one refused delta deletes
+              // every OTHER constraint's correctly-computed verdict, and the
+              // disclosure then says "1 constraint was not evaluated" when in
+              // fact none were. That is the precise harm the refusal design
+              // rejected the drop-the-frame alternative to avoid; the first
+              // version of this fix reproduced it. Proven by execution: 2 levels
+              // + 1 refused delta → 0 results; byte-identical payload with
+              // 'level' instead of 'delta' → 3 results.
+              //
+              // THE PRE-EXISTING DROP MECHANISM SHOWS THE CORRECT SHAPE: the
+              // temporal filter REPLACES the list (`constraintCompilation
+              // .constraints = temporalFilterResult.passed`) *before*
+              // `activeGoalConstraints` is derived from it. This drop happens
+              // ~700 lines later, so it must do the equivalent explicitly.
+              //
+              // Reassigning here (rather than at the single response-builder
+              // call site) fixes EVERY downstream consumer at once, including
+              // `buildConstraintScaleProvenance` below — which would otherwise
+              // build a trust marker for a refused constraint that has no
+              // diagnostic, disclosing it as a forwarded-raw
+              // `source: 'default'` constraint that was never sent at all.
+              const refusedIds = new Set(
+                constraintNormResult.refused.map((r) => r.constraint_id),
+              );
+              activeGoalConstraints = activeGoalConstraints.filter(
+                (c) => !refusedIds.has(c.constraint_id),
+              );
+
+              // ⚠ ROADMAP 2.878 F3 — NO QUANTITIES ON THIS EVENT. `stated_value`
+              // is only digested when `String(v).length >= 4` (MIN_TOKEN_LEN),
+              // so `0.5` / `-5` / `12` ship in the clear; `would_have_sent` is
+              // DERIVED, so it is never a registered token and its key is not a
+              // DECISION_DOMAIN_KEY — it would never be redacted at all. That is
+              // exactly the class removed from the sibling events ~100 lines
+              // above. The precedent to match is
+              // `plot.temporal_constraints_filtered`, which logs
+              // `FilteredConstraintRecord` — no quantity by construction.
+              // `range.source` is flattened to `range_source` deliberately: the
+              // `source` key is in both DECISION_DOMAIN_KEYS and
+              // LITERAL_VALUE_KEYS and the decision branch is checked first, so
+              // a nested `range` would digest the range vocabulary into
+              // uselessness. The quantities remain in the `removed` repair
+              // record, which is response content rather than an info log.
               req.log.warn({
                 event: 'plot.constraint_refused',
                 refused_count: constraintNormResult.refused.length,
                 forwarded_count: constraintNormResult.constraints.length,
-                refused: constraintNormResult.refused,
+                refused: constraintNormResult.refused.map((r) => ({
+                  constraint_id: r.constraint_id,
+                  node_id: r.node_id,
+                  reason: r.reason,
+                  range_source: r.range.source,
+                })),
               });
             }
 

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -5978,8 +5978,29 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
         // toISLRobustnessRequest below — filteredGraph.nodes is not mutated
         // between here and the request build, so the request sends byte-identical
         // PUs while paying for the pass only once. This also closes the
-        // lockstep-drift hazard: the plan count can no longer diverge from what
-        // the request actually carries.
+        // lockstep-drift hazard for the FACTOR PUs: the plan count can no longer
+        // diverge from what the request actually carries.
+        //
+        // ⚠ ROADMAP 2.878 — THAT EXACTNESS CLAIM IS NOW NARROWER THAN IT READS,
+        // AND THE CAVEAT IS DELIBERATE. `activeGoalConstraints` is REASSIGNED
+        // further down (at the delta-frame refusal) to drop constraints PLoT
+        // declines to forward, so the identifier denotes TWO DIFFERENT SETS
+        // either side of that point: the full set here at plan time, the
+        // forwarded set at request-build time. The CONSTRAINT-PU count planned
+        // here can therefore exceed what `injectConstraintParameterUncertainties`
+        // actually injects (it is handed `constraintsForISL`).
+        //
+        // This is a PRICING divergence, not a correctness one — the request
+        // still carries exactly the PUs for the constraints it forwards; only
+        // the EVPI depth pricing may have been computed against one more
+        // constrained node than survives. Bounded, not asserted: measured at
+        // ZERO divergence across the fixtures exercised so far, because a
+        // refused constraint's target node is usually still constrained by a
+        // sibling. **Reachability of a non-zero divergence is UNKNOWN** — it
+        // needs a refused delta that is the ONLY constraint on its target node.
+        // Recorded here rather than silently left as a stale exactness claim;
+        // the settling experiment is to instrument the two counts and drive a
+        // single-constraint-per-node refusal.
         const factorParameterUncertainties = buildParameterUncertaintiesV3(filteredGraph.nodes) ?? [];
         const factorPuNodeIds = new Set(factorParameterUncertainties.map((pu) => pu.node_id));
         // One id→node map shared by the plan-time constraint-PU selection and the

--- a/tests/constraint-delta-frame-fidelity.test.ts
+++ b/tests/constraint-delta-frame-fidelity.test.ts
@@ -264,8 +264,21 @@ describe('2.878 — the guard is not a SIGN check: the positive half of the delt
     // AUDIT THE PREDICATE'S DOMAIN, not just the named case. The reduction
     // constraint is negative, so a guard written as `value < 0` would pass every
     // other test in this file while leaving the whole positive half of the delta
-    // domain corrupted. "increase throughput by 0.05" against the cost node's
-    // [0,200] scale becomes 0.00025 — a 200x understatement, silently.
+    // domain unguarded. "increase throughput by 0.05" against the cost node's
+    // [0,200] scale is substituted by 0.00025.
+    //
+    // ⚠ THAT SUBSTITUTION IS NOT A MEASURED ERROR, AND AN EARLIER VERSION OF
+    // THIS COMMENT CALLED IT "a 200x understatement, silently". Withdrawn: for
+    // any min-0 range the map reduces to `v / width`, which IS the correct
+    // NORMALISED-SPACE delta — so the number is only wrong under the RAW-UNIT
+    // reading, and `intervention-normaliser.ts` states that which reading ISL
+    // takes is NOT established at the bytes. It is **unverifiable in either
+    // direction**, which is precisely why refusing is right: under genuine
+    // uncertainty a gap beats a number nobody can check.
+    //
+    // The point this test actually makes is therefore about the PREDICATE, not
+    // about the magnitude: a sign-keyed guard would not fire here at all, so
+    // half the delta domain would pass through unexamined.
     const c = REDUCTION_CONSTRAINT({
       constraint_id: 'gc-increase-positive-delta',
       operator: '>=',

--- a/tests/constraint-delta-frame-fidelity.test.ts
+++ b/tests/constraint-delta-frame-fidelity.test.ts
@@ -1,0 +1,392 @@
+/**
+ * ROADMAP 2.878 (P0) — A `delta`-FRAMED CONSTRAINT REACHES ISL AS THE QUANTITY
+ * THE USER STATED, OR IT DOES NOT REACH ISL AT ALL.
+ *
+ * THE DEFECT, as measured against this module before the fix. CEE's
+ * `extractReductionConstraints` mints `{ operator: '<=', value: -N }` for
+ * "reduce X by N" and attests it `'delta'`. PLoT normalised that value through
+ * `(v − min) / (max − min)` and clamped to [0,1], so `-0.15` became **0** — and
+ * forwarded the `'delta'` attestation with it, unchanged and unflagged. ISL then
+ * answers `<= 0` in the delta frame, i.e. **"what is the probability cost falls
+ * AT ALL"**, in place of the user's "…falls by at least 15%". It answers with a
+ * confident `prob_satisfied` and NO warning, because a frame-faithful `0` is a
+ * perfectly well-formed delta — the corruption is invisible at the far end, and
+ * `original_value` is a PLoT-internal field the translator never sends.
+ *
+ * WHY NOTHING WENT RED: no PLoT test covered a negative constraint value, and
+ * `constraintsNeedNormalisation` — which uses the negative SIGN as the
+ * normalisation TRIGGER — had zero branch coverage. Both are closed here.
+ *
+ * ⚠ THE INPUT SPACE IS BOUNDED BY THE PRODUCER, NOT BY THIS AUTHOR (trap 16
+ * inverse — "a fixture you wrote yourself is not evidence about the wire", and
+ * trap 13c — derive the expectation from the producer's declared semantics).
+ * `REDUCTION_CONSTRAINT` below reproduces what CEE actually mints, read at the
+ * bytes at `olumi-assistants-service@2d29951b`,
+ * `src/cee/compound-goal/extractor.ts:468-485`:
+ *
+ *     operator: "<=",  value: -value,  valueFrame: "delta",  provenance: "explicit"
+ *
+ * — and its `unit` is **"fraction"**, not "%", because `normaliseConstraintUnits`
+ * (same file, ROADMAP 1.52) relabels a "%" unit whose `0 < |value| < 1`. That
+ * detail decides which range rung is reachable: `isPercentUnit('fraction')` is
+ * FALSE (`PERCENT_UNIT_TOKENS` = ['%','percent','pct','percentage']), so the
+ * `unit_percent` [0,100] rung is NOT on this path and the constraint falls
+ * through to `deriveRange(node)`. A fixture that used unit "%" would have tested
+ * a rung the producer cannot reach.
+ *
+ * The surrounding constraint shape (label / unit / provenance / confidence /
+ * source_quote / constraint_id) matches the real captures in
+ * `PHASE0-EVIDENCE-2026-07-28/l60-artefacts/scenario-{people,pricing}.json`.
+ * Those captures are also the evidence that every LIVE constraint today is
+ * positive and level-shaped (`value: 2` unit "count", `value: 0.8` unit
+ * "fraction") — which is exactly why this defect could sit unobserved.
+ *
+ * Every assertion binds its constraint by `constraint_id` IDENTITY, never by a
+ * value predicate another constraint could satisfy (trap 19).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  normaliseGoalConstraints,
+  constraintsNeedNormalisation,
+} from '../src/lib/intervention-normaliser.js';
+import { toISLRobustnessRequest } from '../src/integrations/isl/translator-v3.js';
+import type { EngineNodeV3, GoalConstraint } from '../src/types/engine-v3.js';
+
+type RawGoalConstraint = GoalConstraint & Record<string, unknown>;
+
+/**
+ * A cost factor with an observed level of 100. `deriveRange` Priority 3
+ * (inferred_value) resolves [0, 200] for it — the ordinary, positive-domain
+ * shape the overwhelming majority of real graphs present.
+ */
+const COST_NODE: EngineNodeV3 = {
+  id: 'fac_unit_cost',
+  kind: 'factor',
+  label: 'Unit cost',
+  observed_state: { value: 100 },
+} as unknown as EngineNodeV3;
+
+/**
+ * A factor whose observed level is NEGATIVE. `deriveRange` Priority 3 is
+ * sign-preserving (D-9), so this resolves [-1, 0] — a range whose floor is below
+ * a `-0.15` delta, which therefore does NOT clamp. It is the second, independent
+ * corruption: the affine map's translation term (`− min`) is meaningless on a
+ * DIFFERENCE, and turns -0.15 into +0.85 with `clamped: false`.
+ */
+const SIGNED_NODE: EngineNodeV3 = {
+  id: 'fac_net_margin_delta',
+  kind: 'factor',
+  label: 'Net margin change',
+  observed_state: { value: -0.5 },
+} as unknown as EngineNodeV3;
+
+const NODES: EngineNodeV3[] = [COST_NODE, SIGNED_NODE];
+
+/**
+ * What CEE mints for "reduce unit cost by 15%" — see the header for the byte
+ * provenance of every field.
+ */
+const REDUCTION_CONSTRAINT = (over: Partial<RawGoalConstraint> = {}): RawGoalConstraint =>
+  ({
+    constraint_id: 'gc-reduce-unit-cost',
+    node_id: 'fac_unit_cost',
+    operator: '<=',
+    value: -0.15,
+    value_frame: 'delta',
+    unit: 'fraction',
+    label: 'Unit cost down by 15%',
+    source_quote: 'reduce unit cost by 15%',
+    confidence: 0.85,
+    provenance: 'explicit',
+    ...over,
+  }) as RawGoalConstraint;
+
+// -----------------------------------------------------------------------------
+// 1. The P0 itself, at the producer's own shape
+// -----------------------------------------------------------------------------
+
+describe("2.878 — a 'delta' whose value normalisation would ALTER is refused, not forwarded", () => {
+  it('DEFECT: the reduction constraint CEE mints is NOT forwarded to ISL', () => {
+    const out = normaliseGoalConstraints([REDUCTION_CONSTRAINT()], NODES);
+
+    // Bind by identity — not by "the list is empty", which a different bug
+    // (dropping every constraint) would also satisfy.
+    const forwarded = out.constraints.find((c) => c.constraint_id === 'gc-reduce-unit-cost');
+    expect(forwarded).toBeUndefined();
+  });
+
+  it('DEFECT: the refusal names the constraint, the stated quantity, and the number it replaced it with', () => {
+    const out = normaliseGoalConstraints([REDUCTION_CONSTRAINT()], NODES);
+
+    const refusal = out.refused.find((r) => r.constraint_id === 'gc-reduce-unit-cost');
+    expect(refusal).toBeDefined();
+    expect(refusal!.reason).toBe('delta_frame_value_altered_by_normalisation');
+    expect(refusal!.node_id).toBe('fac_unit_cost');
+
+    // The user's quantity, byte-identical.
+    expect(refusal!.stated_value).toBe(-0.15);
+
+    // ⚠ THE DEFECT NUMBER, PINNED. This is precisely what shipped: `0`, an
+    // attested delta meaning "changes by at most nothing" — the probability
+    // cost falls AT ALL. If this expectation ever stops being 0, the clamp
+    // arithmetic moved and this whole file needs re-deriving.
+    expect(refusal!.would_have_sent).toBe(0);
+
+    // And the range that produced it — the ordinary positive-domain rung.
+    expect(refusal!.range).toEqual({ min: 0, max: 200, source: 'inferred_value' });
+  });
+
+  it('DEFECT: the refused constraint never reaches the ISL wire', () => {
+    const out = normaliseGoalConstraints([REDUCTION_CONSTRAINT()], NODES);
+
+    const request = toISLRobustnessRequest(
+      { nodes: NODES, edges: [] } as never,
+      [{ id: 'opt_a', interventions: {} }] as never,
+      'fac_unit_cost',
+      'req-2878',
+      100,
+      undefined,
+      out.constraints,
+    );
+
+    // The whole key is omitted when nothing survives — but assert the ABSENCE of
+    // THIS constraint by identity, so a future run carrying other constraints
+    // still fails if this one slips through.
+    const sent = (request.goal_constraints ?? []).find(
+      (c) => c.constraint_id === 'gc-reduce-unit-cost',
+    );
+    expect(sent).toBeUndefined();
+  });
+
+  it('DEFECT: a `removed` repair record discloses the refusal in the audit ledger', () => {
+    const out = normaliseGoalConstraints([REDUCTION_CONSTRAINT()], NODES);
+
+    const repair = out.repairs.find((r) => r.field === 'constraint.value.gc-reduce-unit-cost');
+    expect(repair).toBeDefined();
+    expect(repair!.action).toBe('removed');
+    expect(repair!.from_value).toBe(-0.15);
+    // Not a 'normalised' repair claiming a successful conversion.
+    expect(repair!.to_value).toBe('refused');
+  });
+
+  it('DEFECT: a refused constraint emits NO normalisation diagnostic — it has no scale to disclose', () => {
+    const out = normaliseGoalConstraints([REDUCTION_CONSTRAINT()], NODES);
+
+    const diag = out.diagnostics.find((d) => d.constraint_id === 'gc-reduce-unit-cost');
+    expect(diag).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// 2. The second corruption: the translation term, with NO clamp
+// -----------------------------------------------------------------------------
+
+describe('2.878 — the guard is on the OUTCOME, so it also catches the un-clamped corruption', () => {
+  it('DEFECT: a delta against a sign-preserving range is refused even though it never clamped', () => {
+    const c = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-reduce-margin',
+      node_id: 'fac_net_margin_delta',
+    });
+    const out = normaliseGoalConstraints([c], NODES);
+
+    expect(out.constraints.find((x) => x.constraint_id === 'gc-reduce-margin')).toBeUndefined();
+
+    const refusal = out.refused.find((r) => r.constraint_id === 'gc-reduce-margin');
+    expect(refusal).toBeDefined();
+    expect(refusal!.stated_value).toBe(-0.15);
+
+    // (-0.15 − (−1)) / (0 − (−1)) = 0.85. A POSITIVE number, in place of a
+    // reduction, with `clamped` FALSE — so a guard keyed on `clamped` would
+    // have missed this entirely. That is why the predicate is "the value
+    // changed", not "the value was clamped".
+    expect(refusal!.would_have_sent).toBeCloseTo(0.85, 10);
+    expect(refusal!.range).toEqual({ min: -1, max: 0, source: 'inferred_value' });
+  });
+});
+
+describe('2.878 — the guard is not a SIGN check: the positive half of the delta domain', () => {
+  it('DEFECT: a POSITIVE delta that normalisation rescales is refused too — the guard is not a sign check', () => {
+    // AUDIT THE PREDICATE'S DOMAIN, not just the named case. The reduction
+    // constraint is negative, so a guard written as `value < 0` would pass every
+    // other test in this file while leaving the whole positive half of the delta
+    // domain corrupted. "increase throughput by 0.05" against the cost node's
+    // [0,200] scale becomes 0.00025 — a 200x understatement, silently.
+    const c = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-increase-positive-delta',
+      operator: '>=',
+      value: 0.05,
+    });
+    const out = normaliseGoalConstraints([c], NODES);
+
+    expect(out.constraints.find((x) => x.constraint_id === 'gc-increase-positive-delta')).toBeUndefined();
+
+    const refusal = out.refused.find((r) => r.constraint_id === 'gc-increase-positive-delta');
+    expect(refusal).toBeDefined();
+    expect(refusal!.stated_value).toBe(0.05);
+    expect(refusal!.would_have_sent).toBeCloseTo(0.00025, 12);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// 3. The discrimination: a FAITHFUL delta is forwarded, untouched
+// -----------------------------------------------------------------------------
+
+describe('2.878 — a delta normalisation does NOT alter is forwarded, frame intact', () => {
+  it('PIN: an identity range leaves the value alone, so the constraint delivers', () => {
+    // No matching node ⇒ range default [0,1] ⇒ (v − 0) / 1 === v exactly.
+    const c = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-faithful-delta',
+      node_id: 'node_not_in_graph',
+      operator: '>=',
+      value: 0.05,
+    });
+    const out = normaliseGoalConstraints([c], NODES);
+
+    expect(out.refused).toHaveLength(0);
+
+    const forwarded = out.constraints.find((x) => x.constraint_id === 'gc-faithful-delta');
+    expect(forwarded).toBeDefined();
+    expect(forwarded!.value).toBe(0.05);
+    // The attestation rides through unchanged — this fix must not become a
+    // reason the frame stops being forwarded (that would silently re-open
+    // 2.855 by deleting every constraint's analysis block at ISL).
+    expect(forwarded!.value_frame).toBe('delta');
+  });
+
+  it('PIN: the forward-raw branch (gate FALSE, no intervention scale) is an identity, so it is not refused', () => {
+    const c = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-forward-raw',
+      node_id: 'fac_unit_cost',
+      operator: '>=',
+      value: 0.42,
+    });
+    const out = normaliseGoalConstraints([c], NODES, { normaliseWithoutScale: false });
+
+    expect(out.refused).toHaveLength(0);
+    const forwarded = out.constraints.find((x) => x.constraint_id === 'gc-forward-raw');
+    expect(forwarded!.value).toBe(0.42);
+    expect(forwarded!.value_frame).toBe('delta');
+  });
+
+  it('THE DISCRIMINATING PAIR, in one call: the altered delta is refused and the faithful one is not', () => {
+    // Both are `delta`. Both are negative-or-not is irrelevant. The ONLY thing
+    // that differs is whether normalisation moved the number. A guard that
+    // refused "all deltas", or "all negatives", or "all clamped", would fail
+    // this test — it is what binds the guard to its actual invariant.
+    const altered = REDUCTION_CONSTRAINT({ constraint_id: 'gc-altered' });
+    const faithful = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-faithful',
+      node_id: 'node_not_in_graph',
+      operator: '>=',
+      value: 0.05,
+    });
+
+    const out = normaliseGoalConstraints([altered, faithful], NODES);
+
+    expect(out.refused.map((r) => r.constraint_id)).toEqual(['gc-altered']);
+    expect(out.constraints.map((c) => c.constraint_id)).toEqual(['gc-faithful']);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// 4. The clamp is UNCHANGED for the purpose it was built for
+// -----------------------------------------------------------------------------
+
+describe('2.878 — a LEVEL still clamps and still delivers (the clamp is a domain guard, not a bug)', () => {
+  it('PIN: a level below the range floor is clamped to 0 and FORWARDED, exactly as before', () => {
+    const c = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-level-below-floor',
+      value_frame: 'level',
+    });
+    const out = normaliseGoalConstraints([c], NODES);
+
+    expect(out.refused).toHaveLength(0);
+
+    const forwarded = out.constraints.find((x) => x.constraint_id === 'gc-level-below-floor');
+    expect(forwarded).toBeDefined();
+    expect(forwarded!.value).toBe(0);
+    expect(forwarded!.original_value).toBe(-0.15);
+    expect(forwarded!.value_frame).toBe('level');
+
+    // And the clamp signal downstream depends on is still recorded.
+    const diag = out.diagnostics.find((d) => d.constraint_id === 'gc-level-below-floor');
+    expect(diag!.clamped).toBe(true);
+    expect(diag!.normalised_value).toBe(0);
+  });
+
+  it('PIN: a level above the range ceiling is clamped to 1 and FORWARDED', () => {
+    const c = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-level-above-ceiling',
+      operator: '>=',
+      value: 500,
+      value_frame: 'level',
+    });
+    const out = normaliseGoalConstraints([c], NODES);
+
+    expect(out.refused).toHaveLength(0);
+    const forwarded = out.constraints.find((x) => x.constraint_id === 'gc-level-above-ceiling');
+    expect(forwarded!.value).toBe(1);
+    const diag = out.diagnostics.find((d) => d.constraint_id === 'gc-level-above-ceiling');
+    expect(diag!.clamped).toBe(true);
+  });
+
+  it('PIN: an UNATTESTED constraint is untouched by this guard — PLoT never infers a frame', () => {
+    // Inferring `delta` from (operator '<=', negative value) is exactly the
+    // guess CEE #862 refused to make, on the grounds that `<=` with a POSITIVE
+    // value is a level. PLoT must not make it either. This one still normalises
+    // to 0 and is still forwarded; ISL fail-closes it on the missing frame with
+    // a named reason, which is the honest disposal for an unattested number.
+    const c = REDUCTION_CONSTRAINT({ constraint_id: 'gc-unattested' });
+    delete (c as Record<string, unknown>).value_frame;
+
+    const out = normaliseGoalConstraints([c], NODES);
+
+    expect(out.refused).toHaveLength(0);
+    const forwarded = out.constraints.find((x) => x.constraint_id === 'gc-unattested');
+    expect(forwarded).toBeDefined();
+    expect(forwarded!.value).toBe(0);
+    expect('value_frame' in forwarded!).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// 5. `constraintsNeedNormalisation` — the zero-branch-coverage trigger site
+// -----------------------------------------------------------------------------
+
+describe('2.878 — constraintsNeedNormalisation: the site whose negative branch had no coverage', () => {
+  const at = (value: number, constraint_id = 'gc-probe'): GoalConstraint =>
+    ({ constraint_id, node_id: 'fac_unit_cost', operator: '<=', value }) as GoalConstraint;
+
+  it('fires on a NEGATIVE value — the branch that made the reduction constraint normalise at all', () => {
+    expect(constraintsNeedNormalisation([at(-0.15)])).toBe(true);
+  });
+
+  it('fires on a value ABOVE 1', () => {
+    expect(constraintsNeedNormalisation([at(1.000001)])).toBe(true);
+    expect(constraintsNeedNormalisation([at(200)])).toBe(true);
+  });
+
+  it('does NOT fire at either boundary — 0 and 1 are inside [0,1]', () => {
+    expect(constraintsNeedNormalisation([at(0)])).toBe(false);
+    expect(constraintsNeedNormalisation([at(1)])).toBe(false);
+  });
+
+  it('does NOT fire strictly inside the range', () => {
+    expect(constraintsNeedNormalisation([at(0.5)])).toBe(false);
+  });
+
+  it('does NOT fire on an empty list', () => {
+    expect(constraintsNeedNormalisation([])).toBe(false);
+  });
+
+  it('fires when ANY member is out of range, not only the first', () => {
+    expect(constraintsNeedNormalisation([at(0.5, 'a'), at(-0.15, 'b')])).toBe(true);
+    expect(constraintsNeedNormalisation([at(-0.15, 'a'), at(0.5, 'b')])).toBe(true);
+  });
+
+  it('does not fire when EVERY member is in range', () => {
+    expect(constraintsNeedNormalisation([at(0, 'a'), at(0.5, 'b'), at(1, 'c')])).toBe(false);
+  });
+});

--- a/tests/constraint-delta-frame-fidelity.test.ts
+++ b/tests/constraint-delta-frame-fidelity.test.ts
@@ -206,6 +206,59 @@ describe('2.878 — the guard is on the OUTCOME, so it also catches the un-clamp
   });
 });
 
+describe('2.878 F2 — the affine map has FIXED POINTS, so the outcome test alone is not enough', () => {
+  it('DEFECT: a delta CLAMPED onto its own stated value is still refused', () => {
+    // ⚠ THE COUNTER-EXAMPLE THAT REFUTED "an outcome test cannot be escaped".
+    // Range [0, 0.5], delta 1: raw = (1 − 0)/0.5 = 2, clamped DOWN to 1 — so
+    // `normalised === value` and the outcome test does NOT fire, while the
+    // quantity has been HALVED and ships with the 'delta' attestation intact.
+    // Identity of the OUTPUT does not imply identity of the TRANSFORM.
+    // This is the arm `|| clamped` exists for; delete it and this test alone
+    // goes red while every other test in the file stays green.
+    const node = {
+      id: 'fac_narrow',
+      kind: 'factor',
+      label: 'Narrow-domain factor',
+      // observed 0.25 ⇒ inferred_value range [0, 0.5], width 0.5.
+      observed_state: { value: 0.25 },
+    } as unknown as EngineNodeV3;
+
+    const c = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-fixed-point',
+      node_id: 'fac_narrow',
+      operator: '>=',
+      value: 1,
+    });
+    const out = normaliseGoalConstraints([c], [node]);
+
+    const refusal = out.refused.find((r) => r.constraint_id === 'gc-fixed-point');
+    expect(refusal).toBeDefined();
+    expect(refusal!.stated_value).toBe(1);
+
+    // The tell: the substituted number EQUALS the stated one, which is exactly
+    // why `normalised !== value` is blind here.
+    expect(refusal!.would_have_sent).toBe(1);
+    expect(refusal!.range).toEqual({ min: 0, max: 0.5, source: 'inferred_value' });
+
+    expect(out.constraints.find((x) => x.constraint_id === 'gc-fixed-point')).toBeUndefined();
+  });
+
+  it('PIN: the added `clamped` arm does not catch an UN-clamped faithful delta', () => {
+    // The other half of F2's discrimination — widening the predicate must not
+    // start refusing deltas that pass through untouched.
+    const c = REDUCTION_CONSTRAINT({
+      constraint_id: 'gc-still-faithful',
+      node_id: 'node_not_in_graph',
+      operator: '>=',
+      value: 0.05,
+    });
+    const out = normaliseGoalConstraints([c], NODES);
+
+    expect(out.refused).toHaveLength(0);
+    expect(out.constraints.find((x) => x.constraint_id === 'gc-still-faithful')!.value).toBe(0.05);
+  });
+});
+
 describe('2.878 — the guard is not a SIGN check: the positive half of the delta domain', () => {
   it('DEFECT: a POSITIVE delta that normalisation rescales is refused too — the guard is not a sign check', () => {
     // AUDIT THE PREDICATE'S DOMAIN, not just the named case. The reduction

--- a/tests/constraint-delta-frame-refusal.route.test.ts
+++ b/tests/constraint-delta-frame-refusal.route.test.ts
@@ -34,6 +34,45 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 
+/**
+ * ROADMAP 2.878 F3 — BIND TO THE EMISSION, NOT TO THE SITE OR THE NAME.
+ *
+ * Two earlier guards both failed, in the same way one level apart:
+ *   · guard A enumerated log sites and scanned for quantity field NAMES — blind
+ *     to a whole record logged BY REFERENCE, because the keys never appear in
+ *     the source text (mutant R6 survived it);
+ *   · guard B fixed that by asserting the `plot.constraint_refused` site logs a
+ *     key PROJECTION — but it is scoped to that one event name, so a NEW site
+ *     logging the same record under a DIFFERENT event name walks past it
+ *     (mutant M-F3c survived it, and survived all five guards).
+ *
+ * Both are mirrors of where the code happens to be today. The property is not
+ * "this site is safe"; it is **"no log line this service emits ever carries a
+ * decision quantity"** — so the guard has to observe the EMISSION.
+ *
+ * `createServer` wires `formatters: { log: redactLogRecord }`, which pino calls
+ * for the root logger AND every child, i.e. for every record from every site.
+ * Wrapping it and capturing its RETURN value observes exactly what ships to the
+ * log sink, after redaction, regardless of which site produced it or what the
+ * event is called. A new leaking site is covered the moment it is written.
+ *
+ * (Capturing the boundary's OUTPUT rather than its input is deliberate — the
+ * input is pre-redaction and would flag values the boundary correctly digests.)
+ */
+const logCapture = vi.hoisted(() => ({ records: [] as Record<string, unknown>[] }));
+
+vi.mock('../src/logging/log-boundary.js', async () => {
+  const actual = await vi.importActual<any>('../src/logging/log-boundary.js');
+  return {
+    ...actual,
+    redactLogRecord: (rec: Record<string, unknown>) => {
+      const out = actual.redactLogRecord(rec);
+      logCapture.records.push(out);
+      return out;
+    },
+  };
+});
+
 /** Every `goal_constraints` array ISL was handed, in call order. */
 let islRequests: any[][] = [];
 
@@ -274,6 +313,55 @@ describe('2.878 F1 — a refused delta must not destroy its siblings verdicts', 
     expect(filtered.find((f: any) => f.constraint_id === 'cost-reduce')).toBeUndefined();
     expect((body.critiques ?? []).find((x: any) => x.code === 'CONSTRAINT_REFUSED_FRAME_FIDELITY'))
       .toBeUndefined();
+  });
+
+  it('DEFECT (F3): NO EMITTED LOG LINE carries a decision quantity — bound to the emission, not the site', async () => {
+    // A value distinctive enough that finding it anywhere is unambiguous, and
+    // long enough that MIN_TOKEN_LEN cannot be the reason it is absent.
+    const MARKER = -0.1567891234;
+
+    logCapture.records = [];
+    await run(baseUrl, [
+      ...TWO_LEVELS,
+      { ...reduction('delta'), constraint_id: 'cost-marker', value: MARKER },
+    ]);
+    const records = logCapture.records;
+
+    // ⚠ POSITIVE CONTROL — an absence assertion over an empty capture passes by
+    // testing nothing (this repo has shipped exactly that: a leak test that
+    // captured 0 bytes because pino writes via sonic-boom). Prove the
+    // instrument sees emissions AT ALL, and specifically sees the site under
+    // test, before concluding anything from an absence.
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.map((r) => r.event)).toContain('plot.constraint_refused');
+
+    // Walk every emitted record exhaustively — keys and primitive values.
+    const keys: string[] = [];
+    const values: unknown[] = [];
+    const walk = (v: unknown): void => {
+      if (Array.isArray(v)) { v.forEach(walk); return; }
+      if (v && typeof v === 'object') {
+        for (const [k, val] of Object.entries(v)) { keys.push(k); walk(val); }
+        return;
+      }
+      values.push(v);
+    };
+    records.forEach(walk);
+
+    // Sanity: the walker actually descended into nested structures.
+    expect(keys).toContain('event');
+    expect(keys.length).toBeGreaterThan(records.length);
+
+    // THE PROPERTY. No quantity-bearing key, from any site, under any event.
+    for (const forbidden of ['stated_value', 'would_have_sent', 'original_value', 'normalised_value']) {
+      expect(keys).not.toContain(forbidden);
+    }
+
+    // …and the stated quantity itself never reaches a log line, whatever key it
+    // might be hiding under. This is the arm that survives a site being renamed
+    // or a new one being added.
+    expect(values).not.toContain(MARKER);
+    expect(values.map((v) => String(v))).not.toContain(String(MARKER));
   });
 
   it('DEFECT (F9): a refused constraint discloses NO scale provenance — with a positive control', async () => {

--- a/tests/constraint-delta-frame-refusal.route.test.ts
+++ b/tests/constraint-delta-frame-refusal.route.test.ts
@@ -1,0 +1,307 @@
+/**
+ * ROADMAP 2.878 F1 — REFUSING ONE DELTA CONSTRAINT MUST NOT DELETE EVERY OTHER
+ * CONSTRAINT'S VERDICT.
+ *
+ * THE DEFECT THIS FILE EXISTS FOR, and it is the harm the refusal design
+ * explicitly rejected the drop-the-frame alternative to avoid — reproduced by
+ * the fix itself, in the half of the change that had no tests:
+ *
+ *   `buildConstraintFields` (routes/v2/run.ts) enforces an EXACT one-to-one
+ *   correspondence between ISL's constraint results and the ACTIVE constraint
+ *   list, and is handed `activeGoalConstraints`. The pre-existing temporal
+ *   filter keeps that invariant by REPLACING the list *before* the active set
+ *   is derived. The refusal drops ~700 lines later and originally never removed
+ *   the constraint from the active set, so `results (N−1) !== active (N)`, the
+ *   guard returned `constraints_status: 'unavailable'`, and the run reported
+ *   **ZERO** constraint results — while the disclosure said "1 constraint was
+ *   not evaluated". A partial-loss notice over a total loss is worse than
+ *   silence.
+ *
+ * ⚠ WHY THE MODULE-LEVEL SUITE COULD NOT SEE IT. Its wire test passes
+ * `out.constraints` — the ALREADY-FILTERED list — into the translator, so it
+ * asserts absence from a list built by removing the item. It would stay green
+ * no matter what `run.ts` did with the active set. Every assertion here goes
+ * through the real route.
+ *
+ * THE ISL MOCK DERIVES ITS RESULTS FROM THE CONSTRAINTS IT ACTUALLY RECEIVED
+ * rather than returning a hardcoded list. That is deliberate: a fixed mock
+ * would return N results regardless of what PLoT forwarded, which is exactly
+ * the blindness that let the count mismatch ship. Deriving makes the mock a
+ * witness to the wire — if PLoT forwards the refused constraint after all, the
+ * mock echoes it back and the ISOLATOR/PROBE distinction collapses.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+/** Every `goal_constraints` array ISL was handed, in call order. */
+let islRequests: any[][] = [];
+
+/** Build one ISL constraint result per constraint actually received. */
+function echoConstraintAnalysis(goalConstraints: any[] | undefined) {
+  if (!goalConstraints || goalConstraints.length === 0) return undefined;
+  return {
+    constraints: goalConstraints.map((c: any, i: number) => ({
+      constraint_id: c.constraint_id,
+      node_id: c.node_id,
+      operator: c.operator,
+      value: c.value,
+      prob_satisfied: 0.8 + i * 0.05,
+      failure_margin_median: 0.04,
+      near_miss_fraction: 0.1,
+      binding: false,
+    })),
+    joint_probability: 0.75,
+    conditional_probabilities: null,
+  };
+}
+
+function optionResults(options: any[], goalConstraints: any[] | undefined) {
+  const ca = echoConstraintAnalysis(goalConstraints);
+  return options.map((opt: any, idx: number) => ({
+    option_id: opt.id,
+    outcome: {
+      mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9,
+      n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0,
+    },
+    rank: idx + 1,
+    ...(ca && { constraint_analysis: ca }),
+  }));
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [],
+      backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock validation', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[], _t?: any, constraints?: any[]) {
+    islRequests.push(constraints ?? []);
+    return {
+      options: optionResults(options, constraints),
+      edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [], value_of_information: [], factors_provenance: 'unavailable' as const,
+      factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.8,
+      fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return {
+      factors: [], value_of_information: [], robustness_label: 'robust' as const,
+      robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const,
+    };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    // THE WIRE. This is the payload the translator built.
+    islRequests.push(body.goal_constraints ?? []);
+    return {
+      data: {
+        options: optionResults(body.options || [], body.goal_constraints),
+        edges: [], factors: [], value_of_information: [],
+        overall_robustness: 'robust', robustness_score: 0.8,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+// -----------------------------------------------------------------------------
+// Fixtures — constraint targets carry observed values so their ranges derive
+// from real data (inferred_value), matching tests/cil-constraint-passthrough.
+// -----------------------------------------------------------------------------
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', goal_threshold_frame: 'delta', label: 'Revenue', observed_state: { value: 15000 } },
+    { id: 'factor-a', kind: 'factor', label: 'Market Size' },
+    { id: 'factor-b', kind: 'factor', label: 'Retention', observed_state: { value: 4000 } },
+    { id: 'factor-c', kind: 'factor', label: 'Unit cost', observed_state: { value: 100 } },
+  ],
+  edges: [
+    { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'factor-b', to: 'goal', strength: { mean: 0.7, std: 0.1 } },
+    { from: 'factor-c', to: 'goal', strength: { mean: 0.3, std: 0.1 } },
+  ],
+};
+
+const OPTIONS = [
+  { id: 'opt1', label: 'Option 1', interventions: { 'factor-a': 1.5 } },
+  { id: 'opt2', label: 'Option 2', interventions: { 'factor-b': 2.0 } },
+];
+
+const BASE_PAYLOAD = { graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '42' };
+
+/** Two ordinary LEVEL constraints — the verdicts that must survive. */
+const TWO_LEVELS = [
+  { constraint_id: 'revenue-min', node_id: 'goal', operator: '>=', value: 20000 },
+  { constraint_id: 'retention-max', node_id: 'factor-b', operator: '<=', value: 5000 },
+];
+
+/**
+ * The reduction constraint, in the shape CEE mints it
+ * (`extractor.ts` — `operator: '<=', value: -N, valueFrame: 'delta'`).
+ * `frame` is the ONE field the ISOLATOR varies.
+ */
+const reduction = (frame: 'delta' | 'level') => ({
+  constraint_id: 'cost-reduce',
+  node_id: 'factor-c',
+  operator: '<=',
+  value: -0.15,
+  value_frame: frame,
+  unit: 'fraction',
+  label: 'Unit cost down by 15%',
+});
+
+async function run(app: string, goal_constraints: any[]) {
+  islRequests = [];
+  const res = await fetch(`${app}/v2/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...BASE_PAYLOAD, goal_constraints }),
+  });
+  expect(res.status).toBe(200);
+  return res.json();
+}
+
+describe('2.878 F1 — a refused delta must not destroy its siblings verdicts', () => {
+  let app: FastifyInstance;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const addr = app.server.address();
+    baseUrl = `http://127.0.0.1:${typeof addr === 'object' && addr ? addr.port : 0}`;
+  });
+
+  afterAll(async () => { await app?.close(); });
+
+  it('CONTROL: two level constraints alone are computed and both delivered', async () => {
+    const body = await run(baseUrl, TWO_LEVELS);
+
+    expect(body.constraints_status).toBe('computed');
+    expect((body.constraint_results ?? []).map((r: any) => r.constraint_id).sort())
+      .toEqual(['retention-max', 'revenue-min']);
+  });
+
+  it('DEFECT: adding a REFUSED delta leaves both level verdicts intact', async () => {
+    const body = await run(baseUrl, [...TWO_LEVELS, reduction('delta')]);
+
+    // THE BLOCK. Before the fix this was 'unavailable' with zero results.
+    expect(body.constraints_status).toBe('computed');
+
+    const ids = (body.constraint_results ?? []).map((r: any) => r.constraint_id).sort();
+    expect(ids).toEqual(['retention-max', 'revenue-min']);
+
+    // Bind by identity: the refused one is absent, the siblings are present.
+    expect(ids).not.toContain('cost-reduce');
+  });
+
+  it('DEFECT: the refused constraint never reaches the ISL wire — asserted on the REAL payload', async () => {
+    await run(baseUrl, [...TWO_LEVELS, reduction('delta')]);
+
+    expect(islRequests.length).toBeGreaterThan(0);
+    for (const sent of islRequests) {
+      const ids = sent.map((c: any) => c.constraint_id);
+      expect(ids).not.toContain('cost-reduce');
+      // …and the siblings DID travel, so this is not vacuous absence.
+      expect(ids).toContain('revenue-min');
+      expect(ids).toContain('retention-max');
+    }
+  });
+
+  it('ISOLATOR / DISCRIMINATING PAIR: the SAME payload with value_frame "level" delivers all THREE', async () => {
+    // Byte-identical but for one string. If this arm ever stops delivering 3,
+    // the refusal has started catching levels and the separation has broken.
+    const body = await run(baseUrl, [...TWO_LEVELS, reduction('level')]);
+
+    expect(body.constraints_status).toBe('computed');
+    expect((body.constraint_results ?? []).map((r: any) => r.constraint_id).sort())
+      .toEqual(['cost-reduce', 'retention-max', 'revenue-min']);
+  });
+
+  it('DEFECT: the refusal is disclosed by name in _meta.filtered_constraints', async () => {
+    const body = await run(baseUrl, [...TWO_LEVELS, reduction('delta')]);
+
+    const filtered = body._meta?.filtered_constraints ?? [];
+    const row = filtered.find((f: any) => f.constraint_id === 'cost-reduce');
+    expect(row).toBeDefined();
+    expect(row.reason).toBe('delta_frame_value_altered_by_normalisation');
+    expect(row.node_id).toBe('factor-c');
+  });
+
+  it('DEFECT: a CONSTRAINT_REFUSED_FRAME_FIDELITY critique names it, and does not block the run', async () => {
+    const body = await run(baseUrl, [...TWO_LEVELS, reduction('delta')]);
+
+    const critiques = body.critiques ?? [];
+    const c = critiques.find((x: any) => x.code === 'CONSTRAINT_REFUSED_FRAME_FIDELITY');
+    expect(c).toBeDefined();
+    expect(c.severity).toBe('warning');
+    expect(c.blocks_analysis).toBe(false);
+    expect(c.message).toContain('cost-reduce');
+    expect(c.affected_node_ids).toContain('factor-c');
+
+    // The count in the notice must be TRUE of what happened — the original
+    // defect said "1 constraint(s) were not evaluated" while in fact ZERO were.
+    expect(c.message).toContain('1 constraint(s) were not evaluated');
+    expect(body.constraints_status).toBe('computed');
+  });
+
+  it('PIN: a run with NO refusal discloses nothing and is byte-unchanged in these fields', async () => {
+    const body = await run(baseUrl, TWO_LEVELS);
+
+    const filtered = body._meta?.filtered_constraints ?? [];
+    expect(filtered.find((f: any) => f.constraint_id === 'cost-reduce')).toBeUndefined();
+    expect((body.critiques ?? []).find((x: any) => x.code === 'CONSTRAINT_REFUSED_FRAME_FIDELITY'))
+      .toBeUndefined();
+  });
+
+  it('DEFECT (F9): a refused constraint discloses NO scale provenance — with a positive control', async () => {
+    const body = await run(baseUrl, [...TWO_LEVELS, reduction('delta')]);
+
+    const results = body.constraint_results ?? [];
+
+    // ⚠ POSITIVE CONTROL FIRST. `scale_provenance` rides on each
+    // `constraint_results[]` row, so an "it is absent" assertion is vacuous
+    // unless the field is demonstrably POPULATED for the constraints that DID
+    // travel. Prove the instrument can see a presence before trusting it about
+    // an absence.
+    const survivors = results.filter((r: any) =>
+      r.constraint_id === 'revenue-min' || r.constraint_id === 'retention-max');
+    expect(survivors).toHaveLength(2);
+    for (const s of survivors) {
+      expect(s.scale_provenance).toBeDefined();
+      // Field is `source` (RangeSource) — derived from
+      // `ConstraintScaleProvenance` in types/engine-v3.ts, not assumed.
+      expect(typeof s.scale_provenance.source).toBe('string');
+      expect(typeof s.scale_provenance.range_unified).toBe('boolean');
+    }
+
+    // Now the absence is meaningful: the refused constraint was never sent, so
+    // it must carry no provenance claim anywhere. Left in the active set it
+    // would have disclosed as `source: 'default', range_unified: true` — i.e.
+    // as a constraint that WAS forwarded raw — a wrong disclosure about a
+    // constraint that never travelled.
+    expect(results.map((r: any) => r.constraint_id)).not.toContain('cost-reduce');
+  });
+});

--- a/tests/pii-residual-redaction.test.ts
+++ b/tests/pii-residual-redaction.test.ts
@@ -536,12 +536,53 @@ describe('F7: constraint/intervention normalisation logs carry no raw numeric va
     return readFile(new URL('../src/routes/v2/run.ts', import.meta.url), 'utf8');
   }
 
+  /**
+   * ROADMAP 2.878 F3 — EXTRACT THE LOG CALL BY ITS OWN BRACES, NOT BY A BYTE COUNT.
+   *
+   * These pins used to slice a fixed 1,300 bytes from each `event:` marker.
+   * That is a hand-maintained mirror of the FILE'S LAYOUT: it silently stops
+   * covering as the file grows, and it stops covering the thing it names
+   * without ever going red. It was measured doing exactly that — a new
+   * `plot.constraint_refused` log site landed ~5.3 KB outside both windows,
+   * carrying two raw quantity fields, and neither pin could see it.
+   *
+   * Walking back to the opening `{` of the log object and forward to its
+   * matching `}` derives the site's true extent from the source, so the window
+   * cannot drift out from under the assertion.
+   */
+  function logCallAt(src: string, marker: string): string {
+    const at = src.indexOf(marker);
+    if (at < 0) throw new Error(`marker not found: ${marker}`);
+    // Back up to the `{` that opens the object literal holding this event key.
+    let open = src.lastIndexOf('{', at);
+    if (open < 0) throw new Error(`no opening brace before: ${marker}`);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+      if (src[i] === '{') depth++;
+      else if (src[i] === '}') {
+        depth--;
+        if (depth === 0) return src.slice(open, i + 1);
+      }
+    }
+    throw new Error(`unbalanced braces from: ${marker}`);
+  }
+
+  it('the site extractor is bounded and does NOT swallow the whole file (precondition)', async () => {
+    const src = await runSource();
+    const site = logCallAt(src, "event: 'constraint_normalisation'");
+    // Without this the assertions below could pass by covering everything, or
+    // fail by covering nothing. Bound it in both directions.
+    expect(site.length).toBeGreaterThan(50);
+    expect(site.length).toBeLessThan(src.length / 4);
+    expect(site).toContain("event: 'constraint_normalisation'");
+  });
+
   it('intervention_normalisation info log drops original/normalised, keeps factor_id + range_source + clamped', async () => {
     const src = await runSource();
     const at = src.indexOf("event: 'intervention_normalisation'");
     expect(at).toBeGreaterThan(-1);
-    // The info log (first occurrence) carries the sample; window covers it.
-    const site = src.slice(at, at + 1300);
+    // Derived extent, not a byte count.
+    const site = logCallAt(src, "event: 'intervention_normalisation'");
     // Positive control: the site still exists and still samples the SAFE fields.
     expect(site).toContain('sample:');
     expect(site).toMatch(/factor_id:\s*d\.factor_id\b/);
@@ -556,7 +597,7 @@ describe('F7: constraint/intervention normalisation logs carry no raw numeric va
     const src = await runSource();
     const at = src.indexOf("event: 'constraint_normalisation'");
     expect(at).toBeGreaterThan(-1);
-    const site = src.slice(at, at + 1300);
+    const site = logCallAt(src, "event: 'constraint_normalisation'");
     // Positive control: the site still exists and still samples identifiers + source.
     expect(site).toContain('sample:');
     expect(site).toMatch(/constraint_id:\s*d\.constraint_id\b/);
@@ -565,5 +606,126 @@ describe('F7: constraint/intervention normalisation logs carry no raw numeric va
     // THE FIX: the raw numeric decision values are gone.
     expect(site).not.toMatch(/original:\s*d\.original_value\b/);
     expect(site).not.toMatch(/normalised:\s*d\.normalised_value\b/);
+  });
+
+  /**
+   * ROADMAP 2.878 F3 — THE GUARD THAT WAS MISSING ENTIRELY.
+   *
+   * The two pins above name TWO events. Nothing enumerated the rest, so a NEW
+   * log site could carry raw decision quantities and no test anywhere would
+   * object — which is exactly what happened: `plot.constraint_refused` shipped
+   * `stated_value` and `would_have_sent` in plaintext (the first is digested
+   * only when `String(v).length >= 4`, so `0.5` / `-5` / `12` travel in the
+   * clear; the second is DERIVED, so it is never a registered token and its key
+   * is not a DECISION_DOMAIN_KEY — it is never redacted at all).
+   *
+   * This guard DERIVES the site list from the source rather than naming it, so
+   * a new log site is covered the moment it is written. It is the trap-12 shape:
+   * where you cannot avoid a list, make the list fail loud on drift.
+   */
+  it('NO req.log site in run.ts logs a raw decision quantity — derived over ALL sites', async () => {
+    const src = await runSource();
+
+    // Every `req.log.<level>({ … })` call, extent derived by brace matching.
+    const sites: Array<{ event: string; body: string }> = [];
+    const callRe = /req\.log\.(?:info|warn|debug|error)\(\s*\{/g;
+    let m: RegExpExecArray | null;
+    while ((m = callRe.exec(src)) !== null) {
+      const open = src.indexOf('{', m.index);
+      let depth = 0;
+      for (let i = open; i < src.length; i++) {
+        if (src[i] === '{') depth++;
+        else if (src[i] === '}') {
+          depth--;
+          if (depth === 0) {
+            const body = src.slice(open, i + 1);
+            const ev = /event:\s*'([^']+)'/.exec(body);
+            sites.push({ event: ev ? ev[1] : '(no event key)', body });
+            break;
+          }
+        }
+      }
+    }
+
+    // ⚠ PRECONDITION — a derived enumeration that finds nothing passes
+    // vacuously. Prove the instrument sees a real population, and specifically
+    // that it sees the site this guard was written for.
+    expect(sites.length).toBeGreaterThan(30);
+    expect(sites.map((s) => s.event)).toContain('plot.constraint_refused');
+    expect(sites.map((s) => s.event)).toContain('constraint_normalisation');
+
+    // Quantity-bearing property names that must never be logged. These are the
+    // DECISION VALUES themselves — identifiers, sources and booleans are fine
+    // and are what the safe sites already sample.
+    const FORBIDDEN = [
+      'stated_value',
+      'would_have_sent',
+      'original_value',
+      'normalised_value',
+    ];
+
+    const offenders: string[] = [];
+    for (const s of sites) {
+      for (const key of FORBIDDEN) {
+        // Match the identifier as a property read or shorthand, not in prose.
+        if (new RegExp(`\\b${key}\\b`).test(s.body.replace(/\/\/[^\n]*/g, ''))) {
+          offenders.push(`${s.event} → ${key}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * ROADMAP 2.878 F3 — THE GUARD ABOVE IS NOT ENOUGH, AND A MUTANT PROVED IT.
+   *
+   * ⚠ The enumerator above scans for quantity field NAMES appearing literally
+   * in a log call. It therefore cannot see the commonest form of this leak:
+   * logging a WHOLE typed record by reference (`refused: result.refused`),
+   * where the quantity keys live on the object and never appear in the log
+   * site's text at all. Measured: a mutant restoring exactly that leak SURVIVED
+   * the enumerator — a guard agreeing with itself.
+   *
+   * `RefusedConstraintRecord` carries `stated_value` and `would_have_sent`, so
+   * for this site the safety property is not "no forbidden name is spelled
+   * here" but "the value is a KEY PROJECTION onto an allow-list". That is what
+   * is asserted, with the projected keys DERIVED from the source.
+   *
+   * ⚠ SCOPE, stated rather than implied: this is a SOURCE-level check on one
+   * site. The general property — "no log LINE ever contains a decision
+   * quantity" — needs a runtime capture of the real `/v2/run` logger, and
+   * `createServer` exposes no stream injection point (pino writes to fd 1 via
+   * sonic-boom, where a naive capture reads zero bytes and every absence
+   * assertion passes vacuously). Not attempted here rather than faked.
+   */
+  it('plot.constraint_refused logs a KEY PROJECTION, never the whole record', async () => {
+    const src = await runSource();
+    const site = logCallAt(src, "event: 'plot.constraint_refused'");
+
+    // Precondition: we are looking at the right site.
+    expect(site).toContain('refused_count:');
+
+    // The `refused:` property's value expression, up to the end of the call.
+    const m = /refused:\s*([\s\S]+?)\n\s*\}\);?\s*$/.exec(site + '\n');
+    const valueExpr = m ? m[1] : site.slice(site.indexOf('refused:'));
+
+    // It must be a projection, not a bare reference. `refused: x.refused` — the
+    // shipped defect — has no `.map(`.
+    expect(valueExpr).toMatch(/\.map\(/);
+
+    // …and the keys it projects must all be safe. Derived from the source text:
+    // take the object literal the arrow function returns (`=> ({ … })`), so the
+    // enclosing `refused:` property name itself is not counted as a key.
+    const ALLOWED = new Set(['constraint_id', 'node_id', 'reason', 'range_source']);
+    const objStart = valueExpr.indexOf('({');
+    expect(objStart).toBeGreaterThan(-1);
+    const projection = valueExpr.slice(objStart);
+    const projected = [...projection.matchAll(/^\s*([a-z_]+):/gm)].map((x) => x[1]);
+
+    // Precondition again: an empty key list would make the subset check vacuous.
+    expect(projected.length).toBeGreaterThan(0);
+
+    const unsafe = projected.filter((k) => !ALLOWED.has(k));
+    expect(unsafe).toEqual([]);
   });
 });


### PR DESCRIPTION
**ROADMAP 2.878 (P0)** + **2.879 (4)**. Pairs with **Talchain/olumi-assistants-service#862**, which was declined to merge over exactly this.
**Do not merge without independent review** — trust surface. ⚠ **Read the lint note at the bottom before merging.**

## ⚠⚠ THIS PR IS A PRECONDITION, NOT A FIX FOR THE LIVE CORRUPTION — read this first

**Today, on staging, PLoT still clamps `-0.15` → `0` and forwards it.** This PR does not stop that, and anyone reading it as closing the live corruption will be wrong.

The guard keys on `value_frame === 'delta'`, and **that attestation does not exist yet**. Re-derived at the bytes:

| fact | evidence |
|---|---|
| CEE `staging` `b5204544` has **zero** `value_frame` occurrences | repo-wide grep at that tip |
| `extractor.ts:451` mints `value: -value` **unattested** | source at that tip |
| `translator-v3.ts:950` forwards by presence and **never invents a frame** | source at this tip |

So the reduction constraint still normalises to `0` and is still forwarded, exactly as before — because the attestation the guard needs is precisely what is absent.

**What this PR does is close the seam BEFORE #862 opens it.** #862 stamps `'delta'` on every reduction branch, at which point *every* decision containing a "reduce X by N" phrase would hit this path. Landing this first means the fabrication never becomes reachable. **Blast radius today: zero for CEE-originated traffic** (nothing is stamped) — though PLoT's `/v2/run` ingress does not validate `value_frame`, so any direct client stamping it reaches this code now.

---

## The defect, reproduced by execution against this module

CEE's `extractReductionConstraints` mints `{ operator: '<=', value: -N }` for *"reduce X by N"* and attests it `'delta'`. PLoT then:

```
normaliseGoalConstraints([{ value: -0.15, value_frame: 'delta', operator: '<=' }], [costNode])
  → constraint out: { operator: '<=', value: 0, original_value: -0.15, value_frame: 'delta' }
  → diagnostic:     { normalised_value: 0, clamped: true, range: {0, 200, inferred_value} }
```

The translator sends `value: c.value` — the clamped **`0`** — and the `'delta'` attestation with it. **ISL is asked `<= 0` in the delta frame: "what is the probability cost changes by at most nothing", i.e. the probability cost falls AT ALL.** It answers with a confident `prob_satisfied` and no warning, because a frame-faithful `0` is a perfectly well-formed delta. `original_value` is a PLoT-internal field the translator never sends, so nothing downstream can recover the question.

**Corrected premise (one).** The row says `-0.15` → `0` *"for every range"*. Measured: for every range whose **floor is 0** — `default`, `unit_percent`, `goal_threshold_cap`, `explicit_cap`, and `inferred_value` on any positive-domain node, i.e. the overwhelming majority. Against a **sign-preserving** range like `[-1, 0]` (D-9) it becomes **`+0.85`**, *not clamped and not flagged* — a second, independent corruption the row did not name, and one a `clamped`-based guard would miss entirely. Both are closed here.

> ⚠ **An earlier version of this body said `+0.425` here. That was wrong** — `0.425` is the `[-1, 1]` case; `[-1, 0]` gives `0.85`, which is what the spec has always asserted. The error propagated from this body into a register row and a dispatch brief before review caught it. Corrected in all four places.

## The clamp's original purpose, as derived — and why it is left alone

`normaliseFiniteValue` computes `(v − min) / (max − min)` and clamps to `[0,1]`. For a **LEVEL** — an absolute position on a factor's own bounded scale, which is what every other producer mints — that is correct, and the clamp is a **domain guard**: ISL's sample space is `[0,1]` by construction, so a level outside the derived range must be pinned to the nearest endpoint. `clamped: true` is the honest signal that the derived range was too narrow. **Downstream depends on exactly that** — `constraintThresholdClampByConstraintId` reads the clamp *direction* so the margin egress never labels an understated `failure_margin_median` 'exact'.

It is category-wrong for a **DELTA** in two ways: the translation term `− min` is meaningless on a *difference*, and the `[0,1]` clamp deletes the sign, which is the entire content of a reduction.

**So the two paths are separated, and neither is weakened.** The clamp is untouched; three PIN tests hold it in place (level below floor → 0 + forwarded, level above ceiling → 1 + forwarded, unattested → unchanged).

## The chosen outcome: PLoT fails closed, per-constraint

Of the two recorded options, **"PLoT fails closed on clamp"**, widened to the invariant itself.

**Why not "the reduction branch stamps nothing":** that is a *CEE* change, it permanently retires the only constraint class that delivers today, and **it fixes nothing here** — an unattested negative value is still clamped to `0` and still forwarded, and any other producer that later stamps `'delta'` (the `add_constraint` handler and client ingress are both live, unconstrained paths) re-opens it. That option closes one producer; this closes the seam.

**Why the predicate is `normalised !== value` and not `clamped`, the sign, or a range-source list:**

| candidate guard | what it misses | mutant |
|---|---|---|
| `clamped` | the un-clamped translation corruption (`-0.15` → `+0.425`), and the rescaled positive delta | **M2 → RED** |
| `value < 0` | the entire positive half of the delta domain (`+0.05` → `0.00025`) | **M3 → RED** |
| a list of "safe" range sources | a hand-maintained mirror a new ladder rung silently escapes | — |
| **`normalised !== value` ALONE** | **the affine map's FIXED POINTS** — `[0,0.5]` with delta `1` clamps `2`→`1`, so `normalised === value` while the quantity is HALVED | **R4 → RED** |

**⚠ The shipped predicate is the UNION `(normalised !== value \|\| clamped)`, and an earlier version of this PR was wrong to claim the outcome test "cannot be escaped".** Review refuted it by execution: the two guards have **disjoint blind spots** and neither dominates. Both arms are load-bearing — removing either reopens a class (R4 and R5 below).

No false positives from floating point: the only exact-identity path is `min = 0 ∧ width = 1`, where `(v − 0) / 1 === v` exactly in IEEE-754, so a faithfully-forwarded delta is never refused.

> ⚠ **A second record correction.** An earlier version called `+0.05` → `0.00025` "a 200× understatement". **That presupposes the raw-unit reading, which this same PR declares unestablished** — for any `min = 0` range, `(v − min)/w ≡ v/w`, i.e. the shipped number *is* the arithmetically correct **normalised-space** delta. The substitution is **unverifiable in either direction**, and that is exactly why failing closed is right. Arguing it with a magnitude claim that assumes the semantics is the same over-read this fix exists to prevent. (The **clamp**, by contrast, is a corruption under *both* readings: no reading makes `<= 0` mean `<= −0.15`.)

**Why refuse rather than rescale.** Correctly rescaling a delta means dividing by the range *width* with no offset — but whether ISL's `delta` frame expects a raw-unit or normalised-space difference **is not established at the bytes**. The only witness we hold (arm B of `tests/fixtures/isl-constraint-value-frame-20260807`) sent `0.05` already on the normalised scale. Minting arithmetic on an unverified semantics is the fabrication class this chain exists to remove. When ISL's delta scale contract is established, this guard is where the conversion goes — and it will still be the thing that refuses what it cannot convert faithfully.

**Why drop rather than throw.** A throw would take out every option result over one constraint. The refusal is per-constraint and **reported by name**: a `CONSTRAINT_REFUSED_FRAME_FIDELITY` preflight warning, a `'removed'` repair record, an entry in `_meta.filtered_constraints`, and a `plot.constraint_refused` log event. *Dropping the `value_frame` instead was considered and rejected* — ISL fail-closes an unstamped constraint by omitting the **entire** `constraint_analysis` block, so one bad constraint would silently delete every other constraint's verdict, and it would still send the corrupted number.

## The input space is bounded by the producer, not by me

Trap 16-inverse — *a fixture you wrote yourself is not evidence about the wire.* The fixture reproduces what CEE actually mints, read at `olumi-assistants-service@2d29951b`, `src/cee/compound-goal/extractor.ts:468-485`. **One detail that changes which code is reachable:** its `unit` is **`"fraction"`, not `"%"`** — `normaliseConstraintUnits` (ROADMAP 1.52) relabels a `%` unit whose `0 < |value| < 1`. `isPercentUnit('fraction')` is **false**, so the `unit_percent` `[0,100]` rung is *not on this path*; a fixture using `"%"` would have tested a rung the producer cannot reach. Constraint shape cross-checked against the real captures in `l60-artefacts/scenario-{people,pricing}.json` — which are also the evidence that every live constraint today is positive and level-shaped, and thus why this sat unobserved.

## Evidence at this head (`c5305b5`)

**RED-first.** Module suite at pristine: **16 red / 8 green** (6 red on the defect; 6 more red only because `result.refused` did not exist yet — labelled **`PIN:`** rather than shipped as `DEFECT:` theatre; the 8 green are the `constraintsNeedNormalisation` branch tests, correctly green because that trigger was never wrong and simply had **zero** coverage). Route suite: reverting only the F1 fix REDs **3 of 9**.

**Mutation — 13 mutants across three rounds, every one as predicted, no survivors.** Throwaway worktree outside the repo root each round, **isolation proven by WRITING** a sentinel (distinct inodes, source sha256 unchanged), applied-check scoped to `src/` with the **control reading exactly ZERO**, collected count constant within each round.

| # | mutant | expected | result |
|---|---|---|---|
| M1 | guard deleted | RED | **RED** ×8 |
| M2 | predicate → `clamped` only | RED | **RED** ×2 |
| M3 | predicate → `value < 0` | RED | **RED** ×1 |
| M4 | frame flipped to `'level'` | RED | **RED** ×10 |
| M5 | `continue` removed | RED | **RED** ×6 |
| **M6** | **narrowed to an UNRELATED id** | **GREEN** | **GREEN** ✅ |
| **M7** | **narrowed to exclude the NAMED id only** | RED | **RED** ×5 |
| R1 | F1 fix removed | RED | **RED** ×3 |
| R2 | F1 filter inverted | RED | **RED** ×3 |
| **R3** | **filter keyed on an id never refused** | **GREEN** | **GREEN** ✅ |
| R4 | `\|\| clamped` arm removed | RED | **RED** ×1 |
| R5 | outcome arm removed | RED | **RED** ×2 |
| R7 | critique suppressed | RED | **RED** ×1 |
| M-F3c | new log site, different event, record by reference | RED | **RED** ×1 |
| M-F3d | same, nested two levels deep | RED | **RED** ×1 |
| **M-F3e** | **new log site with only SAFE fields** | **GREEN** | **GREEN** ✅ |

**R4 and R5 red DIFFERENT tests** — that is the evidence neither predicate arm is redundant. **M6/M7 and R3** are the identity-discrimination pairs. **M-F3c/M-F3e** prove the log guard bans quantities rather than new log sites.

⚠ **Two guards of mine failed under their own mutants and were rebuilt — disclosed because it is the more useful half.** `R6` (whole record logged by reference) **survived** a name-scanning guard; the replacement was site-scoped and then **M-F3c survived that**. The guard now binds to the **emission** — `createServer` wires `formatters.log = redactLogRecord`, called for every record from every site, so wrapping it and capturing its return value observes what actually ships, regardless of site or event name. A site-scoped guard is a mirror of where the code is today.

## Gates at this tip

| gate | result |
|---|---|
| `npm run lint` | ✅ 0 |
| `npm run typecheck` | ✅ 0 |
| `npm run validate:contracts` | ✅ 8 files / 3 scenarios, 0 failed |
| `npm run build` | ✅ 0, no stale `.js` |
| `RATE_LIMIT_ENABLED=0 npm test` | ✅ **631 files / 7,081 passed**, 0 failed, 28 skipped |

`#317`'s baseline was 629 files / 7,056 tests. This branch adds **1 file / 20 tests**; the full-suite figure above was measured when the eslint gate test was still on the branch (+2/+25) — see the split note below. **CI is the authority for this tip.**

**`dependency-audit` — proven pre-existing, not assumed.** PLoT's `staging` does not run the `audit` workflow, so it is not usable as a control; **I ran the exact CI command (`npm audit --omit=dev --audit-level=high`) myself against staging tip `1b36c34a` as the baseline** and against this branch. Output is **byte-identical**: `5 high severity vulnerabilities`, all `fast-uri` `GHSA-7p8r-x3mc-p8w7` (row 2.385). This PR touches **no** dependency file — `git diff staging..HEAD -- package.json package-lock.json` is empty. **Zero delta.**

## ⚠ Split — this PR is the P0 ONLY

This branch originally also carried a fix to `eslint.config.js` (ROADMAP 2.879 (4): `@eslint/js` was imported and never spread, so only **5 rules** resolved and `no-dupe-keys` was **absent** — the rule that would have caught the duplicate object key which silently overrode `'delta'` with `'level'` in this same chain).

Making the linter able to see brought **7 pre-existing findings** into view and turned `npm run lint` red, which **gated the test step so CI never ran the suite**. That was the wrong trade for a P0: it would have shipped a live-fabrication fix on a *local* test number.

**The eslint change now lives in its own PR (linked below), with those 7 findings listed and untouched.** They are not swept — two may be deliberate (`no-control-regex` on what looks like the intentional NUL sentinel, and `no-async-promise-executor`) and are being rowed rather than cleaned under cover of a config change.

**This branch is `c13a49c` alone and is lint-green.**

## What this does NOT claim

- **Not a deployed witness.** Unit + module level only; no staging run drove a refusal.
- **Delta constraints do not start delivering.** Today CEE stamps nothing, so nothing is refused in production either — blast radius is **zero at the current deploy state**, which is exactly why this should land *before* #862, not after.
- **`'level'` is still blocked** one hop on, at ISL's `missing_target_baseline` (ROADMAP 2.877). Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
