### PR TITLE
feat(auth): dual-acceptance bearer (ACTIVE + STAGED) for zero-downtime rotation

### DIFF
--- a/src/config/auth-token.ts
+++ b/src/config/auth-token.ts
@@ -22,5 +22,38 @@
  * AUTH_ENABLED so it is inert while auth is off.
  */
 export function getExpectedAuthToken(): string {
-  return String(process.env.PLOT_AUTH_TOKEN || process.env.AUTH_TOKEN || '').trim();
+  return String(
+    process.env.PLOT_AUTH_TOKEN_ACTIVE || process.env.PLOT_AUTH_TOKEN || process.env.AUTH_TOKEN || '',
+  ).trim();
+}
+
+/**
+ * The OPTIONAL second accepted secret, for zero-downtime rotation.
+ *
+ * ── WHY A SECOND ACCEPTED VALUE ────────────────────────────────────────────
+ * `getExpectedAuthToken` resolves ONE value, and `authGuard` accepts only that,
+ * so every caller has to change in the same instant the server's value changes:
+ * CEE's Render env, the UI's Netlify env, and the `PLOT_AUTH_TOKEN` GitHub Actions
+ * secret used by `staging-smoke.yml` (which runs on every push to staging) and
+ * `load-probe-nightly.yml`. No ordering of those edits avoids a window in which
+ * something is sending a value the server no longer accepts — and because the
+ * smoke workflow is one of those callers, a blind cutover disables the check that
+ * would report the breakage it caused.
+ *
+ * With STAGED set, rotation becomes: set STAGED to the new value → update every
+ * caller → watch `plot_engine_auth_token_match_total{used="active"}` stop climbing
+ * → promote STAGED into the active name and clear STAGED. Nothing is ever sending
+ * a value the server will not accept.
+ *
+ * The counter is what makes the final step safe: without evidence that nothing
+ * matches ACTIVE any more, deleting it is a guess.
+ *
+ * Same shape as `PRINCIPAL_HMAC_SECRET_STAGED` (P0-2, `verifyPrincipalSignature`),
+ * deliberately — one rotation idiom in this service, not two under different names.
+ *
+ * Empty/unset is the normal state and means "no rotation in progress": the guard
+ * then behaves exactly as before.
+ */
+export function getStagedAuthToken(): string {
+  return String(process.env.PLOT_AUTH_TOKEN_STAGED || process.env.AUTH_TOKEN_STAGED || '').trim();
 }

--- a/src/middleware/auth-guard.ts
+++ b/src/middleware/auth-guard.ts
@@ -9,7 +9,8 @@ import type { FastifyRequest, FastifyReply } from 'fastify';
 import { timingSafeEqual } from 'crypto';
 import { replyWithAppError } from '../errors.js';
 import { isDemoMode } from './demo-mode.js';
