### PR TITLE
fix(honesty): flip-aware robustness caveat; no fabricated review defaults (2.1247+2.1248)

### DIFF
--- a/src/assembly/decision-brief.ts
+++ b/src/assembly/decision-brief.ts
@@ -15,7 +15,7 @@
  * top_drivers:       factor_sensitivity[] top 5 by abs(elasticity)
  * key_assumptions:   m1_coaching.evidence_gaps[].factor_label → []
  * what_would_change: robustness.fragile_edges[].from_label/to_label → factor_sensitivity[].factor_label (sorted by |elasticity|)
- * robustness:        robustness.level → 'moderate' (default)
+ * robustness:        robustness.level → 'not_assessed' when absent/unrecognised (2.1248 — never a fabricated 'moderate')
  * warnings:          critiques (severity>=warning) + m1_coaching.model_critiques → []
  * lineage.response_hash: meta.response_hash (computed before brief assembly)
  * lineage.config_version: SHA-256 hash of n_samples_default + review/facts flags + brief_assembly_version
@@ -43,6 +43,10 @@ import { NEAR_TIE_THRESHOLD } from '../trust/result-coherence.js';
 // A1b: intervention-controlled levers are not independently tunable; exclude them
 // from the |elasticity|-ranked tunability surfaces (top_drivers, what_would_change).
 import { filterInterventionOverrides, interventionOverrideFactorIds, filterLeverSourcedFragileEdges } from '../lib/intervention-override.js';
+// ROADMAP 2.1247: the single source of truth for flip-threshold classification
+// — the caveat's flip claim derives its status here, never re-reads
+// flip_reason strings (the hand-maintained-mirror defect class).
+import { classifyFlipThresholdsStatus } from '../lib/flip-threshold-status.js';
 
 // =============================================================================
 // Constants
@@ -140,6 +144,16 @@ export type BriefAssemblyInput = Pick<RunResponseV3, 'analysis_status' | 'critiq
    * (DEFAULT-coded disclosures). Absent → both surfaces treat as none.
    */
   inference_warnings?: RunResponseV3['inference_warnings'];
