### PR TITLE
fix(trust): drop the placeholder term from published confidence and renormalise (fabrication)

### DIFF
--- a/src/fixtures/demo-payloads.ts
+++ b/src/fixtures/demo-payloads.ts
@@ -59,7 +59,6 @@ export function getDemoRunResponse(seed: number = 42): any {
     identifiable: true,
     in_linear_range: true,
     k_samples: 1000,
-    calibrated: false,
   });
 
   const linearity_warning = checkLinearity({

--- a/src/routes/v1/run.ts
+++ b/src/routes/v1/run.ts
@@ -823,7 +823,6 @@ export async function registerRunRoute(app: FastifyInstance) {
         identifiable: identifiability.identifiable,
         in_linear_range: !linearity_warning.outside_range,
         k_samples: K_evaluated ?? budget.k,
-        calibrated: false,
       });
 
       // Threshold crossings with actual p50

--- a/src/routes/v1/self-check.ts
+++ b/src/routes/v1/self-check.ts
@@ -81,7 +81,6 @@ export async function registerSelfCheckRoute(app: FastifyInstance) {
       identifiable: identifiability.identifiable,
       in_linear_range: !linearity_warning.outside_range,
       k_samples: budget.k,
-      calibrated: false,
     });
 
     // Threshold crossings

--- a/src/trust/confidence.ts
+++ b/src/trust/confidence.ts
@@ -9,11 +9,18 @@ export interface ConfidenceInputs {
   identifiable: boolean;
   in_linear_range: boolean;
   k_samples?: number;
-  calibrated?: boolean;
 }
 
 /**
- * Calculate confidence score based on graph quality and coverage
+ * Calculate confidence score based on graph quality and coverage.
+ *
+ * Every term below is a computed function of the inputs. The former
+ * "calibration" factor was a placeholder that resolved to a fixed 0.5 for
+ * every production call (all callers passed `calibrated: false`, so it never
+ * varied) yet carried 15% of the weight budget — a constant standing in for a
+ * computation. It has been removed and its weight redistributed across the
+ * three genuinely-computed factors, proportionally, so the score remains a
+ * well-formed value in [0, 1] traceable end-to-end to inputs.
  */
 export function calculateConfidence(inputs: ConfidenceInputs): ConfidenceBadge {
   const {
@@ -21,7 +28,6 @@ export function calculateConfidence(inputs: ConfidenceInputs): ConfidenceBadge {
     identifiable,
     in_linear_range,
     k_samples = 1000,
-    calibrated = false,
   } = inputs;
 
   const node_count = graph.nodes.length;
@@ -40,22 +46,19 @@ export function calculateConfidence(inputs: ConfidenceInputs): ConfidenceBadge {
   else if (k_samples >= 500) k_coverage_score = 0.7;
   else k_coverage_score = 0.3;
 
-  // Factor 4: Calibration (placeholder - no behavior change when false)
-  // When true, would use actual calibration metrics; for now, neutral value
-  const calibration_score = calibrated ? 1.0 : 0.5;
-
-  // Integer math for determinism (weights sum to 1000)
-  // Weights: 350 (identifiability) + 250 (linearity) + 250 (k_coverage) + 150 (calibration)
+  // Integer math for determinism (weights sum to 1000).
+  // Weights: 412 (identifiability) + 294 (linearity) + 294 (k_coverage).
+  // These are the original 350 : 250 : 250 weights renormalised to sum 1000
+  // after dropping the 150-weight calibration placeholder
+  // (350 * 1000/850 = 412, 250 * 1000/850 = 294).
   const ident_raw = Math.round(identifiability_score * 1000);
   const linear_raw = Math.round(linearity_score * 1000);
   const kcov_raw = Math.round(k_coverage_score * 1000);
-  const calib_raw = Math.round(calibration_score * 1000);
 
-  const overall_raw = 
-    Math.round(ident_raw * 350 / 1000) +
-    Math.round(linear_raw * 250 / 1000) +
-    Math.round(kcov_raw * 250 / 1000) +
-    Math.round(calib_raw * 150 / 1000);
+  const overall_raw =
+    Math.round(ident_raw * 412 / 1000) +
+    Math.round(linear_raw * 294 / 1000) +
+    Math.round(kcov_raw * 294 / 1000);
 
   // Thresholds: high >= 750, medium >= 500 (out of 1000)
   let level: ConfidenceLevel;
@@ -106,7 +109,6 @@ export function calculateConfidence(inputs: ConfidenceInputs): ConfidenceBadge {
       identifiability: identifiability_score,
       linearity_distance: linearity_score,
       k_coverage: k_coverage_score,
-      calibration: calibration_score,
     },
   };
 }

--- a/src/trust/types.ts
+++ b/src/trust/types.ts
@@ -273,7 +273,11 @@ export interface ConfidenceBadge {
     identifiability: number; // 0-1
     linearity_distance: number; // 0-1 (1 = in range)
     k_coverage: number; // 0-1
-    calibration: number; // 0-1
+    // Optional/legacy: the canonical calculateConfidence() no longer emits a
+    // calibration factor (it was a fixed-0.5 placeholder — see confidence.ts).
+    // Only the SCM meta fallback in routes/v1/run.ts still populates this,
+    // from a real sign_stability value.
+    calibration?: number; // 0-1
   };
 }
 