-import { getExpectedAuthToken } from '../config/auth-token.js';
+import { getExpectedAuthToken, getStagedAuthToken } from '../config/auth-token.js';
+import { incAuthTokenMatch } from '../observability/authTokenMetrics.js';
 
 export interface AuthGuardOptions {
   /** Allow demo mode bypass (for SSE streaming routes) */
@@ -79,11 +80,16 @@ export async function authGuard(
   // Get authorization header
   const headers = req.headers || {};
   const authHeader = String(headers.authorization || headers.Authorization || '');
-  // Single source of truth: PLOT_AUTH_TOKEN (the caller-facing name every live
-  // caller — CEE PLoTClient — already sends, and the only auth var provisioned
-  // on staging) with a fallback to the historical AUTH_TOKEN. No two-var mirror
-  // to keep in sync. This read is reached only after the AUTH_ENABLED early-return
-  // above, so it stays inert until the auth flip.
+  // The ACTIVE secret: PLOT_AUTH_TOKEN (the caller-facing name every live caller
+  // — CEE PLoTClient, the staging smoke + load-probe workflows — already sends,
+  // and the only auth var provisioned on staging), resolved through one function
+  // rather than a hand-maintained two-var mirror. Reached only after the
+  // AUTH_ENABLED early-return above, so it stays inert until the auth flip.
+  //
+  // ⚠ It is no longer the ONLY accepted value: an optional STAGED secret is
+  // accepted alongside it during a rotation (see below). This comment used to say
+  // "single source of truth", which the code beneath it now contradicts — the
+  // single source of truth is the RESOLVER, not the number of accepted secrets.
   const expectedToken = getExpectedAuthToken();
 
   // Check for Bearer token
@@ -111,29 +117,69 @@ export async function authGuard(
   // Extract and validate token
   const providedToken = authHeader.slice('Bearer '.length).trim();
 
-  // Check token length first (prevent timing attacks)
-  if (!expectedToken || providedToken.length !== expectedToken.length) {
-    await replyWithAppError(reply, {
-      type: 'BAD_INPUT',
-      statusCode: 403,
-      message: 'Invalid token',
-      fields: { code: 'FORBIDDEN' },
-    });
-    return false;
+  // ── DUAL ACCEPTANCE: ACTIVE, then optional STAGED ────────────────────────
+  //
+  // ⚠ EACH CANDIDATE IS LENGTH-CHECKED AND COMPARED INDEPENDENTLY, AND BOTH ARE
+  // EVALUATED UNCONDITIONALLY. Do not "simplify" this to `matches(active) ||
+  // matches(staged)`, and do not hoist a single length check above the pair.
+  //
+  // The length test exists only because `timingSafeEqual` THROWS on unequal
+  // lengths — it is a precondition, not a security check. With two candidates a
+  // single hoisted length test (against ACTIVE) returns 403 before STAGED is ever
+  // considered, which is wrong twice over:
+  //
+  //   1. FUNCTIONALLY — a staged token of a different length is rejected, so
+  //      rotation fails for the exact case it exists to serve. A genuinely NEW
+  //      secret will not share the old one's length.
+  //   2. AS A DISCLOSURE — the work performed would vary with WHICH candidate the
+  //      provided token matched on length, making the guard's behaviour a function
+  //      of a property of the secrets. A rotation mechanism that leaks which of two
+  //      secrets you hold is worse than the manual cutover it replaces.
+  //
+  // A `||` short-circuit has the same defect in the other direction: it skips the
+  // second comparison whenever the first matches, so the work depends on which
+  // secret was presented. Both are computed, then the outcome is chosen.
+  //
+  // Pinned by tests/auth.dual-acceptance.test.ts, whose staged fixture is
+  // deliberately a DIFFERENT LENGTH from the active one — an equal-length fixture
+  // would pass against the single-check version and prove nothing.
+  const stagedToken = getStagedAuthToken();
+
+  const activeMatch = tokenMatches(providedToken, expectedToken);
+  const stagedMatch = tokenMatches(providedToken, stagedToken);
+
+  if (activeMatch) {
+    incAuthTokenMatch('active');
+    return true;
+  }
+  if (stagedMatch) {
+    // Still on the old secret's replacement path — the counter is what tells an
+    // operator when ACTIVE has stopped being used and may safely be removed.
+    incAuthTokenMatch('staged');
+    return true;
   }
 
-  // Timing-safe comparison
-  if (!timingSafeEqual(Buffer.from(providedToken), Buffer.from(expectedToken))) {
-    await replyWithAppError(reply, {
-      type: 'BAD_INPUT',
-      statusCode: 403,
-      message: 'Invalid token',
-      fields: { code: 'FORBIDDEN' },
-    });
-    return false;
-  }
+  await replyWithAppError(reply, {
+    type: 'BAD_INPUT',
+    statusCode: 403,
+    message: 'Invalid token',
+    fields: { code: 'FORBIDDEN' },
+  });
+  return false;
+}
 
-  return true;
+/**
+ * Constant-shape comparison of one candidate.
+ *
+ * Returns false for an absent candidate (unset STAGED is the normal state) and for
+ * a length mismatch — the latter because `timingSafeEqual` throws on unequal
+ * lengths, so the check is a precondition of calling it, not a security decision.
+ * Never throws, never logs, never returns anything derived from the secret.
+ */
+function tokenMatches(provided: string, candidate: string): boolean {
+  if (!candidate) return false;
+  if (provided.length !== candidate.length) return false;
+  return timingSafeEqual(Buffer.from(provided), Buffer.from(candidate));
 }
 
 /**

--- a/src/observability/authTokenMetrics.ts
+++ b/src/observability/authTokenMetrics.ts
@@ -1,0 +1,56 @@
+/**
+ * Bearer auth token rotation metrics.
+ *
+ * Tracks WHICH configured token a successful request matched — ACTIVE or STAGED —
+ * so a rotation can be completed on evidence rather than on hope.
+ *
+ * THIS COUNTER IS THE POINT OF THE DUAL-ACCEPTANCE CHANGE, not a by-product of it.
+ * Accepting two tokens is what makes a rotation possible; knowing that nothing has
+ * matched ACTIVE for a while is what makes DELETING the old one safe. Without it,
+ * removal is a guess — the same failure mode as invalidating a live credential
+ * blind, only deferred to the end of the rollout.
+ *
+ * Operationally: set STAGED to the new value, update every caller (CEE's Render
+ * env, the UI's Netlify env, the `PLOT_AUTH_TOKEN` GitHub Actions secret), watch
+ * `used="active"` stop climbing, then promote STAGED and clear it. The counter is
+ * what tells you when that last step is safe.
+ *
+ * ⚠ NEVER records or exposes a token VALUE — only which candidate matched. A
+ * rotation aid that leaked either secret would be worse than the manual cutover it
+ * replaces.
+ *
+ * Mirrors `principalSecretMetrics.ts` (P0-2) deliberately: same shape, same label
+ * name, same reset-for-test helper, so there is one rotation idiom in this service
+ * rather than two under different names.
+ */
+
+const counts = { active: 0, staged: 0 };
+
+export function incAuthTokenMatch(kind: 'active' | 'staged'): void {
+  counts[kind]++;
+}
+
+/**
+ * Prometheus exposition, or '' when nothing has matched yet.
+ *
+ * BOTH labels are always emitted once anything has matched — including a zero.
+ * That is deliberate: `used="active"} 0` is the signal an operator is waiting for,
+ * and a series that vanished when it hit zero would be indistinguishable from a
+ * series that was never scraped.
+ */
+export function renderAuthTokenMatch(): string {
+  const total = counts.active + counts.staged;
+  if (total === 0) return '';
+  return [
+    '# HELP plot_engine_auth_token_match_total Which configured bearer token a successful request matched',
+    '# TYPE plot_engine_auth_token_match_total counter',
+    `plot_engine_auth_token_match_total{used="active"} ${counts.active}`,
+    `plot_engine_auth_token_match_total{used="staged"} ${counts.staged}`,
+  ].join('\n');
+}
+
+// Test helper
+export function __resetAuthTokenMetricsForTest(): void {
+  counts.active = 0;
+  counts.staged = 0;
+}

--- a/src/plugins/metrics.ts
+++ b/src/plugins/metrics.ts
@@ -13,6 +13,7 @@ import {
 import { renderHistograms } from '../metrics/registry.js';
 import { renderValidationMetrics } from '../observability/validationMetrics.js';
 import { renderPrincipalSecretFallback } from '../observability/principalSecretMetrics.js';
+import { renderAuthTokenMatch } from '../observability/authTokenMetrics.js';
 import { renderStreamMetrics } from '../observability/streamMetrics.js';
 import { renderIdempotencyMetrics } from '../observability/idempotencyMetrics.js';
 import { renderRouteCallerMetrics } from '../observability/routeCallerTelemetry.js';
@@ -77,6 +78,13 @@ export async function registerPrometheusMetrics(app: FastifyInstance) {
     const secretFallback = renderPrincipalSecretFallback();
     if (secretFallback) {
       metrics.push(secretFallback);
+    }
+
+    // Bearer rotation: WHICH configured token matched. This is the signal that
+    // permits deleting the old secret — without it, removal is a guess.
+    const authTokenMatch = renderAuthTokenMatch();
+    if (authTokenMatch) {
+      metrics.push(authTokenMatch);
     }
 
     // D-PLoT evidence (arch step 1): full route × caller-class breakdown.

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -11,6 +11,7 @@ import {
   snapshot,
   replaySnapshot,
 } from '../metrics.js';
+import { getExpectedAuthToken, getStagedAuthToken } from '../config/auth-token.js';
 import { getCeeCircuitBreakerStats } from '../cee/circuit-breaker.js';
 import { getIslCircuitBreakerStats } from '../integrations/isl-circuit-breaker.js';
 import { getRouteCallerSnapshot } from '../observability/routeCallerTelemetry.js';
@@ -60,6 +61,14 @@ export async function registerHealthRoutes(app: FastifyInstance, opts: HealthRou
         idempotency_current: opts.idemCacheSize(),
       },
       rate_limit: rateLimitState(),
+      // Bearer rotation state. PRESENCE BOOLEANS ONLY — never a value, never a
+      // length, never a prefix. `staged: true` means a rotation is in progress;
+      // the authoritative "is it safe to delete ACTIVE yet" signal is the
+      // plot_engine_auth_token_match_total counter on /metrics, not this.
+      auth_secrets: {
+        active: Boolean(getExpectedAuthToken()),
+        staged: Boolean(getStagedAuthToken()),
+      },
       cee_circuit_breaker: getCeeCircuitBreakerStats(),
       // ROADMAP 1.209: the ISL breaker's state was surfaced NOWHERE, while the
       // CEE breaker beside it was published — so a reader would reasonably infer

--- a/tests/auth.dual-acceptance.test.ts
+++ b/tests/auth.dual-acceptance.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Dual-acceptance auth: ACTIVE + STAGED, for zero-downtime bearer rotation.
+ *
+ * ── WHY THIS EXISTS ────────────────────────────────────────────────────────
+ * `authGuard` accepts exactly ONE token. Every caller therefore has to change in
+ * the same instant the server's value changes: CEE's Render env, the UI's Netlify
+ * env, and the `PLOT_AUTH_TOKEN` GitHub Actions secret used by `staging-smoke.yml`
+ * and `load-probe-nightly.yml`. There is no ordering of those edits that avoids a
+ * window where something is sending a value the server no longer accepts.
+ *
+ * That matters beyond convenience. The smoke workflow runs on every push to
+ * staging, so a blind cutover kills the check that would tell us the cutover broke
+ * something — the alarm dies with the thing it monitors.
+ *
+ * ── THE ACCEPTANCE CRITERION IS THE METRIC, NOT THE SECOND TOKEN ───────────
+ * Accepting two tokens is the easy half. The half that makes rotation SAFE is
+ * being able to prove the old token has stopped being used before deleting it.
+ * Without "which candidate matched", removal is a guess — the same failure mode
+ * as invalidating blind, just deferred. So `plot_engine_auth_token_match_total`
+ * is the deliverable and the dual read is what makes it possible.
+ *
+ * Modelled on the rotation pattern this repo already runs for a different secret
+ * (`verifyPrincipalSignature` / `incPrincipalSecretFallback`, P0-2) rather than a
+ * second mechanism under a different name.
+ *
+ * ── ⚠ THE PRIMARY CORRECTNESS REQUIREMENT: NO LENGTH SHORT-CIRCUIT ─────────
+ * The pre-change guard reads:
+ *
+ *     if (!expectedToken || providedToken.length !== expectedToken.length) → 403
+ *     if (!timingSafeEqual(provided, expected))                            → 403
+ *
+ * The length test exists because `timingSafeEqual` throws on unequal lengths. With
+ * TWO candidates, a naive extension checks length against ACTIVE and returns 403
+ * before STAGED is ever considered. That is wrong twice over:
+ *
+ *   1. FUNCTIONALLY — a staged token of a different length is rejected, so the
+ *      rotation silently does not work for the case it exists to serve (rotating
+ *      to a NEW secret, which will not share the old one's length).
+ *   2. AS A DISCLOSURE — the work performed varies with WHICH candidate the
+ *      provided token happens to match on length, so the guard's behaviour is a
+ *      function of a property of the secrets. A rotation mechanism that leaks
+ *      which of two secrets you are holding is worse than the problem it solves.
+ *
+ * So each candidate is length-checked and compared INDEPENDENTLY, and both are
+ * evaluated unconditionally — no `||` short-circuit, which would skip the second
+ * comparison whenever the first matched.
+ *
+ * `DIFFERENT_LENGTH_STAGED` below is the discriminating fixture: it is deliberately
+ * a different length from the active token, so it fails against the pre-change
+ * guard and passes only against a per-candidate implementation. A staged token of
+ * EQUAL length would pass either way and prove nothing.
+ *
+ * No token value is ever asserted into a response, a log, a metric or /health —
+ * the metric reports which candidate matched, never what it was.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { createServer } from '../src/createServer.js';
+import {
+  renderAuthTokenMatch,
+  __resetAuthTokenMetricsForTest,
+} from '../src/observability/authTokenMetrics.js';
+
+/** Obviously synthetic. Never a real or realistic-looking credential. */
+const ACTIVE_TOKEN = 'active-token-aaaaaaaaaaaa';
+/** ⭐ DELIBERATELY a different length from ACTIVE — this is what makes the pin bite. */
+const DIFFERENT_LENGTH_STAGED = 'staged-token-bbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+/** Same length as ACTIVE, for the "wrong bytes" arm. */
+const WRONG_SAME_LENGTH = 'wrongX-token-aaaaaaaaaaaa';
+
+let app: FastifyInstance;
+let port = 0;
+const prev = {
+  AUTH_ENABLED: process.env.AUTH_ENABLED,
+  AUTH_TOKEN: process.env.AUTH_TOKEN,
+  PLOT_AUTH_TOKEN: process.env.PLOT_AUTH_TOKEN,
+  PLOT_AUTH_TOKEN_STAGED: process.env.PLOT_AUTH_TOKEN_STAGED,
+  RATE_LIMIT_ENABLED: process.env.RATE_LIMIT_ENABLED,
+};
+
+const BASE = () => `http://127.0.0.1:${port}`;
+const get = (token?: string) =>
+  fetch(`${BASE()}/v1/health`, token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
+
+beforeAll(async () => {
+  process.env.AUTH_ENABLED = '1';
+  delete process.env.AUTH_TOKEN;
+  process.env.PLOT_AUTH_TOKEN = ACTIVE_TOKEN;
+  process.env.PLOT_AUTH_TOKEN_STAGED = DIFFERENT_LENGTH_STAGED;
+  process.env.RATE_LIMIT_ENABLED = '0';
+  app = await createServer({ enableTestRoutes: false });
+  await app.listen({ port: 0, host: '127.0.0.1' });
+  const addr = app.server.address();
+  port = typeof addr === 'object' && addr ? (addr.port as number) : 0;
+});
+
+afterAll(async () => {
+  await app.close();
+  for (const [k, v] of Object.entries(prev)) {
+    if (v === undefined) delete (process.env as Record<string, string | undefined>)[k];
+    else (process.env as Record<string, string>)[k] = v;
+  }
+});
+
+beforeEach(() => {
+  process.env.PLOT_AUTH_TOKEN = ACTIVE_TOKEN;
+  process.env.PLOT_AUTH_TOKEN_STAGED = DIFFERENT_LENGTH_STAGED;
+  __resetAuthTokenMetricsForTest();
+});
+
+describe('CONTROL — the fixture is live, so the assertions below are not vacuous', () => {
+  it('the ACTIVE token is accepted (trap 13: prove a presence before asserting an absence)', async () => {
+    expect((await get(ACTIVE_TOKEN)).status).toBe(200);
+  });
+
+  it('the two tokens are DIFFERENT LENGTHS — the property the pin depends on', () => {
+    expect(DIFFERENT_LENGTH_STAGED.length).not.toBe(ACTIVE_TOKEN.length);
+  });
+});
+
+describe('⭐ PRIMARY: no length short-circuit — each candidate is checked independently', () => {
+  it('accepts a STAGED token whose length DIFFERS from ACTIVE', async () => {
+    // Against the pre-change guard this is 403: the length test runs once, against
+    // ACTIVE, and returns before STAGED is considered. This is THE pin.
+    expect((await get(DIFFERENT_LENGTH_STAGED)).status).toBe(200);
+  });
+
+  it('still rejects a wrong token that happens to match ACTIVE length', async () => {
+    expect((await get(WRONG_SAME_LENGTH)).status).toBe(403);
+  });
+
+  it('still rejects a wrong token that happens to match STAGED length', async () => {
+    const wrongStagedLength = 'z'.repeat(DIFFERENT_LENGTH_STAGED.length);
+    expect((await get(wrongStagedLength)).status).toBe(403);
+  });
+
+  it('a rejection is 403 regardless of WHICH candidate length it matched — no behavioural tell', async () => {
+    const matchesActiveLength = await get('q'.repeat(ACTIVE_TOKEN.length));
+    const matchesStagedLength = await get('q'.repeat(DIFFERENT_LENGTH_STAGED.length));
+    const matchesNeither = await get('q'.repeat(7));
+    expect(matchesActiveLength.status).toBe(403);
+    expect(matchesStagedLength.status).toBe(403);
+    expect(matchesNeither.status).toBe(403);
+    // Identical error SHAPE: the response must not disclose which candidate was
+    // closer. Compared on code/message, not the raw body — every error carries a
+    // unique `request_id`, so a raw-text comparison could never match and the
+    // assertion would fail for a reason that has nothing to do with disclosure.
+    const shapeOf = async (r: Response) => {
+      const body = JSON.parse(await r.text()) as { code?: string; message?: string };
+      return `${r.status}|${body.code}|${body.message}`;
+    };
+    const shapes = await Promise.all([
+      shapeOf(matchesActiveLength),
+      shapeOf(matchesStagedLength),
+      shapeOf(matchesNeither),
+    ]);
+    expect(new Set(shapes).size).toBe(1);
+  });
+});
+
+describe('⭐ ACCEPTANCE CRITERION: the metric proves which token is still in use', () => {
+  it('records a match against ACTIVE', async () => {
+    await get(ACTIVE_TOKEN);
+    expect(renderAuthTokenMatch()).toContain('used="active"} 1');
+  });
+
+  it('records a match against STAGED', async () => {
+    await get(DIFFERENT_LENGTH_STAGED);
+    expect(renderAuthTokenMatch()).toContain('used="staged"} 1');
+  });
+
+  it('DISCRIMINATES: after only-staged traffic, active reads 0 — the signal that permits deletion', async () => {
+    await get(DIFFERENT_LENGTH_STAGED);
+    await get(DIFFERENT_LENGTH_STAGED);
+    const rendered = renderAuthTokenMatch();
+    expect(rendered).toContain('used="staged"} 2');
+    expect(rendered).toContain('used="active"} 0');
+  });
+
+  it('a REJECTED token increments neither counter', async () => {
+    await get(WRONG_SAME_LENGTH);
+    const rendered = renderAuthTokenMatch();
+    expect(rendered === '' || rendered.includes('used="active"} 0')).toBe(true);
+    expect(rendered === '' || rendered.includes('used="staged"} 0')).toBe(true);
+  });
+
+  it('NEVER emits a token value', () => {
+    const rendered = renderAuthTokenMatch();
+    expect(rendered).not.toContain(ACTIVE_TOKEN);
+    expect(rendered).not.toContain(DIFFERENT_LENGTH_STAGED);
+  });
+});
+
+describe('BACKWARDS COMPATIBLE — unchanged behaviour when no STAGED is set', () => {
+  beforeEach(() => {
+    delete process.env.PLOT_AUTH_TOKEN_STAGED;
+  });
+
+  it('ACTIVE is accepted', async () => {
+    expect((await get(ACTIVE_TOKEN)).status).toBe(200);
+  });
+
+  it('the former staged value is now rejected', async () => {
+    expect((await get(DIFFERENT_LENGTH_STAGED)).status).toBe(403);
+  });
+
+  it('a missing bearer is still 401, not 403', async () => {
+    expect((await get()).status).toBe(401);
+  });
+});
+
+describe('FAIL CLOSED — no configured token accepts nothing', () => {
+  it('403 when both ACTIVE and STAGED are absent', async () => {
+    delete process.env.PLOT_AUTH_TOKEN;
+    delete process.env.PLOT_AUTH_TOKEN_STAGED;
+    expect((await get(ACTIVE_TOKEN)).status).toBe(403);
+  });
+});
+
+describe('NO DISCLOSURE — a token value never reaches a response', () => {
+  it('neither token appears in a success body/headers nor a rejection body', async () => {
+    const ok = await get(ACTIVE_TOKEN);
+    const okText = await ok.text();
+    const okHeaders = JSON.stringify([...ok.headers.entries()]);
+    const bad = await get(WRONG_SAME_LENGTH);
+    const badText = await bad.text();
+    for (const haystack of [okText, okHeaders, badText]) {
+      expect(haystack).not.toContain(ACTIVE_TOKEN);
+      expect(haystack).not.toContain(DIFFERENT_LENGTH_STAGED);
+    }
+  });
+});

--- a/tests/auth.dual-acceptance.test.ts
+++ b/tests/auth.dual-acceptance.test.ts
@@ -184,10 +184,39 @@ describe('⭐ ACCEPTANCE CRITERION: the metric proves which token is still in us
     expect(rendered === '' || rendered.includes('used="staged"} 0')).toBe(true);
   });
 
-  it('NEVER emits a token value', () => {
+  it('NEVER emits a token value', async () => {
+    // ⚠ THE REQUESTS ARE LOAD-BEARING, NOT SETUP. `renderAuthTokenMatch()` returns
+    // '' until something has matched, and `beforeEach` resets the counters — so an
+    // assertion made without driving traffic first checks "'' does not contain the
+    // token", which is true of every possible implementation.
+    //
+    // That is not hypothetical: this test was written that way, and a mutation that
+    // rendered the ACTIVE token straight into the exposition SURVIVED it. Both
+    // candidates are exercised so the rendered output is non-empty for the right
+    // reason, and the non-emptiness is asserted before the absence is.
+    await get(ACTIVE_TOKEN);
+    await get(DIFFERENT_LENGTH_STAGED);
     const rendered = renderAuthTokenMatch();
+    expect(rendered).not.toBe('');
+    expect(rendered).toContain('used="active"} 1');
+    expect(rendered).toContain('used="staged"} 1');
     expect(rendered).not.toContain(ACTIVE_TOKEN);
     expect(rendered).not.toContain(DIFFERENT_LENGTH_STAGED);
+  });
+
+  it('/health exposes rotation PRESENCE only — never a value, length or prefix', async () => {
+    // The ROOT `/health` (open) carries the operational payload; `/v1/health` is a
+    // different, auth-gated route and does not. Asserted against the one that
+    // actually publishes it — an operator watching a rotation reads this one.
+    const body = await (await fetch(`${BASE()}/health`)).text();
+    const parsed = JSON.parse(body) as { auth_secrets?: { active?: unknown; staged?: unknown } };
+    // Bind by identity: the booleans must actually be present and true here, so a
+    // renamed or dropped field fails rather than silently satisfying the absence.
+    expect(parsed.auth_secrets).toEqual({ active: true, staged: true });
+    expect(body).not.toContain(ACTIVE_TOKEN);
+    expect(body).not.toContain(DIFFERENT_LENGTH_STAGED);
+    // No length disclosure either — a bare count would narrow a brute-force search.
+    expect(body).not.toContain(String(ACTIVE_TOKEN.length));
   });
 });
 


### PR DESCRIPTION
**DRAFT — do not merge.** An integration freeze is live; opening for review only.

## Why

`authGuard` accepts exactly **one** token, so rotating it forces every caller to change in the same instant the server's value does: CEE's Render env, the UI's Netlify env, and the **`PLOT_AUTH_TOKEN` GitHub Actions secret** used by `staging-smoke.yml` and `load-probe-nightly.yml`. No ordering of those edits avoids a window where something is sending a value the server no longer accepts.

And because `staging-smoke.yml` runs on **every push to staging** and is itself one of those callers, a blind cutover disables the check that would report the breakage it just caused. **The alarm dies with the thing it monitors.**

## The deliverable is the metric, not the second token

Accepting two secrets makes rotation *possible*. `plot_engine_auth_token_match_total{used="active"|"staged"}` is what makes *finishing* it safe — without evidence that nothing matches ACTIVE any more, deleting the old secret is a guess, which is the same failure mode as invalidating blind, only deferred.

Rotation becomes: set STAGED → update callers → watch `used="active"` stop climbing → promote and clear STAGED.

## ⚠ Primary correctness requirement: no hoisted length check, no `||`

The old guard length-checked **once**, against the single expected token, because `timingSafeEqual` throws on unequal lengths — a precondition, not a security check. Extending that naively to two candidates is wrong twice:

1. **Functionally** — a staged token of a different length is rejected before it is considered, so rotation fails for the exact case it exists to serve. A genuinely new secret will not share the old one's length.
2. **As a disclosure** — the work performed would vary with *which* candidate matched on length, making the guard's behaviour a function of a property of the secrets. **A rotation mechanism that leaks which of two secrets you hold is worse than the manual cutover it replaces.**

Each candidate is length-checked and compared **independently**, both evaluated unconditionally before the outcome is chosen.

**The pin is discriminating by construction:** the staged fixture is deliberately a **different length** from the active one. An equal-length fixture would pass against the old shape and prove nothing. RED-first at pristine: 5 failures, including `accepts a STAGED token whose length DIFFERS from ACTIVE` (403 vs 200).

## Copied, not invented

Modelled on the rotation idiom this service already runs for a different secret (`verifyPrincipalSignature` / `incPrincipalSecretFallback`, P0-2) — same shape, same label convention, same test-reset helper — rather than a second mechanism under a different name.

## No secret is ever emitted

The counter records **which** candidate matched, never what it was. `/health` exposes `auth_secrets: {active, staged}` **presence booleans only** — no value, no length, no prefix. Both pinned, and both pins proven by mutants that leak.

## Mutation kit

**8/9 bitten first pass. The survivor was my own defective mutant** (`counts[kind] += 0` leaks nothing, so surviving was correct) — replaced with two genuine leak mutants.

⚠ **One of them exposed a real gap: my "NEVER emits a token value" test was VACUOUS.** `renderAuthTokenMatch()` returns `''` until something matches and `beforeEach` resets the counters, so it asserted *"'' does not contain the token"* — true of every implementation, including one rendering the secret into the exposition. Fixed to drive traffic first, assert non-empty, then assert absence. Both leak mutants now RED. Controls exactly 0 before and after; isolation proven by writing a sentinel; restore from a pristine archive.

## Gate at this tip

- `npm test` (named gate): **exit 0**
- pre-push validation: **6/6 PASS — 7202 passed | 28 skipped**
- typecheck clean · lint clean (`--max-warnings 0`)
- new spec: **17/17**, asserted by name

**Known pre-existing red, not caused here:** `tests/auth.minimal.test.ts` fails identically at **pristine `d39b4fa`** with the same env — verified with a control run in an isolated worktree (same `waitFor` signature, same 2-skipped outcome).

## Scope discipline

Deliberately did **not** touch `/v1`-vs-`/v2` gating or `AUTH_V2_ENABLED`. That was established as a scope toggle rather than a second auth scheme — a fact worth having, not an invitation to tidy.

Also corrects a comment this change made stale: it claimed `PLOT_AUTH_TOKEN` was the *"single source of truth"* with *"no two-var mirror"*, which the code beneath it now contradicts. The single source of truth is the **resolver**, not the number of accepted secrets.

Backwards compatible: with no STAGED set the guard behaves exactly as before; fail-closed when neither is configured.

⚠ **`staging` on this repo is UNPROTECTED** (derived: `branches/staging/protection` → 404), so there is no required status check — the push is the gate. Flagging so the merge decision is made knowingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)