### PR TITLE
[2.879] spread @eslint/js so the recommended rule set actually resolves — 5 rules resolved, no-dupe-keys was absent

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,41 @@ export default [
       '@typescript-eslint': tsPlugin,
     },
     rules: {
+      // ROADMAP 2.879 — `@eslint/js` was IMPORTED and never SPREAD, so this
+      // config resolved exactly FIVE rules and the entire core recommended set
+      // was absent, `no-dupe-keys` among them. That is not a style gap: a
+      // duplicate object key silently overriding a `value_frame: 'delta'` stamp
+      // with `'level'` is a live fabrication shape in this repo's constraint
+      // chain (2.855/2.878), and the linter was structurally incapable of
+      // seeing it. An unspread plugin import is the hand-maintained-mirror
+      // defect in its purest form — the config LOOKED like it enabled the
+      // recommended set and enabled none of it.
+      //
+      // Guarded by tests/gates/eslint-config-resolution.test.ts, which DERIVES
+      // the expected rule set from `@eslint/js` itself rather than pinning a
+      // copied count, so a future edit that drops the spread REDs by name.
+      ...js.configs.recommended.rules,
+
+      // `no-undef` is OFF for TypeScript, and this is the VENDOR's own position
+      // read at the bytes in this repo's tree, not a preference:
+      // `node_modules/@typescript-eslint/eslint-plugin/dist/configs/
+      //  eslint-recommended-raw.js:31` sets `'no-undef': 'off'` with the comment
+      // `ts(2304) & ts(2552)` — i.e. the compiler already reports an undefined
+      // identifier, with type information eslint does not have.
+      //
+      // Measured here: with the recommended set spread and this rule left on,
+      // `no-undef` produced 950 of 957 findings and EVERY ONE was a false
+      // positive against the `globals` list below — `fetch` (872), `performance`
+      // (49), `expect` (9), `NodeJS`, `global`, `require`, `structuredClone`.
+      // All resolve under `tsc`. Leaving it on would not add a guard; it would
+      // add 950 findings that teach a reader to stop reading lint output, which
+      // is the broken-alarm failure this repo has paid for before.
+      //
+      // Note what that also shows: the `globals` block above is a
+      // hand-maintained mirror of the runtime environment and had already
+      // drifted. It now feeds no enabled rule.
+      'no-undef': 'off',
+
       // Core ESLint rules
       'no-empty': ['error', { allowEmptyCatch: false }],
       'no-console': ['warn', { allow: ['error', 'warn'] }],

--- a/src/integrations/isl/errors.ts
+++ b/src/integrations/isl/errors.ts
@@ -182,6 +182,30 @@ export function parseIslErrorReason(body: string | null | undefined): string | u
   for (const candidate of candidates) {
     if (typeof candidate !== 'string') continue;
     // Strip control characters so one field cannot forge extra log lines.
+    //
+    // ROADMAP 2.879 — `no-control-regex` fires on the class below, and this is
+    // the one case the rule is explicitly NOT for. The rule exists to catch
+    // control characters an author did not mean to write; here they are the
+    // entire subject of the expression. This is a log-injection defence on an
+    // ATTACKER-INFLUENCED string (an ISL error body), and the range it names —
+    // the whole C0 block, where CR and LF live, plus DEL — is exactly the set
+    // that can forge extra NDJSON log lines downstream. Narrowing it to please
+    // the linter would weaken a live security control, and re-expressing the
+    // same codepoints via `new RegExp` or `String.fromCharCode` would be
+    // obfuscation rather than a fix: `no-control-regex` inspects the RegExp
+    // constructor too, so that would only hide the intent from the next reader.
+    //
+    // NOTE this is NOT the deliberate NUL sentinel of CLAUDE.md trap 17, which
+    // PR #319's own body guessed it might be. Derived at the bytes in this
+    // tree: `file(1)` reports this file as "Unicode text, UTF-8 text" and a
+    // byte scan finds ZERO NUL bytes in it. Trap 17's sentinel lives in CEE's
+    // `edit-graph-referee-gate.ts`. Unrelated — ROADMAP 2.119 does not apply.
+    //
+    // The suppression is backed by evidence rather than asserted: every
+    // codepoint of the stripped range is pinned by
+    // tests/plot-2202b-isl-error-reason.test.ts ("the stripped set is the FULL
+    // C0 range plus DEL"), which reds if this class is narrowed.
+    // eslint-disable-next-line no-control-regex -- intentional C0+DEL log-injection strip; see above
     const cleaned = candidate.replace(/[\u0000-\u001f\u007f]/g, ' ').trim();
     if (cleaned === '') continue;
     return cleaned.length > ISL_ERROR_REASON_MAX_LEN

--- a/src/routes/v1/key-insight.ts
+++ b/src/routes/v1/key-insight.ts
@@ -43,13 +43,13 @@ import { CEE_TIMEOUT_MS } from '../../config/timeouts.js';
  * Patterns for classifying goal types
  */
 const CONTINUOUS_PATTERNS = [
-  /reach\s+[\$£€]?\d/i,           // "Reach $20k", "Reach £20k"
+  /reach\s+[$£€]?\d/i,           // "Reach $20k", "Reach £20k"
   /increase.*to\s+\d/i,           // "Increase to 100"
   /reduce.*to\s+\d/i,             // "Reduce to 5%"
   /grow.*to\s+\d/i,               // "Grow to $1M"
   /achieve\s+\d/i,                // "Achieve 90%"
-  /hit\s+[\$£€]?\d/i,             // "Hit $50k"
-  /target[:\s]+[\$£€]?\d/i,       // "Target: $100k"
+  /hit\s+[$£€]?\d/i,             // "Hit $50k"
+  /target[:\s]+[$£€]?\d/i,       // "Target: $100k"
   /\d+[%kKmM]\s*(mrr|arr|revenue|growth|churn|retention)/i,  // "20k MRR"
   /(mrr|arr|revenue|growth|churn|retention).*\d+[%kKmM]/i,   // "MRR of 20k"
   /under\s+\d/i,                  // "Keep under 5%"

--- a/tests/contracts.report.schema.test.ts
+++ b/tests/contracts.report.schema.test.ts
@@ -2,17 +2,33 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import Ajv from 'ajv';
 import { readFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
+import { waitFor } from './utils.js';
 
-function waitFor(url: string, timeoutMs = 5000): Promise<void> {
-  const start = Date.now();
-  return new Promise(async (resolve, reject) => {
-    while (Date.now() - start < timeoutMs) {
-      try { const r = await fetch(url); if (r.ok) return resolve(); } catch {}
-      await new Promise(r => setTimeout(r, 100));
-    }
-    reject(new Error('timeout'));
-  });
-}
+// ROADMAP 2.879 — this file used to carry a private `waitFor` built on
+// `new Promise(async (resolve, reject) => …)`, the repo's only async promise
+// executor and the `no-async-promise-executor` finding that spreading
+// `@eslint/js`'s recommended set surfaced. It is deleted rather than reshaped:
+// `tests/utils.ts` already exports a shared `waitFor` that ~20 specs use, and
+// this file's ~45 sibling copies are already plain `async function`s.
+//
+// The rejection semantics that changed, stated rather than left silent: the
+// `Promise` constructor DISCARDS an async executor's rejection, so any throw
+// escaping the executor's inner `try` left the promise permanently unsettled —
+// a silent hang, with the real error lost. Here the only rejecting `await`
+// (`fetch`) sat inside the `try/catch`, so nothing was being swallowed on a
+// reachable path; the hazard was latent. Resolve/poll/deadline behaviour is
+// unchanged; only the timeout message is now labelled instead of bare
+// 'timeout', and nothing asserts it.
+//
+// The shared helper's semantics are pinned by tests/gates/wait-for-semantics.test.ts.
+const waitForOk = (url: string, timeoutMs = 5000): Promise<boolean> =>
+  waitFor(
+    async () => {
+      const r = await fetch(url);
+      return r.ok;
+    },
+    { timeout: timeoutMs, interval: 100, label: url },
+  );
 
 describe('Contracts: Report v1 schema', () => {
   const schema = JSON.parse(readFileSync('contracts/report.v1.schema.json', 'utf8'));
@@ -25,7 +41,7 @@ describe('Contracts: Report v1 schema', () => {
 
   beforeAll(async () => {
     child = spawn(process.execPath, ['tools/test-server.js'], { env: { ...process.env, TEST_PORT: PORT }, stdio: 'ignore' });
-    await waitFor(`${BASE}/health`, 5000);
+    await waitForOk(`${BASE}/health`, 5000);
   });
   afterAll(async () => { try { if (child?.pid) process.kill(child.pid, 'SIGINT'); } catch {} });
 

--- a/tests/gates/eslint-config-resolution.test.ts
+++ b/tests/gates/eslint-config-resolution.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ROADMAP 2.879 (4) — THE LINTER'S RECOMMENDED SET MUST ACTUALLY RESOLVE.
+ *
+ * `eslint.config.js` IMPORTED `@eslint/js` and never SPREAD it. The config
+ * therefore resolved exactly FIVE rules for a `src/**` file, and the entire core
+ * recommended set was absent — `no-dupe-keys` among them.
+ *
+ * That is not a style gap. A duplicate object key silently overriding a
+ * `value_frame: 'delta'` stamp with `'level'` is a fabrication shape this very
+ * chain produced by accident (recorded in CEE #862's body: "a duplicate object
+ * key silently overrode 'delta' with 'level'"), and the linter that would have
+ * caught it was structurally incapable of doing so. An unspread plugin import is
+ * the hand-maintained-mirror defect (trap 12) in its purest form: the config
+ * LOOKED like it enabled the recommended set, and enabled none of it — and
+ * `npm run lint` was GREEN throughout, which is what made it invisible.
+ *
+ * ⚠ THIS GUARD IS DERIVED, NOT PINNED. It imports `@eslint/js` and asserts the
+ * resolved config is a SUPERSET of whatever that package currently recommends.
+ * A pinned COUNT would have to be hand-updated on every eslint upgrade and would
+ * drift into exactly the mirror it exists to replace — and it would still pass
+ * if the set changed membership while keeping its size.
+ *
+ * ⚠ AND IT PINS ITS OWN PRECONDITION (trap 13b, third face). A derived
+ * superset check is vacuously true if the reference set is empty, so the test
+ * asserts the reference is non-empty and names `no-dupe-keys` explicitly before
+ * it can conclude anything. Without that, this guard would keep passing after an
+ * upgrade that renamed or emptied `configs.recommended`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ESLint } from 'eslint';
+import js from '@eslint/js';
+
+/** A source file the `**\/*.ts` block certainly matches. */
+const SRC_FILE = 'src/lib/intervention-normaliser.ts';
+/** A test file, which additionally picks up the relaxed override block. */
+const TEST_FILE = 'tests/gates/eslint-config-resolution.test.ts';
+
+async function resolvedRuleNames(file: string): Promise<string[]> {
+  const eslint = new ESLint();
+  const config = await eslint.calculateConfigForFile(file);
+  return Object.keys(config.rules ?? {});
+}
+
+describe('2.879 — eslint.config.js resolves the core recommended rule set', () => {
+  it('PRECONDITION: @eslint/js still exposes a non-empty recommended set containing no-dupe-keys', () => {
+    // Without this, every assertion below is vacuous.
+    const recommended = Object.keys(js.configs.recommended.rules ?? {});
+    expect(recommended.length).toBeGreaterThan(20);
+    expect(recommended).toContain('no-dupe-keys');
+  });
+
+  it('DEFECT: no-dupe-keys resolves for src/ — the rule that would have caught the delta/level key collision', async () => {
+    const rules = await resolvedRuleNames(SRC_FILE);
+    expect(rules).toContain('no-dupe-keys');
+  });
+
+  it('DEFECT: EVERY rule @eslint/js recommends resolves for src/ — derived, so an upgrade cannot silently shrink it', async () => {
+    const recommended = Object.keys(js.configs.recommended.rules ?? {});
+    const resolved = new Set(await resolvedRuleNames(SRC_FILE));
+
+    // `no-undef` is deliberately turned OFF for TypeScript — typescript-eslint's
+    // own config does the same (`@typescript-eslint/eslint-plugin/dist/configs/
+    // eslint-recommended-raw.js`, "ts(2304) & ts(2552)"). An explicitly disabled
+    // rule is still RESOLVED, so it appears in `resolved` and needs no carve-out
+    // here. The assertion is about the set being PRESENT, not about severity.
+    const missing = recommended.filter((r) => !resolved.has(r));
+    expect(missing).toEqual([]);
+  });
+
+  it('DEFECT: the recommended set reaches tests/ too — the override block must relax rules, not replace them', async () => {
+    const recommended = Object.keys(js.configs.recommended.rules ?? {});
+    const resolved = new Set(await resolvedRuleNames(TEST_FILE));
+
+    const missing = recommended.filter((r) => !resolved.has(r));
+    expect(missing).toEqual([]);
+  });
+
+  it("the repo's own overrides still win over the recommended defaults", async () => {
+    const eslint = new ESLint();
+    const config = await eslint.calculateConfigForFile(SRC_FILE);
+    const rules = config.rules ?? {};
+
+    // Spread order matters: `...js.configs.recommended.rules` must come FIRST so
+    // these local decisions are not reverted by it. If someone moves the spread
+    // below them, this reds.
+    // `calculateConfigForFile` returns NUMERIC severities (2 === 'error'),
+    // measured — not the string form written in the config file.
+    expect(rules['no-empty']).toEqual([2, { allowEmptyCatch: false }]);
+    // 'no-undef' is OFF by local decision, against the recommended 'error' —
+    // severity 0, again numeric. This is the assertion that would red if the
+    // spread were moved BELOW the local rules and clobbered them back to error.
+    const noUndef = rules['no-undef'];
+    expect(Array.isArray(noUndef) ? noUndef[0] : noUndef).toBe(0);
+  });
+});

--- a/tests/gates/wait-for-semantics.test.ts
+++ b/tests/gates/wait-for-semantics.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { waitFor } from '../utils.js';
+
+/**
+ * ROADMAP 2.879 — semantics pin for the shared `waitFor` helper.
+ *
+ * WHY THIS EXISTS. Spreading `@eslint/js`'s recommended set turned on
+ * `no-async-promise-executor`, which surfaced the repo's only
+ * `new Promise(async (resolve, reject) => …)` — a private `waitFor` inside
+ * `tests/contracts.report.schema.test.ts`. That helper was DELETED rather than
+ * reshaped: its ~45 siblings across `tests/` are already plain `async function`s,
+ * and `tests/utils.ts` already exports a shared, general one that ~20 specs use.
+ * The contracts test now calls the shared helper.
+ *
+ * That moves a behaviour the contracts test's `beforeAll` depends on behind a
+ * module boundary, so it is pinned here. Nothing tested `waitFor` before, and
+ * ~20 specs rely on it.
+ *
+ * THE ONE BEHAVIOUR THAT CHANGED, stated explicitly rather than left silent:
+ * an async promise executor's rejection is dropped on the floor by the `Promise`
+ * constructor, so any throw escaping the executor's inner `try` left the
+ * returned promise PERMANENTLY UNSETTLED — a silent hang to the vitest timeout
+ * with the real error lost. In the deleted helper the only rejecting `await`
+ * (`fetch`) sat inside a `try/catch`, so no rejection was in fact being
+ * swallowed on a reachable path; the hazard was latent, not live. It is now
+ * structurally impossible, and case (4) pins that.
+ *
+ * Each case binds by IDENTITY (the exact sentinel value / the exact probe's
+ * call count), never by a predicate another object could satisfy.
+ */
+describe('2.879 — shared waitFor semantics (the contract contracts.report.schema.test.ts depends on)', () => {
+  it('resolves with the FIRST TRUTHY value, and does not settle on falsy polls', async () => {
+    const READY = { sentinel: 'ready-value' };
+    let calls = 0;
+    const probe = () => {
+      calls += 1;
+      return calls < 3 ? false : READY;
+    };
+
+    const got = await waitFor(probe, { timeout: 2000, interval: 10, label: 'truthy' });
+
+    // Identity, not shape: it must be the very object the probe returned.
+    expect(got).toBe(READY);
+    // It must have kept polling through the falsy returns, not resolved on the first.
+    expect(calls).toBe(3);
+  });
+
+  it('SWALLOWS a throwing probe and keeps polling — the connection-refused case beforeAll relies on', async () => {
+    const READY = { sentinel: 'up-at-last' };
+    let calls = 0;
+    const probe = async () => {
+      calls += 1;
+      // Stands in for `fetch` against a server that has not bound its port yet.
+      if (calls < 3) throw new Error('ECONNREFUSED');
+      return READY;
+    };
+
+    const got = await waitFor(probe, { timeout: 2000, interval: 10, label: 'throwing' });
+
+    expect(got).toBe(READY);
+    expect(calls).toBe(3);
+  });
+
+  it('REJECTS with a labelled timeout Error when the condition never becomes true', async () => {
+    let calls = 0;
+    const probe = () => {
+      calls += 1;
+      return false;
+    };
+
+    await expect(
+      waitFor(probe, { timeout: 120, interval: 20, label: 'never-ready' }),
+    ).rejects.toThrow(/waitFor\(never-ready\) timed out after 120ms/);
+
+    // Pin the precondition: the rejection must come from the deadline being
+    // reached after real polling, not from the probe never running at all.
+    expect(calls).toBeGreaterThan(1);
+  });
+
+  it('SETTLES on the timeout path — it cannot hang, which an async promise executor could', async () => {
+    // The defect `no-async-promise-executor` names: a promise that never
+    // settles is indistinguishable from a slow one until the runner's own
+    // timeout fires. Race the helper against a sentinel and require it to win.
+    const outcome = await Promise.race([
+      waitFor(() => false, { timeout: 150, interval: 25, label: 'settles' }).then(
+        () => 'settled:resolved' as const,
+        () => 'settled:rejected' as const,
+      ),
+      new Promise<'HUNG'>((resolve) => setTimeout(() => resolve('HUNG'), 3000)),
+    ]);
+
+    expect(outcome).toBe('settled:rejected');
+  });
+});

--- a/tests/openapi.unique-keys.test.ts
+++ b/tests/openapi.unique-keys.test.ts
@@ -14,7 +14,7 @@ describe('OpenAPI YAML unique keys', () => {
     const seenByIndent: Map<number, Set<string>> = new Map();
     let lastIndent = 0;
     let blockIndent: number | null = null; // when inside a block scalar (|), ignore keys until dedent
-    const keyRe = /^(\s*)(?!-\s)([A-Za-z0-9_\/[\]$#{}.'\"-]+):\s*(?:\S.*)?$/;
+    const keyRe = /^(\s*)(?!-\s)([A-Za-z0-9_/[\]$#{}.'"-]+):\s*(?:\S.*)?$/;
     const listRe = /^(\s*)-\s/;
 
     for (const line of lines) {

--- a/tests/plot-2202b-isl-error-reason.test.ts
+++ b/tests/plot-2202b-isl-error-reason.test.ts
@@ -115,6 +115,75 @@ describe('2.202 ①b — parseIslErrorReason names the governor cause the probe 
     expect(parseIslErrorReason(JSON.stringify({ reason: 'a\nb\r{"event":"forged"}' })))
       .toBe('a b {"event":"forged"}');
   });
+
+  it('ROADMAP 2.879 — the stripped set is the FULL C0 range plus DEL, exhaustively', () => {
+    // BACKS A SUPPRESSION. `no-control-regex` is disabled on exactly one line in
+    // src/integrations/isl/errors.ts because the control characters there are the
+    // point of the expression, not an accident. A suppression asserted in a comment
+    // is worth nothing, so the behaviour it protects is pinned here BY EXECUTION and
+    // EXHAUSTIVELY, rather than by the two representative characters (CR, LF) the
+    // case above happens to use. Narrow the class in errors.ts and this reds by name.
+    //
+    // ORACLE CORRECTION, derived from running it rather than from reading the regex:
+    // 0x20 (SPACE) is UNOBSERVABLE through this parser. The sanitiser replaces each
+    // stripped character WITH a space, so a surviving space and a stripped space
+    // produce byte-identical output. My first version of this test classified 0x20 as
+    // "stripped" and was wrong about the code while agreeing with itself. It is now
+    // excluded by name, and the exclusion set is itself asserted, so a future change
+    // that made some OTHER codepoint ambiguous reds here instead of hiding.
+    const stripped: number[] = [];
+    const kept: number[] = [];
+    const unobservable: number[] = [];
+
+    // Sweep the whole Latin-1 space so the boundaries are measured, not assumed:
+    // 0x00-0x1F must strip, 0x21-0x7E must survive, 0x7F must strip, 0x80+ survives.
+    for (let cp = 0x00; cp <= 0xff; cp++) {
+      const ch = String.fromCharCode(cp);
+      // Sentinels either side so trim() cannot mask an edge codepoint, and so a
+      // parser that returned a constant could not satisfy this.
+      const out = parseIslErrorReason(JSON.stringify({ reason: `A${ch}Z` }));
+      const survived = `A${ch}Z`;
+      const replaced = 'A Z';
+      if (survived === replaced) unobservable.push(cp);
+      else if (out === replaced) stripped.push(cp);
+      else if (out === survived) kept.push(cp);
+      else throw new Error(`unexpected output for cp 0x${cp.toString(16)}: ${JSON.stringify(out)}`);
+    }
+
+    const expectedStripped = [
+      ...Array.from({ length: 0x20 }, (_, i) => i), // C0 controls 0x00-0x1F
+      0x7f, // DEL
+    ];
+    expect(stripped).toEqual(expectedStripped);
+
+    // The ambiguity is bounded to the one codepoint that IS the replacement char.
+    expect(unobservable).toEqual([0x20]);
+
+    // POSITIVE CONTROL — the sweep must actually be discriminating. Without these a
+    // parser that stripped EVERYTHING, or a sweep that observed nothing at all,
+    // could still satisfy the equality above.
+    expect(stripped).toHaveLength(33);
+    expect(kept).toHaveLength(256 - 33 - 1);
+    expect(kept).toContain(0x21); // '!' survives — the codepoint directly above the boundary
+    expect(kept).toContain(0x7e); // '~' survives — directly below DEL
+    expect(kept).toContain(0x80); // C1 is deliberately NOT in the class
+    expect(kept).not.toContain(0x00);
+    expect(kept).not.toContain(0x7f);
+
+    // And the security property the suppression exists for, stated directly: no
+    // output may carry a character that could forge an NDJSON log line.
+    for (let cp = 0x00; cp <= 0xff; cp++) {
+      const ch = String.fromCharCode(cp);
+      const out = parseIslErrorReason(JSON.stringify({ reason: `A${ch}Z` }))!;
+      // Deliberately NOT the production regex: an independent codepoint predicate,
+      // so this asserts the property rather than mirroring the implementation.
+      const carriesControl = Array.from(out).some((c) => {
+        const n = c.charCodeAt(0);
+        return n <= 0x1f || n === 0x7f;
+      });
+      expect(carriesControl).toBe(false);
+    }
+  });
 });
 
 describe('2.202 ①b — ISLHttpError.getReason() is the reader that closes the write-only field', () => {


### PR DESCRIPTION
## [2.879] Spread `@eslint/js` so the recommended rule set actually resolves — and fix everything it surfaces

**Status: COMPLETE — lint 0, all gates green.** (An earlier revision of this PR deliberately left lint RED on the 7 surfaced findings; that phase is over — the findings are fixed at this head, so the old "merge options" are moot.)

**The defect:** `eslint.config.js` imported `@eslint/js` and never spread it — the config resolved exactly FIVE rules and the entire core recommended set was silently absent (`no-dupe-keys` among them, the rule that would catch a duplicate object key silently overriding a `value_frame: 'delta'` stamp — a live fabrication shape in this repo's constraint chain). Trap 12 in its purest form: the config LOOKED like it enabled the set and enabled none of it, under a green lint.

**What this PR ships:**
- `...js.configs.recommended.rules` spread (order-guarded), `no-undef` off for TS with the vendor's own rationale (950/957 findings were false positives against `tsc`).
- `tests/gates/eslint-config-resolution.test.ts` — DERIVED guard (superset of whatever `@eslint/js` currently recommends, with a non-vacuity precondition naming `no-dupe-keys`), plus a spread-order assertion.
- The 7 surfaced findings fixed properly: the repo's only `new Promise(async …)` (a private `waitFor`) DELETED in favour of the shared `tests/utils.ts` helper, semantics pinned by `tests/gates/wait-for-semantics.test.ts` (proven green against the untouched helper BEFORE the refactor; the latent unsettled-promise hazard is now structurally impossible); useless escapes removed with equivalence proven over all 65,536 BMP codepoints + the real 7,025-line openapi.yaml corpus; `no-control-regex` suppressed on exactly one line — a log-injection strip on an attacker-influenced ISL body — backed by an exhaustive C0+DEL execution pin.
- **Corrected premise recorded:** this PR's earlier body guessed the errors.ts finding was trap 17's NUL sentinel. False at the bytes (zero NULs; the sentinel is in CEE). ROADMAP 2.119 does not apply; the correction is in the source comment.
- **Honest bycatch (rowed, not fixed here):** mutation testing found `key-insight.test.ts` passes on the digit FALLBACK, not the currency patterns its assertions name (deleting `£` from all three patterns leaves 36/36 green — trap 19). Separate task.

**Gates at `ae48925`:** lint 0 · typecheck 0 · build 0 · validate:contracts 0 · full suite 7,066 passed / 0 failed. CI 10 green / 1 standing red (`audit` = fast-uri GHSA-7p8r-x3mc-p8w7, also red at the staging tip — row 2.385, untouched by this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
