### PR TITLE
fix(2.957): a %-unit threshold must mean the same thing alone and batched

### DIFF
--- a/src/lib/intervention-normaliser.ts
+++ b/src/lib/intervention-normaliser.ts
@@ -1099,6 +1099,118 @@ export function isPercentUnit(unit: string | undefined): boolean {
 }
 
 /**
+ * ROADMAP 2.957 — THE PERCENT SCALE IS DECIDED BY THE PRODUCER'S CONVENTION,
+ * AND THAT CONVENTION IS MAGNITUDE-DEPENDENT. THIS IS NOT PLoT'S CHOICE.
+ *
+ * ⚠ READ THE PRODUCER BEFORE CHANGING THIS. A `'%'` constraint does NOT always
+ * carry percentage points. CEE's LLM extractor emits **`"4%"` as
+ * `value: 0.04, unit: "%"`** — a FRACTION under a `'%'` label — and CEE's own
+ * `normaliseConstraintUnits` exists to relabel exactly that case, with a
+ * comment naming the opposite reading as the defect it prevents
+ * (`olumi-assistants-service/src/cee/compound-goal/extractor.ts:925-934`):
+ *
+ *     "The LLM extractor converts "4%" to value: 0.04, unit: "%".
+ *      If a consumer interprets unit: "%" as "value is percentage points",
+ *      0.04% ≠ 4%.  This normaliser detects the fractional case and relabels
+ *      the unit to "fraction" so the convention is unambiguous.
+ *      Rule: if unit === "%" and 0 < value < 1 → already fractional."
+ *
+ * It relabels WITHOUT dividing — the value was already fractional. And the
+ * relabel is NOT guaranteed to have happened: `normaliseConstraintUnits` is
+ * called only on the REGEX-extracted branch
+ * (`stages/repair/compound-goals.ts` — the LLM-emitted branch below it does
+ * not call it), so a fractional value under a raw `'%'` label reaches PLoT on
+ * the primary draft path.
+ *
+ * THE OTHER HALF OF THE PRODUCER'S RULE, equally load-bearing: a `'%'`
+ * constraint whose value is `>= 1` IS percentage points. CEE pins this itself —
+ * `tests/unit/cee.constraint-unit-normalisation.test.ts`:
+ *   "preserves percentage-unit constraints where value >= 1 (already in pp
+ *    form)" · "// value: 4, unit: "%" means "4 percentage points""
+ * and `value === 0` is preserved as `'%'` (0 is 0 on either reading).
+ *
+ * So the boundary below is CEE's boundary, transcribed — not a heuristic:
+ *   |v| <  1  ⇒ already fractional ⇒ IDENTITY [0,1]; forward the value as-is.
+ *   |v| >= 1  ⇒ percentage points  ⇒ [0,100]; divide by 100 (UNCHANGED
+ *               behaviour — this is what the rung has always done).
+ *
+ * ⚠ WHAT THIS FIXES. The rung previously used [0,100] unconditionally, so
+ * `{unit:'%', value:0.04}` — the producer's own canonical example, meaning 4% —
+ * became **0.0004** whenever any constraint in the batch opened the
+ * normalisation gate, and stayed a correct **0.04** when none did. A hundredfold
+ * understatement decided by an UNRELATED constraint's value. Fixing the
+ * gate-OPEN arm (rather than dragging the gate-closed arm to match it) is what
+ * makes the two agree on the value the producer meant.
+ *
+ * ⚠ AN EARLIER REVISION OF THIS ROW MOVED THE OTHER WAY — it read `'%'` as
+ * always-percentage-points and normalised the sub-1 cell to `v/100`. That was
+ * refuted at the producer's bytes: it would have turned `0.04` into `0.0004` on
+ * the primary draft path, i.e. it would have INTRODUCED the defect above on the
+ * one path that was still correct. The lesson is recorded here because the
+ * mistake is re-makeable from PLoT's side alone: the contract line
+ * ("Threshold in the user's units; PLoT normalises downstream") does NOT settle
+ * which scale `'%'` denotes, and a full mutant kill-rate against that wrong
+ * oracle proves only sensitivity, never correctness.
+ *
+ * ⚠ KNOWN-AMBIGUOUS, deliberately left as CEE has it: a ratio that legitimately
+ * exceeds 100% (NRR 110%) is emitted by the draft prompt as `value: 1.10,
+ * unit: "%"` on a NODE, while CEE's CONSTRAINT rule reads `>= 1` as percentage
+ * points. For a constraint that lands at `1.10` the two readings differ. This
+ * function does NOT resolve it — it reproduces CEE's stated constraint rule
+ * exactly, so PLoT is never the service that invented a third convention.
+ */
+function percentRangeForValue(value: number): NormalisationRange {
+  return Math.abs(value) < 1
+    ? { min: 0, max: 1, source: 'unit_percent' }
+    : { min: 0, max: 100, source: 'unit_percent' };
+}
+
+/**
+ * ROADMAP 2.957 — true when a `'%'` constraint exists whose value the percent
+ * rung WOULD rescale (i.e. percentage-point form, `|value| >= 1`).
+ *
+ * WHY THIS EXISTS, and it is a narrow, derived thing. `constraintsNeedNormalisation`
+ * opens the gate on `value < 0 || value > 1`. `value === 1` satisfies neither,
+ * so a lone `{unit:'%', value:1}` — ONE PERCENT by CEE's `>= 1` rule — was
+ * forwarded raw as `1.0` (a hundred percent) when alone, while resolving to
+ * `0.01` the moment any batch-mate opened the gate. Every other percentage-point
+ * value already opens the gate by magnitude, so this closes the single
+ * remaining cell where the answer still depended on a DIFFERENT constraint.
+ *
+ * Stated as `|value| >= 1` rather than `value === 1` on purpose: it is the
+ * genuine precondition ("the rung would rescale this"), so it stays correct if
+ * the gate's own bounds ever move, instead of encoding today's off-by-one.
+ */
+export function constraintsHavePercentPointValue(
+  constraints: GoalConstraint[],
+  unitsByConstraintId: Map<string, string> | undefined,
+): boolean {
+  if (unitsByConstraintId === undefined || unitsByConstraintId.size === 0) return false;
+  for (const constraint of constraints) {
+    if (isPercentPointValue(unitsByConstraintId.get(constraint.constraint_id), constraint.value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * ROADMAP 2.957 — THE single predicate for "this constraint is stated in
+ * PERCENTAGE POINTS and the '%' rung will therefore rescale it".
+ *
+ * Three sites need this exact question — the route's invocation condition, the
+ * forward-raw rung's exemption, and (as its complement) the scale chosen by
+ * `percentRangeForValue`. They MUST agree: if the route forces the normaliser
+ * to run for a value the forward-raw rung then forwards untouched, the extra
+ * invocation is a no-op and the batch-dependence survives. That is not a
+ * hypothetical — it is what a first cut of this fix did at `value === 1`,
+ * caught by the batch-invariance sweep. One predicate, three callers.
+ */
+function isPercentPointValue(unit: string | undefined, value: number): boolean {
+  return isPercentUnit(unit) && Number.isFinite(value) && Math.abs(value) >= 1;
+}
+
+/**
  * Range sources whose numeric bounds are read off the TARGET NODE's
  * `observed_state`, and which therefore inherit `observed_state.unit` as the
  * declared unit OF THE SCALE. Only for these can a constraint's own declared
@@ -1359,7 +1471,24 @@ export function normaliseGoalConstraints(
       // invariant here; the pick is provisional. (F4: this branch is now gated on
       // NON-identity — an identity scale is an assumption, demoted to branch 5.)
       range = interventionScale;
-    } else if (!applyChainWithoutScale) {
+    } else if (!applyChainWithoutScale && !isPercentPointValue(unit, value)) {
+      // ROADMAP 2.957 — the `!isPercentPointValue` conjunct closes the LAST cell
+      // where a '%' threshold's meaning depended on a DIFFERENT constraint.
+      // The gate fires on `value < 0 || value > 1`, so `value === 1` opens
+      // nothing: `{unit:'%', value:1}` — ONE percentage point by CEE's `>= 1`
+      // rule — was forwarded raw here as `1.0` (a HUNDRED percent) when alone,
+      // while resolving to `0.01` the moment any batch-mate opened the gate.
+      // `value === 1` is the only value this can reach (every other
+      // percentage-point magnitude already opens the gate), so the blast radius
+      // is exactly that cell.
+      //
+      // ⚠ NOTE THE NARROWNESS, and do NOT widen it to all '%' units. A sub-1
+      // '%' value is ALREADY FRACTIONAL (CEE's LLM extractor emits "4%" as
+      // 0.04), so forwarding it raw here is CORRECT and must stay — exempting
+      // it would rescale 0.04 to 0.0004. See `percentRangeForValue` for the
+      // producer citations; an earlier revision of this row made exactly that
+      // mistake.
+      //
       // F1 (adversarial review): the global gate did NOT fire and this node has
       // NO intervention scale ⇒ the value is already in [0,1] by definition of
       // the gate; forward it verbatim (identity). This decision MUST precede the
@@ -1376,7 +1505,7 @@ export function normaliseGoalConstraints(
     } else if (typeof nodeCap === 'number' && Number.isFinite(nodeCap) && nodeCap > 0) {
       range = { min: 0, max: nodeCap, source: 'goal_threshold_cap' };
     } else if (isPercentUnit(unit)) {
-      range = { min: 0, max: 100, source: 'unit_percent' };
+      range = percentRangeForValue(value);
     } else if (interventionScale) {
       // F4 branch 5: an IDENTITY [0,1] intervention scale (Phase 4a skipped for
       // this intervened node). Reached only when no producer '%'/cap declared it
@@ -1404,7 +1533,10 @@ export function normaliseGoalConstraints(
       typeof nodeCap === 'number' && Number.isFinite(nodeCap) && nodeCap > 0
         ? { min: 0, max: nodeCap, source: 'goal_threshold_cap' }
         : isPercentUnit(unit)
-          ? { min: 0, max: 100, source: 'unit_percent' }
+          // DERIVED from the same helper the rung uses (2.957) — two copies of
+          // the percent-scale decision is exactly the hand-maintained mirror
+          // that lets the divergence verdict drift from the range it describes.
+          ? percentRangeForValue(value)
           : undefined;
     const rangeUnified =
       interventionScale === undefined ||

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -195,6 +195,7 @@ import {
   needsNormalisation,
   normaliseGoalConstraints,
   constraintsNeedNormalisation,
+  constraintsHavePercentPointValue,
   isIdentityRange,
   type NormalisationContext,
   type NormalisationDiagnostic,
@@ -6538,7 +6539,24 @@ export async function registerRunV2Route(app: FastifyInstance): Promise<void> {
             }
           }
 
-          if (gateNeedsNorm || anyNonIdentityScale) {
+          // ROADMAP 2.957 — closes the ONE cell where a '%' threshold's meaning
+          // still depended on a DIFFERENT constraint's value. `gateNeedsNorm`
+          // fires on `value < 0 || value > 1`, so `value === 1` opens nothing:
+          // a lone `{unit:'%', value:1}` — ONE percent, by CEE's `>= 1`
+          // percentage-point rule — was forwarded raw as `1.0` (a HUNDRED
+          // percent), yet resolved to `0.01` as soon as any batch-mate opened
+          // the gate. Every other percentage-point magnitude already opens it.
+          //
+          // This forces INVOCATION only; `normaliseWithoutScale` still carries
+          // `gateNeedsNorm` unchanged, so nothing else moves. The sub-1
+          // fractional cell needs no disjunct at all — the rung now agrees with
+          // the forwarded-raw value there, which is why that arm is invariant.
+          const anyPercentPointValue = constraintsHavePercentPointValue(
+            activeGoalConstraints,
+            constraintUnitsByConstraintId,
+          );
+
+          if (gateNeedsNorm || anyNonIdentityScale || anyPercentPointValue) {
             const constraintNormResult = normaliseGoalConstraints(
               activeGoalConstraints,
               filteredGraph.nodes,

--- a/tests/constraint-percent-unit-scale-authority.route.test.ts
+++ b/tests/constraint-percent-unit-scale-authority.route.test.ts
@@ -1,0 +1,269 @@
+/**
+ * ROADMAP 2.957 — BATCH-INVARIANCE, ASSERTED ON THE REAL ISL WIRE.
+ *
+ * ⚠ WHY A ROUTE TEST IS NOT REDUNDANT WITH THE MODULE SUITE. The invocation
+ * decision lives in `routes/v2/run.ts`, not in `normaliseGoalConstraints`: when
+ * the legacy gate reads false and no node carries a non-identity intervention
+ * scale, the route's `else` arm forwards `activeGoalConstraints` VERBATIM and
+ * the normaliser never runs. A module-level suite calls the normaliser directly,
+ * so it cannot observe that arm at all — it would stay green with the route
+ * disjunct deleted. Every assertion here reads the payload the translator
+ * actually built.
+ *
+ * THE PROPERTY: the value PLoT sends for a constraint is a function of THAT
+ * CONSTRAINT ALONE. Each case below is run twice against byte-identical
+ * payloads but for the presence of an unrelated, out-of-range batch-mate, and
+ * the '%' row's wire value must be the same both times — and must be the value
+ * the PRODUCER meant:
+ *
+ *   {unit:'%', value:0.04}  → 0.04   (CEE's LLM emits "4%" as 0.04 — a FRACTION
+ *                                     under a '%' label; NOT 0.0004)
+ *   {unit:'%', value:1}     → 0.01   (CEE reads '%' with value >= 1 as
+ *                                     PERCENTAGE POINTS; NOT 1.0)
+ *   {unit:'%', value:40}    → 0.4    (unchanged behaviour, pinned as a control)
+ *
+ * ⚠ THE FIXTURE PINS ITS OWN PRECONDITION (trap 13b). The no-batch-mate arm is
+ * only meaningful if it genuinely reproduces the GATE-CLOSED state: all
+ * interventions inside [0,1] (Phase 4a skipped ⇒ every intervention scale is
+ * identity) and no out-of-range constraint. The PRECONDITION test observes a
+ * NON-percent constraint being forwarded raw — an outcome possible only when
+ * both legacy disjuncts are false. If either drifts, it REDs rather than
+ * letting the other arms pass for an unrelated reason.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+/** Every `goal_constraints` array ISL was handed, in call order. THE WIRE. */
+let islRequests: any[][] = [];
+
+function echoConstraintAnalysis(goalConstraints: any[] | undefined) {
+  if (!goalConstraints || goalConstraints.length === 0) return undefined;
+  return {
+    constraints: goalConstraints.map((c: any, i: number) => ({
+      constraint_id: c.constraint_id,
+      node_id: c.node_id,
+      operator: c.operator,
+      value: c.value,
+      prob_satisfied: 0.8 + i * 0.05,
+      failure_margin_median: 0.04,
+      near_miss_fraction: 0.1,
+      binding: false,
+    })),
+    joint_probability: 0.75,
+    conditional_probabilities: null,
+  };
+}
+
+function optionResults(options: any[], goalConstraints: any[] | undefined) {
+  const ca = echoConstraintAnalysis(goalConstraints);
+  return options.map((opt: any, idx: number) => ({
+    option_id: opt.id,
+    outcome: {
+      mean: 0.7 + idx * 0.1, std: 0.1, p10: 0.5, p50: 0.7, p90: 0.9,
+      n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1.0,
+    },
+    rank: idx + 1,
+    ...(ca && { constraint_analysis: ca }),
+  }));
+}
+
+const mockISLService = {
+  isEnabled(): boolean { return true; },
+  async isAvailable(): Promise<boolean> { return true; },
+  async validateCausal() {
+    return {
+      status: 'identifiable', confidence: 'high', adjustment_sets: [], minimal_set: [],
+      backdoor_paths: [], issues: [],
+      explanation: { summary: 'Mock validation', reasoning: 'Test' }, source: 'isl',
+    };
+  },
+  async analyseSensitivity() {
+    return { overall_robustness: 'robust', sensitive_parameters: [], recommendations: [], source: 'isl' };
+  },
+  async analyseRobustness(_graph: any, _goalNodeId: string, options: any[], _t?: any, constraints?: any[]) {
+    islRequests.push(constraints ?? []);
+    return {
+      options: optionResults(options, constraints),
+      edges: [], edges_provenance: 'isl:/api/v1/robustness/analyze/v2' as const,
+      edge_sensitivity_status: 'available' as const,
+      factors: [], value_of_information: [], factors_provenance: 'unavailable' as const,
+      factor_sensitivity_status: 'skipped_no_factor_values' as const,
+      overall_robustness: 'robust' as const, robustness_score: 0.8,
+      fragile_edges: [], robust_edges: [], latency_ms: 50, source: 'isl' as const,
+    };
+  },
+  async analyseFactorSensitivity() {
+    return {
+      factors: [], value_of_information: [], robustness_label: 'robust' as const,
+      robustness_score: 0.8, latency_ms: 0, source: 'unavailable' as const,
+    };
+  },
+  async computeCounterfactual(): Promise<never> { throw new Error('not called'); },
+  async callAnalysisEndpoint<T>(_endpoint: string, body: any): Promise<{ data: T | null; error: string | null }> {
+    islRequests.push(body.goal_constraints ?? []);
+    return {
+      data: {
+        options: optionResults(body.options || [], body.goal_constraints),
+        edges: [], factors: [], value_of_information: [],
+        overall_robustness: 'robust', robustness_score: 0.8,
+        fragile_edges: [], robust_edges: [],
+      } as T,
+      error: null,
+    };
+  },
+};
+
+vi.mock('../src/integrations/isl/index.ts', async () => {
+  const actual = await vi.importActual<any>('../src/integrations/isl/index.ts');
+  return { ...actual, getISLService: () => mockISLService, islService: mockISLService };
+});
+
+import { createServer } from '../src/createServer.js';
+
+const GRAPH = {
+  nodes: [
+    { id: 'goal', kind: 'goal', label: 'Revenue', observed_state: { value: 15000 } },
+    { id: 'factor-a', kind: 'factor', label: 'Market Size' },
+    { id: 'factor-b', kind: 'factor', label: 'Retention' },
+    // Carries an observed value so the constraint pipeline delivers a verdict.
+    // It feeds `deriveRange` rung 6 (`inferred_value`), BELOW the '%' rung (4),
+    // so it can never be the source of the '%' arms' answers.
+    { id: 'factor-c', kind: 'factor', label: 'Churn rate', observed_state: { value: 0.1 } },
+  ],
+  edges: [
+    { from: 'factor-a', to: 'goal', strength: { mean: 0.5, std: 0.1 } },
+    { from: 'factor-b', to: 'goal', strength: { mean: 0.7, std: 0.1 } },
+    { from: 'factor-c', to: 'goal', strength: { mean: 0.3, std: 0.1 } },
+  ],
+};
+
+/**
+ * Interventions ALL inside [0,1] on purpose: Phase 4a is skipped, every
+ * intervention scale is identity, and the route's `anyNonIdentityScale`
+ * disjunct reads FALSE. Moving these outside [0,1] would invoke the normaliser
+ * for an unrelated reason and silently hollow this file out.
+ */
+const OPTIONS = [
+  { id: 'opt1', label: 'Option 1', interventions: { 'factor-a': 0.5 } },
+  { id: 'opt2', label: 'Option 2', interventions: { 'factor-b': 0.6 } },
+];
+
+const BASE_PAYLOAD = { graph: GRAPH, options: OPTIONS, goal_node_id: 'goal', seed: '42' };
+
+const churn = (unit: string, value: number) => ({
+  constraint_id: 'churn-cap',
+  node_id: 'factor-c',
+  operator: '<=',
+  value,
+  unit,
+  label: 'Churn target',
+});
+
+/** Unrelated, out-of-range, NON-percent — its only job is to open the gate. */
+const GATE_OPENER = {
+  constraint_id: 'revenue-min',
+  node_id: 'goal',
+  operator: '>=',
+  value: 20_000,
+  unit: '£',
+  label: 'Revenue floor',
+};
+
+async function run(baseUrl: string, goal_constraints: any[]) {
+  islRequests = [];
+  const res = await fetch(`${baseUrl}/v2/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...BASE_PAYLOAD, goal_constraints }),
+  });
+  expect(res.status).toBe(200);
+  return res.json();
+}
+
+/** The value ISL was actually handed for `churn-cap` on every recorded call. */
+function churnWire(): number[] {
+  expect(islRequests.length).toBeGreaterThan(0);
+  const seen: number[] = [];
+  for (const sent of islRequests) {
+    const row = sent.find((c: any) => c.constraint_id === 'churn-cap');
+    expect(row, 'churn-cap must reach the ISL wire').toBeDefined();
+    seen.push(row.value);
+  }
+  expect(seen.length).toBeGreaterThan(0);
+  return seen;
+}
+
+describe('2.957 route — a % threshold reaches ISL with the same meaning, alone or batched', () => {
+  let app: FastifyInstance;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_ENABLED = '0';
+    process.env.CEE_ORCHESTRATOR_ENABLED = '0';
+    app = await createServer();
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const addr = app.server.address();
+    baseUrl = `http://127.0.0.1:${typeof addr === 'object' && addr ? addr.port : 0}`;
+    // The global hookTimeout is 10s and a COLD vitest cache spends ~8s
+    // transforming before `createServer` is reached — measured. A route suite
+    // that reds only on a cold cache is a flake, and a flake in a wrong-number
+    // guard is worse than no guard.
+  }, 60_000);
+
+  afterAll(async () => { await app?.close(); });
+
+  it('PRECONDITION: the no-batch-mate arm is genuinely GATE-CLOSED', async () => {
+    // A non-percent 0.9 forwarded raw is only possible when BOTH legacy
+    // disjuncts are false. If this reds, every "alone" arm below is void.
+    await run(baseUrl, [churn('count', 0.9)]);
+    for (const v of churnWire()) expect(v).toBe(0.9);
+  });
+
+  it('0.04 with unit "%" reaches ISL as 0.04 — alone AND batched (not 0.0004)', async () => {
+    await run(baseUrl, [churn('%', 0.04)]);
+    const alone = churnWire();
+    await run(baseUrl, [churn('%', 0.04), GATE_OPENER]);
+    const batched = churnWire();
+
+    for (const v of alone) expect(v).toBeCloseTo(0.04, 12);
+    for (const v of batched) expect(v).toBeCloseTo(0.04, 12);
+    expect(alone[0]).toBe(batched[0]);
+    // The refuted direction, named so a regression is unmistakable.
+    expect(batched[0]).not.toBeCloseTo(0.0004, 12);
+  });
+
+  it('1 with unit "%" reaches ISL as 0.01 — alone AND batched (not 1.0)', async () => {
+    // The cell the route disjunct exists for: value 1 opens no gate.
+    await run(baseUrl, [churn('%', 1)]);
+    const alone = churnWire();
+    await run(baseUrl, [churn('%', 1), GATE_OPENER]);
+    const batched = churnWire();
+
+    for (const v of alone) expect(v).toBeCloseTo(0.01, 12);
+    for (const v of batched) expect(v).toBeCloseTo(0.01, 12);
+    expect(alone[0]).toBe(batched[0]);
+    expect(alone[0]).not.toBe(1);
+  });
+
+  it('CONTROL: 40 with unit "%" reaches ISL as 0.4 — unchanged behaviour', async () => {
+    await run(baseUrl, [churn('%', 40)]);
+    for (const v of churnWire()) expect(v).toBeCloseTo(0.4, 12);
+  });
+
+  it('DISCRIMINATING PAIR: same value, different unit string, different wire value', async () => {
+    await run(baseUrl, [churn('%', 1)]);
+    const pct = churnWire();
+    await run(baseUrl, [churn('count', 1)]);
+    const cnt = churnWire();
+    expect(pct[0]).toBeCloseTo(0.01, 12);
+    expect(cnt[0]).toBe(1);
+    expect(pct[0]).not.toBe(cnt[0]);
+  });
+
+  it('CONTROL: the run still succeeds and delivers the constraint verdict', async () => {
+    const body = await run(baseUrl, [churn('%', 0.04)]);
+    expect(body.constraints_status).toBe('computed');
+    expect((body.constraint_results ?? []).map((r: any) => r.constraint_id)).toContain('churn-cap');
+  });
+});

--- a/tests/constraint-percent-unit-scale-authority.test.ts
+++ b/tests/constraint-percent-unit-scale-authority.test.ts
@@ -277,6 +277,52 @@ describe('2.957 controls — behaviours that MUST NOT change', () => {
     expect(isPercentUnit(undefined)).toBe(false);
   });
 
+  it('the range_unified mirror is DERIVED: a fractional % against a [0,100] sample scale is a real divergence', () => {
+    // ⚠ THIS TEST EXISTS BECAUSE A MUTANT SURVIVED. Hardcoding
+    // `producerDeclaredRange` back to [0,100] (instead of deriving it from the
+    // same `percentRangeForValue` the rung uses) left the whole suite GREEN.
+    // A surviving mutant is a claim either way, so it was measured rather than
+    // waved through as equivalent — and it is NOT equivalent:
+    //
+    //   node's MEASURED intervention scale = [0,100]
+    //   constraint  {unit:'%', value:0.04}  ⇒ producer scale is [0,1] (fractional)
+    //
+    // Branch 1 adopts the measured scale, so the threshold is normalised
+    // against [0,100] while the producer declared [0,1] — a genuine scale
+    // divergence, and `range_unified` must be FALSE (which in turn denies the
+    // decision-grade trust bit). With the mirror hardcoded to [0,100] the two
+    // compare EQUAL and the divergence is silently certified as unified.
+    const r = normaliseGoalConstraints([constraint('c_frac', 0.04)], NODES, {
+      unitsByConstraintId: units([['c_frac', '%']]),
+      interventionScaleByNodeId: new Map([
+        ['n_churn', { min: 0, max: 100, source: 'inferred_spread' as const }],
+      ]),
+      normaliseWithoutScale: true,
+    });
+    const d = r.diagnostics.find((x) => x.constraint_id === 'c_frac')!;
+    // Precondition pinned in-test: the measured scale really was adopted, so
+    // this cell is the divergence cell and not some other branch.
+    expect(d.range).toEqual({ min: 0, max: 100, source: 'inferred_spread' });
+    expect(d.range_unified).toBe(false);
+  });
+
+  it('CONTROL: a percentage-POINT % against the same [0,100] scale is NOT a divergence', () => {
+    // The discriminating twin of the test above: same node, same measured
+    // scale, same unit — only the VALUE's form differs. Here the producer scale
+    // IS [0,100], so the two agree and `range_unified` is TRUE. Without this
+    // pair, the assertion above could pass by always reporting divergence.
+    const r = normaliseGoalConstraints([constraint('c_pp', 40)], NODES, {
+      unitsByConstraintId: units([['c_pp', '%']]),
+      interventionScaleByNodeId: new Map([
+        ['n_churn', { min: 0, max: 100, source: 'inferred_spread' as const }],
+      ]),
+      normaliseWithoutScale: true,
+    });
+    const d = r.diagnostics.find((x) => x.constraint_id === 'c_pp')!;
+    expect(d.range).toEqual({ min: 0, max: 100, source: 'inferred_spread' });
+    expect(d.range_unified).toBe(true);
+  });
+
   it('CONTROL: a negative percentage-point delta still resolves on [0,100] as before', () => {
     // "reduce churn by 33 percentage points" — |−33| >= 1 ⇒ pp form, unchanged.
     const r = sendBatch([constraint('c_neg', -33)], [['c_neg', '%']]);

--- a/tests/constraint-percent-unit-scale-authority.test.ts
+++ b/tests/constraint-percent-unit-scale-authority.test.ts
@@ -1,0 +1,286 @@
+/**
+ * ROADMAP 2.957 — A '%' THRESHOLD MUST NOT MEAN TWO DIFFERENT THINGS DEPENDING
+ * ON WHAT ELSE IS IN THE REQUEST.
+ *
+ * THE DEFECT, measured at `519d3111` / `747a3aa4`:
+ *
+ *   `normaliseGoalConstraints`' `unit_percent` rung resolved `[0,100]`
+ *   UNCONDITIONALLY. The route only invokes the normaliser when
+ *   `constraintsNeedNormalisation` fires (`value < 0 || value > 1`) or some node
+ *   carries a non-identity intervention scale. So for `{unit:'%', value:0.04}`:
+ *
+ *     alone (gate closed)                   → forwarded raw as 0.04   ✅ correct
+ *     batched with any out-of-range row     → 0.04/100 = **0.0004**   ❌ 100× low
+ *
+ *   One constraint, two meanings, decided by an UNRELATED constraint's value.
+ *
+ * WHICH ARM IS WRONG IS SETTLED BY THE PRODUCER, NOT BY PLoT (trap 13c). CEE's
+ * LLM extractor emits **"4%" as `value: 0.04, unit: "%"`** — a FRACTION under a
+ * `'%'` label — and says so in the comment on the very function written to stop
+ * a consumer misreading it (`olumi-assistants-service`,
+ * `src/cee/compound-goal/extractor.ts:925-934`):
+ *
+ *     "If a consumer interprets unit: "%" as "value is percentage points",
+ *      0.04% ≠ 4%. … Rule: if unit === "%" and 0 < value < 1 → already
+ *      fractional → unit = "fraction"."
+ *
+ * It relabels WITHOUT dividing, and it runs only on the REGEX branch
+ * (`stages/repair/compound-goals.ts`; the LLM branch below it does not call it),
+ * so a fractional value under a raw `'%'` label reaches PLoT on the primary
+ * draft path. The `>= 1` half is CEE's too, pinned in its own suite
+ * (`tests/unit/cee.constraint-unit-normalisation.test.ts`): *"preserves
+ * percentage-unit constraints where value >= 1 (already in pp form) —
+ * value: 4, unit: "%" means 4 percentage points"*.
+ *
+ * ⚠ AN EARLIER REVISION OF THIS ROW WENT THE OTHER WAY and was refuted at the
+ * producer's bytes: it read `'%'` as always-percentage-points and rescaled the
+ * sub-1 cell, which would have turned `0.04` into `0.0004` on the one path that
+ * was still correct. It passed a 6-mutant kit — against the wrong oracle. The
+ * expectations below are therefore derived from CEE's rule, not from PLoT's
+ * contract line, which does not settle which scale `'%'` denotes.
+ *
+ * THE PROPERTY THIS FILE PINS IS **BATCH-INVARIANCE**: the value PLoT sends for
+ * a constraint is a function of that constraint alone.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normaliseGoalConstraints,
+  constraintsNeedNormalisation,
+  constraintsHavePercentPointValue,
+  isPercentUnit,
+} from '../src/lib/intervention-normaliser.js';
+import { PERCENT_UNIT_TOKENS } from '../src/lib/constraint-units.js';
+import type { EngineNodeV3, GoalConstraint } from '../src/types/engine-v3.js';
+
+/**
+ * Capless, rangeless factor nodes: `deriveRange` lands on the `default` rung, so
+ * nothing on the NODE can supply a scale and any answer must come from the
+ * constraint's own unit + value.
+ */
+const CHURN = { id: 'n_churn', label: 'Churn rate', type: 'factor' } as unknown as EngineNodeV3;
+const COST = { id: 'n_cost', label: 'Unit cost', type: 'factor' } as unknown as EngineNodeV3;
+const NODES: EngineNodeV3[] = [CHURN, COST];
+
+function constraint(
+  constraint_id: string,
+  value: number,
+  node_id = 'n_churn',
+  extra: Partial<GoalConstraint> = {},
+): GoalConstraint {
+  return { constraint_id, node_id, operator: '<=', value, ...extra } as GoalConstraint;
+}
+
+function units(pairs: Array<[string, string]>): Map<string, string> {
+  return new Map(pairs);
+}
+
+/** A batch-mate whose only job is to open the legacy gate. NOT percent. */
+const GATE_OPENER = constraint('c_gate_opener', 50_000, 'n_cost');
+
+/**
+ * Send `c` through the normaliser the way the route would, deriving
+ * `normaliseWithoutScale` from the real gate over the whole batch — so the
+ * fixture cannot silently stop reproducing the gate state it names.
+ */
+function sendBatch(batch: GoalConstraint[], unitPairs: Array<[string, string]>) {
+  return normaliseGoalConstraints(batch, NODES, {
+    unitsByConstraintId: units(unitPairs),
+    normaliseWithoutScale: constraintsNeedNormalisation(batch),
+  });
+}
+
+/** The value that would reach ISL for `id`, or `undefined` if it was refused. */
+function wire(result: ReturnType<typeof normaliseGoalConstraints>, id: string) {
+  return result.constraints.find((c) => c.constraint_id === id)?.value;
+}
+
+// =============================================================================
+// 1. THE PIN — batch-invariance, and the producer's two cases
+// =============================================================================
+
+describe('2.957 — a % threshold means the same thing alone and in company', () => {
+  it('the legacy gate is value-based and blind to units (unchanged, pinned for scope)', () => {
+    expect(constraintsNeedNormalisation([constraint('c', 0.04)])).toBe(false);
+    expect(constraintsNeedNormalisation([constraint('c', 0.04), GATE_OPENER])).toBe(true);
+    // value === 1 opens NOTHING — the cell the route disjunct exists for.
+    expect(constraintsNeedNormalisation([constraint('c', 1)])).toBe(false);
+  });
+
+  it("PIN: 0.04 with unit '%' is FOUR PERCENT — it stays 0.04, batched or not", () => {
+    // The producer's own canonical example. Pre-fix this was 0.0004 in the
+    // batched arm — a hundredfold understatement of the user's target.
+    const alone = sendBatch([constraint('c_frac', 0.04)], [['c_frac', '%']]);
+    const batched = sendBatch(
+      [constraint('c_frac', 0.04), GATE_OPENER],
+      [['c_frac', '%']],
+    );
+
+    expect(wire(alone, 'c_frac')).toBeCloseTo(0.04, 12);
+    expect(wire(batched, 'c_frac')).toBeCloseTo(0.04, 12);
+    // Named explicitly so a regression to the refuted direction is unmistakable.
+    expect(wire(batched, 'c_frac')).not.toBeCloseTo(0.0004, 12);
+  });
+
+  it("PIN: 40 with unit '%' is FORTY PERCENT — it becomes 0.4, batched or not", () => {
+    const alone = sendBatch([constraint('c_pp', 40)], [['c_pp', '%']]);
+    const batched = sendBatch([constraint('c_pp', 40), GATE_OPENER], [['c_pp', '%']]);
+
+    expect(wire(alone, 'c_pp')).toBeCloseTo(0.4, 12);
+    expect(wire(batched, 'c_pp')).toBeCloseTo(0.4, 12);
+  });
+
+  it('PIN: BATCH-INVARIANCE as a property, swept across the producer\'s range', () => {
+    // The whole row in one assertion: the value sent for a constraint is a
+    // function of THAT CONSTRAINT ALONE. Swept across both sides of CEE's
+    // boundary and both sides of the legacy gate's boundary.
+    const cases: Array<[string, number]> = [
+      ['c_p_0', 0],
+      ['c_p_0004', 0.004],
+      ['c_p_004', 0.04],
+      ['c_p_09', 0.9],
+      ['c_p_1', 1],       // the cell the route disjunct closes
+      ['c_p_4', 4],
+      ['c_p_40', 40],
+      ['c_p_100', 100],
+    ];
+    for (const [id, value] of cases) {
+      const alone = sendBatch([constraint(id, value)], [[id, '%']]);
+      const batched = sendBatch([constraint(id, value), GATE_OPENER], [[id, '%']]);
+      expect(wire(alone, id), `${id} (${value}%) alone`).toBe(wire(batched, id));
+    }
+  });
+
+  it('PIN: the producer boundary is reproduced exactly — <1 fractional, >=1 percentage points', () => {
+    const expectations: Array<[string, number, number]> = [
+      // id, stated value, value sent to ISL
+      ['c_b_0', 0, 0],           // 0 is 0 on either reading
+      ['c_b_003', 0.03, 0.03],   // "3% churn" as CEE's LLM emits it
+      ['c_b_099', 0.99, 0.99],   // still fractional
+      ['c_b_1', 1, 0.01],        // >= 1 ⇒ ONE percentage point
+      ['c_b_4', 4, 0.04],        // CEE's own pinned example
+      ['c_b_100', 100, 1],       // full scale
+    ];
+    for (const [id, value, expected] of expectations) {
+      const r = sendBatch([constraint(id, value), GATE_OPENER], [[id, '%']]);
+      expect(wire(r, id), `${id}: ${value} '%' → ${expected}`).toBeCloseTo(expected, 12);
+    }
+  });
+
+  it('every token in the canonical percent vocabulary behaves identically (derived, not mirrored)', () => {
+    expect(PERCENT_UNIT_TOKENS.length).toBeGreaterThan(0);
+    for (const token of PERCENT_UNIT_TOKENS) {
+      const fracId = `c_tok_frac_${token}`;
+      const ppId = `c_tok_pp_${token}`;
+      const frac = sendBatch([constraint(fracId, 0.04), GATE_OPENER], [[fracId, token]]);
+      const pp = sendBatch([constraint(ppId, 40), GATE_OPENER], [[ppId, token]]);
+      expect(wire(frac, fracId), `'${token}' fractional`).toBeCloseTo(0.04, 12);
+      expect(wire(pp, ppId), `'${token}' percentage points`).toBeCloseTo(0.4, 12);
+    }
+  });
+
+  it('the invocation predicate fires only for percentage-POINT values, by constraint identity', () => {
+    const pp = constraint('c_pp', 1);
+    const frac = constraint('c_frac', 0.04);
+    expect(constraintsHavePercentPointValue([pp], units([['c_pp', '%']]))).toBe(true);
+    // A fractional '%' needs no forced invocation — the rung already agrees
+    // with the forwarded-raw value there.
+    expect(constraintsHavePercentPointValue([frac], units([['c_frac', '%']]))).toBe(false);
+    // Non-percent unit at the same magnitude must NOT fire.
+    expect(constraintsHavePercentPointValue([pp], units([['c_pp', 'count']]))).toBe(false);
+    // Identity-bound: a percent unit registered under ANOTHER id is not evidence.
+    expect(constraintsHavePercentPointValue([pp], units([['c_somebody_else', '%']]))).toBe(false);
+    expect(constraintsHavePercentPointValue([pp], undefined)).toBe(false);
+    expect(constraintsHavePercentPointValue([pp], new Map())).toBe(false);
+  });
+});
+
+// =============================================================================
+// 2. CONTROLS — the currently-correct cells, which must not move
+// =============================================================================
+
+describe('2.957 controls — behaviours that MUST NOT change', () => {
+  it('CONTROL: a NON-percent sub-1 row on a scale-less node is still forwarded RAW, no diagnostic', () => {
+    const r = normaliseGoalConstraints(
+      [constraint('c_plain', 0.5), constraint('c_count', 0.5, 'n_cost')],
+      NODES,
+      { unitsByConstraintId: units([['c_count', 'count']]), normaliseWithoutScale: false },
+    );
+    expect(wire(r, 'c_plain')).toBe(0.5);
+    expect(wire(r, 'c_count')).toBe(0.5);
+    expect(r.diagnostics).toHaveLength(0);
+    expect(r.repairs).toHaveLength(0);
+  });
+
+  it('CONTROL: rung precedence unchanged — goal_threshold_cap (3) outranks unit_percent (4)', () => {
+    const r = normaliseGoalConstraints([constraint('c_pct', 4)], NODES, {
+      unitsByConstraintId: units([['c_pct', '%']]),
+      goalThresholdMetaByNodeId: new Map([['n_churn', { goal_threshold_cap: 10 }]]) as never,
+      normaliseWithoutScale: true,
+    });
+    expect(r.diagnostics[0].range).toEqual({ min: 0, max: 10, source: 'goal_threshold_cap' });
+    expect(wire(r, 'c_pct')).toBeCloseTo(0.4, 12);
+  });
+
+  it('CONTROL: rung precedence unchanged — a MEASURED (non-identity) intervention scale (1) wins', () => {
+    const r = normaliseGoalConstraints([constraint('c_pct', 4)], NODES, {
+      unitsByConstraintId: units([['c_pct', '%']]),
+      interventionScaleByNodeId: new Map([
+        ['n_churn', { min: 0, max: 5, source: 'inferred_spread' as const }],
+      ]),
+      normaliseWithoutScale: true,
+    });
+    expect(r.diagnostics[0].range).toEqual({ min: 0, max: 5, source: 'inferred_spread' });
+    expect(wire(r, 'c_pct')).toBeCloseTo(0.8, 12);
+  });
+
+  it('CONTROL: rung precedence unchanged — unit_percent (4) outranks an IDENTITY intervention scale (5)', () => {
+    const r = normaliseGoalConstraints([constraint('c_pct', 4)], NODES, {
+      unitsByConstraintId: units([['c_pct', '%']]),
+      interventionScaleByNodeId: new Map([
+        ['n_churn', { min: 0, max: 1, source: 'default' as const }],
+      ]),
+      normaliseWithoutScale: true,
+    });
+    expect(r.diagnostics[0].range.source).toBe('unit_percent');
+    expect(wire(r, 'c_pct')).toBeCloseTo(0.04, 12);
+  });
+
+  it('CONTROL: a >100 %-unit row still clamps to 1 and still reports clamped:true', () => {
+    const r = sendBatch([constraint('c_over', 140)], [['c_over', '%']]);
+    expect(wire(r, 'c_over')).toBe(1);
+    expect(r.diagnostics[0].clamped).toBe(true);
+  });
+
+  it('CONTROL: a percentage-POINT row still discloses the [0,100] producer scale', () => {
+    const r = sendBatch([constraint('c_pp', 40)], [['c_pp', '%']]);
+    const d = r.diagnostics.find((x) => x.constraint_id === 'c_pp')!;
+    expect(d.range).toEqual({ min: 0, max: 100, source: 'unit_percent' });
+    expect(d.used_heuristic).toBe(false);
+  });
+
+  it('CONTROL: a FRACTIONAL row discloses unit_percent too — a real producer scale, not "default"', () => {
+    // It is normalised against the identity range, so the VALUE is unchanged,
+    // but the provenance records that the '%' rung decided it — which keeps it
+    // decision-grade rather than disclosing as an evidence-free `default`.
+    const r = sendBatch([constraint('c_frac', 0.04), GATE_OPENER], [['c_frac', '%']]);
+    const d = r.diagnostics.find((x) => x.constraint_id === 'c_frac')!;
+    expect(d.range).toEqual({ min: 0, max: 1, source: 'unit_percent' });
+    expect(d.clamped).toBe(false);
+  });
+
+  it('CONTROL: isPercentUnit unchanged; rejects non-percent tokens', () => {
+    expect(isPercentUnit('%')).toBe(true);
+    expect(isPercentUnit('count')).toBe(false);
+    expect(isPercentUnit('months')).toBe(false);
+    expect(isPercentUnit('fraction')).toBe(false);
+    expect(isPercentUnit(undefined)).toBe(false);
+  });
+
+  it('CONTROL: a negative percentage-point delta still resolves on [0,100] as before', () => {
+    // "reduce churn by 33 percentage points" — |−33| >= 1 ⇒ pp form, unchanged.
+    const r = sendBatch([constraint('c_neg', -33)], [['c_neg', '%']]);
+    const d = r.diagnostics.find((x) => x.constraint_id === 'c_neg')!;
+    expect(d.range).toEqual({ min: 0, max: 100, source: 'unit_percent' });
+  });
+});


### PR DESCRIPTION
> **⚠ This PR was reversed in direction after adversarial review.** The first revision read `unit:'%'` as always meaning percentage points and rescaled the sub-1 cell. That was **refuted at the producer's bytes** — it would have turned `0.04` (four percent) into `0.0004` on CEE's primary draft path, i.e. it would have *introduced* a 100× error on the one path that was still correct. The defect it aimed at is real; the fix was pointed the wrong way. Rebuilt below. The post-mortem is at the end, kept deliberately.

## The defect (ROADMAP 2.957)

`normaliseGoalConstraints`' `unit_percent` rung resolved `[0,100]` **unconditionally**, while the route only invokes the normaliser when `constraintsNeedNormalisation` fires (`value < 0 || value > 1`) or some node carries a non-identity intervention scale. So the same constraint got **two different meanings depending on an unrelated constraint's value**:

| Payload | Wire value sent to ISL |
|---|---|
| `{unit:'%', value:0.04}` **alone** | `0.04` ✅ correct |
| the **same row** + any out-of-range batch-mate | **`0.0004`** ❌ 100× low |

One constraint, two meanings, decided by a *different* constraint. That is indefensible whichever convention wins — which is why the row stands even though its original direction did not.

## Which arm is wrong is settled by the PRODUCER, not by PLoT

CEE's LLM extractor emits **`"4%"` as `value: 0.04, unit: "%"`** — a *fraction* under a `'%'` label. It says so on the very function written to stop a consumer misreading it (`olumi-assistants-service`, `src/cee/compound-goal/extractor.ts:925-934`):

> *"The LLM extractor converts "4%" to value: 0.04, unit: "%". If a consumer interprets unit: "%" as "value is percentage points", **0.04% ≠ 4%**. … Rule: if unit === "%" and 0 < value < 1 → already fractional → unit = "fraction"."*

It **relabels without dividing**, and it runs **only on the regex branch** (`stages/repair/compound-goals.ts` — the LLM-emitted branch below it does not call it), so a fractional value under a raw `'%'` label reaches PLoT on the primary draft path.

The other half of the rule is CEE's too, pinned in its own suite (`tests/unit/cee.constraint-unit-normalisation.test.ts`):

> *"preserves percentage-unit constraints where value >= 1 (already in pp form)"* — `// value: 4, unit: "%" means "4 percentage points"`

## The fix

The rung now reproduces **CEE's boundary exactly** — transcribed, not invented:

| Constraint | Reading | Range | Change |
|---|---|---|---|
| `\|v\| < 1` | already fractional | identity `[0,1]` — forward as-is | **fixed** (was `v/100`) |
| `\|v\| >= 1` | percentage points | `[0,100]` — divide by 100 | **unchanged** |

Plus one narrow conjunct closing the last batch-dependent cell: `value === 1` satisfies neither gate bound, so a lone `{unit:'%', value:1}` — *one* percentage point — was forwarded raw as `1.0` (a *hundred* percent) yet resolved to `0.01` once batched. Every other percentage-point magnitude already opens the gate, so the blast radius is exactly that cell.

**One shared predicate** (`isPercentPointValue`) serves the route disjunct, the forward-raw exemption and the rung's complement, so the three cannot drift. A first cut had them disagree at `value === 1` — the route forced an invocation the forward-raw rung then no-opped — caught by the batch-invariance sweep.

**The F1 pin (`'%' 0.5 → 0.5`) is UNTOUCHED.** Under this direction it is correct as written, which is itself corroboration: `constraint-intervention-range-unify.test.ts` does not appear in this diff at all.

## The property: batch-invariance

**The value PLoT sends for a constraint is a function of that constraint alone.** Pinned as a sweep across both sides of CEE's boundary *and* both sides of the legacy gate's boundary (`0, 0.004, 0.04, 0.9, 1, 4, 40, 100`), each run twice — with and without a gate-opening batch-mate — asserting the two agree.

## ⚠ Behaviours that MUST NOT change — declared, with fixtures

| # | Must-not-change behaviour | Fixture |
|---|---|---|
| 1 | `40%` → `0.4` (percentage points still rescale) | `PIN: 40 with unit '%' is FORTY PERCENT` — *passes at pristine too*, by design |
| 2 | A non-percent sub-1 row is still forwarded raw, no repair/diagnostic | `CONTROL: a NON-percent sub-1 row …` |
| 3 | `goal_threshold_cap` (3) still outranks `unit_percent` (4) | `CONTROL: rung precedence … (3)` |
| 4 | A measured non-identity intervention scale (1) still wins | `CONTROL: rung precedence … MEASURED …` |
| 5 | `unit_percent` (4) still outranks an identity scale (5) | `CONTROL: rung precedence … IDENTITY …` |
| 6 | `>100%` still clamps to 1 with `clamped: true` | `CONTROL: a >100 %-unit row still clamps` |
| 7 | A negative percentage-point delta still resolves on `[0,100]` | `CONTROL: a negative percentage-point delta` |
| 8 | `isPercentUnit` unchanged (rejects `count`, `months`, `fraction`) | `CONTROL: isPercentUnit unchanged` |
| 9 | **The F1 forward-raw parity pin, in full** | `constraint-intervention-range-unify.test.ts` — **not in this diff** |

Percent-token handling is **derived from `PERCENT_UNIT_TOKENS`** and swept over every token, fractional and percentage-point.

## Evidence

**RED-first at pristine `747a3aa4`:** 6 failed / 10 passed. The failures are the fractional and batch-invariance pins; the `40 → 0.4` control passes at pristine *by design* — it guards an arm this PR does not move.

**Route-level wire witness.** The invocation decision lives in `run.ts`, so a module suite is structurally blind to it. The route suite asserts the value ISL *actually receives*, and **pins its own gate-closed precondition** (a non-percent row observed being forwarded raw — possible only when both legacy disjuncts are false), so no arm can pass for an unrelated reason.

**Mutation kit** — worktree outside the repo root, isolation proven by **sentinel write** (source SHA unchanged) + inode comparison; applied-check scoped to `src/`; control exactly zero; collected count matches pristine every run.

| Mutant | Verdict | Killed by |
|---|---|---|
| CONTROL (pristine) | GREEN | baseline, 43 collected |
| **M1** sub-1 `'%'` never fractional (**the refuted direction**) | **RED** 6 | the `0.04` pins, module **and** wire |
| **M2** `'%'` always fractional (never rescale pp) | **RED** 12 | `40 → 0.4`, `1 → 0.01`, and pre-existing `'%'` coverage |
| **M3** drop the route disjunct | **RED** 2 | *only* the wire tests — module suite green |
| **M4** drop the forward-raw pp exemption | RED 3 | the `value === 1` cell + batch-invariance sweep |
| **M5** `>= 1` → `> 1` (off-by-one at the producer boundary) | RED 4 | the boundary + invariance pins |
| **M6** hardcode the `producerDeclaredRange` mirror | GREEN → **RED** 1 | see below |

**M1/M2 are the discriminating pair**, and they now straddle the *actual* question: M1 is the direction this PR was reversed from, M2 is its opposite. Both bite, on different assertions. **M3** proves the wire witness is not redundant with the module suite.

**M6 survived the first kit, and was measured rather than assumed equivalent.** It is *not* equivalent: with a measured `[0,100]` intervention scale and a fractional `{unit:'%', value:0.04}`, the producer scale is `[0,1]`, so the threshold sits on a different scale than its samples — a real divergence that must deny the decision-grade trust bit. Hardcoded, the two compare equal and the divergence is silently certified as unified. Closed with a test **and its discriminating twin** (a percentage-point value against the same scale *is* unified), so the new assertion cannot pass by always reporting divergence.

**Full named gate** (`npm test`) at `f9aa7657`, via the repo's own pre-push validation: **`Tests 7142 passed | 28 skipped (7181)` — 0 failures.** `tsc --noEmit` clean.

**No changes to `package.json`, `vendor/`, or the lockfile.** Rebased onto current `staging` (`747a3aa4`), so this is tested against the **schemas 0.39.0** pin that actually ships.

## Interaction with ROADMAP 2.958 — explicit ruling

**Unchanged for `|v| >= 1`, and this PR now moves 2.958 in the *right* direction for `|v| < 1`.** The percentage-point arm is byte-identical to before. The fractional arm stops PLoT applying a percentage-points reading to a value CEE emits as a fraction — which is precisely the cross-service convention skew 2.958 records. The CEE half remains out of scope for this lane.

**Residual, recorded not fixed** (both confirmed by the reviewer):
- The `constraint-compiler.ts` path pairs `observed_state.value` with the node's top-level `unit`; for a true-90% node it now yields `0.009` in **both** gate states. The "already broken when the gate is open" claim is verified — but this converts a correct-by-accident cell into a consistently wrong one. Not fixed here; it belongs with 2.958's compiler half.
- `parseValue`'s `'%/month'` suffix escapes both `isPercentUnit` and the new predicate. **Pre-existing**, untouched.
- A ratio that legitimately exceeds 100% (NRR `110%` → `value: 1.10, unit:"%"` on a *node*) sits on the ambiguous side of CEE's `>= 1` constraint rule. This PR **does not resolve it** — it reproduces CEE's stated constraint rule exactly, so PLoT never invents a third convention.

## Post-mortem — why the first revision was wrong

I derived the convention from PLoT's own pinned contract (*"Threshold in the user's units; PLoT normalises downstream"*) plus the existence of a percent→fraction rewrite, and concluded that a surviving `'%'` label meant raw percent. **That contract line does not settle which scale `'%'` denotes**, and the rewrite does not run on the LLM path. The evidence that settles it lives in the CEE repo — **which my own PR body named as a location I could not reach**.

Two lessons, both already in the estate's doctrine and both re-earned here:

1. **A disclosed unreached location is where the refutation lives.** I disclosed it correctly and then reasoned as though the gap were immaterial. The disclosure is not the mitigation.
2. **A full mutant kill-rate proves sensitivity, never correctness** (trap 13c). The first revision passed 6/6 against an oracle derived from the consumer's contract rather than the producer's behaviour — a perfect score on the wrong exam. Every expectation in this revision is transcribed from CEE's source and its own test suite, with file and line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
