### PR TITLE
feat(2.919): include observed_state.baseline in the canonical request hash (bounded flip)

### DIFF
--- a/src/normalisation/canonicalise.ts
+++ b/src/normalisation/canonicalise.ts
@@ -104,6 +104,42 @@
  * field); this change does not rewrite history — new runs emit v7.
  * `n_samples` is request-derived and deterministic, consistent with the v6
  * principle that the hash is computable from the request alone.
+ *
+ * ## AMENDMENT (v7, ROADMAP 2.919 — baseline inclusion, NO version bump)
+ *
+ * `observed_state.baseline` now participates in the canonical form,
+ * presence-conditionally (finite numbers only; absent/null contribute no key):
+ *
+ * 1. **Why it must be in the hash**: baseline is a computation input. ISL
+ *    converts a `'level'` goal threshold via
+ *    `threshold − goal_baseline + goal_intercept` (see translator-v3.ts,
+ *    where `baseline` is called out as LOAD-BEARING on
+ *    `ISL_DECLARED_OBSERVED_STATE_FIELDS`) and evaluates goal_constraints
+ *    against change-from-baseline samples — so the goal baseline already
+ *    changes `probability_of_goal`. Two requests differing only in a
+ *    baseline were sharing a response_hash, which defeats the UI's
+ *    run-identity gates (dedupe + dirty-overlay clearing compare hashes).
+ *
+ * 2. **Why NO version bump (deliberate, not forgotten)**: a bump puts the
+ *    new version number in EVERY canonical form and flips every stored
+ *    hash. A presence-conditional key bounds the flip instead: an absent
+ *    baseline contributes no key, so every baseline-free request
+ *    canonicalises BYTE-IDENTICALLY to pre-amendment v7 and keeps its
+ *    hash. Only baseline-BEARING requests change — and the live producer
+ *    writes none today (the 2.281 witness; CEE 2.877 begins minting
+ *    `observed_state.baseline` after this lands, which is why this must
+ *    land first). Collision safety without the bump: no pre-amendment
+ *    canonical form ever contained a `baseline` key, so no new
+ *    baseline-bearing form can collide with any old form.
+ *
+ * 3. **Semantics**: absent is NOT coerced to 0 — a stated baseline of 0
+ *    and no baseline are different computations (ISL refuses a `'level'`
+ *    threshold as `missing_goal_baseline` when absent). Values are
+ *    12dp-normalised like every other float in the form.
+ *
+ * Guarded by tests/hash-baseline-awareness.test.ts; the bounded-flip
+ * byte-stability is witnessed by tests/isl-v2-golden-response.pin.test.ts
+ * (baseline-free live capture, pinned hash unchanged).
  */
 
 import { createHash } from 'node:crypto';
@@ -169,6 +205,8 @@ interface CanonicalNode {
   observed_state?: {
     value: number;
     std?: number;
+    /** 2.919: computation input (ISL level-threshold conversion + change-from-baseline framing). Presence-conditional — absent contributes no key. */
+    baseline?: number;
   };
 }
 
@@ -193,6 +231,19 @@ function canonicaliseNode(node: EngineGraphV3['nodes'][0]): CanonicalNode {
     const std = (node.observed_state as any).std;
     if (std !== undefined) {
       canonical.observed_state.std = normaliseFloat(std);
+    }
+
+    // 2.919 (v7 amendment): include baseline if present — it is a computation
+    // input (ISL level-threshold conversion `threshold − goal_baseline +
+    // goal_intercept`, change-from-baseline constraint framing), so two
+    // requests differing only in a baseline must hash differently.
+    // Presence-conditional AND finite-guarded: absent/null/non-finite
+    // contribute no key, so every baseline-free request keeps its exact
+    // pre-amendment hash (bounded flip — see the header). Absent is NOT
+    // coerced to 0: baseline 0 and no baseline are different computations.
+    const baseline = (node.observed_state as any).baseline;
+    if (typeof baseline === 'number' && Number.isFinite(baseline)) {
+      canonical.observed_state.baseline = normaliseFloat(baseline);
     }
   }
 