--- a/tests/confidence-integer-math.test.ts
+++ b/tests/confidence-integer-math.test.ts
@@ -8,30 +8,28 @@ describe('Confidence Integer Math (determinism)', () => {
   };
 
   it('HIGH threshold: exactly 750/1000', () => {
-    // identifiable=1, linear=1, k=1000 (kcov=1), calibrated=false (0.5)
-    // raw = 350*1 + 250*1 + 250*1 + 150*0.5 = 350+250+250+75 = 925
+    // identifiable=1 (412), linear=1 (294), k=1000 -> kcov=1 (294)
+    // raw = 412 + 294 + 294 = 1000
     const result = calculateConfidence({
       graph: mockGraph,
       identifiable: true,
       in_linear_range: true,
       k_samples: 1000,
-      calibrated: false,
     });
     expect(result.level).toBe('HIGH');
     expect(result.score).toBeGreaterThanOrEqual(0.75);
   });
 
   it('MEDIUM threshold: exactly 500/1000', () => {
-    // identifiable=0.3, linear=0.5, k=500 (kcov=0.7), calibrated=false (0.5)
-    // raw = 350*0.3 + 250*0.5 + 250*0.7 + 150*0.5 = 105+125+175+75 = 480
+    // identifiable=0.3, linear=0.5, k=500 -> kcov=0.7
+    // raw = round(300*412/1000)=124 + round(500*294/1000)=147 + round(700*294/1000)=206 = 477
     const result = calculateConfidence({
       graph: mockGraph,
       identifiable: false,
       in_linear_range: false,
       k_samples: 500,
-      calibrated: false,
     });
-    expect(result.level).toBe('LOW'); // 480 < 500
+    expect(result.level).toBe('LOW'); // 477 < 500
   });
 
   it('deterministic: same inputs produce same output', () => {
@@ -40,7 +38,6 @@ describe('Confidence Integer Math (determinism)', () => {
       identifiable: true,
       in_linear_range: true,
       k_samples: 800,
-      calibrated: false,
     };
     
     const r1 = calculateConfidence(inputs);
@@ -58,7 +55,6 @@ describe('Confidence Integer Math (determinism)', () => {
       identifiable: true,
       in_linear_range: true,
       k_samples: 1000,
-      calibrated: false,
     };
     
     const r1 = calculateConfidence(base);

--- a/tests/confidence.defabrication.test.ts
+++ b/tests/confidence.defabrication.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { calculateConfidence } from '../src/trust/confidence.js';
+import type { Graph } from '../src/trust/types.js';
+
+/**
+ * Fabrication removal (disposition 11(b), simplify-review confirmed).
+ *
+ * The former "calibration" factor was a placeholder: it resolved to a fixed
+ * 0.5 on every production call (all callers passed `calibrated: false`, so the
+ * term never varied with any input) yet carried 15% of the 1000-unit weight
+ * budget and added a constant +75/1000 (+0.075) to every published score. A
+ * confidence number the product presents as computed was 15% (by weight) a
+ * fabricated constant.
+ *
+ * These tests pin the published confidence to ONLY its three genuinely-computed
+ * factors — identifiability, linearity, k-coverage — renormalised to sum 1000
+ * (412 : 294 : 294). Every expected value below was computed by hand from that
+ * formula, independent of the implementation, so the corpus is an external
+ * oracle rather than a mirror of the code.
+ *
+ * RED-first: every case here fails while the 0.5 calibration placeholder is
+ * present (it shifts scores and injects a `factors.calibration` field).
+ */
+
+const g = (nodes: number, edges: number): Graph => ({
+  nodes: Array.from({ length: nodes }, (_, i) => ({ id: `n${i}`, label: `n${i}` })),
+  edges: Array.from({ length: edges }, (_, i) => ({ from: `n${i}`, to: `n${i + 1}` })),
+});
+
+// k_samples buckets: >=1000 -> k_coverage 1.0, 500-999 -> 0.7, <500 -> 0.3
+// Expected scores derived by hand from raw = round(ident*412/1000)
+//   + round(linear*294/1000) + round(kcov*294/1000), score = round(raw/10)/100.
+interface Case {
+  name: string;
+  identifiable: boolean;
+  in_linear_range: boolean;
+  k_samples: number;
+  score: number;
+  level: 'HIGH' | 'MEDIUM' | 'LOW';
+}
+
+const CORPUS: Case[] = [
+  // all-factors-strong: only reachable to 1.00 if the 3 factors carry FULL weight
+  { name: 'all-strong', identifiable: true, in_linear_range: true, k_samples: 1000, score: 1.0, level: 'HIGH' },
+  // all-factors-weak
+  { name: 'all-weak', identifiable: false, in_linear_range: false, k_samples: 100, score: 0.36, level: 'LOW' },
+  // mixed: strong identifiability, outside linear range, full k
+  { name: 'strong-ident-outside-linear-fullK', identifiable: true, in_linear_range: false, k_samples: 1000, score: 0.85, level: 'HIGH' },
+  // mixed: weak identifiability, in range, full k
+  { name: 'weak-ident-inrange-fullK', identifiable: false, in_linear_range: true, k_samples: 1000, score: 0.71, level: 'MEDIUM' },
+  // mixed: strong ident, outside range, low k -> genuine MEDIUM
+  { name: 'strong-ident-outside-lowK', identifiable: true, in_linear_range: false, k_samples: 100, score: 0.65, level: 'MEDIUM' },
+  // boundary: strong ident+linear, low k
+  { name: 'strong-ident-linear-lowK', identifiable: true, in_linear_range: true, k_samples: 100, score: 0.79, level: 'HIGH' },
+  // boundary just above MEDIUM floor
+  { name: 'weak-ident-inrange-lowK', identifiable: false, in_linear_range: true, k_samples: 100, score: 0.51, level: 'MEDIUM' },
+  // weak ident, outside range, full k
+  { name: 'weak-ident-outside-fullK', identifiable: false, in_linear_range: false, k_samples: 1000, score: 0.57, level: 'MEDIUM' },
+];
+
+describe('Confidence — no fabricated calibration term', () => {
+  it('emits no calibration factor (the placeholder is gone)', () => {
+    const out = calculateConfidence({ graph: g(5, 4), identifiable: true, in_linear_range: true, k_samples: 1000 });
+    // RED while the placeholder exists: it emits factors.calibration = 0.5
+    expect('calibration' in out.factors).toBe(false);
+    expect((out.factors as Record<string, unknown>).calibration).toBeUndefined();
+  });
+
+  it('all-strong reaches exactly 1.00 — only possible if the 3 real factors carry the whole budget', () => {
+    // RED while the placeholder exists: max score is capped at 0.93 because the
+    // 0.5 calibration term contributes 75 of a possible 150 to the 1000 scale.
+    const out = calculateConfidence({ graph: g(5, 4), identifiable: true, in_linear_range: true, k_samples: 1000 });
+    expect(out.score).toBe(1.0);
+  });
+
+  it.each(CORPUS)('$name -> score $score, level $level (computed factors only)', (c) => {
+    const out = calculateConfidence({
+      graph: g(5, 4),
+      identifiable: c.identifiable,
+      in_linear_range: c.in_linear_range,
+      k_samples: c.k_samples,
+    });
+    expect(out.score).toBe(c.score);
+    expect(out.level).toBe(c.level);
+    // The three factors are present and computed; no fabricated fourth term.
+    expect(out.factors.identifiability).toBe(c.identifiable ? 1.0 : 0.3);
+    expect(out.factors.linearity_distance).toBe(c.in_linear_range ? 1.0 : 0.5);
+  });
+
+  it('score is fully explained by the three factors — no residual constant floor', () => {
+    // With the placeholder gone, the weakest possible inputs must NOT retain a
+    // hidden constant addend. Weakest = ident 0.3, linear 0.5, kcov 0.3:
+    //   round(300*412/1000)=124 + round(500*294/1000)=147 + round(300*294/1000)=88 = 359
+    // RED while the placeholder exists: it adds +75 -> raw 380 -> score 0.38.
+    const out = calculateConfidence({ graph: g(1, 0), identifiable: false, in_linear_range: false, k_samples: 100 });
+    expect(out.score).toBe(0.36);
+  });
+});

--- a/tests/trust-signals.test.ts
+++ b/tests/trust-signals.test.ts
@@ -26,7 +26,6 @@ describe('Trust Signals - Unit Tests', () => {
         identifiable: true,
         in_linear_range: true,
         k_samples: 1000,
-        calibrated: false,
       });
 
       expect(confidence.level).toBe('HIGH');
@@ -54,11 +53,18 @@ describe('Trust Signals - Unit Tests', () => {
     });
 
     it('returns MEDIUM for acceptable graph', () => {
+      // NOTE: after removing the fixed-0.5 calibration placeholder and
+      // renormalising the three real factors, the old input
+      // (identifiable, outside-linear, k=500) now scores 0.77 -> HIGH, because
+      // the placeholder was artificially suppressing genuinely-strong cases.
+      // A genuine MEDIUM under the corrected formula is strong identifiability
+      // but outside the linear range AND low sample coverage:
+      //   round(1000*412/1000)=412 + round(500*294/1000)=147 + round(300*294/1000)=88 = 647 -> 0.65
       const confidence = calculateConfidence({
         graph: simpleGraph,
         identifiable: true,
         in_linear_range: false,
-        k_samples: 500,
+        k_samples: 100,
       });
 
       expect(confidence.level).toBe('MEDIUM');

--- a/tests/trust.confidence.casing.test.ts
+++ b/tests/trust.confidence.casing.test.ts
@@ -15,7 +15,6 @@ describe('Confidence Level Casing Invariant', () => {
       identifiable: true,
       in_linear_range: true,
       k_samples: 1000,
-      calibrated: false,
     });
 
     // Must be one of uppercase values (UI contract)
@@ -35,7 +34,6 @@ describe('Confidence Level Casing Invariant', () => {
       identifiable: true,
       in_linear_range: true,
       k_samples: 5000,
-      calibrated: true,
     });
     expect(high.level).toBe('HIGH');
     expect(high.level).toBe(high.level.toUpperCase());
@@ -49,7 +47,6 @@ describe('Confidence Level Casing Invariant', () => {
       identifiable: true,
       in_linear_range: true,
       k_samples: 1000,
-      calibrated: false,
     });
     expect(['HIGH', 'MEDIUM']).toContain(medium.level);
     expect(medium.level).toBe(medium.level.toUpperCase());
@@ -63,7 +60,6 @@ describe('Confidence Level Casing Invariant', () => {
       identifiable: false,
       in_linear_range: false,
       k_samples: 100,
-      calibrated: false,
     });
     expect(low.level).toBe('LOW');
     expect(low.level).toBe(low.level.toUpperCase());


### PR DESCRIPTION
## What & why

The published confidence badge carried a factor its own code marked `// placeholder`. It resolved to a **fixed 0.5 for every production call** (all three callers passed `calibrated: false`, so the term never varied with any input) yet held **15% of the 1000-unit weight budget**. A confidence number the product presents as computed was, by weight, a fabricated constant.

**Scientific integrity — no fabricated confidence.** This drops the placeholder and renormalises the three genuinely-computed factors so the score stays a well-formed value in [0, 1] traceable end-to-end to inputs.

Disposition item 11(b); confirmed by the 13 Aug simplify review.

## Confirmation + the 15% arithmetic (verified at the bytes, tip `d39b4fa`)

`src/trust/confidence.ts` `calculateConfidence()` is the canonical assembler. Integer math, weights sum to 1000:

| Factor | Weight | Source |
|---|---|---|
| identifiability | 350 | computed (`identifiable ? 1.0 : 0.3`) |
| linearity | 250 | computed (`in_linear_range ? 1.0 : 0.5`) |
| k_coverage | 250 | computed (k buckets) |
| **calibration** | **150** | **placeholder — `calibrated ? 1.0 : 0.5`, and `calibrated` is hardcoded `false` at every caller → always 0.5** |

- `calib_raw = round(0.5 × 1000) = 500`; contribution to `overall_raw` = `round(500 × 150 / 1000) = 75/1000`.
- **The placeholder is 15.0% of the weight budget (150/1000)** and adds a **constant +0.075** to every published score in production. As a share of a typical score it runs ~8% (all-strong: 75/925 = 8.1%) up to ~20% (weakest scores). The precise, defensible reading of "~15%" is the **weight allocation**: 15% of the confidence formula is a placeholder constant that never varies with any input.

`calibrated: true` is never passed by any production caller — confirmed at `src/routes/v1/run.ts`, `src/routes/v1/self-check.ts`, `src/inference/model_of_inference.ts` (uses the `false` default), `src/fixtures/demo-payloads.ts`.

## Reader manifest (is it user-reachable?)

Producer → transport → surface, within PLoT (tip `d39b4fa`):

- **Producer:** `calculateConfidence()` — `src/trust/confidence.ts:18`.
- **`/v1/run`:** `src/routes/v1/run.ts:821` builds the badge; placed in the response `base.confidence` at `run.ts:1272`. `confidence.level` also feeds `insights` (`run.ts:1228`).
- **`/v1/self-check`:** `src/routes/v1/self-check.ts:79` → self-check response.
- **`model_of_inference`:** `src/inference/model_of_inference.ts:183`; `confidence.score` feeds `meta_reasoning.quality_assessment.overall_score` at **40% weight** (`model_of_inference.ts:218`) and `confidence_level` (`:232`); `meta_reasoning` surfaces in the `/v1/run` response (`run.ts:1310`).

So the placeholder was **user-reachable twice over**: directly as `confidence.score`/`.level`, and indirectly inside `overall_score`. **Reachable, not dark.**

No downstream code reads `factors.calibration` for any decision (only the producer, the type, and the separate SCM fallback set it). The response JSON schema (`src/schemas/response.ts:7`) is `additionalProperties: true` and does not require `factors`, so dropping the field is wire-safe.

## The fix (one authority)

Fixed only in the canonical assembler `src/trust/confidence.ts`:

- Removed the calibration factor, its weight, its output field, and the now-dead `calibrated` input param.
- **Renormalised the three genuine factors proportionally to sum 1000: 412 : 294 : 294** (`350 × 1000/850 = 412`, `250 × 1000/850 = 294`). Relative importance of the real factors is preserved; the constant floor is gone.
- Dead `calibrated: false` arg removed from the three callers (`run.ts`, `self-check.ts`, `demo-payloads.ts`).
- `ConfidenceBadge.factors.calibration` made optional in `src/trust/types.ts` (the separate SCM-meta fallback at `run.ts:859` still sets its own real `sign_stability` value — left untouched; see Not addressed).

No second normalisation path was added.

## Before / after (calibrated=false, the production value)

Score shifts by −0.02 … +0.07: strong cases rise (the 0.5 placeholder was suppressing them), weak cases fall slightly.

| ident | linear | k | before | after | Δ | level |
|---|---|---|---|---|---|---|
| ✓ | ✓ | ≥1000 | 0.93 | **1.00** | +0.07 | HIGH → HIGH |
| ✓ | ✓ | 500–999 | 0.85 | 0.91 | +0.06 | HIGH → HIGH |
| ✓ | ✓ | <500 | 0.75 | 0.79 | +0.04 | HIGH → HIGH |
| ✓ | ✗ | ≥1000 | 0.80 | 0.85 | +0.05 | HIGH → HIGH |
| ✓ | ✗ | 500–999 | 0.73 | 0.77 | +0.04 | **MEDIUM → HIGH** |
| ✓ | ✗ | <500 | 0.63 | 0.65 | +0.02 | MEDIUM → MEDIUM |
| ✗ | ✓ | ≥1000 | 0.68 | 0.71 | +0.03 | MEDIUM → MEDIUM |
| ✗ | ✓ | 500–999 | 0.61 | 0.62 | +0.01 | MEDIUM → MEDIUM |
| ✗ | ✓ | <500 | 0.51 | 0.51 | 0.00 | MEDIUM → MEDIUM |
| ✗ | ✗ | ≥1000 | 0.56 | 0.57 | +0.01 | MEDIUM → MEDIUM |
| ✗ | ✗ | 500–999 | 0.48 | 0.48 | 0.00 | LOW → LOW |
| ✗ | ✗ | <500 | 0.38 | 0.36 | −0.02 | LOW → LOW |

**Material change disclosed:** exactly **one** production-space level flip — `identifiable=true, outside-linear-range, k=500–999` moves **MEDIUM → HIGH** (0.73→0.77). This is the direct consequence of renormalisation: identifiability's weight rises 35%→41.2%, so a case with strong identifiability legitimately scores higher once the placeholder no longer suppresses it. Disclosed, not hidden; the previously-affected existing test (`trust-signals` "returns MEDIUM") was updated to a genuinely-MEDIUM input with an in-file comment explaining the boundary moved.

## RED-first (named signatures)

New spec `tests/confidence.defabrication.test.ts` — corpus computed by hand (external oracle), covering all-strong / all-weak / mixed / boundary. Against **pristine** source: **10 of 11 assertions FAIL** (the 1 pass is the documented non-discriminating case where before==after score). Discriminating assertions:

- `'calibration' in out.factors` → `false` — REDs at pristine (placeholder emits it).
- all-strong `score === 1.00` — REDs at pristine (capped at 0.93 by the 0.5 term).
- `weakest score === 0.36` (no residual constant floor) — REDs at pristine (0.38 with the +75 addend).

After the fix: **34/34 green** across the new spec + the three updated specs.

## Mutation table (throwaway worktree outside repo root; isolation proven by sentinel write + APFS inode compare; applied-check scoped to `src/`, control exactly 0; restores HEAD-relative)

| # | Mutation | Result |
|---|---|---|
| M1 | ident weight 412 → 350 | **KILLED** (10 failed) |
| M2 | re-add +75 calibration constant addend | **KILLED** (11 failed) |
| M3 | linearity weight 294 → 250 | **KILLED** (10 failed) |
| M4 | re-emit `factors.calibration = 0.5` | **KILLED** (1 failed — precise) |
| M5 | ident weight 412 → 402 (breaks sum=1000) | **KILLED** (7 failed) |

Control: pristine worktree 0 changed files under `src/`, 34/34 green, before and after the run.

## Gate results

- `npm test` (named gate: `node tools/run-all-tests.js` — build + full vitest suite against test server): **exit 0** (run twice).
- `tsc -p tsconfig.json --noEmit`: **exit 0**.
- Full `scripts/pre-push-validate.sh` (7 checks): **exit 0**. Verbatim fast checks: [4/7] 0 stale tracked `.js`; [5/7] `POLICY OK`; [6/7] spectral `0 errors` (5 pre-existing warnings).

## Not addressed (out of scope; candidate for a separate row)

`src/routes/v1/run.ts:859-868` is a **separate constant-confidence path**: when `inferenceResult.meta.unique_graphs` is present it *overrides* the whole badge with a hardcoded `score: 0.6, level: 'MEDIUM'` and `calibration: sign_stability || 0.5` — bypassing `calculateConfidence` entirely. That is a distinct fabrication with its own reachability question and was left untouched to keep this change to one authority. Flagging for a separate assessment.

## Reachability boundary I could not reach from this repo

Within PLoT the badge is definitively produced and placed in the `/v1/run` and `/v1/self-check` responses. Which PLoT route CEE's analyse path actually invokes, and whether the UI renders `confidence.score`/`.level` on the **external PoC surface**, is beyond this repo (v2/run uses a *different* confidence mechanism — `confidence-tier`/`confidence-basis` — not this badge). Not verified here; establishing it needs a live CEE→PLoT capture.

⛔ **DO NOT MERGE** — the deployed quartet is held stable for external review; the orchestrator merges.