+  /**
+   * ROADMAP 2.1247 (additive, optional): the SAME denormalised flip-threshold
+   * array the response publishes at `flip_thresholds` — run.ts passes the one
+   * variable both read, so the caveat and the evidence it cites can never come
+   * from two different runs (the same-run doctrine as `display_verdict_reason`,
+   * ROADMAP 2.278). Feeds `robustness_caveat.flip_evidence` (claim 2) and the
+   * attested-no-flip rewording of claim 1. Absent → classified 'unavailable'
+   * → caveat byte-identical to its pre-2.1247 shape.
+   */
+  flip_thresholds?: RunResponseV3['flip_thresholds'];
   response_hash?: string;
   meta: {
     seed_used: string;
@@ -166,18 +180,27 @@ export type BriefAssemblyInput = Pick<RunResponseV3, 'analysis_status' | 'critiq
  *   - low driver confidence and near-tie status → tone gate `headline`.
  *
  * The semantic mapping is "graph perturbation stability under ISL's
- * robustness analysis" — `high → 'robust'`, `moderate → 'moderate'`,
+ * robustness analysis" — `high → 'robust'`, `medium | moderate → 'moderate'`
+ * (ISL V2 wire vocabulary is 'medium'; 'moderate' tolerated — the same
+ * normalisation `deriveVerdict` applies in robustness-display-verdict.ts),
  * `low | very_low → 'fragile'`. See `src/types/decision-brief.ts` jsdoc
  * for the consumer-facing contract and the readiness-widening follow-up
  * for the longer-term action-readiness surface.
+ *
+ * ROADMAP 2.1248: an ABSENT or unrecognised level maps to `'not_assessed'`
+ * — never to a fabricated `'moderate'`. Before this fix the `default` branch
+ * did double duty: it correctly normalised 'medium' AND silently converted
+ * "nobody measured this" into a confident middle value. 'medium' is now an
+ * explicit case, so the default only ever sees genuinely unassessable input.
  */
-function mapRobustnessLevel(level: string | undefined): 'robust' | 'moderate' | 'fragile' {
+function mapRobustnessLevel(level: string | undefined): 'robust' | 'moderate' | 'fragile' | 'not_assessed' {
   switch (level) {
     case 'high': return 'robust';
+    case 'medium':
     case 'moderate': return 'moderate';
     case 'low':
     case 'very_low': return 'fragile';
-    default: return 'moderate';
+    default: return 'not_assessed';
   }
 }
 
@@ -687,10 +710,51 @@ function buildDefaultedAssumptions(input: BriefAssemblyInput): BriefDefaultedAss
 }
 
 /**
- * Honest robustness caveat (provisional_doctrine_v0). Wording is derived
- * strictly from upstream signals; when neither is_robust nor level is
- * present the caveat SAYS robustness was not assessed instead of implying
- * stability.
+ * ROADMAP 2.1247 — claim-2 wording per attest-bearing flip status
+ * (provisional_doctrine_v0; claim-safe, no numbers; scope is the PROBED SET,
+ * per the 2.292 scoping ruling — "the factors we could test", never a
+ * universal over the whole graph).
+ *
+ * 'unavailable' and 'unresolved' are intentionally absent: an uncomputed or
+ * unfinished probe attests nothing, so no claim is made (mirrors the
+ * deliberate per-status handling in deriveRobustnessDisplayVerdict).
+ */
+const FLIP_EVIDENCE_CLAIMS: Record<
+  'computed' | 'all_no_effect' | 'partial_no_effect',
+  string
+> = {
+  all_no_effect:
+    'None of the factors we could test changed which option leads on its own.',
+  computed:
+    'Changing at least one tested factor on its own could change which option leads.',
+  partial_no_effect:
+    'Changing at least one tested factor on its own could change which option leads; the other factors we could test could not.',
+};
+
+/**
+ * Honest robustness caveat (provisional_doctrine_v0), composed as TWO NAMED
+ * CLAIMS with named scopes (ROADMAP 2.1247; trap-21 — two questions must
+ * never share one name):
+ *
+ *   claim 1 (`text`)          — aggregate stability under the perturbations
+ *                               tested, derived strictly from the robustness
+ *                               MARGINALS (is_robust / level). When neither
+ *                               is present it SAYS robustness was not
+ *                               assessed instead of implying stability.
+ *   claim 2 (`flip_evidence`) — what the SAME run's per-factor flip probes
+ *                               attest, classified by the shared
+ *                               `classifyFlipThresholdsStatus` (single source
+ *                               of truth — never re-derived here; the
+ *                               hand-maintained-mirror defect is exactly what
+ *                               that classifier exists to prevent).
+ *
+ * The caveat was previously composed from marginals ALONE, so a payload whose
+ * flip evidence attested "no tested factor can flip the leader" could carry a
+ * caveat claiming "small changes … could change which option leads" — the
+ * self-contradiction the display verdict's reason fixed in ROADMAP 2.278.
+ * The fix here is the same shape: on an ATTESTED no-flip, claim 1 keeps its
+ * marginal verdict but drops the flip language its own payload refutes; the
+ * flip statement lives only in claim 2, scoped to the probed set.
  */
 function buildRobustnessCaveat(input: BriefAssemblyInput): BriefRobustnessCaveat {
   const robustness = input.robustness;
@@ -700,25 +764,46 @@ function buildRobustnessCaveat(input: BriefAssemblyInput): BriefRobustnessCaveat
   const basis: BriefRobustnessCaveat['basis'] =
     isRobust !== undefined ? 'is_robust' : level !== undefined ? 'level' : 'absent';
 
-  // provisional_doctrine_v0 wording matrix
+  // Claim 2's classification — derived by the single source of truth.
+  const flipStatus = classifyFlipThresholdsStatus(input.flip_thresholds).status;
+  const attestedNoFlip = flipStatus === 'all_no_effect';
+
+  // provisional_doctrine_v0 wording matrix for claim 1. The two branches that
+  // used to assert "small changes to assumptions could change which option
+  // leads" switch to flip-free stability wording when this run's own evidence
+  // attests no tested factor can flip the leader. The verdict itself ("did
+  // not pass" / "fragile") is a marginal claim and NEVER moves on flip
+  // evidence (same invariant as the display verdict).
   let text: string;
   if (basis === 'absent') {
     text = 'Robustness was not assessed for this run — treat the ranking as unverified against perturbations.';
   } else if (isRobust === true || (isRobust === undefined && level === 'high')) {
     text = 'This ranking held up under the perturbations tested. That is not a guarantee — defaulted or uncertain inputs can still change the result.';
   } else if (isRobust === false && level === undefined) {
-    text = 'This ranking did not pass the robustness checks — small changes to assumptions could change which option leads.';
+    text = attestedNoFlip
+      ? 'This ranking did not pass the robustness checks — it scored low on the stability measures tested.'
+      : 'This ranking did not pass the robustness checks — small changes to assumptions could change which option leads.';
   } else if (level === 'medium' || level === 'moderate') {
     text = 'This ranking was only moderately stable under the perturbations tested — treat the lead as provisional.';
   } else if (level === 'low' || level === 'very_low') {
-    text = 'This ranking was fragile under the perturbations tested — small changes to assumptions could change which option leads.';
+    text = attestedNoFlip
+      ? 'This ranking was fragile under the perturbations tested — it scored low on the stability measures tested.'
+      : 'This ranking was fragile under the perturbations tested — small changes to assumptions could change which option leads.';
   } else {
     // is_robust === false with a level that is not low/very_low, or an
     // unrecognised level value — state the weaker of the two signals.
-    text = 'This ranking did not pass the robustness checks — small changes to assumptions could change which option leads.';
+    text = attestedNoFlip
+      ? 'This ranking did not pass the robustness checks — it scored low on the stability measures tested.'
+      : 'This ranking did not pass the robustness checks — small changes to assumptions could change which option leads.';
   }
 
-  return { text, basis, doctrine: 'provisional_doctrine_v0' };
+  // Claim 2 — present ONLY when the probes support a claim.
+  const flipEvidence =
+    flipStatus === 'computed' || flipStatus === 'all_no_effect' || flipStatus === 'partial_no_effect'
+      ? { flip_evidence: { status: flipStatus, text: FLIP_EVIDENCE_CLAIMS[flipStatus] } }
+      : {};
+
+  return { text, basis, ...flipEvidence, doctrine: 'provisional_doctrine_v0' };
 }
 
 /**

--- a/src/cee/decision-review-orchestrator.ts
+++ b/src/cee/decision-review-orchestrator.ts
@@ -149,6 +149,24 @@ export async function orchestrateDecisionReview(
     input.m1Coaching
   );
 
+  // ROADMAP 2.1248: null ⇔ ISL returned no analysed options, so no winner
+  // exists. CEE's DecisionReviewInputSchema requires a non-null winner, and
+  // the old fabricated `{id:'', label:'', win_probability: 0}` reached the
+  // reviewing model as a measured figure. Skip with a named reason instead —
+  // visible absence over confident wrongness.
+  if (request === null) {
+    logger?.warn({
+      event: DecisionReviewEvents.SKIPPED,
+      request_id: input.requestId,
+      reason: ReviewSkipReasons.NO_ANALYSED_OPTIONS,
+    });
+    return {
+      m1_review: null,
+      review_status: 'skipped',
+      review_skip_reason: ReviewSkipReasons.NO_ANALYSED_OPTIONS,
+    };
+  }
+
   // Use pre-resolved flip data from run.ts if available (avoids redundant ISL calls).
   // Otherwise fall back to resolving via binary search (backward compatibility).
   if (input.preResolvedFlipData) {
@@ -455,8 +473,15 @@ export function buildIslResultsForCorrection(
       win_probability: opt.win_probability ?? 0,
       expected_outcome: opt.expected_outcome ?? opt.outcome?.mean,
     })),
+    // ROADMAP 2.1248: absent stability stays ABSENT. `?? 0` handed the
+    // number-corrector a fabricated 0 as an AUTHORITATIVE
+    // 'robustness.recommendation_stability' source — it could "correct" a
+    // model-written figure TO 0, or bless a written "0%" as grounded, for a
+    // run ISL never assessed. A measured 0 is real and is preserved.
     robustness: {
-      recommendation_stability: islResult.robustness?.recommendation_stability ?? 0,
+      ...(islResult.robustness?.recommendation_stability !== undefined
+        ? { recommendation_stability: islResult.robustness.recommendation_stability }
+        : {}),
     },
     factor_sensitivity: (islResult.factor_sensitivity ?? [])
       .filter((f) => !isOptionControlledLever(f, structuralLeverIds))

--- a/src/cee/decision-review-request.ts
+++ b/src/cee/decision-review-request.ts
@@ -104,7 +104,15 @@ export interface ISLResultInput {
  * @param options Request options
  * @param islResult ISL response data
  * @param m1Coaching M1 coaching output
- * @returns DecisionReviewRequest ready to send to CEE
+ * @returns DecisionReviewRequest ready to send to CEE, or NULL when ISL
+ *   returned no analysed options. ROADMAP 2.1248: the builder previously
+ *   fabricated `winner: {id:'', label:'', win_probability: 0}` in that case
+ *   — a confident empty-identity winner at 0% that CEE serialises verbatim
+ *   into the reviewing model's prompt. CEE's `DecisionReviewInputSchema`
+ *   requires a non-null winner, so an honest absent winner is NOT
+ *   representable on this wire — the honest behaviour is to not build the
+ *   request at all; the orchestrator skips with a named reason
+ *   (`NO_ANALYSED_OPTIONS`), visible absence instead of confident wrongness.
  */
 export function buildDecisionReviewRequest(
   brief: string,
@@ -112,7 +120,7 @@ export function buildDecisionReviewRequest(
   options: OptionV3[],
   islResult: ISLResultInput,
   m1Coaching: M1Coaching
-): DecisionReviewRequest {
+): DecisionReviewRequest | null {
   // Compute brief hash
   const briefHash = computeBriefHash(brief);
 
@@ -135,8 +143,12 @@ export function buildDecisionReviewRequest(
   // Build deterministic coaching data
   const deterministicCoaching = buildDeterministicCoaching(m1Coaching);
 
-  // Get winner and runner-up
+  // Get winner and runner-up. No winner ⇒ no request: a review of a decision
+  // with no analysed options has nothing true to say, and the old
+  // `{id:'', label:'', win_probability: 0}` fallback fed the reviewing model
+  // a fabricated measurement (ROADMAP 2.1248).
   const { winner, runnerUp } = getWinnerAndRunnerUp(optionComparison);
+  if (!winner) return null;
 
   // Compute flip threshold data. Excluded set is the STRUCTURAL UNION, not
   // just the all-options intersection: a some-but-not-all-options lever must
@@ -170,16 +182,16 @@ export function buildDecisionReviewRequest(
     // 2.480(a): outcome_mean is emitted ONLY when extractOptionComparison
     // measured one. The key is omitted rather than sent as an explicit
     // undefined, so the in-memory object and the wire agree.
-    winner: winner
-      ? {
-          id: winner.option_id,
-          label: winner.option_label ?? winner.option_id,
-          win_probability: winner.win_probability,
-          ...(winner.expected_outcome !== undefined
-            ? { outcome_mean: winner.expected_outcome }
-            : {}),
-        }
-      : { id: '', label: '', win_probability: 0 },
+    // 2.1248: winner is non-null by the guard above — the fabricated
+    // empty-identity fallback is gone; no winner means no request.
+    winner: {
+      id: winner.option_id,
+      label: winner.option_label ?? winner.option_id,
+      win_probability: winner.win_probability,
+      ...(winner.expected_outcome !== undefined
+        ? { outcome_mean: winner.expected_outcome }
+        : {}),
+    },
     runner_up: runnerUp
       ? {
           id: runnerUp.option_id,
@@ -360,14 +372,27 @@ function parseEdgeId(edgeId: string): [string, string] {
 
 /**
  * Extract robustness data from ISL result.
+ *
+ * ROADMAP 2.1248: absent inputs propagate as ABSENT keys — never as a
+ * plausible middle value. `?? 0` / `?? false` / `?? 'unknown'` manufactured
+ * a confident "not robust, 0% stability" claim for runs ISL never assessed,
+ * and CEE serialises this object verbatim into the reviewing model's prompt.
+ * A MEASURED 0 or false is a real measurement and is preserved. CEE's
+ * request schema admits absence (`z.record(z.unknown()).optional()`).
  */
 function extractRobustness(islResult: ISLResultInput): RobustnessData {
   const robustness = islResult.robustness;
 
   return {
-    recommendation_stability: robustness?.recommendation_stability ?? 0,
-    flip_risk_category: robustness?.flip_risk_category ?? 'unknown',
-    is_robust: robustness?.is_robust ?? false,
+    ...(robustness?.recommendation_stability !== undefined
+      ? { recommendation_stability: robustness.recommendation_stability }
+      : {}),
+    ...(robustness?.flip_risk_category !== undefined
+      ? { flip_risk_category: robustness.flip_risk_category }
+      : {}),
+    ...(robustness?.is_robust !== undefined
+      ? { is_robust: robustness.is_robust }
+      : {}),
   };
 }
 

--- a/src/cee/validation/m1-review-constants.ts
+++ b/src/cee/validation/m1-review-constants.ts
@@ -237,6 +237,13 @@ export const ReviewSkipReasons = {
   NO_M1_COACHING: 'NO_M1_COACHING',
   /** User's decision brief text not provided — review requires context */
   BRIEF_MISSING: 'BRIEF_MISSING',
+  /**
+   * ROADMAP 2.1248: ISL returned no analysed options, so no winner exists.
+   * The request builder previously fabricated `winner: {id:'', label:'',
+   * win_probability: 0}` and sent it to CEE as a measured figure; the honest
+   * behaviour is this named skip — visible absence over confident wrongness.
+   */
+  NO_ANALYSED_OPTIONS: 'NO_ANALYSED_OPTIONS',
 } as const;
 
 export type ReviewSkipReason = typeof ReviewSkipReasons[keyof typeof ReviewSkipReasons];

--- a/src/cee/validation/m1-review-types.ts
+++ b/src/cee/validation/m1-review-types.ts
@@ -317,11 +317,26 @@ export interface FragileEdgeData {
 
 /**
  * Robustness summary from ISL.
+ *
+ * ROADMAP 2.1248: every field OPTIONAL — absent when ISL did not measure it.
+ *
+ * Previously all three were required, which forced `extractRobustness` to
+ * fabricate `recommendation_stability ?? 0`, `is_robust ?? false` and
+ * `flip_risk_category ?? 'unknown'` for runs ISL never assessed. CEE
+ * serialises this object VERBATIM into the reviewing model's prompt
+ * (`buildDecisionReviewUserMessage` → `<ISL_RESULTS>` JSON block), so an
+ * unassessed run reached the model as a measured "not robust, 0% stability"
+ * — and the fabricated 0 was then allowlisted by the Tier-4 grounding
+ * validator as a citable figure. CEE's `DecisionReviewInputSchema` admits
+ * absence (`robustness: z.record(z.unknown()).optional()`, verified at CEE
+ * staging tip c5e24307), so absence is representable and never has to be
+ * fabricated into a claim — the same correction FragileEdgeData's
+ * `switch_probability` received above.
  */
 export interface RobustnessData {
-  recommendation_stability: number;
-  flip_risk_category: string;
-  is_robust: boolean;
+  recommendation_stability?: number;
+  flip_risk_category?: string;
+  is_robust?: boolean;
 }
 
 /**

--- a/src/cee/validation/m1-review-validator.ts
+++ b/src/cee/validation/m1-review-validator.ts
@@ -890,7 +890,7 @@ export function buildValidationContext(
       option_comparison: Array<{ option_id: string; option_label: string; win_probability: number }>;
       factor_sensitivity: Array<{ factor_id: string; elasticity: number; confidence: number }>;
       fragile_edges: Array<{ edge_id: string; switch_probability?: number; marginal_switch_probability?: number }>;
-      robustness: { recommendation_stability: number };
+      robustness: { recommendation_stability?: number };
     };
     deterministic_coaching: {
       readiness: string;
@@ -908,8 +908,12 @@ export function buildValidationContext(
     allowedNumbers.push(opt.win_probability);
   }
 
-  // Recommendation stability
-  allowedNumbers.push(request.isl_results.robustness.recommendation_stability);
+  // Recommendation stability. 2.1248: only a MEASURED stability is grounded —
+  // the old required field forced a fabricated 0 into this allowlist, which
+  // let the review cite "0" as a grounded figure for a run ISL never assessed.
+  if (typeof request.isl_results.robustness.recommendation_stability === 'number') {
+    allowedNumbers.push(request.isl_results.robustness.recommendation_stability);
+  }
 
   // Elasticity and confidence values
   for (const f of request.isl_results.factor_sensitivity) {

--- a/src/cee/validation/number-corrector.ts
+++ b/src/cee/validation/number-corrector.ts
@@ -26,7 +26,12 @@ export interface IslResultsForCorrection {
     expected_outcome?: number;
   }>;
   robustness: {
-    recommendation_stability: number;
+    /**
+     * ROADMAP 2.1248: OPTIONAL — absent when ISL did not measure it. A
+     * fabricated `?? 0` here became an authoritative correction source; the
+     * source is now emitted only for a measured value (a measured 0 is real).
+     */
+    recommendation_stability?: number;
     overall_confidence?: number;
   };
   factor_sensitivity: Array<{
@@ -193,12 +198,15 @@ function buildIslNumberSources(
     });
   }
 
-  // Robustness
-  sources.push({
-    value: islResults.robustness.recommendation_stability,
-    source: 'robustness.recommendation_stability',
-    isPercentage: true,
-  });
+  // Robustness. 2.1248: only a MEASURED stability is an authoritative source
+  // — an absent one must not enter the corrector as a confident 0.
+  if (islResults.robustness.recommendation_stability !== undefined) {
+    sources.push({
+      value: islResults.robustness.recommendation_stability,
+      source: 'robustness.recommendation_stability',
+      isPercentage: true,
+    });
+  }
   if (islResults.robustness.overall_confidence !== undefined) {
     sources.push({
       value: islResults.robustness.overall_confidence,

--- a/src/routes/v2/run.ts
+++ b/src/routes/v2/run.ts
@@ -3656,6 +3656,11 @@ function buildResponse(
     // Lane PLoT-R3: warning_codes echo + DEFAULT-coded disclosures for the
     // brief's claim-safe surfaces (provisional_doctrine_v0 wording).
     inference_warnings: inferenceWarnings,
+    // ROADMAP 2.1247: the SAME flip array the response publishes at
+    // `flip_thresholds` below and the display verdict already consumes —
+    // one variable, so the brief's robustness_caveat and the evidence it
+    // cites can never come from two different runs.
+    flip_thresholds: flipThresholds,
     response_hash: responseHash,
     // Track S: depth-aware brief lineage (config_version + lineage.n_samples).
     meta: { seed_used: meta.seedUsed, n_samples: meta.nSamples },

--- a/src/types/decision-brief.ts
+++ b/src/types/decision-brief.ts
@@ -59,8 +59,13 @@ export interface DecisionBriefV1 {
    *     `src/coaching/readiness-tone.ts` against the broader signal set —
    *     fragile edges, robustness level, recommendation stability, evidence
    *     gaps, low driver confidence, near-tie status).
+   *
+   * ROADMAP 2.1248: an ABSENT or unrecognised level maps to `'not_assessed'`
+   * — the same honest token the sibling `robustness.display_verdict` already
+   * ships for exactly these runs. It previously defaulted to `'moderate'`,
+   * presenting a fabricated middle value as a measured one.
    */
-  robustness: 'robust' | 'moderate' | 'fragile';
+  robustness: 'robust' | 'moderate' | 'fragile' | 'not_assessed';
 
   /** Merged warnings from critiques and model critiques (max 10) */
   warnings: BriefWarning[];
@@ -184,14 +189,52 @@ export interface BriefDefaultedAssumption {
 }
 
 export interface BriefRobustnessCaveat {
-  /** provisional_doctrine_v0 wording — honest, no invented certainty */
+  /**
+   * CLAIM 1 — aggregate stability under the perturbations tested, derived
+   * from the robustness MARGINALS (is_robust / level). provisional_doctrine_v0
+   * wording — honest, no invented certainty.
+   *
+   * ROADMAP 2.1247: when the same run's flip evidence ATTESTS that no tested
+   * factor flips the leader (`all_no_effect`), this claim keeps its marginal
+   * verdict but drops the flip language ("small changes … could change which
+   * option leads") that the payload's own evidence refutes — the same
+   * correction `display_verdict_reason` received in ROADMAP 2.278.
+   */
   text: string;
   /**
-   * Which upstream signal the wording was derived from:
+   * Which upstream signal claim 1's wording was derived from:
    * 'is_robust' — ISL boolean flag; 'level' — ISL robustness level;
    * 'absent' — neither present (wording says robustness was not assessed).
+   * Flip evidence NEVER changes the basis (it is claim 2's input, not claim 1's).
    */
   basis: 'is_robust' | 'level' | 'absent';
+  /**
+   * CLAIM 2 — what this run's per-factor flip probes attest, scoped to the
+   * PROBED SET (ROADMAP 2.292 scoping: ISL probes only eligible root factors,
+   * so the copy says "the factors we could test", never a universal).
+   *
+   * Present ONLY when the probes support a claim:
+   *   'all_no_effect'     — every probed factor attested unable to flip;
+   *   'computed'          — at least one real flip threshold was found;
+   *   'partial_no_effect' — at least one flip found AND every other probed
+   *                         factor attested unable to flip.
+   * ABSENT when flip evidence is 'unavailable' (nobody computed it) or
+   * 'unresolved' (probes timed out / errored / were never evaluated) — an
+   * unfinished probe attests nothing, so no claim is made.
+   *
+   * `status` is DERIVED via `classifyFlipThresholdsStatus` (the single source
+   * of truth for the classification vocabulary) — never re-derived here.
+   *
+   * Two named claims with named scopes: claim 1 speaks about aggregate
+   * perturbation stability, claim 2 about single-factor flips. They cannot
+   * contradict each other because neither claims the other's scope
+   * (ROADMAP 2.1247; trap-21 — two questions must not share one name).
+   */
+  flip_evidence?: {
+    status: 'computed' | 'all_no_effect' | 'partial_no_effect';
+    /** provisional_doctrine_v0 wording — claim-safe, no numbers. */
+    text: string;
+  };
   doctrine: 'provisional_doctrine_v0';
 }
 

--- a/tests/cee-decision-review-absent-honesty.test.ts
+++ b/tests/cee-decision-review-absent-honesty.test.ts
@@ -1,0 +1,186 @@
+/**
+ * ROADMAP 2.1248 — fabricated defaults on the review path.
+ *
+ * Every mechanism here used to manufacture a confident claim from missing
+ * data, and each fabrication reached the reviewing model as a GROUNDED
+ * figure (CEE serialises `isl_results` and `winner` verbatim into the
+ * decision-review prompt, and PLoT's own Tier-4 grounding allowlist admitted
+ * the fabricated numbers):
+ *
+ *   - `extractRobustness` sent `is_robust ?? false`,
+ *     `recommendation_stability ?? 0`, `flip_risk_category ?? 'unknown'` —
+ *     an unassessed run reached the model as "not robust, 0% stability";
+ *   - `buildDecisionReviewRequest` fell back to a fabricated winner
+ *     `{id:'', label:'', win_probability: 0}` when no analysed options exist;
+ *   - `buildIslResultsForCorrection` fed the number-corrector
+ *     `recommendation_stability ?? 0` as an authoritative source;
+ *   - `buildValidationContext` allowlisted the fabricated 0 for grounding;
+ *   - `mapRobustnessLevel` defaulted an ABSENT level to 'moderate' on the
+ *     decision brief (tested in tests/decision-brief.test.ts).
+ *
+ * SPEC (what the consumer contract admits, derived at CEE staging tip
+ * c5e24307 `DecisionReviewInputSchema`): `isl_results.robustness` is
+ * `z.record(z.unknown()).optional()` — absent keys are admitted; `winner` is
+ * REQUIRED non-nullable — an absent winner is NOT admitted on the wire, so
+ * the honest behaviour is to not build the request at all (the orchestrator
+ * skips with a named reason). Invariants below are written against that
+ * spec, not against any single failure mode (trap 13d).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildDecisionReviewRequest,
+  type ISLResultInput,
+} from '../src/cee/decision-review-request.js';
+import { buildValidationContext } from '../src/cee/validation/m1-review-validator.js';
+import { buildIslResultsForCorrection } from '../src/cee/decision-review-orchestrator.js';
+import type { M1Coaching } from '../src/coaching/types.js';
+import type { EngineGraphV3, OptionV3 } from '../src/types/engine-v3.js';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const GRAPH: EngineGraphV3 = {
+  nodes: [
+    { id: 'opt_a', label: 'Option A', kind: 'option' },
+    { id: 'opt_b', label: 'Option B', kind: 'option' },
+    { id: 'fac_x', label: 'Factor X', kind: 'factor' },
+  ],
+  edges: [{ from: 'fac_x', to: 'opt_a', strength: { mean: 0.5, std: 0.2 } }],
+} as any;
+
+const OPTIONS: OptionV3[] = [
+  { id: 'opt_a', label: 'Option A' },
+  { id: 'opt_b', label: 'Option B' },
+] as any;
+
+const M1_COACHING: M1Coaching = {
+  readiness: 'ready',
+  headline_type: 'clear_winner',
+  evidence_gaps: [],
+  model_critiques: [],
+} as any;
+
+/** Two analysed options; NO robustness object; nothing legitimately zero. */
+function islResultNoRobustness(): ISLResultInput {
+  return {
+    options: [
+      { option_id: 'opt_a', option_label: 'Option A', win_probability: 0.62 },
+      { option_id: 'opt_b', option_label: 'Option B', win_probability: 0.38 },
+    ],
+    factor_sensitivity: [
+      { factor_id: 'fac_x', factor_label: 'Factor X', elasticity: 0.7, confidence: 0.8 },
+    ],
+  };
+}
+
+// =============================================================================
+// extractRobustness — absence propagates as absence
+// =============================================================================
+
+describe('decision-review request robustness — absent inputs stay absent (2.1248)', () => {
+  it('no robustness object from ISL → no fabricated is_robust / recommendation_stability / flip_risk_category keys', () => {
+    const request = buildDecisionReviewRequest('brief', GRAPH, OPTIONS, islResultNoRobustness(), M1_COACHING);
+    expect(request).not.toBeNull();
+    const rob = request!.isl_results.robustness as Record<string, unknown>;
+    expect('is_robust' in rob).toBe(false);
+    expect('recommendation_stability' in rob).toBe(false);
+    expect('flip_risk_category' in rob).toBe(false);
+  });
+
+  it('partially-measured robustness → only the measured keys are sent', () => {
+    const isl = islResultNoRobustness();
+    isl.robustness = { recommendation_stability: 0.42 };
+    const request = buildDecisionReviewRequest('brief', GRAPH, OPTIONS, isl, M1_COACHING);
+    const rob = request!.isl_results.robustness as Record<string, unknown>;
+    expect(rob.recommendation_stability).toBe(0.42);
+    expect('is_robust' in rob).toBe(false);
+    expect('flip_risk_category' in rob).toBe(false);
+  });
+
+  it('a MEASURED false / 0 is a real measurement and is preserved verbatim', () => {
+    const isl = islResultNoRobustness();
+    isl.robustness = { is_robust: false, recommendation_stability: 0, flip_risk_category: 'high' };
+    const request = buildDecisionReviewRequest('brief', GRAPH, OPTIONS, isl, M1_COACHING);
+    const rob = request!.isl_results.robustness as Record<string, unknown>;
+    expect(rob.is_robust).toBe(false);
+    expect(rob.recommendation_stability).toBe(0);
+    expect(rob.flip_risk_category).toBe('high');
+  });
+});
+
+// =============================================================================
+// Winner — never fabricated; the request is not built at all
+// =============================================================================
+
+describe('decision-review winner — no fabricated empty winner (2.1248)', () => {
+  it('no analysed options → returns null instead of a fabricated {id:"", win_probability: 0} winner', () => {
+    const isl: ISLResultInput = { factor_sensitivity: [] };
+    const request = buildDecisionReviewRequest('brief', GRAPH, OPTIONS, isl, M1_COACHING);
+    expect(request).toBeNull();
+  });
+
+  it('empty options array → returns null (not an empty-identity winner)', () => {
+    const isl: ISLResultInput = { options: [], factor_sensitivity: [] };
+    const request = buildDecisionReviewRequest('brief', GRAPH, OPTIONS, isl, M1_COACHING);
+    expect(request).toBeNull();
+  });
+
+  it('analysed options present → real winner, bound by identity', () => {
+    const request = buildDecisionReviewRequest('brief', GRAPH, OPTIONS, islResultNoRobustness(), M1_COACHING);
+    expect(request).not.toBeNull();
+    expect(request!.winner).toEqual({ id: 'opt_a', label: 'Option A', win_probability: 0.62 });
+    expect(request!.runner_up).toEqual({ id: 'opt_b', label: 'Option B', win_probability: 0.38 });
+  });
+});
+
+// =============================================================================
+// Number-corrector sources — no authoritative fabricated 0
+// =============================================================================
+
+describe('buildIslResultsForCorrection — absent stability never becomes an authoritative 0 (2.1248)', () => {
+  it('no robustness object → recommendation_stability key absent from corrector input', () => {
+    const out = buildIslResultsForCorrection(islResultNoRobustness());
+    expect('recommendation_stability' in out.robustness).toBe(false);
+  });
+
+  it('measured stability → preserved verbatim (including a measured 0)', () => {
+    const isl = islResultNoRobustness();
+    isl.robustness = { recommendation_stability: 0 };
+    const out = buildIslResultsForCorrection(isl);
+    expect(out.robustness.recommendation_stability).toBe(0);
+  });
+});
+
+// =============================================================================
+// Grounding allowlist — a number nobody measured is not grounded
+// =============================================================================
+
+describe('buildValidationContext — fabricated stability never enters the grounding allowlist (2.1248)', () => {
+  it('absent recommendation_stability → 0 is NOT allowlisted (fixture carries no legitimate zero)', () => {
+    const request = buildDecisionReviewRequest('brief', GRAPH, OPTIONS, islResultNoRobustness(), M1_COACHING);
+    expect(request).not.toBeNull();
+    const ctx = buildValidationContext(request! as any);
+    // Identity binding: the fixture is constructed so NO legitimate source is 0
+    // (win probabilities .62/.38, elasticity .7, confidence .8, margin .24) —
+    // a 0 in the allowlist could only be the fabricated stability.
+    expect(ctx.allowedNumbers).not.toContain(0);
+    // SPEC invariant (trap 13d — written against what Tier-4 is FOR, not
+    // against the old failure mode): a grounding allowlist of numbers contains
+    // ONLY finite numbers. This is what catches the residual shape of the old
+    // defect — an unconditional push now inserts `undefined` rather than the
+    // fabricated 0, which the toContain(0) guard alone cannot see (the M7
+    // mutant survived exactly that way before this assertion existed).
+    expect(ctx.allowedNumbers.every((n) => typeof n === 'number' && Number.isFinite(n))).toBe(true);
+    expect(ctx.allowedNumbers.length).toBeGreaterThan(0);
+  });
+
+  it('measured recommendation_stability → allowlisted verbatim', () => {
+    const isl = islResultNoRobustness();
+    isl.robustness = { recommendation_stability: 0.42 };
+    const request = buildDecisionReviewRequest('brief', GRAPH, OPTIONS, isl, M1_COACHING);
+    const ctx = buildValidationContext(request! as any);
+    expect(ctx.allowedNumbers).toContain(0.42);
+  });
+});

--- a/tests/decision-brief.flip-caveat.test.ts
+++ b/tests/decision-brief.flip-caveat.test.ts
@@ -1,0 +1,246 @@
+/**
+ * ROADMAP 2.1247 — robustness_caveat flip-evidence composition.
+ *
+ * The caveat used to be composed from robustness MARGINALS alone
+ * (is_robust / level); per-factor flip evidence in the SAME response could
+ * attest that no tested factor flips the leader while the caveat claimed
+ * "small changes to assumptions could change which option leads" — the same
+ * self-contradiction the display verdict fixed for its reason string
+ * (ROADMAP 2.278, witness-2267-onscreen-flip.md).
+ *
+ * SPEC (what the consumer of the brief is entitled to): the caveat is TWO
+ * NAMED CLAIMS that cannot contradict each other —
+ *   claim 1 (`text`)          — aggregate stability under the perturbations
+ *                               tested (marginals scope);
+ *   claim 2 (`flip_evidence`) — what this run's per-factor flip probes
+ *                               attest (probed-set scope). Present ONLY when
+ *                               the probes support a claim (computed /
+ *                               all_no_effect / partial_no_effect); absent
+ *                               when probes were unavailable or unresolved,
+ *                               because an unfinished probe attests nothing.
+ *
+ * Invariants here are written against that spec over the WHOLE input domain
+ * (trap 13d: never against the single witnessed failure mode), and the flip
+ * classification is asserted EQUAL to `classifyFlipThresholdsStatus` — the
+ * single source of truth — so the caveat can never re-derive its own
+ * vocabulary and drift (trap 12).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assembleBrief, type BriefAssemblyInput } from '../src/assembly/decision-brief.js';
+import { classifyFlipThresholdsStatus } from '../src/lib/flip-threshold-status.js';
+import type { DenormalisedFlipThreshold } from '../src/lib/flip-threshold-denormaliser.js';
+
+// =============================================================================
+// Fixture builders
+// =============================================================================
+
+const OPTIONS = [
+  { option_id: 'opt_a', option_label: 'Option A', win_probability: 0.62 },
+  { option_id: 'opt_b', option_label: 'Option B', win_probability: 0.38 },
+] as any[];
+
+function attestedNoFlipRow(id: string, reason: 'structurally_invariant' | 'no_effect_within_bounds' = 'structurally_invariant'): DenormalisedFlipThreshold {
+  return {
+    factor_id: id,
+    factor_label: `Factor ${id}`,
+    current_value: 100,
+    flip_value: null,
+    no_flip_in_range: true,
+    alternative_winner_id: null,
+    alternative_winner_label: null,
+    flip_reason: reason,
+  };
+}
+
+function computedFlipRow(id: string): DenormalisedFlipThreshold {
+  return {
+    factor_id: id,
+    factor_label: `Factor ${id}`,
+    current_value: 100,
+    flip_value: 140,
+    direction: 'increase',
+    alternative_winner_id: 'opt_b',
+    alternative_winner_label: 'Option B',
+    flip_reason: 'found',
+  };
+}
+
+function unresolvedRow(id: string, reason = 'timeout'): DenormalisedFlipThreshold {
+  return {
+    factor_id: id,
+    factor_label: `Factor ${id}`,
+    current_value: 100,
+    flip_value: null,
+    alternative_winner_id: null,
+    alternative_winner_label: null,
+    flip_reason: reason,
+  };
+}
+
+function buildInput(
+  robustness: Record<string, unknown>,
+  flipThresholds?: DenormalisedFlipThreshold[],
+): BriefAssemblyInput {
+  return {
+    analysis_status: 'computed',
+    critiques: [],
+    option_comparison: OPTIONS,
+    robustness: { fragile_edges: [], robust_edges: [], ...robustness } as any,
+    ...(flipThresholds !== undefined ? { flip_thresholds: flipThresholds } : {}),
+    meta: { seed_used: '42' },
+  } as BriefAssemblyInput;
+}
+
+/** The flip-language predicate claim 1 must never use against an attested no-flip. */
+const FLIP_CLAIM = /change which option leads|flip/i;
+
+// =============================================================================
+// The witnessed contradiction class (named cases)
+// =============================================================================
+
+describe('robustness_caveat — attested no-flip evidence (2.1247)', () => {
+  it('CONTRADICTION KILL: fragile marginals + all rows attested no-flip → text no longer claims a flip', () => {
+    const brief = assembleBrief(
+      buildInput({ is_robust: false, level: 'low' }, [attestedNoFlipRow('f1'), attestedNoFlipRow('f2', 'no_effect_within_bounds')]),
+    );
+    const caveat = brief?.robustness_caveat;
+    expect(caveat).toBeDefined();
+    // Claim 1 keeps its marginal-scoped verdict but must not assert the flip
+    // this same payload's evidence refutes.
+    expect(caveat!.text).not.toMatch(FLIP_CLAIM);
+    expect(caveat!.text).toContain('perturbations tested');
+    // Claim 2 carries the attestation, scoped to the probed set (2.292 scoping).
+    expect(caveat!.flip_evidence).toBeDefined();
+    expect(caveat!.flip_evidence!.status).toBe('all_no_effect');
+    expect(caveat!.flip_evidence!.text).toContain('factors we could test');
+  });
+
+  it('is_robust false with no level + attested no-flip → text no longer claims a flip', () => {
+    const brief = assembleBrief(buildInput({ is_robust: false }, [attestedNoFlipRow('f1')]));
+    const caveat = brief?.robustness_caveat;
+    expect(caveat!.basis).toBe('is_robust');
+    expect(caveat!.text).not.toMatch(FLIP_CLAIM);
+    expect(caveat!.text).toContain('did not pass');
+    expect(caveat!.flip_evidence!.status).toBe('all_no_effect');
+  });
+
+  it('a computed flip is acknowledged as a named claim (earned flip language)', () => {
+    const brief = assembleBrief(buildInput({ is_robust: false, level: 'low' }, [computedFlipRow('f1'), computedFlipRow('f2')]));
+    const caveat = brief?.robustness_caveat;
+    expect(caveat!.flip_evidence).toBeDefined();
+    expect(caveat!.flip_evidence!.status).toBe('computed');
+    expect(caveat!.flip_evidence!.text).toMatch(/change which option leads/);
+    // Aggregate claim keeps its original wording — consistent with the evidence.
+    expect(caveat!.text).toContain('fragile under the perturbations tested');
+  });
+
+  it('partial no-effect (computed + attested rest) carries its own claim', () => {
+    const brief = assembleBrief(buildInput({ level: 'medium' }, [computedFlipRow('f1'), attestedNoFlipRow('f2')]));
+    const caveat = brief?.robustness_caveat;
+    expect(caveat!.flip_evidence!.status).toBe('partial_no_effect');
+    expect(caveat!.flip_evidence!.text).toMatch(/change which option leads/);
+  });
+
+  it('unresolved probes attest nothing: no flip_evidence claim, wording unchanged', () => {
+    const brief = assembleBrief(buildInput({ is_robust: false, level: 'low' }, [attestedNoFlipRow('f1'), unresolvedRow('f2')]));
+    const caveat = brief?.robustness_caveat;
+    expect(caveat!.flip_evidence).toBeUndefined();
+    expect(caveat!.text).toContain('small changes to assumptions could change which option leads');
+  });
+
+  it('absent flip evidence: caveat byte-identical to the pre-2.1247 shape (no flip_evidence key)', () => {
+    const brief = assembleBrief(buildInput({ is_robust: false, level: 'low' }));
+    const caveat = brief?.robustness_caveat;
+    expect(caveat).toEqual({
+      text: 'This ranking was fragile under the perturbations tested — small changes to assumptions could change which option leads.',
+      basis: 'is_robust',
+      doctrine: 'provisional_doctrine_v0',
+    });
+    expect(Object.keys(caveat as object)).not.toContain('flip_evidence');
+  });
+
+  it('empty flip array is unavailable, not an attestation: no flip_evidence claim', () => {
+    const brief = assembleBrief(buildInput({ level: 'low' }, []));
+    expect(brief?.robustness_caveat?.flip_evidence).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Spec invariants over the whole input domain
+// =============================================================================
+
+describe('robustness_caveat — domain-wide consistency invariants (2.1247)', () => {
+  const IS_ROBUST_VALUES = [true, false, undefined] as const;
+  const LEVEL_VALUES = ['high', 'medium', 'moderate', 'low', 'very_low', undefined, 'unrecognised_future_level'] as const;
+  const FLIP_CLASSES: Array<{ name: string; rows?: DenormalisedFlipThreshold[] }> = [
+    { name: 'absent', rows: undefined },
+    { name: 'empty', rows: [] },
+    { name: 'all_attested', rows: [attestedNoFlipRow('f1'), attestedNoFlipRow('f2')] },
+    { name: 'all_computed', rows: [computedFlipRow('f1')] },
+    { name: 'computed_plus_attested', rows: [computedFlipRow('f1'), attestedNoFlipRow('f2')] },
+    { name: 'attested_plus_unresolved', rows: [attestedNoFlipRow('f1'), unresolvedRow('f2')] },
+    { name: 'all_unresolved', rows: [unresolvedRow('f1', 'candidate_cap_exceeded')] },
+  ];
+
+  it('claims never contradict: every marginal state × every flip-evidence class', () => {
+    for (const is_robust of IS_ROBUST_VALUES) {
+      for (const level of LEVEL_VALUES) {
+        for (const flips of FLIP_CLASSES) {
+          const robustness: Record<string, unknown> = {};
+          if (is_robust !== undefined) robustness.is_robust = is_robust;
+          if (level !== undefined) robustness.level = level;
+
+          const brief = assembleBrief(buildInput(robustness, flips.rows));
+          const caveat = brief?.robustness_caveat;
+          expect(caveat, `caveat missing for ${JSON.stringify({ is_robust, level, flips: flips.name })}`).toBeDefined();
+
+          // The spec's classification, derived from the single source of truth.
+          const { status } = classifyFlipThresholdsStatus(flips.rows);
+          const label = JSON.stringify({ is_robust, level, flips: flips.name, status });
+
+          if (status === 'all_no_effect') {
+            // An attested no-flip payload must never carry a caveat claiming a flip.
+            expect(caveat!.text, `claim-1 flip language despite attestation: ${label}`).not.toMatch(FLIP_CLAIM);
+          }
+
+          if (caveat!.flip_evidence !== undefined) {
+            // Claim 2 exists only when the evidence supports a claim, and its
+            // status must EQUAL the shared classifier's (derived, not mirrored).
+            expect(['computed', 'all_no_effect', 'partial_no_effect'], label).toContain(caveat!.flip_evidence.status);
+            expect(caveat!.flip_evidence.status, label).toBe(status);
+            expect(caveat!.flip_evidence.text.length, label).toBeGreaterThan(0);
+            // Claim-safety: no numbers in the flip claim.
+            expect(caveat!.flip_evidence.text, label).not.toMatch(/\d/);
+            // No self-contradiction inside claim 2 either.
+            if (caveat!.flip_evidence.status === 'all_no_effect') {
+              expect(caveat!.flip_evidence.text, label).not.toMatch(/could change which option leads(?! on its own)/);
+            }
+          } else {
+            // Absence of claim 2 is only honest when nothing was attested.
+            expect(['unavailable', 'unresolved'], label).toContain(status);
+          }
+
+          // basis (claim 1's scope marker) is untouched by flip evidence.
+          const expectedBasis = is_robust !== undefined ? 'is_robust' : level !== undefined ? 'level' : 'absent';
+          expect(caveat!.basis, label).toBe(expectedBasis);
+        }
+      }
+    }
+  });
+
+  it('run.ts threads the SAME flip array the response publishes (same-run doctrine)', async () => {
+    // Structural pin: the assembleBrief call site in run.ts must pass
+    // flip_thresholds. A name-grep is not a wire witness, but this seam has no
+    // public route harness here; the integration is additionally covered by the
+    // input-threading tests above running through the public assembleBrief API.
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, join } = await import('node:path');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const runTs = readFileSync(join(here, '..', 'src', 'routes', 'v2', 'run.ts'), 'utf8');
+    const callSite = runTs.slice(runTs.indexOf('const assembledBrief = assembleBrief({'));
+    const callBlock = callSite.slice(0, callSite.indexOf('});') + 3);
+    expect(callBlock).toContain('flip_thresholds: flipThresholds');
+  });
+});

--- a/tests/decision-brief.test.ts
+++ b/tests/decision-brief.test.ts
@@ -321,6 +321,9 @@ describe('assembleBrief — robustness mapping', () => {
 
   it.each([
     ['high', 'robust'],
+    // ISL V2 wire vocabulary is 'medium'; 'moderate' tolerated — the SAME
+    // normalisation deriveVerdict applies (robustness-display-verdict.ts).
+    ['medium', 'moderate'],
     ['moderate', 'moderate'],
     ['low', 'fragile'],
     ['very_low', 'fragile'],
@@ -332,12 +335,24 @@ describe('assembleBrief — robustness mapping', () => {
     expect(result?.robustness).toBe(expected);
   });
 
-  it('defaults to "moderate" when robustness level is undefined', () => {
+  // ROADMAP 2.1248: an ABSENT level used to default to 'moderate' — a
+  // fabricated middle value presented as a measured one. Absence now
+  // propagates as the honest 'not_assessed' (the same token the sibling
+  // robustness.display_verdict already ships for exactly these runs).
+  it('HONESTY: absent robustness level → "not_assessed", never a fabricated "moderate"', () => {
     const result = assembleBrief({
       ...base,
       robustness: { fragile_edges: [], robust_edges: [] } as any,
     });
-    expect(result?.robustness).toBe('moderate');
+    expect(result?.robustness).toBe('not_assessed');
+  });
+
+  it('HONESTY: unrecognised robustness level → "not_assessed", never a fabricated "moderate"', () => {
+    const result = assembleBrief({
+      ...base,
+      robustness: { level: 'some_future_level', fragile_edges: [], robust_edges: [] } as any,
+    });
+    expect(result?.robustness).toBe('not_assessed');
   });
 
   it('returns null when robustness is not provided', () => {

--- a/tests/fragile-edges.cee-order.test.ts
+++ b/tests/fragile-edges.cee-order.test.ts
@@ -64,7 +64,15 @@ const options = [
 const islResult = {
   robustness: { fragile_edges: ISL_FRAGILE_EDGES, robust_edges: [] },
   factor_sensitivity: [],
-  option_comparison: [],
+  // 2.1248: the builder no longer fabricates a winner when ISL returned no
+  // analysed options — it returns null. This fixture's subject is fragile-edge
+  // ORDER, so it now carries the minimal analysed options a constructible
+  // request requires (previously it carried none, and the fabricated
+  // `{id:'', win_probability: 0}` winner rode along unnoticed).
+  options: [
+    { option_id: 'optA', option_label: 'A', win_probability: 0.55 },
+    { option_id: 'optB', option_label: 'B', win_probability: 0.45 },
+  ],
 } as any;
 
 /** Minimal but complete M1 coaching input — buildDeterministicCoaching maps
@@ -127,8 +135,16 @@ describe('buildRobustnessDataForCee — CEE-facing fragile edge order', () => {
 });
 
 describe('buildDecisionReviewRequest — CEE-facing fragile edge order', () => {
+  // 2.1248: non-null asserted via the fixture's analysed options — a request
+  // is only constructible when a real winner exists.
   const build = () =>
-    buildDecisionReviewRequest('a brief', graph, options, islResult, m1Coaching);
+    buildDecisionReviewRequest('a brief', graph, options, islResult, m1Coaching)!;
+
+  it('is constructible: the fixture carries analysed options, so a real winner exists', () => {
+    const request = buildDecisionReviewRequest('a brief', graph, options, islResult, m1Coaching);
+    expect(request).not.toBeNull();
+    expect(request!.winner.id).toBe('optA');
+  });
 
   it('emits fragile edges most-fragile-first', () => {
     const edges = build().isl_results.fragile_edges;

--- a/tests/golden/decision-review/orchestrator.test.ts
+++ b/tests/golden/decision-review/orchestrator.test.ts
@@ -209,6 +209,33 @@ describe('Decision Review Orchestrator', () => {
     });
   });
 
+  describe('No Analysed Options (ROADMAP 2.1248)', () => {
+    // The request builder used to fabricate winner {id:'', label:'',
+    // win_probability: 0} when ISL returned no analysed options, and the
+    // fabricated winner reached the reviewing model as a measured figure.
+    // CEE's DecisionReviewInputSchema requires a non-null winner, so the
+    // honest behaviour is to SKIP with a named reason — visible absence,
+    // never a plausible fabrication.
+    it('skips with NO_ANALYSED_OPTIONS instead of sending a fabricated empty winner to CEE', async () => {
+      vi.spyOn(FLAGS, 'DECISION_REVIEW_ENABLE', 'get').mockReturnValue(true);
+
+      const input = buildTestInput({
+        islResult: { options: [], factor_sensitivity: [] } as any,
+      });
+      const config = { baseUrl: 'https://cee.test', apiKey: 'test-key' };
+
+      const mockCall = vi.spyOn(ceeClient, 'callDecisionReview');
+
+      const result = await orchestrateDecisionReview(input, config);
+
+      expect(result.review_status).toBe('skipped');
+      expect(result.review_skip_reason).toBe('NO_ANALYSED_OPTIONS');
+      expect(result.m1_review).toBeNull();
+      // The fabricated request must never reach CEE at all.
+      expect(mockCall).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Validation Failure', () => {
     it('returns failed status when validation fails', async () => {
       vi.spyOn(FLAGS, 'DECISION_REVIEW_ENABLE', 'get').mockReturnValue(true);


### PR DESCRIPTION
## ROADMAP 2.1247 + 2.1248 — analysis-honesty on the wire

Feeds the ratified acceptance target: *never present conflicting claims about whether analysis ran, is fresh or can support a conclusion*. Derived and fixed at base `a5345a5e`.

### 2.1247 — `robustness_caveat` was structurally blind to flip evidence

**Mechanism (confirmed at the bytes at `a5345a5e`):** `src/assembly/decision-brief.ts:695-722` composed the caveat from robustness marginals alone; `BriefAssemblyInput` (`:121-149`) had no `flip_thresholds` member, so the caveat could ship *"small changes to assumptions could change which option leads"* while the same payload's flip evidence attested (`structurally_invariant` / `no_effect_within_bounds`) that no tested factor can flip the leader — the same self-contradiction witnessed live for the display verdict and fixed for its reason string in ROADMAP 2.278.

**Derivation refinement (2.1247's second clause):** the display-verdict side has **no remaining blindness** — `robustness-display-verdict.ts` already consumes the same run's flip evidence for its reason (2.278) and deliberately, correctly never moves the verdict on it (`:40`, `:82-89`). No change made there; the file's documented behaviour is the ratified pattern this PR extends to the brief.

**Fix — two named claims that cannot contradict (trap-21: never two questions under one name):**
- **Claim 1** (`robustness_caveat.text`) — aggregate stability under the perturbations tested, marginals scope, unchanged basis semantics. On an attested no-flip (`all_no_effect`), the two branches that previously asserted a flip drop the flip language but keep their marginal verdict (mirrors 2.278's correction shape; verdict never moves).
- **Claim 2** (`robustness_caveat.flip_evidence`, additive optional) — `{status, text}`, status **derived via `classifyFlipThresholdsStatus`** (single source of truth, never re-derived — the hand-maintained-mirror class). Present only when probes support a claim (`computed` / `all_no_effect` / `partial_no_effect`); absent on `unavailable`/`unresolved` — an unfinished probe attests nothing. Wording claim-safe (no numbers), scoped to the probed set per the 2.292 scoping ruling ("the factors we could test", never a universal).
- `run.ts` threads the **same `flipThresholds` variable** the response publishes and the display verdict consumes — one array, so the caveat can never cite a different run's evidence.

Consumer safety: `decision_brief` is an open passthrough in the shared contract (`@talchain/schemas` 0.40.0: `z.object({}).passthrough().nullable().optional()`); `flip_evidence` is additive-optional; with flip evidence absent the caveat is **byte-identical** to its pre-change shape (pinned by test). Golden fixtures unaffected (all four carry recognised levels; the live golden's flip status is `unavailable`).

### 2.1248 — fabricated defaults on the review path

Consumer contract derived before changing anything: CEE's `DecisionReviewInputSchema` (read-only at CEE staging tip `c5e24307`, `src/routes/assist.v1.decision-review.ts:150-224`) admits `isl_results.robustness` as `z.record(z.unknown()).optional()` — absent keys are admitted — and requires `winner` **non-null** `{id, label, win_probability}`. CEE serialises `isl_results` and `winner` **verbatim into the reviewing model's prompt** (`buildDecisionReviewUserMessage`), so every fabricated default below reached the model as a measured figure. The vendored `@talchain/schemas` 0.40.0 pin carries no DecisionReviewRequest schema (checked at the tarball) — CEE's Zod is the authority.

**Absent-propagation table:**

| Field | Old default | New behaviour | Consumer effect |
|---|---|---|---|
| `decision_brief.robustness` (level absent/unrecognised) | `'moderate'` — fabricated middle value | `'not_assessed'` | Same honest token the sibling `robustness.display_verdict` already ships to the same consumers for the same runs; shared contract is open passthrough. `'medium'` now an explicit case (ISL V2 vocabulary — previously mapped correctly only *by accident of the fabricating default*) |
| `isl_results.robustness.is_robust` | `?? false` — "not robust" claimed for unassessed runs | key omitted | CEE schema admits; prompt JSON block simply lacks the key; a **measured** `false` preserved verbatim |
| `isl_results.robustness.recommendation_stability` | `?? 0` — "0% stability" | key omitted | As above; a measured 0 preserved |
| `isl_results.robustness.flip_risk_category` | `?? 'unknown'` — presented as ISL's categorisation | key omitted | As above |
| `winner` (no analysed options) | `{id:'', label:'', win_probability: 0}` sent to CEE | request not built (`buildDecisionReviewRequest` returns `null`); orchestrator skips with named reason `NO_ANALYSED_OPTIONS` | CEE requires non-null winner, so honest absence is not representable on this wire — visible skip instead of confident fabrication. `review_skip_reason` is a PLoT-owned union (`engine-v3.ts:1615`); additive value, not pinned in the schemas tarball (target-zero + contrast-positive sweep) |
| corrector source `robustness.recommendation_stability` (`decision-review-orchestrator.ts:459`) | `?? 0` — authoritative correction source | emitted only when measured | number-corrector can no longer "correct" a model figure **to** a fabricated 0, or bless a written "0%" as grounded |
| Tier-4 grounding allowlist (`m1-review-validator.ts:912`) | fabricated 0 pushed unconditionally | pushed only when a number was measured | a review citing "0" stability for an unassessed run now trips `UNGROUNDED_NUMBER` (warning-grade) instead of passing as grounded |

**Refinement to the row's wording:** "winner/runner-up fall back to `{id:'',…}`" — at `a5345a5e` only **`winner`** fabricated (`:182`); `runner_up` already fell back to honest `null` (`:192`). Fixed the real half.

**Same-family fixes included with their own file:line** (named mechanisms' twins on the identical review path, not scope expansion): `buildIslResultsForCorrection` `?? 0` and the validator's unconditional allowlist push — both launder the same fabricated stability into the same review.

**Deliberately NOT changed (boundary):** `extractOptionComparison`'s `win_probability ?? 0` (`decision-review-request.ts:273`) and `buildIslResultsForCorrection`'s option `win_probability ?? 0`. CEE's schema requires `winner.win_probability: z.number()` (non-optional), and win_probability drives winner selection, margin, and ranking semantics — honest absence is not representable for it on this wire without a CEE-side schema change. Smallest enabling change if wanted: CEE makes `winner.win_probability` optional (or admits a `win_probability_basis` marker); until then rows with absent win probabilities keep today's behaviour. Reported, not forced.

### Evidence

- **RED-first at pristine `a5345a5e`:** 15 named failures across 4 files (contradiction kill, domain-wide consistency matrix, absent-key honesty, null-winner, corrector/allowlist, `not_assessed` mapping, orchestrator skip — the skip test additionally proved the fabricated request was previously **sent** to CEE). All GREEN post-fix (97/97 in the four files, same collection count as RED).
- **Spec-level invariant (trap 13d):** the domain matrix runs every `is_robust × level × flip-class` combination (126 cells) and asserts claims cannot contradict + `flip_evidence.status` equals the shared classifier's output — written against the consumer spec, not the witnessed failure.
- **Mutant kit — 12/12 BITTEN** (throwaway worktree outside the repo root, isolation proven by sentinel WRITE test + inode comparison before any mutant ran, HEAD-relative restores, applied-check scoped to `src/` asserting exactly the intended file, clean-tree assertion before/after every mutant, trailing zero-diff GREEN control 97/97):
  - M1 `?? 'moderate'` restored → 2 tests RED · M2 `?? false` → 2 RED · M3 `?? 0` (extract) → 2 RED · M4 `?? 'unknown'` → 2 RED · M5 empty-winner fallback restored → 3 RED (incl. proof the request would again be SENT to CEE) · M6 `?? 0` (corrector source) → 1 RED · M8 run.ts de-threads `flip_thresholds` → structural pin RED · M9 caveat ignores flip evidence → 3 RED · M10 flip claim emitted for unresolved → 2 RED · M11 local status re-derivation misfiling unresolved as attested (mirror-drift simulation) → 2 RED · M12 all_no_effect wording swapped for computed's (scope lie) → 2 RED.
  - **M7 (unconditional allowlist push) initially SURVIVED and was NOT waved through as equivalent** (trap 13c: equivalence must be demonstrated): with `extractRobustness` fixed, the restored push inserts `undefined` rather than the old fabricated 0, which a `not.toContain(0)` guard cannot see — a guard watching one door. The test now also pins the SPEC (every allowlisted entry is a finite number, non-empty), and M7 REDs against the amended tip.
- **Gates at tip (derived from `.github/workflows/ci.yml`: stale-js → lint → validate:contracts → build → test):** lint clean, contracts validated, build clean, typecheck clean.
- **Full suite with delta attribution:** pristine `a5345a5e` control (fresh worktree, machine quiet): **7202 passed / 0 failed / 28 skipped**. Lane commit, machine quiet: **7225 passed / 0 failed / 28 skipped** — +23 tests, exactly this PR's additions; **empty failure delta**. (An earlier run of the lane commit showed 1 perf-gate red + 8 server-boot `waitFor` file timeouts with 78 hook-skipped tests; it overlapped a concurrent `npm ci` in another worktree, and the quiet re-run proved all of it environmental rather than asserting it.) Full-suite numbers were measured at `6007b11`; the amend to `2b12fa1` is test-only in one file, re-run green at tip (10/10 + 97/97 four-file control); CI on this PR is the authoritative at-tip gate.
- **Collateral:** `tests/fragile-edges.cee-order.test.ts` fixture carried no analysed options (its fabricated empty winner rode along unnoticed); now carries minimal real options with a non-null constructibility assertion. One historic-corpus check: no capture corpora touched (trap 14b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