--- a/tests/hash-baseline-awareness.test.ts
+++ b/tests/hash-baseline-awareness.test.ts
@@ -1,0 +1,174 @@
+/**
+ * ROADMAP 2.919 — Baseline in the canonical request hash (v7 amendment)
+ *
+ * The goal baseline changes `probability_of_goal`: ISL converts a `'level'`
+ * goal threshold via `threshold − goal_baseline + goal_intercept`
+ * (translator-v3.ts, `ISL_DECLARED_OBSERVED_STATE_FIELDS` — `baseline` is
+ * load-bearing on that list), and evaluates goal_constraints against
+ * change-from-baseline samples. Two requests differing ONLY in a baseline are
+ * genuinely different computations and MUST hash differently. Before this
+ * change they shared a response_hash, so the UI's run-identity gates
+ * (applyV5State.ts dedupe / dirty-overlay clearing) could mistake a
+ * baseline-only rerun for a re-delivered echo.
+ *
+ * Bounded-flip guarantee (the load-bearing property of this amendment):
+ * an ABSENT baseline contributes no key to the canonical form, so every
+ * baseline-free request canonicalises BYTE-IDENTICALLY to pre-change v7 —
+ * only baseline-BEARING requests change hash. Witnessed at the integration
+ * level by tests/isl-v2-golden-response.pin.test.ts, whose live-capture
+ * fixture carries no baseline and whose pinned hash 60e3ac213554be4f must
+ * NOT move under this change.
+ *
+ * Trap-13b discipline: the discrimination tests pin their own precondition
+ * (the fixtures provably differ in baseline before hashing), so a fixture
+ * tidy-up cannot hollow them into always-green.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  canonicaliseRequest,
+  computeResponseHash,
+  HASH_VERSION,
+} from '../src/normalisation/canonicalise.js';
+import type { RunRequestV3, EngineGraphV3 } from '../src/types/engine-v3.js';
+
+/**
+ * Build a graph whose goal node and one factor node can carry
+ * observed_state.baseline. Mirrors the post-normalisation EngineGraphV3 shape
+ * hashRequest receives (run.ts:6306/7808 pass filteredGraph = normaliser
+ * output with option nodes filtered).
+ */
+function makeGraph(opts: {
+  goalBaseline?: number;
+  factorABaseline?: number;
+  goalValue?: number;
+} = {}): EngineGraphV3 {
+  const goalObserved: { value: number; baseline?: number } = {
+    value: opts.goalValue ?? 100,
+  };
+  if (opts.goalBaseline !== undefined) goalObserved.baseline = opts.goalBaseline;
+
+  const factorAObserved: { value: number; baseline?: number } = { value: 10 };
+  if (opts.factorABaseline !== undefined) factorAObserved.baseline = opts.factorABaseline;
+
+  return {
+    nodes: [
+      { id: 'factor-a', kind: 'factor', label: 'Factor A', observed_state: factorAObserved },
+      { id: 'factor-b', kind: 'factor', label: 'Factor B' },
+      { id: 'goal', kind: 'goal', label: 'Goal', observed_state: goalObserved },
+    ],
+    edges: [
+      { from: 'factor-a', to: 'goal', exists_probability: 0.8, strength: { mean: 0.5, std: 0.1 } },
+      { from: 'factor-b', to: 'goal', exists_probability: 0.9, strength: { mean: 0.7, std: 0.1 } },
+    ],
+  } as EngineGraphV3;
+}
+
+const OPTIONS = [
+  { id: 'opt1', label: 'Option 1', interventions: { 'factor-a': { value: 1.5, source: 'user_specified' } } },
+  { id: 'opt2', label: 'Option 2', interventions: { 'factor-b': { value: 2.0, source: 'user_specified' } } },
+];
+
+function makeRequest(graph: EngineGraphV3): RunRequestV3 {
+  return {
+    graph,
+    options: OPTIONS,
+    goal_node_id: 'goal',
+    seed: '42',
+  } as unknown as RunRequestV3;
+}
+
+const canonOf = (graph: EngineGraphV3) =>
+  canonicaliseRequest(makeRequest(graph), graph, '42');
+const hashOf = (graph: EngineGraphV3) => computeResponseHash(canonOf(graph));
+
+/** Pull a node's canonical observed_state out of the serialised canonical form. */
+function canonicalNode(canonical: string, id: string): any {
+  const parsed = JSON.parse(canonical);
+  return parsed.graph.nodes.find((n: any) => n.id === id);
+}
+
+describe('Hash baseline-awareness (2.919, v7 amendment)', () => {
+  it('B1: two requests differing ONLY in the goal node baseline → different hashes, identity-bound to the exact values', () => {
+    const gA = makeGraph({ goalBaseline: 0.42 });
+    const gB = makeGraph({ goalBaseline: 0.58 });
+
+    // Trap-13b: pin the precondition — the fixtures genuinely differ in
+    // baseline, on the goal node, and in nothing else the hash can see.
+    const goalA = gA.nodes.find((n) => n.id === 'goal')!;
+    const goalB = gB.nodes.find((n) => n.id === 'goal')!;
+    expect(goalA.observed_state?.baseline).toBe(0.42);
+    expect(goalB.observed_state?.baseline).toBe(0.58);
+    expect(goalA.observed_state?.baseline).not.toBe(goalB.observed_state?.baseline);
+
+    // Identity binding: the canonical form must carry EACH exact baseline
+    // (not merely "some difference somewhere").
+    expect(canonicalNode(canonOf(gA), 'goal').observed_state.baseline).toBe(0.42);
+    expect(canonicalNode(canonOf(gB), 'goal').observed_state.baseline).toBe(0.58);
+
+    expect(hashOf(gA)).not.toBe(hashOf(gB));
+  });
+
+  it('B2 (discriminating control): two requests identical INCLUDING baseline → SAME hash', () => {
+    const gA = makeGraph({ goalBaseline: 0.42, factorABaseline: 7 });
+    const gB = makeGraph({ goalBaseline: 0.42, factorABaseline: 7 });
+    expect(hashOf(gA)).toBe(hashOf(gB));
+  });
+
+  it('B3: baseline present vs absent on the SAME node → different hashes (absent is NOT coerced to 0)', () => {
+    // A baseline of 0 and no baseline are different computations: ISL refuses
+    // a 'level' threshold as missing_goal_baseline when absent, but computes
+    // with baseline=0 when stated. They must not share a hash.
+    const gAbsent = makeGraph({});
+    const gZero = makeGraph({ goalBaseline: 0 });
+    expect(canonicalNode(canonOf(gAbsent), 'goal').observed_state).not.toHaveProperty('baseline');
+    expect(canonicalNode(canonOf(gZero), 'goal').observed_state.baseline).toBe(0);
+    expect(hashOf(gAbsent)).not.toBe(hashOf(gZero));
+  });
+
+  it('B4: a NON-goal factor node baseline also participates (translator forwards baseline for every node)', () => {
+    const gA = makeGraph({ factorABaseline: 5 });
+    const gB = makeGraph({ factorABaseline: 9 });
+    // Precondition pin (trap 13b)
+    expect(gA.nodes.find((n) => n.id === 'factor-a')!.observed_state?.baseline).toBe(5);
+    expect(gB.nodes.find((n) => n.id === 'factor-a')!.observed_state?.baseline).toBe(9);
+    expect(hashOf(gA)).not.toBe(hashOf(gB));
+  });
+
+  it('B5: absent baseline contributes NO key — canonical form is byte-identical to a graph that never mentions baseline', () => {
+    // The bounded-flip guarantee at unit grain: an absent baseline must
+    // canonicalise exactly as today's absent case does. Structural half:
+    // no `baseline` key anywhere in the canonical form.
+    const canonical = canonOf(makeGraph({}));
+    expect(canonical).not.toContain('"baseline"');
+    // Byte-stability against the pre-change serialisation is witnessed at
+    // integration grain by isl-v2-golden-response.pin.test.ts (pinned hash
+    // 60e3ac213554be4f over a baseline-free live capture, untouched here).
+  });
+
+  it('B6: baseline is float-normalised (12dp) — representationally-equal values share a hash', () => {
+    const gA = makeGraph({ goalBaseline: 0.5 });
+    const gB = makeGraph({ goalBaseline: 0.5000000000001 }); // beyond 12dp → rounds to 0.5
+    expect(hashOf(gA)).toBe(hashOf(gB));
+    const gC = makeGraph({ goalBaseline: 0.500000000001 }); // within 12dp → distinct
+    expect(hashOf(gA)).not.toBe(hashOf(gC));
+  });
+
+  it('B7: a null/non-finite baseline hashes as absent (defensive: JSON can deliver null; NaN/Infinity cannot)', () => {
+    const gNull = makeGraph({});
+    (gNull.nodes.find((n) => n.id === 'goal')!.observed_state as any).baseline = null;
+    const gAbsent = makeGraph({});
+    expect(hashOf(gNull)).toBe(hashOf(gAbsent));
+    expect(canonOf(gNull)).not.toContain('"baseline"');
+  });
+
+  it('B8: HASH_VERSION deliberately stays 7 — the amendment is presence-conditional, so no universal flip', () => {
+    // A version bump would put the new number in EVERY canonical form and
+    // flip every stored hash. Keeping v7 with a presence-conditional key
+    // bounds the flip to baseline-BEARING requests only (none exist on the
+    // live wire today — CEE 2.877 mints them from here on). A new
+    // baseline-bearing canonical form cannot collide with any pre-change
+    // form: no pre-change form ever contained the key.
+    expect(HASH_VERSION).toBe(7);
+  });
+});


### PR DESCRIPTION
ROADMAP **2.919** — include the baseline in PLoT's canonical request hash. Found by the 2.877 lane (surfaced-not-built): two runs differing ONLY in a baseline shared a `response_hash`, while the goal baseline already changes `probability_of_goal`. This must land before CEE link 2 (2.877) starts minting `observed_state.baseline` from user statements.

## What changed
`src/normalisation/canonicalise.ts` — `canonicaliseNode` now includes `observed_state.baseline` in the canonical form, **presence-conditionally** (finite numbers only, 12dp-normalised; absent/null/non-finite contribute no key). Derived at the bytes from the translator: `baseline` is on `ISL_DECLARED_OBSERVED_STATE_FIELDS` (translator-v3.ts:404, marked LOAD-BEARING — ISL's `'level'` threshold conversion is `threshold − goal_baseline + goal_intercept`), and it is forwarded for EVERY node, so per-node baselines participate, goal node included. There is **no separate request-level baseline field** on `RunRequestV3` — the "goal baseline" IS the goal node's `observed_state.baseline`.

Absent is NOT coerced to 0: a stated baseline of 0 and no baseline are different computations (ISL refuses `'level'` thresholds as `missing_goal_baseline` when absent).

## Flip radius — bounded, and here is the bound
**`HASH_VERSION` deliberately stays 7** (a bump puts the new number in every canonical form and flips every stored hash — the universal invalidation this design avoids):

- **Baseline-FREE requests keep their exact byte-identical canonical form and hash.** Witnessed at integration grain: `tests/isl-v2-golden-response.pin.test.ts` pins `response_hash === '60e3ac213554be4f'` over a baseline-free LIVE staging capture — untouched by this PR and green.
- **Only baseline-BEARING requests change hash** — and the live producer writes none today (the 2.281 witness recorded in run.ts: no captured live run carried `observed_state.baseline`). So the deploy-time flip radius is ~zero; hashes only start differing when 2.877 begins varying baselines, which is the intended effect.
- Collision safety without a bump: no pre-change canonical form ever contained a `baseline` key, so no new baseline-bearing form can collide with any pre-change form.

## Consumer trace for `responseHash` (producer → wire → consumer, at the bytes)
Producer: `run.ts:6306` / `run.ts:7808` (`hashRequest` over the normalised, option-filtered graph).

**PLoT-internal:** top-level `response_hash` (run.ts:4007) · `_meta.response_hash` + `hash_version` (run.ts:4035-4036) · decision_brief `graph_hash`/`brief_id`/`lineage.response_hash` (run.ts:3658 → assembleBrief) · legacy CEE review scenario ID (run.ts:7971) · decision-review in-memory cache key (run.ts:8492 → `src/cee/decision-review-orchestrator.ts:126` — a hash change is one cache miss, recompute, harmless).

**CEE (staging `129fa7b8`):** passthrough + telemetry ONLY — enrichment manifest carries it to the UI (`enrichment-manifest.ts:161,384,489`), telemetry `plot_response_id` (`enrichment-validation.ts:90-93`), schema fields (`schemas/cee.ts:24,114`, `review.ts:164`). **⚠ Brief premise corrected: CEE's freshness gate does NOT read PLoT's `response_hash`.** The `analysis_ready.freshness` fresh/stale verdict compares CEE's OWN `computeAnalysisAffectingGraphHash` over the persisted graph (`run-analysis.ts:484` → `graph_hash_at_run` vs current graph hash; `decision-records/store-adapter.ts:110` explicitly forbids using PLoT's response_hash there). **No persisted analysis reads stale because of this change — the fresh/stale verdict is computed from a hash this PR does not touch.**
**UI (staging `d33e20df`):** the real equality gates — run-identity/dedupe: `useConversation.ts:3236` (skip duplicate hydration when `response_hash === store.results.hash`) and `applyV5State.ts:1112-1114` (dedupe vs `currentResultsHash`) + `applyV5State.ts:1144` (a NEW hash = genuinely new run ⇒ clear the dirty overlay, gated on an explicit freshness verdict). **The defect's live harm is here: a baseline-only rerun was indistinguishable from a re-delivered echo — the UI would skip hydration and keep the stale overlay. This PR fixes that.** A hash change on these gates in the flip direction (same request, new hash) causes at most one redundant re-hydration of identical content — and the bounded design makes even that ~zero at deploy.

## Evidence
- **RED-first at pristine `a8dfd3a4`:** B1 (goal-baseline discrimination, identity-bound to 0.42/0.58), B3 (present-vs-absent), B4 (non-goal node baseline), B6 (12dp normalisation) all RED with `expected '<hash>' not to be '<hash>'`; controls B2 (identical-incl-baseline ⇒ same hash), B5 (no key when absent), B7 (null ⇒ absent), B8 (version stays 7) green.
- **Mutant kit** (throwaway worktree outside the repo root; inode-distinct, sentinel-write isolation proven, applied-check scoped to src/tests with control asserting exactly zero):
  | Mutant | Expectation | Result |
  |---|---|---|
  | M1 drop `baseline` from hash | my tests RED | RED: B1, B3, B4, B6 (4 failed) |
  | M2 drop a DIFFERENT field (`n_samples`) | my tests GREEN; existing coverage REDs | mine 8/8 green; `hash-sample-awareness` 3 RED |
  | M3 fixture rot (builder silently drops baseline) | B1 REDs on the PRECONDITION assertion | RED: `expected undefined to be 0.42` — different assertion than M1 (13b pair) |
- **Full named gate at tip:** `npm test` (tools/run-all-tests.js) — 634 files / 7118 tests passed, 0 failed, 28 pre-existing skips. `npm run build` green. Empty delta vs standing reds (the known PLoT `audit` red is a separate CI job; this PR's dep surface is empty — no package changes).

## Doctrine unchanged
`response_hash` canonicalises the REQUEST — it is not an output-determinism witness. This PR adds a request input to the request hash; the recorded meaning stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
